### PR TITLE
Changed Select to add compact property

### DIFF
--- a/src/js/components/Select/__tests__/Select-test.js
+++ b/src/js/components/Select/__tests__/Select-test.js
@@ -639,6 +639,32 @@ describe('Select', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  test('compact', () => {
+    const onChange = jest.fn();
+    const { getByPlaceholderText, container } = render(
+      <Select
+        id="test-select"
+        placeholder="test select"
+        options={['one', 'two']}
+        onChange={onChange}
+        compact
+        plain
+      />,
+    );
+    const select = getByPlaceholderText('test select');
+    expect(container.firstChild).toMatchSnapshot();
+    fireEvent.click(getByPlaceholderText('test select'));
+
+    fireEvent.click(
+      document.getElementById('test-select__drop').querySelector('button'),
+    );
+
+    // checks if select has a value assigned to it after option is selected
+    expect(select.value).toEqual('one');
+    // verify that the width of the input has changed
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
   test('modifies select control style on open', () => {
     const customTheme = {
       select: {

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -2376,6 +2376,313 @@ exports[`Select basic 1`] = `
 </button>
 `;
 
+exports[`Select compact 1`] = `
+.c7 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #7D4CDB;
+  stroke: #7D4CDB;
+}
+
+.c7 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c7 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c7 *[stroke*="#"],
+.c7 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c7 *[fill-rule],
+.c7 *[FILL-RULE],
+.c7 *[fill*="#"],
+.c7 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c0 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c0:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c0:focus > circle,
+.c0:focus > ellipse,
+.c0:focus > line,
+.c0:focus > path,
+.c0:focus > polygon,
+.c0:focus > polyline,
+.c0:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c0:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c0:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c0:focus:not(:focus-visible) > circle,
+.c0:focus:not(:focus-visible) > ellipse,
+.c0:focus:not(:focus-visible) > line,
+.c0:focus:not(:focus-visible) > path,
+.c0:focus:not(:focus-visible) > polygon,
+.c0:focus:not(:focus-visible) > polyline,
+.c0:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c0:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c4 {
+  box-sizing: border-box;
+  font-size: inherit;
+  font-family: inherit;
+  border: none;
+  -webkit-appearance: none;
+  background: transparent;
+  color: inherit;
+  width: 100%;
+  padding: 11px;
+  font-weight: 600;
+  margin: 0;
+  border: 1px solid rgba(0,0,0,0.33);
+  border-radius: 4px;
+  outline: none;
+  border: none;
+}
+
+.c4::-webkit-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c4::-moz-placeholder {
+  color: #AAAAAA;
+}
+
+.c4:-ms-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c4::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+.c4::-moz-focus-inner {
+  border: none;
+  outline: none;
+}
+
+.c4:-moz-placeholder,
+.c4::-moz-placeholder {
+  opacity: 1;
+}
+
+.c3 {
+  position: relative;
+  width: 100%;
+}
+
+.c5 {
+  cursor: pointer;
+}
+
+<button
+  aria-expanded="false"
+  aria-haspopup="listbox"
+  aria-label="test select"
+  class="c0 "
+  id="test-select"
+  type="button"
+>
+  <div
+    class="c1"
+  >
+    <div
+      class="c2"
+    >
+      <div
+        class="c3"
+      >
+        <input
+          autocomplete="off"
+          class="c4 c5"
+          id="test-select__input"
+          placeholder="test select"
+          readonly=""
+          style="width: 0px;"
+          tabindex="-1"
+          type="text"
+          value=""
+        />
+      </div>
+    </div>
+    <div
+      class="c6"
+      style="min-width: auto;"
+    >
+      <svg
+        aria-label="FormDown"
+        class="c7"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="m18 9-6 6-6-6"
+          fill="none"
+          stroke="#000"
+          stroke-width="2"
+        />
+      </svg>
+    </div>
+  </div>
+</button>
+`;
+
+exports[`Select compact 2`] = `
+<button
+  aria-expanded="false"
+  aria-haspopup="listbox"
+  aria-label="test select; Selected: one"
+  class="StyledButton-sc-323bzc-0 eiEooU Select__StyledSelectDropButton-sc-17idtfo-2 fJfYtd"
+  id="test-select"
+  type="button"
+>
+  <div
+    class="StyledBox-sc-13pk1d4-0 bBHevx"
+  >
+    <div
+      class="StyledBox-sc-13pk1d4-0 gSrxin"
+    >
+      <div
+        class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 jqwtzG"
+      >
+        <input
+          autocomplete="off"
+          class="StyledTextInput-sc-1x30a0s-0 bmcLpb Select__SelectTextInput-sc-17idtfo-0 ecWLed"
+          id="test-select__input"
+          placeholder="test select"
+          readonly=""
+          style="width: 0px;"
+          tabindex="-1"
+          type="text"
+          value="one"
+        />
+      </div>
+    </div>
+    <div
+      class="StyledBox-sc-13pk1d4-0 hDxjsI"
+      style="min-width: auto;"
+    >
+      <svg
+        aria-label="FormDown"
+        class="StyledIcon-sc-ofa7kd-0 kxOTGz"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="m18 9-6 6-6-6"
+          fill="none"
+          stroke="#000"
+          stroke-width="2"
+        />
+      </svg>
+    </div>
+  </div>
+</button>
+`;
+
 exports[`Select complex options and children 1`] = `
 .c8 {
   display: inline-block;

--- a/src/js/components/Select/index.d.ts
+++ b/src/js/components/Select/index.d.ts
@@ -15,6 +15,7 @@ export interface SelectProps {
   children?: (...args: any[]) => any;
   clear?: boolean | { position?: 'top' | 'bottom'; label?: string };
   closeOnChange?: boolean;
+  compact?: boolean;
   defaultValue?: string | number | object | (string | number | object)[];
   disabled?: boolean | (number | string | object)[];
   disabledKey?: string | ((...args: any[]) => any);

--- a/src/js/components/Select/propTypes.js
+++ b/src/js/components/Select/propTypes.js
@@ -14,6 +14,7 @@ if (process.env.NODE_ENV !== 'production') {
       }),
     ]),
     closeOnChange: PropTypes.bool,
+    compact: PropTypes.bool,
     defaultValue: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.object,

--- a/src/js/components/Select/stories/Compact.js
+++ b/src/js/components/Select/stories/Compact.js
@@ -1,0 +1,33 @@
+import React, { useState } from 'react';
+
+import { Box, Select } from 'grommet';
+
+export const Compact = () => {
+  const options = ['one', 'two', 'one hundred fifty seven'];
+  const [value, setValue] = useState('');
+  return (
+    // Uncomment <Grommet> lines when using outside of storybook
+    // <Grommet theme={...}>
+    <Box fill align="center" justify="start" pad="large" gap="medium">
+      <Select
+        id="select"
+        name="select"
+        placeholder="Select"
+        value={value}
+        options={options}
+        onChange={({ option }) => setValue(option)}
+        compact
+        plain
+      />
+    </Box>
+    // </Grommet>
+  );
+};
+
+Compact.args = {
+  full: true,
+};
+
+export default {
+  title: 'Input/Select/Compact',
+};

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -2399,6 +2399,7 @@ Object {
       "children": [Function],
       "clear": [Function],
       "closeOnChange": [Function],
+      "compact": [Function],
       "defaultValue": [Function],
       "disabled": [Function],
       "disabledKey": [Function],


### PR DESCRIPTION
#### What does this PR do?

Changed Select to add compact property.

This allows Select to be used in tighter places, like in a Header with a selector for context.

#### Where should the reviewer start?

index.d.ts

#### What testing has been done on this PR?

Added a story, Compact

#### How should this be manually tested?

Compact story

#### Do Jest tests follow these best practices?

followed existing Select tests

#### Screenshots (if appropriate)

![Screen Shot 2022-03-15 at 5 44 50 PM](https://user-images.githubusercontent.com/11637956/158495061-6cebcc61-8879-41f1-b685-60a9ffd7b673.png)

#### Do the grommet docs need to be updated?

yes

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
