### PR TITLE
Remove non-interactive children of Tip from story

### DIFF
--- a/src/js/components/Tip/stories/typescript/Children.tsx
+++ b/src/js/components/Tip/stories/typescript/Children.tsx
@@ -1,61 +1,77 @@
 import React from 'react';
 
-import { grommet, Box, Button, Grommet, Heading, Text, Tip } from 'grommet';
+import {
+  grommet,
+  Anchor,
+  Box,
+  Button,
+  Grommet,
+  Heading,
+  Paragraph,
+  Text,
+  Tip,
+} from 'grommet';
 
 export const Children = () => (
   // Uncomment <Grommet> lines when using outside of storybook
   // <Grommet theme={...}>
-  <Box align="center" pad="large" gap="xlarge" fill>
-    <Heading size="xsmall">
-      Tooltip will be displayed once hovering on the Tip child
-    </Heading>
-    <Tip
-      content={
-        <Box align="center">
-          <Text>Hello</Text>
+  <Box align="center" pad="large" fill>
+    <Heading size="xsmall">Tip's Child</Heading>
+
+    <Paragraph margin="none" textAlign="center">
+      Tooltip is displayed once hovering on the Tip's child or when using
+      keyboard navigation to skim through the webpage via tabbing.
+    </Paragraph>
+
+    <Paragraph textAlign="center">
+      To ensure accessibility support for the tooltip content when using
+      keyboard navigation, please use an{' '}
+      <Anchor href="https://github.com/grommet/grommet/issues/5971">
+        interactive element as the Tip's child component
+      </Anchor>
+      .
+    </Paragraph>
+
+    <Box align="center" pad="large" gap="xlarge" fill>
+      <Tip
+        plain
+        dropProps={{ align: { right: 'left' } }}
+        content={
+          <Box
+            animation="slideLeft"
+            align="center"
+            background="accent-2"
+            round={{ size: 'medium', corner: 'left' }}
+            pad="small"
+            margin="small"
+          >
+            <Text color="brand">Tooltip</Text>
+          </Box>
+        }
+      >
+        <Box background="brand" pad="small" flex={false} onClick={() => {}}>
+          Box Child
         </Box>
-      }
-    >
-      String Child
-    </Tip>
-    <Tip
-      plain
-      dropProps={{ align: { right: 'left' } }}
-      content={
-        <Box
-          animation="slideLeft"
-          align="center"
-          background="light-4"
-          round={{ size: 'medium', corner: 'left' }}
-          pad="small"
-          margin="small"
-        >
-          <Text color="brand">Tooltip</Text>
-        </Box>
-      }
-    >
-      <Box background="brand" pad="small" flex={false}>
-        Box Child
-      </Box>
-    </Tip>
-    <Tip
-      plain
-      dropProps={{ align: { left: 'right' } }}
-      content={
-        <Box
-          align="center"
-          background="accent-1"
-          margin="xsmall"
-          pad="xsmall"
-          round="medium"
-          flex={false}
-        >
-          <Text color="brand">Tooltip</Text>
-        </Box>
-      }
-    >
-      <Button label="Button Child" />
-    </Tip>
+      </Tip>
+      <Tip
+        plain
+        dropProps={{ align: { left: 'right' } }}
+        content={
+          <Box
+            align="center"
+            background="accent-1"
+            margin="xsmall"
+            pad="xsmall"
+            round="medium"
+            flex={false}
+          >
+            <Text color="brand">Tooltip</Text>
+          </Box>
+        }
+      >
+        <Button label="Button Child" />
+      </Tip>
+    </Box>
   </Box>
   // </Grommet>
 );


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Remove non-interactive children of Tip from the Tip Children story

#### Where should the reviewer start?
Tip Children story
#### What testing has been done on this PR?
Manual
#### How should this be manually tested?
Check the story
#### Do Jest tests follow these best practices?
N/A
- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
https://github.com/grommet/grommet/issues/5971

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?
No
#### Is this change backwards compatible or is it a breaking change?
backwards compatible