### PR TITLE
Changed DataChart to ensure y guide encompasses thickness

### DIFF
--- a/src/js/components/DataChart/DataChart.js
+++ b/src/js/components/DataChart/DataChart.js
@@ -540,7 +540,7 @@ const DataChart = forwardRef(
         <YAxis
           axis={axis}
           values={
-            boundsProp?.y?.reverse() ||
+            boundsProp?.y?.slice(0).reverse() ||
             (Array.isArray(chartProps[0]) ? chartProps[0][0] : chartProps[0])
               .axis[1]
           }

--- a/src/js/components/DataChart/YGuide.js
+++ b/src/js/components/DataChart/YGuide.js
@@ -1,13 +1,21 @@
 import React, { forwardRef } from 'react';
 import { Box } from '../Box';
 
-const YGuide = forwardRef(({ guide, pad }, ref) => (
-  <Box ref={ref} fill justify="between" pad={pad} responsive={false}>
-    {Array.from({ length: guide.y.count }).map((_, i) => (
-      // eslint-disable-next-line react/no-array-index-key
-      <Box key={i} border="top" />
-    ))}
-  </Box>
-));
+const YGuide = forwardRef(({ guide, pad: padArg }, ref) => {
+  // omit any horizontal pad so the guides cover the thickness that
+  // is within the pad
+  let pad;
+  if (typeof padArg === 'object')
+    pad = { ...padArg, start: 'none', end: 'none' };
+  else if (typeof padArg === 'string') pad = { vertical: padArg };
+  return (
+    <Box ref={ref} fill justify="between" pad={pad} responsive={false}>
+      {Array.from({ length: guide.y.count }).map((_, i) => (
+        // eslint-disable-next-line react/no-array-index-key
+        <Box key={i} border="top" />
+      ))}
+    </Box>
+  );
+});
 
 export { YGuide };

--- a/src/js/components/DataChart/__tests__/__snapshots__/DataChart-test.js.snap
+++ b/src/js/components/DataChart/__tests__/__snapshots__/DataChart-test.js.snap
@@ -3967,6 +3967,8 @@ exports[`DataChart dates 1`] = `
   justify-content: space-between;
   padding-left: 48px;
   padding-right: 48px;
+  padding-inline-start: 0px;
+  padding-inline-end: 0px;
 }
 
 .c11 {
@@ -6068,6 +6070,8 @@ exports[`DataChart guide 1`] = `
   justify-content: space-between;
   padding-left: 48px;
   padding-right: 48px;
+  padding-inline-start: 0px;
+  padding-inline-end: 0px;
 }
 
 .c11 {


### PR DESCRIPTION
#### What does this PR do?

Changed DataChart to ensure y guide encompasses thickness.

Because of how we draw the graphics in SVG, any line thickness overflows into the padding area. This change ensures that the `guide` for the Y dimension always covers the horizontal padding area.

#### Where should the reviewer start?

YGuide.js

#### What testing has been done on this PR?

visually with storybook and inspecting unit test snapshots

#### How should this be manually tested?

Guide Default storybook

#### Do Jest tests follow these best practices?

no test changes

#### Screenshots (if appropriate)
<img width="471" alt="Screen Shot 2022-03-05 at 10 16 37 AM" src="https://user-images.githubusercontent.com/11637956/156895429-9900acf7-d815-44e9-8338-bf08a5a5d135.png">

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
