### PR TITLE
Changed Box to fix an issue with desired height using an object

### DIFF
--- a/src/js/components/Box/__tests__/Box-test.tsx
+++ b/src/js/components/Box/__tests__/Box-test.tsx
@@ -579,6 +579,7 @@ describe('Box', () => {
         <Box height="large" />
         <Box height="xlarge" />
         <Box height="111px" />
+        <Box height={{ min: 'small', max: '100%', height: 'large' }} />
       </Grommet>,
     );
 

--- a/src/js/components/Box/__tests__/__snapshots__/Box-test.tsx.snap
+++ b/src/js/components/Box/__tests__/__snapshots__/Box-test.tsx.snap
@@ -3175,6 +3175,23 @@ exports[`Box height 1`] = `
   height: 111px;
 }
 
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  max-height: 100%;
+  min-height: 192px;
+  height: 768px;
+}
+
 <div
   class="c0"
 >
@@ -3195,6 +3212,9 @@ exports[`Box height 1`] = `
   />
   <div
     class="c6"
+  />
+  <div
+    class="c7"
   />
 </div>
 `;

--- a/src/js/components/Grid/__tests__/__snapshots__/Grid-test.js.snap
+++ b/src/js/components/Grid/__tests__/__snapshots__/Grid-test.js.snap
@@ -1143,6 +1143,7 @@ exports[`Grid height object 1`] = `
   display: grid;
   box-sizing: border-box;
   max-height: 100%;
+  height: 100px;
 }
 
 <div>

--- a/src/js/utils/styles.js
+++ b/src/js/utils/styles.js
@@ -840,7 +840,14 @@ const heightObjectStyle = (height, theme) => {
         min-height: ${getSize(theme, height.min)};
       `,
     );
+  // backwards compatibile
   if (height.width)
+    result.push(
+      css`
+        height: ${getSize(theme, height.height)};
+      `,
+    );
+  if (height.height)
     result.push(
       css`
         height: ${getSize(theme, height.height)};


### PR DESCRIPTION
#### What does this PR do?

Changed Box to fix an issue with desired height using an object.

The prior code was awkwardly using `height={{ min, ..., max: ..., width: ... }}` rather than `height={{ min, ..., max: ..., height: ... }}`. It looks like a cut/paste issue.

#### Where should the reviewer start?

utils function

#### What testing has been done on this PR?

Added a unit test.
Also verified with grommet-designer.

#### Do Jest tests follow these best practices?

Followed existing test patterns.

#### Do the grommet docs need to be updated?

yes

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
