### PR TITLE
DateInput and Calendar stories log selected date in both iso and utc format

### DIFF
--- a/src/js/components/Calendar/stories/Multiple.js
+++ b/src/js/components/Calendar/stories/Multiple.js
@@ -20,7 +20,8 @@ export const Multiple = () => {
             nextDates.splice(index, 1);
           }
           setDates(nextDates);
-          console.log('Select', date, nextDates);
+          console.log('Select iso date:', date, nextDates);
+          console.log('Select utc date:', new Date(date));
         }}
         bounds={['2020-09-08', '2025-12-13']}
       />

--- a/src/js/components/DateInput/stories/Form.js
+++ b/src/js/components/DateInput/stories/Form.js
@@ -5,7 +5,8 @@ import { Box, Button, DateInput, Form, FormField } from 'grommet';
 export const DateForm = () => {
   const [value, setValue] = React.useState({ value: '' });
   const onChange = (nextValue) => {
-    console.log('onChange', nextValue);
+    console.log('onChange iso date:', nextValue);
+    console.log('onChange utc date:', new Date(nextValue));
     setValue(nextValue);
   };
   return (

--- a/src/js/components/DateInput/stories/Format.js
+++ b/src/js/components/DateInput/stories/Format.js
@@ -6,7 +6,8 @@ export const Format = () => {
   const [value, setValue] = React.useState('');
   const onChange = (event) => {
     const nextValue = event.value;
-    console.log('onChange', nextValue);
+    console.log('onChange iso date:', nextValue);
+    console.log('onChange utc date:', new Date(nextValue));
     setValue(nextValue);
   };
   return (

--- a/src/js/components/DateInput/stories/FormatInline.js
+++ b/src/js/components/DateInput/stories/FormatInline.js
@@ -19,49 +19,57 @@ export const FormatInline = () => {
 
   const onChangeEmpty = (event) => {
     const nextValue = event.value;
-    console.log('onChange', nextValue);
+    console.log('onChange iso date:', nextValue);
+    console.log('onChange utc date:', new Date(nextValue));
     setEmptyDate(nextValue);
   };
 
   const onChangeTZ = (event) => {
     const nextValue = event.value;
-    console.log('onChange', nextValue);
+    console.log('onChange iso date:', nextValue);
+    console.log('onChange utc date:', new Date(nextValue));
     setDate(nextValue);
   };
 
   const onChangeNoTZ = (event) => {
     const nextValue = event.value;
-    console.log('onChange', nextValue);
+    console.log('onChange iso date:', nextValue);
+    console.log('onChange utc date:', new Date(nextValue));
     setDateNoTZ(nextValue);
   };
 
   const onChangeRange = (event) => {
     const nextValue = event.value;
-    console.log('onChange', nextValue);
+    console.log('onChange iso date:', nextValue);
+    console.log('onChange utc date:', new Date(nextValue));
     setDateRange(nextValue);
   };
 
   const onChangeRangeNoTZ = (event) => {
     const nextValue = event.value;
-    console.log('onChange', nextValue);
+    console.log('onChange iso date:', nextValue);
+    console.log('onChange utc date:', new Date(nextValue));
     setDateRangeNoTZ(nextValue);
   };
 
   const onChangeNoDefault = (event) => {
     const nextValue = event.value;
-    console.log('onChange', nextValue);
+    console.log('onChange iso date:', nextValue);
+    console.log('onChange utc date:', new Date(nextValue));
     setDateNoDefault(nextValue);
   };
 
   const onChangeStateDefault = (event) => {
     const nextValue = event.value;
-    console.log('onChange', nextValue);
+    console.log('onChange iso date:', nextValue);
+    console.log('onChange utc date:', new Date(nextValue));
     setDateStateDefault(nextValue);
   };
 
   const onChangeStateDefaultNoTZ = (event) => {
     const nextValue = event.value;
-    console.log('onChange', nextValue);
+    console.log('onChange iso date:', nextValue);
+    console.log('onChange utc date:', new Date(nextValue));
     setDateStateDefaultNoTZ(nextValue);
   };
 

--- a/src/js/components/DateInput/stories/Inline.js
+++ b/src/js/components/DateInput/stories/Inline.js
@@ -6,7 +6,8 @@ export const Inline = () => {
   const [value, setValue] = React.useState('');
   const onChange = (event) => {
     const nextValue = event.value;
-    console.log('onChange', nextValue);
+    console.log('onChange iso date:', nextValue);
+    console.log('onChange utc date:', new Date(nextValue));
     setValue(nextValue);
   };
   return (

--- a/src/js/components/DateInput/stories/Range.js
+++ b/src/js/components/DateInput/stories/Range.js
@@ -14,7 +14,8 @@ export const Range = () => {
   ]);
   const onChange = (event) => {
     const nextValue = event.value;
-    console.log('onChange', nextValue);
+    console.log('onChange iso date:', nextValue);
+    console.log('onChange utc date:', new Date(nextValue));
     setValue(nextValue);
   };
   return (

--- a/src/js/components/DateInput/stories/RangeFormat.js
+++ b/src/js/components/DateInput/stories/RangeFormat.js
@@ -9,7 +9,8 @@ export const RangeFormat = () => {
   ]);
   const onChange = (event) => {
     const nextValue = event.value;
-    console.log('onChange', nextValue);
+    console.log('onChange iso date:', nextValue);
+    console.log('onChange utc date:', new Date(nextValue));
     setValue(nextValue);
   };
   return (

--- a/src/js/components/DateInput/stories/Simple.js
+++ b/src/js/components/DateInput/stories/Simple.js
@@ -6,7 +6,8 @@ export const Simple = () => {
   const [value, setValue] = React.useState('');
   const onChange = (event) => {
     const nextValue = event.value;
-    console.log('onChange', nextValue);
+    console.log('onChange iso date:', nextValue);
+    console.log('onChange utc date:', new Date(nextValue));
     setValue(nextValue);
   };
   return (

--- a/src/js/components/DateInput/stories/typescript/European.tsx
+++ b/src/js/components/DateInput/stories/typescript/European.tsx
@@ -6,7 +6,8 @@ export const European = () => {
   const [value, setValue] = React.useState();
   const onChange = (event) => {
     const nextValue = event.value;
-    console.log('onChange', nextValue);
+    console.log('onChange iso date:', nextValue);
+    console.log('onChange utc date:', new Date(nextValue));
     setValue(nextValue);
   };
   return (


### PR DESCRIPTION
#### What does this PR do?
Previously the stories would only log the selected date in iso format which caused confusion in UTC+ timezones since the date logged would be one day before what was selected when displayed in iso format.

Now the stories log the iso date and the utc date to avoid confusion.

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?
Test with storybook in a UTC+ timezone

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes https://github.com/grommet/grommet/issues/5989

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible