### PR TITLE
Remove reference to the design-kit in the contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,8 +15,6 @@ Grommet is divided into several projects, the following are notable:
   contributions are more than welcome! Be sure to check the [good first issues].
 - [grommet-site] - the Grommet website. Any documentation changes should be made here.
 - [grommet-icons] – iconography for Grommet and React.js.
-- [design-kit] – the Grommet Design Kit provides a set of sticker sheets and
-  templates to help bootstrap your design process.
 
 ## You can Become a Contributor
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Removes the reference to the design-kit in the contributing guide since we don't actively maintain the design kit. 

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible