### PR TITLE
Changed DataChart to fix issues with x-axis alignment

### DIFF
--- a/src/js/components/DataChart/DataChart.js
+++ b/src/js/components/DataChart/DataChart.js
@@ -519,7 +519,7 @@ const DataChart = forwardRef(
           ref={xRef}
           axis={axis}
           chartProps={chartProps}
-          data={data}
+          pad={pad}
           renderValue={renderValue}
           serie={axis.x.property && getPropertySeries(axis.x.property)}
         />
@@ -618,6 +618,7 @@ const DataChart = forwardRef(
             activeProperty={activeProperty}
             axis={axis}
             data={data}
+            pad={pad}
             series={series}
             seriesStyles={seriesStyles}
             renderValue={renderValue}

--- a/src/js/components/DataChart/Detail.js
+++ b/src/js/components/DataChart/Detail.js
@@ -6,6 +6,7 @@ import { Grid } from '../Grid';
 import { Keyboard } from '../Keyboard';
 import { Text } from '../Text';
 import { focusStyle, unfocusStyle } from '../../utils';
+import { halfPad } from './utils';
 import { Swatch } from './Swatch';
 
 const DetailControl = styled(Box)`
@@ -21,6 +22,7 @@ const Detail = ({
   activeProperty,
   axis,
   data,
+  pad,
   series,
   seriesStyles,
   renderValue,
@@ -64,6 +66,15 @@ const Detail = ({
           tabIndex={0}
           direction="row"
           fill
+          pad={
+            // ensure the hit targets and center lines align with
+            // the data/guide lines
+            (pad?.horizontal &&
+              halfPad[pad.horizontal] && {
+                horizontal: halfPad[pad.horizontal],
+              }) ||
+            pad
+          }
           justify="between"
           responsive={false}
           onFocus={() => {}}

--- a/src/js/components/DataChart/XAxis.js
+++ b/src/js/components/DataChart/XAxis.js
@@ -16,7 +16,13 @@ const XAxis = forwardRef(({ chartProps, pad, renderValue, serie }, ref) => {
       : { width: '1px', overflow: 'visible', align: 'center' };
 
   return (
-    <Box ref={ref} gridArea="xAxis" direction="row" justify="between" pad={pad}>
+    <Box
+      ref={ref}
+      gridArea="xAxis"
+      direction="row"
+      justify="between"
+      pad={pad?.horizontal ? { horizontal: pad.horizontal } : undefined}
+    >
       {axisValues.map((dataIndex, i) => (
         // eslint-disable-next-line react/no-array-index-key
         <Box key={i} {...itemProps}>

--- a/src/js/components/DataChart/XAxis.js
+++ b/src/js/components/DataChart/XAxis.js
@@ -1,28 +1,28 @@
 import React, { forwardRef } from 'react';
 import { Box } from '../Box';
 
-const XAxis = forwardRef(({ chartProps, data, renderValue, serie }, ref) => {
+const XAxis = forwardRef(({ chartProps, pad, renderValue, serie }, ref) => {
   // pull the x-axis values from the first chart, all should have the same
-  const [axisValues] = (Array.isArray(chartProps[0])
-    ? chartProps[0][0]
-    : chartProps[0]
+  const [axisValues] = (
+    Array.isArray(chartProps[0]) ? chartProps[0][0] : chartProps[0]
   ).axis;
 
+  // When there are only labels at the end of the axis, let them take as much
+  // space as they like. If there are more, align their container to the
+  // data/guide lines and then let their content overflow that.
+  const itemProps =
+    axisValues.length === 2
+      ? {}
+      : { width: '1px', overflow: 'visible', align: 'center' };
+
   return (
-    <Box ref={ref} gridArea="xAxis" direction="row" justify="between">
-      {axisValues.map((dataIndex, i) => {
-        let align;
-        if (axisValues.length === data.length) align = 'center';
-        else if (i === 0) align = 'start';
-        else if (i === axisValues.length - 1) align = 'end';
-        else align = 'center';
-        return (
-          // eslint-disable-next-line react/no-array-index-key
-          <Box key={i} flex align={align}>
-            {serie ? renderValue(serie, dataIndex) : dataIndex}
-          </Box>
-        );
-      })}
+    <Box ref={ref} gridArea="xAxis" direction="row" justify="between" pad={pad}>
+      {axisValues.map((dataIndex, i) => (
+        // eslint-disable-next-line react/no-array-index-key
+        <Box key={i} {...itemProps}>
+          {serie ? renderValue(serie, dataIndex) : dataIndex}
+        </Box>
+      ))}
     </Box>
   );
 });

--- a/src/js/components/DataChart/__tests__/__snapshots__/DataChart-test.js.snap
+++ b/src/js/components/DataChart/__tests__/__snapshots__/DataChart-test.js.snap
@@ -122,27 +122,7 @@ exports[`DataChart areas 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-}
-
-.c11 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 1 1;
-  -ms-flex: 1 1;
-  flex: 1 1;
+  padding: 48px;
 }
 
 .c8 {
@@ -167,6 +147,12 @@ exports[`DataChart areas 1`] = `
   left: 0;
   bottom: 0;
   right: 0;
+}
+
+@media only screen and (max-width:768px) {
+  .c10 {
+    padding: 24px;
+  }
 }
 
 <div
@@ -261,12 +247,12 @@ exports[`DataChart areas 1`] = `
         class="c10"
       >
         <div
-          class="c11"
+          class="c2"
         >
           0
         </div>
         <div
-          class="c11"
+          class="c2"
         >
           1
         </div>
@@ -392,27 +378,8 @@ exports[`DataChart axis 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-}
-
-.c10 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 1 1;
-  -ms-flex: 1 1;
-  flex: 1 1;
+  padding-left: 48px;
+  padding-right: 48px;
 }
 
 .c8 {
@@ -429,6 +396,13 @@ exports[`DataChart axis 1`] = `
 .c7 {
   position: relative;
   display: block;
+}
+
+@media only screen and (max-width:768px) {
+  .c9 {
+    padding-left: 24px;
+    padding-right: 24px;
+  }
 }
 
 <div
@@ -507,12 +481,12 @@ exports[`DataChart axis 1`] = `
         class="c9"
       >
         <div
-          class="c10"
+          class="c2"
         >
           0
         </div>
         <div
-          class="c10"
+          class="c2"
         >
           1
         </div>
@@ -608,12 +582,12 @@ exports[`DataChart axis 1`] = `
       class="c9"
     >
       <div
-        class="c10"
+        class="c2"
       >
         0
       </div>
       <div
-        class="c10"
+        class="c2"
       >
         1
       </div>
@@ -733,12 +707,12 @@ exports[`DataChart axis 1`] = `
       class="c9"
     >
       <div
-        class="c10"
+        class="c2"
       >
         0
       </div>
       <div
-        class="c10"
+        class="c2"
       >
         1
       </div>
@@ -870,6 +844,8 @@ exports[`DataChart axis x granularity 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+  padding-left: 48px;
+  padding-right: 48px;
 }
 
 .c6 {
@@ -888,9 +864,8 @@ exports[`DataChart axis x granularity 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 1 1;
-  -ms-flex: 1 1;
-  flex: 1 1;
+  width: 1px;
+  overflow: visible;
 }
 
 .c7 {
@@ -900,18 +875,18 @@ exports[`DataChart axis x granularity 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
+  grid-area: xAxis;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 1 1;
-  -ms-flex: 1 1;
-  flex: 1 1;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-left: 24px;
+  padding-right: 24px;
 }
 
 .c8 {
@@ -921,18 +896,18 @@ exports[`DataChart axis x granularity 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
+  grid-area: xAxis;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 1 1;
-  -ms-flex: 1 1;
-  flex: 1 1;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-left: 12px;
+  padding-right: 12px;
 }
 
 .c4 {
@@ -949,6 +924,27 @@ exports[`DataChart axis x granularity 1`] = `
 .c3 {
   position: relative;
   display: block;
+}
+
+@media only screen and (max-width:768px) {
+  .c5 {
+    padding-left: 24px;
+    padding-right: 24px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c8 {
+    padding-left: 6px;
+    padding-right: 6px;
+  }
 }
 
 <div
@@ -1079,12 +1075,12 @@ exports[`DataChart axis x granularity 1`] = `
       class="c5"
     >
       <div
-        class="c6"
+        class="c1"
       >
         0
       </div>
       <div
-        class="c6"
+        class="c1"
       >
         1
       </div>
@@ -1316,10 +1312,10 @@ exports[`DataChart axis x granularity 1`] = `
       </div>
     </div>
     <div
-      class="c5"
+      class="c7"
     >
       <div
-        class="c7"
+        class="c6"
       >
         0
       </div>
@@ -1329,7 +1325,7 @@ exports[`DataChart axis x granularity 1`] = `
         2
       </div>
       <div
-        class="c8"
+        class="c6"
       >
         4
       </div>
@@ -1412,15 +1408,15 @@ exports[`DataChart axis x granularity 1`] = `
       </div>
     </div>
     <div
-      class="c5"
+      class="c7"
     >
       <div
-        class="c7"
+        class="c1"
       >
         0
       </div>
       <div
-        class="c8"
+        class="c1"
       >
         5
       </div>
@@ -1511,10 +1507,10 @@ exports[`DataChart axis x granularity 1`] = `
       </div>
     </div>
     <div
-      class="c5"
+      class="c7"
     >
       <div
-        class="c7"
+        class="c6"
       >
         0
       </div>
@@ -1529,7 +1525,7 @@ exports[`DataChart axis x granularity 1`] = `
         4
       </div>
       <div
-        class="c8"
+        class="c6"
       >
         6
       </div>
@@ -1628,15 +1624,15 @@ exports[`DataChart axis x granularity 1`] = `
       </div>
     </div>
     <div
-      class="c5"
+      class="c7"
     >
       <div
-        class="c7"
+        class="c1"
       >
         0
       </div>
       <div
-        class="c8"
+        class="c1"
       >
         7
       </div>
@@ -1743,10 +1739,10 @@ exports[`DataChart axis x granularity 1`] = `
       </div>
     </div>
     <div
-      class="c5"
+      class="c7"
     >
       <div
-        class="c7"
+        class="c6"
       >
         0
       </div>
@@ -1766,7 +1762,7 @@ exports[`DataChart axis x granularity 1`] = `
         6
       </div>
       <div
-        class="c8"
+        class="c6"
       >
         8
       </div>
@@ -1881,10 +1877,10 @@ exports[`DataChart axis x granularity 1`] = `
       </div>
     </div>
     <div
-      class="c5"
+      class="c7"
     >
       <div
-        class="c7"
+        class="c6"
       >
         0
       </div>
@@ -1899,7 +1895,7 @@ exports[`DataChart axis x granularity 1`] = `
         6
       </div>
       <div
-        class="c8"
+        class="c6"
       >
         9
       </div>
@@ -2022,10 +2018,10 @@ exports[`DataChart axis x granularity 1`] = `
       </div>
     </div>
     <div
-      class="c5"
+      class="c8"
     >
       <div
-        class="c7"
+        class="c6"
       >
         0
       </div>
@@ -2035,7 +2031,7 @@ exports[`DataChart axis x granularity 1`] = `
         5
       </div>
       <div
-        class="c8"
+        class="c6"
       >
         10
       </div>
@@ -2166,15 +2162,15 @@ exports[`DataChart axis x granularity 1`] = `
       </div>
     </div>
     <div
-      class="c5"
+      class="c8"
     >
       <div
-        class="c7"
+        class="c1"
       >
         0
       </div>
       <div
-        class="c8"
+        class="c1"
       >
         11
       </div>
@@ -2313,10 +2309,10 @@ exports[`DataChart axis x granularity 1`] = `
       </div>
     </div>
     <div
-      class="c5"
+      class="c8"
     >
       <div
-        class="c7"
+        class="c6"
       >
         0
       </div>
@@ -2336,7 +2332,7 @@ exports[`DataChart axis x granularity 1`] = `
         9
       </div>
       <div
-        class="c8"
+        class="c6"
       >
         12
       </div>
@@ -2467,27 +2463,7 @@ exports[`DataChart bars 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-}
-
-.c11 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 1 1;
-  -ms-flex: 1 1;
-  flex: 1 1;
+  padding: 48px;
 }
 
 .c8 {
@@ -2512,6 +2488,12 @@ exports[`DataChart bars 1`] = `
   left: 0;
   bottom: 0;
   right: 0;
+}
+
+@media only screen and (max-width:768px) {
+  .c10 {
+    padding: 24px;
+  }
 }
 
 <div
@@ -2627,12 +2609,12 @@ exports[`DataChart bars 1`] = `
         class="c10"
       >
         <div
-          class="c11"
+          class="c2"
         >
           0
         </div>
         <div
-          class="c11"
+          class="c2"
         >
           1
         </div>
@@ -2764,27 +2746,7 @@ exports[`DataChart bars colors 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-}
-
-.c11 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 1 1;
-  -ms-flex: 1 1;
-  flex: 1 1;
+  padding: 48px;
 }
 
 .c8 {
@@ -2809,6 +2771,12 @@ exports[`DataChart bars colors 1`] = `
   left: 0;
   bottom: 0;
   right: 0;
+}
+
+@media only screen and (max-width:768px) {
+  .c10 {
+    padding: 24px;
+  }
 }
 
 <div
@@ -2924,12 +2892,12 @@ exports[`DataChart bars colors 1`] = `
         class="c10"
       >
         <div
-          class="c11"
+          class="c2"
         >
           0
         </div>
         <div
-          class="c11"
+          class="c2"
         >
           1
         </div>
@@ -3034,11 +3002,18 @@ exports[`DataChart bars empty 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+  padding: 48px;
 }
 
 .c5 {
   position: relative;
   grid-area: charts;
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    padding: 24px;
+  }
 }
 
 <div
@@ -3194,27 +3169,7 @@ exports[`DataChart bars invalid 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-}
-
-.c11 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 1 1;
-  -ms-flex: 1 1;
-  flex: 1 1;
+  padding: 48px;
 }
 
 .c8 {
@@ -3239,6 +3194,12 @@ exports[`DataChart bars invalid 1`] = `
   left: 0;
   bottom: 0;
   right: 0;
+}
+
+@media only screen and (max-width:768px) {
+  .c10 {
+    padding: 24px;
+  }
 }
 
 <div
@@ -3357,12 +3318,12 @@ exports[`DataChart bars invalid 1`] = `
         class="c10"
       >
         <div
-          class="c11"
+          class="c2"
         >
           0
         </div>
         <div
-          class="c11"
+          class="c2"
         >
           1
         </div>
@@ -3562,48 +3523,8 @@ exports[`DataChart dates 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-}
-
-.c15 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 1 1;
-  -ms-flex: 1 1;
-  flex: 1 1;
-}
-
-.c16 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 1 1;
-  -ms-flex: 1 1;
-  flex: 1 1;
+  padding-left: 48px;
+  padding-right: 48px;
 }
 
 .c13 {
@@ -3639,6 +3560,13 @@ exports[`DataChart dates 1`] = `
 @media only screen and (max-width:768px) {
   .c11 {
     border-top: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c14 {
+    padding-left: 24px;
+    padding-right: 24px;
   }
 }
 
@@ -3762,12 +3690,12 @@ exports[`DataChart dates 1`] = `
         class="c14"
       >
         <div
-          class="c15"
+          class="c2"
         >
           0
         </div>
         <div
-          class="c16"
+          class="c2"
         >
           3
         </div>
@@ -3891,12 +3819,12 @@ exports[`DataChart dates 1`] = `
         class="c14"
       >
         <div
-          class="c15"
+          class="c2"
         >
           0
         </div>
         <div
-          class="c16"
+          class="c2"
         >
           3
         </div>
@@ -4020,12 +3948,12 @@ exports[`DataChart dates 1`] = `
         class="c14"
       >
         <div
-          class="c15"
+          class="c2"
         >
           0
         </div>
         <div
-          class="c16"
+          class="c2"
         >
           3
         </div>
@@ -4149,12 +4077,12 @@ exports[`DataChart dates 1`] = `
         class="c14"
       >
         <div
-          class="c15"
+          class="c2"
         >
           0
         </div>
         <div
-          class="c16"
+          class="c2"
         >
           3
         </div>
@@ -4278,12 +4206,12 @@ exports[`DataChart dates 1`] = `
         class="c14"
       >
         <div
-          class="c15"
+          class="c2"
         >
           0
         </div>
         <div
-          class="c16"
+          class="c2"
         >
           3
         </div>
@@ -4407,12 +4335,12 @@ exports[`DataChart dates 1`] = `
         class="c14"
       >
         <div
-          class="c15"
+          class="c2"
         >
           0
         </div>
         <div
-          class="c16"
+          class="c2"
         >
           3
         </div>
@@ -4538,27 +4466,8 @@ exports[`DataChart default 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-}
-
-.c10 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 1 1;
-  -ms-flex: 1 1;
-  flex: 1 1;
+  padding-left: 48px;
+  padding-right: 48px;
 }
 
 .c8 {
@@ -4575,6 +4484,13 @@ exports[`DataChart default 1`] = `
 .c7 {
   position: relative;
   display: block;
+}
+
+@media only screen and (max-width:768px) {
+  .c9 {
+    padding-left: 24px;
+    padding-right: 24px;
+  }
 }
 
 <div
@@ -4653,12 +4569,12 @@ exports[`DataChart default 1`] = `
         class="c9"
       >
         <div
-          class="c10"
+          class="c2"
         >
           0
         </div>
         <div
-          class="c10"
+          class="c2"
         >
           1
         </div>
@@ -4785,6 +4701,8 @@ exports[`DataChart detail 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+  padding-left: 24px;
+  padding-right: 24px;
 }
 
 .c12 {
@@ -4838,27 +4756,8 @@ exports[`DataChart detail 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-}
-
-.c15 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 1 1;
-  -ms-flex: 1 1;
-  flex: 1 1;
+  padding-left: 48px;
+  padding-right: 48px;
 }
 
 .c8 {
@@ -4923,6 +4822,13 @@ exports[`DataChart detail 1`] = `
 
 .c11:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
+}
+
+@media only screen and (max-width:768px) {
+  .c14 {
+    padding-left: 24px;
+    padding-right: 24px;
+  }
 }
 
 <div
@@ -5024,12 +4930,12 @@ exports[`DataChart detail 1`] = `
         class="c14"
       >
         <div
-          class="c15"
+          class="c2"
         >
           0
         </div>
         <div
-          class="c15"
+          class="c2"
         >
           1
         </div>
@@ -5109,12 +5015,12 @@ exports[`DataChart detail 1`] = `
         class="c14"
       >
         <div
-          class="c15"
+          class="c2"
         >
           0
         </div>
         <div
-          class="c15"
+          class="c2"
         >
           1
         </div>
@@ -5240,27 +5146,8 @@ exports[`DataChart gap 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-}
-
-.c10 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 1 1;
-  -ms-flex: 1 1;
-  flex: 1 1;
+  padding-left: 48px;
+  padding-right: 48px;
 }
 
 .c8 {
@@ -5277,6 +5164,13 @@ exports[`DataChart gap 1`] = `
 .c7 {
   position: relative;
   display: block;
+}
+
+@media only screen and (max-width:768px) {
+  .c9 {
+    padding-left: 24px;
+    padding-right: 24px;
+  }
 }
 
 <div
@@ -5355,12 +5249,12 @@ exports[`DataChart gap 1`] = `
         class="c9"
       >
         <div
-          class="c10"
+          class="c2"
         >
           0
         </div>
         <div
-          class="c10"
+          class="c2"
         >
           1
         </div>
@@ -5440,12 +5334,12 @@ exports[`DataChart gap 1`] = `
         class="c9"
       >
         <div
-          class="c10"
+          class="c2"
         >
           0
         </div>
         <div
-          class="c10"
+          class="c2"
         >
           1
         </div>
@@ -5525,12 +5419,12 @@ exports[`DataChart gap 1`] = `
         class="c9"
       >
         <div
-          class="c10"
+          class="c2"
         >
           0
         </div>
         <div
-          class="c10"
+          class="c2"
         >
           1
         </div>
@@ -5730,27 +5624,8 @@ exports[`DataChart guide 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-}
-
-.c15 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 1 1;
-  -ms-flex: 1 1;
-  flex: 1 1;
+  padding-left: 48px;
+  padding-right: 48px;
 }
 
 .c13 {
@@ -5786,6 +5661,13 @@ exports[`DataChart guide 1`] = `
 @media only screen and (max-width:768px) {
   .c11 {
     border-top: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c14 {
+    padding-left: 24px;
+    padding-right: 24px;
   }
 }
 
@@ -5893,12 +5775,12 @@ exports[`DataChart guide 1`] = `
         class="c14"
       >
         <div
-          class="c15"
+          class="c2"
         >
           0
         </div>
         <div
-          class="c15"
+          class="c2"
         >
           1
         </div>
@@ -5978,12 +5860,12 @@ exports[`DataChart guide 1`] = `
         class="c14"
       >
         <div
-          class="c15"
+          class="c2"
         >
           0
         </div>
         <div
-          class="c15"
+          class="c2"
         >
           1
         </div>
@@ -6077,12 +5959,12 @@ exports[`DataChart guide 1`] = `
         class="c14"
       >
         <div
-          class="c15"
+          class="c2"
         >
           0
         </div>
         <div
-          class="c15"
+          class="c2"
         >
           1
         </div>
@@ -6185,12 +6067,12 @@ exports[`DataChart guide 1`] = `
         class="c14"
       >
         <div
-          class="c15"
+          class="c2"
         >
           0
         </div>
         <div
-          class="c15"
+          class="c2"
         >
           1
         </div>
@@ -6316,30 +6198,11 @@ exports[`DataChart legend 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+  padding-left: 48px;
+  padding-right: 48px;
 }
 
 .c10 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 1 1;
-  -ms-flex: 1 1;
-  flex: 1 1;
-}
-
-.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6357,7 +6220,7 @@ exports[`DataChart legend 1`] = `
   flex-wrap: wrap;
 }
 
-.c12 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6379,7 +6242,7 @@ exports[`DataChart legend 1`] = `
   padding-bottom: 6px;
 }
 
-.c13 {
+.c12 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -6405,33 +6268,40 @@ exports[`DataChart legend 1`] = `
   display: block;
 }
 
-.c14 {
+.c13 {
   font-size: 18px;
   line-height: 24px;
 }
 
 @media only screen and (max-width:768px) {
-  .c11 {
+  .c9 {
+    padding-left: 24px;
+    padding-right: 24px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c10 {
     margin-top: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c12 {
+  .c11 {
     padding-left: 6px;
     padding-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c12 {
+  .c11 {
     padding-top: 3px;
     padding-bottom: 3px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c13 {
+  .c12 {
     width: 3px;
   }
 }
@@ -6515,12 +6385,12 @@ exports[`DataChart legend 1`] = `
           class="c9"
         >
           <div
-            class="c10"
+            class="c1"
           >
             0
           </div>
           <div
-            class="c10"
+            class="c1"
           >
             1
           </div>
@@ -6528,10 +6398,10 @@ exports[`DataChart legend 1`] = `
       </div>
     </div>
     <div
-      class="c11"
+      class="c10"
     >
       <div
-        class="c12"
+        class="c11"
       >
         <svg
           fill="#6FFFB0"
@@ -6545,10 +6415,10 @@ exports[`DataChart legend 1`] = `
           />
         </svg>
         <div
-          class="c13"
+          class="c12"
         />
         <span
-          class="c14"
+          class="c13"
         >
           a
         </span>
@@ -6628,12 +6498,12 @@ exports[`DataChart legend 1`] = `
         class="c9"
       >
         <div
-          class="c10"
+          class="c1"
         >
           0
         </div>
         <div
-          class="c10"
+          class="c1"
         >
           1
         </div>
@@ -6765,27 +6635,7 @@ exports[`DataChart lines 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-}
-
-.c11 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 1 1;
-  -ms-flex: 1 1;
-  flex: 1 1;
+  padding: 48px;
 }
 
 .c8 {
@@ -6810,6 +6660,12 @@ exports[`DataChart lines 1`] = `
   left: 0;
   bottom: 0;
   right: 0;
+}
+
+@media only screen and (max-width:768px) {
+  .c10 {
+    padding: 24px;
+  }
 }
 
 <div
@@ -6909,12 +6765,12 @@ exports[`DataChart lines 1`] = `
         class="c10"
       >
         <div
-          class="c11"
+          class="c2"
         >
           0
         </div>
         <div
-          class="c11"
+          class="c2"
         >
           1
         </div>
@@ -7040,27 +6896,8 @@ exports[`DataChart nothing 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-}
-
-.c10 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 1 1;
-  -ms-flex: 1 1;
-  flex: 1 1;
+  padding-left: 48px;
+  padding-right: 48px;
 }
 
 .c8 {
@@ -7077,6 +6914,13 @@ exports[`DataChart nothing 1`] = `
 .c7 {
   position: relative;
   display: block;
+}
+
+@media only screen and (max-width:768px) {
+  .c9 {
+    padding-left: 24px;
+    padding-right: 24px;
+  }
 }
 
 <div
@@ -7164,12 +7008,12 @@ exports[`DataChart nothing 1`] = `
         class="c9"
       >
         <div
-          class="c10"
+          class="c3"
         >
           0
         </div>
         <div
-          class="c10"
+          class="c3"
         >
           1
         </div>
@@ -7301,27 +7145,8 @@ exports[`DataChart offset 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-}
-
-.c10 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 1 1;
-  -ms-flex: 1 1;
-  flex: 1 1;
+  padding-left: 48px;
+  padding-right: 48px;
 }
 
 .c8 {
@@ -7338,6 +7163,13 @@ exports[`DataChart offset 1`] = `
 .c7 {
   position: relative;
   display: block;
+}
+
+@media only screen and (max-width:768px) {
+  .c9 {
+    padding-left: 24px;
+    padding-right: 24px;
+  }
 }
 
 <div
@@ -7417,12 +7249,12 @@ exports[`DataChart offset 1`] = `
         class="c9"
       >
         <div
-          class="c10"
+          class="c2"
         >
           0
         </div>
         <div
-          class="c10"
+          class="c2"
         >
           1
         </div>
@@ -7554,30 +7386,10 @@ exports[`DataChart pad 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+  padding: 12px;
 }
 
 .c10 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 1 1;
-  -ms-flex: 1 1;
-  flex: 1 1;
-}
-
-.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7602,6 +7414,26 @@ exports[`DataChart pad 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
+}
+
+.c11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  grid-area: xAxis;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding: 24px;
 }
 
 .c12 {
@@ -7631,6 +7463,26 @@ exports[`DataChart pad 1`] = `
   justify-content: center;
 }
 
+.c13 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  grid-area: xAxis;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding: 48px;
+}
+
 .c8 {
   display: block;
   max-width: 100%;
@@ -7645,6 +7497,24 @@ exports[`DataChart pad 1`] = `
 .c7 {
   position: relative;
   display: block;
+}
+
+@media only screen and (max-width:768px) {
+  .c9 {
+    padding: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c11 {
+    padding: 12px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c13 {
+    padding: 24px;
+  }
 }
 
 <div
@@ -7723,12 +7593,12 @@ exports[`DataChart pad 1`] = `
         class="c9"
       >
         <div
-          class="c10"
+          class="c2"
         >
           0
         </div>
         <div
-          class="c10"
+          class="c2"
         >
           1
         </div>
@@ -7745,12 +7615,12 @@ exports[`DataChart pad 1`] = `
         class="c3"
       >
         <div
-          class="c11"
+          class="c10"
         >
           2
         </div>
         <div
-          class="c11"
+          class="c10"
         >
           0.8
         </div>
@@ -7805,15 +7675,15 @@ exports[`DataChart pad 1`] = `
         </div>
       </div>
       <div
-        class="c9"
+        class="c11"
       >
         <div
-          class="c10"
+          class="c2"
         >
           0
         </div>
         <div
-          class="c10"
+          class="c2"
         >
           1
         </div>
@@ -7890,15 +7760,15 @@ exports[`DataChart pad 1`] = `
         </div>
       </div>
       <div
-        class="c9"
+        class="c13"
       >
         <div
-          class="c10"
+          class="c2"
         >
           0
         </div>
         <div
-          class="c10"
+          class="c2"
         >
           1
         </div>
@@ -8024,27 +7894,8 @@ exports[`DataChart size 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-}
-
-.c10 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 1 1;
-  -ms-flex: 1 1;
-  flex: 1 1;
+  padding-left: 48px;
+  padding-right: 48px;
 }
 
 .c8 {
@@ -8069,7 +7920,7 @@ exports[`DataChart size 1`] = `
   display: flex;
 }
 
-.c11 {
+.c10 {
   position: relative;
   grid-area: charts;
   width: 100%;
@@ -8084,7 +7935,7 @@ exports[`DataChart size 1`] = `
   display: flex;
 }
 
-.c12 {
+.c11 {
   position: relative;
   grid-area: charts;
 }
@@ -8096,9 +7947,16 @@ exports[`DataChart size 1`] = `
   height: 100%;
 }
 
-.c13 {
+.c12 {
   position: relative;
   display: block;
+}
+
+@media only screen and (max-width:768px) {
+  .c9 {
+    padding-left: 24px;
+    padding-right: 24px;
+  }
 }
 
 <div
@@ -8177,12 +8035,12 @@ exports[`DataChart size 1`] = `
         class="c9"
       >
         <div
-          class="c10"
+          class="c2"
         >
           0
         </div>
         <div
-          class="c10"
+          class="c2"
         >
           1
         </div>
@@ -8218,7 +8076,7 @@ exports[`DataChart size 1`] = `
       class="c2"
     >
       <div
-        class="c11"
+        class="c10"
       >
         <div
           class="c7"
@@ -8262,12 +8120,12 @@ exports[`DataChart size 1`] = `
         class="c9"
       >
         <div
-          class="c10"
+          class="c2"
         >
           0
         </div>
         <div
-          class="c10"
+          class="c2"
         >
           1
         </div>
@@ -8303,10 +8161,10 @@ exports[`DataChart size 1`] = `
       class="c2"
     >
       <div
-        class="c12"
+        class="c11"
       >
         <div
-          class="c13"
+          class="c12"
         >
           <svg
             class="c8"
@@ -8347,12 +8205,12 @@ exports[`DataChart size 1`] = `
         class="c9"
       >
         <div
-          class="c10"
+          class="c2"
         >
           0
         </div>
         <div
-          class="c10"
+          class="c2"
         >
           1
         </div>
@@ -8478,30 +8336,11 @@ exports[`DataChart type 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+  padding-left: 48px;
+  padding-right: 48px;
 }
 
 .c10 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 1 1;
-  -ms-flex: 1 1;
-  flex: 1 1;
-}
-
-.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8528,6 +8367,26 @@ exports[`DataChart type 1`] = `
   justify-content: center;
 }
 
+.c11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  grid-area: xAxis;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding: 48px;
+}
+
 .c8 {
   display: block;
   max-width: 100%;
@@ -8542,6 +8401,19 @@ exports[`DataChart type 1`] = `
 .c7 {
   position: relative;
   display: block;
+}
+
+@media only screen and (max-width:768px) {
+  .c9 {
+    padding-left: 24px;
+    padding-right: 24px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c11 {
+    padding: 24px;
+  }
 }
 
 <div
@@ -8620,12 +8492,12 @@ exports[`DataChart type 1`] = `
         class="c9"
       >
         <div
-          class="c10"
+          class="c2"
         >
           0
         </div>
         <div
-          class="c10"
+          class="c2"
         >
           1
         </div>
@@ -8642,12 +8514,12 @@ exports[`DataChart type 1`] = `
         class="c3"
       >
         <div
-          class="c11"
+          class="c10"
         >
           2
         </div>
         <div
-          class="c11"
+          class="c10"
         >
           0.8
         </div>
@@ -8694,15 +8566,15 @@ exports[`DataChart type 1`] = `
         </div>
       </div>
       <div
-        class="c9"
+        class="c11"
       >
         <div
-          class="c10"
+          class="c2"
         >
           0
         </div>
         <div
-          class="c10"
+          class="c2"
         >
           1
         </div>
@@ -8719,12 +8591,12 @@ exports[`DataChart type 1`] = `
         class="c3"
       >
         <div
-          class="c11"
+          class="c10"
         >
           2
         </div>
         <div
-          class="c11"
+          class="c10"
         >
           0.8
         </div>
@@ -8768,15 +8640,15 @@ exports[`DataChart type 1`] = `
         </div>
       </div>
       <div
-        class="c9"
+        class="c11"
       >
         <div
-          class="c10"
+          class="c2"
         >
           0
         </div>
         <div
-          class="c10"
+          class="c2"
         >
           1
         </div>

--- a/src/js/components/DataChart/__tests__/__snapshots__/DataChart-test.js.snap
+++ b/src/js/components/DataChart/__tests__/__snapshots__/DataChart-test.js.snap
@@ -122,7 +122,8 @@ exports[`DataChart areas 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  padding: 48px;
+  padding-left: 48px;
+  padding-right: 48px;
 }
 
 .c8 {
@@ -151,7 +152,8 @@ exports[`DataChart areas 1`] = `
 
 @media only screen and (max-width:768px) {
   .c10 {
-    padding: 24px;
+    padding-left: 24px;
+    padding-right: 24px;
   }
 }
 
@@ -2463,7 +2465,8 @@ exports[`DataChart bars 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  padding: 48px;
+  padding-left: 48px;
+  padding-right: 48px;
 }
 
 .c8 {
@@ -2492,7 +2495,8 @@ exports[`DataChart bars 1`] = `
 
 @media only screen and (max-width:768px) {
   .c10 {
-    padding: 24px;
+    padding-left: 24px;
+    padding-right: 24px;
   }
 }
 
@@ -2746,7 +2750,8 @@ exports[`DataChart bars colors 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  padding: 48px;
+  padding-left: 48px;
+  padding-right: 48px;
 }
 
 .c8 {
@@ -2775,7 +2780,8 @@ exports[`DataChart bars colors 1`] = `
 
 @media only screen and (max-width:768px) {
   .c10 {
-    padding: 24px;
+    padding-left: 24px;
+    padding-right: 24px;
   }
 }
 
@@ -3002,7 +3008,8 @@ exports[`DataChart bars empty 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  padding: 48px;
+  padding-left: 48px;
+  padding-right: 48px;
 }
 
 .c5 {
@@ -3012,7 +3019,8 @@ exports[`DataChart bars empty 1`] = `
 
 @media only screen and (max-width:768px) {
   .c6 {
-    padding: 24px;
+    padding-left: 24px;
+    padding-right: 24px;
   }
 }
 
@@ -3169,7 +3177,8 @@ exports[`DataChart bars invalid 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  padding: 48px;
+  padding-left: 48px;
+  padding-right: 48px;
 }
 
 .c8 {
@@ -3198,7 +3207,8 @@ exports[`DataChart bars invalid 1`] = `
 
 @media only screen and (max-width:768px) {
   .c10 {
-    padding: 24px;
+    padding-left: 24px;
+    padding-right: 24px;
   }
 }
 
@@ -6635,7 +6645,8 @@ exports[`DataChart lines 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  padding: 48px;
+  padding-left: 48px;
+  padding-right: 48px;
 }
 
 .c8 {
@@ -6664,7 +6675,8 @@ exports[`DataChart lines 1`] = `
 
 @media only screen and (max-width:768px) {
   .c10 {
-    padding: 24px;
+    padding-left: 24px;
+    padding-right: 24px;
   }
 }
 
@@ -7386,7 +7398,6 @@ exports[`DataChart pad 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  padding: 12px;
 }
 
 .c10 {
@@ -7422,26 +7433,6 @@ exports[`DataChart pad 1`] = `
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
-  max-width: 100%;
-  grid-area: xAxis;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  padding: 24px;
-}
-
-.c12 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
   -webkit-align-items: flex-end;
   -webkit-box-align: flex-end;
   -ms-flex-align: flex-end;
@@ -7463,26 +7454,6 @@ exports[`DataChart pad 1`] = `
   justify-content: center;
 }
 
-.c13 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  grid-area: xAxis;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  padding: 48px;
-}
-
 .c8 {
   display: block;
   max-width: 100%;
@@ -7497,24 +7468,6 @@ exports[`DataChart pad 1`] = `
 .c7 {
   position: relative;
   display: block;
-}
-
-@media only screen and (max-width:768px) {
-  .c9 {
-    padding: 6px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c11 {
-    padding: 12px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c13 {
-    padding: 24px;
-  }
 }
 
 <div
@@ -7675,7 +7628,7 @@ exports[`DataChart pad 1`] = `
         </div>
       </div>
       <div
-        class="c11"
+        class="c9"
       >
         <div
           class="c2"
@@ -7700,12 +7653,12 @@ exports[`DataChart pad 1`] = `
         class="c3"
       >
         <div
-          class="c12"
+          class="c11"
         >
           2
         </div>
         <div
-          class="c12"
+          class="c11"
         >
           0.8
         </div>
@@ -7760,7 +7713,7 @@ exports[`DataChart pad 1`] = `
         </div>
       </div>
       <div
-        class="c13"
+        class="c9"
       >
         <div
           class="c2"
@@ -8367,26 +8320,6 @@ exports[`DataChart type 1`] = `
   justify-content: center;
 }
 
-.c11 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  grid-area: xAxis;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  padding: 48px;
-}
-
 .c8 {
   display: block;
   max-width: 100%;
@@ -8407,12 +8340,6 @@ exports[`DataChart type 1`] = `
   .c9 {
     padding-left: 24px;
     padding-right: 24px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c11 {
-    padding: 24px;
   }
 }
 
@@ -8566,7 +8493,7 @@ exports[`DataChart type 1`] = `
         </div>
       </div>
       <div
-        class="c11"
+        class="c9"
       >
         <div
           class="c2"
@@ -8640,7 +8567,7 @@ exports[`DataChart type 1`] = `
         </div>
       </div>
       <div
-        class="c11"
+        class="c9"
       >
         <div
           class="c2"


### PR DESCRIPTION
#### What does this PR do?

Changed DataChart to fix issues with x-axis alignment.

Previously, the x-axis labels were only roughly aligned to the data/guide lines. You could see this most on bar charts with medium or fine grained x-axis labels. These changes make them align.

#### Where should the reviewer start?

XAxis.js

#### What testing has been done on this PR?

visual verification using stories

#### How should this be manually tested?

storybook

#### Do Jest tests follow these best practices?

no unit test changes

#### Screenshots (if appropriate)

previously:
![Screen Shot 2022-02-17 at 2 23 03 PM](https://user-images.githubusercontent.com/11637956/154580976-10b42c3c-95b4-4728-84ba-66fa0cbd5d73.png)

now:
![Screen Shot 2022-02-17 at 2 23 27 PM](https://user-images.githubusercontent.com/11637956/154581030-7104eab3-0cf3-49bd-a7b2-28ef45e0ca61.png)

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
