### PR TITLE
Changed Tip to not crash when it doesn't have children

### DIFF
--- a/src/js/components/Tip/Tip.js
+++ b/src/js/components/Tip/Tip.js
@@ -31,20 +31,16 @@ const Tip = forwardRef(({ children, content, dropProps, plain }, tipRef) => {
 
   const componentRef = useForwardedRef(tipRef);
 
-  // In cases the child is a primitive
-  const wrapInvalidElement = () =>
-    // Handle the use case of a primitive string child
-    // so we'll be able to assign ref and events on the child.
-    !React.isValidElement(children) ? <span>{children}</span> : children;
-  /* Three use case for children
-    1. Tip has a single child + it is a React Element => Great!
-    2. Tip has a single child +  not React Element => span will wrap the child.
-    3. Tip has more than one child => Abort, display Children.only error 
-  */
+  // Three use case for children
+  // 1. Tip has a single child + it is a React Element => Great!
+  // 2. Tip has a single child +  not React Element =>
+  // span will wrap the child so we can use ref and events.
+  // 3. Tip has more than one child => Abort, display Children.only error 
   const child =
-    Children.count(children) === 1
-      ? wrapInvalidElement()
-      : Children.only(children);
+    (Children.count(children) <= 1 && !React.isValidElement(children) && (
+      <span>{children}</span>
+    )) ||
+    Children.only(children);
 
   const clonedChild = cloneElement(child, {
     onMouseEnter: () => setOver(true),

--- a/src/js/components/Tip/__tests__/Tip-test.tsx
+++ b/src/js/components/Tip/__tests__/Tip-test.tsx
@@ -129,6 +129,16 @@ describe('Tip', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  test(`shouldn't crash with no children`, () => {
+    const { container } = render(
+      <Grommet>
+        <Tip />
+      </Grommet>,
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
   test(`throw error with more than one child`, () => {
     console.error = jest.fn();
     expect(() => {

--- a/src/js/components/Tip/__tests__/__snapshots__/Tip-test.tsx.snap
+++ b/src/js/components/Tip/__tests__/__snapshots__/Tip-test.tsx.snap
@@ -491,6 +491,24 @@ exports[`Tip should work with a child that isn't a React Element 1`] = `
 </div>
 `;
 
+exports[`Tip shouldn't crash with no children 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+<div
+  class="c0"
+>
+  <span />
+</div>
+`;
+
 exports[`Tip themed 1`] = `
 .c0 {
   display: -webkit-box;


### PR DESCRIPTION
#### What does this PR do?

Changed Tip to not crash when it doesn't have children.

This was uncovered when adding Tip to grommet-designer.

#### Where should the reviewer start?

Tip.js

#### What testing has been done on this PR?

Added a unit test.

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

none of the below apply

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
