### PR TITLE
Allow header cells to take full height when DataTable is paginated

### DIFF
--- a/src/js/components/DataTable/DataTable.js
+++ b/src/js/components/DataTable/DataTable.js
@@ -360,7 +360,7 @@ const DataTable = ({
     <Container {...containterProps}>
       <OverflowContainer {...overflowContainerProps}>
         <StyledDataTable
-          fillProp={!paginate ? fill : undefined}
+          fillProp={!paginate ? fill : true}
           {...paginatedDataTableProps}
           {...rest}
         >

--- a/src/js/components/DataTable/DataTable.js
+++ b/src/js/components/DataTable/DataTable.js
@@ -359,11 +359,7 @@ const DataTable = ({
   return (
     <Container {...containterProps}>
       <OverflowContainer {...overflowContainerProps}>
-        <StyledDataTable
-          fillProp={!paginate ? fill : true}
-          {...paginatedDataTableProps}
-          {...rest}
-        >
+        <StyledDataTable fillProp={fill} {...paginatedDataTableProps} {...rest}>
           <Header
             ref={headerRef}
             cellProps={cellProps.header}

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -21220,6 +21220,8 @@ exports[`DataTable should apply pagination styling 1`] = `
   border-spacing: 0;
   border-collapse: separate;
   height: auto;
+  width: 100%;
+  height: 100%;
 }
 
 .c8:focus {
@@ -23084,6 +23086,8 @@ exports[`DataTable should not show paginate controls when data is empty array 1`
   border-spacing: 0;
   border-collapse: separate;
   height: auto;
+  width: 100%;
+  height: 100%;
 }
 
 .c8:focus {
@@ -23264,6 +23268,8 @@ exports[`DataTable should not show paginate controls when length of data < step 
   border-spacing: 0;
   border-collapse: separate;
   height: auto;
+  width: 100%;
+  height: 100%;
 }
 
 .c8:focus {
@@ -24006,6 +24012,8 @@ exports[`DataTable should paginate 1`] = `
   border-spacing: 0;
   border-collapse: separate;
   height: auto;
+  width: 100%;
+  height: 100%;
 }
 
 .c8:focus {
@@ -26350,6 +26358,8 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
   border-spacing: 0;
   border-collapse: separate;
   height: auto;
+  width: 100%;
+  height: 100%;
 }
 
 .c8:focus {
@@ -27648,6 +27658,8 @@ exports[`DataTable should render new data when page changes 1`] = `
   border-spacing: 0;
   border-collapse: separate;
   height: auto;
+  width: 100%;
+  height: 100%;
 }
 
 .c8:focus {
@@ -29428,7 +29440,7 @@ exports[`DataTable should render new data when page changes 2`] = `
       class="StyledBox-sc-13pk1d4-0 BCyrs"
     >
       <table
-        class="StyledTable-sc-1m3u5g-6 bpywQv StyledDataTable-sc-xrlyjm-0 gxHxWr"
+        class="StyledTable-sc-1m3u5g-6 bpywQv StyledDataTable-sc-xrlyjm-0 hJVSAk"
       >
         <thead
           class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -31540,6 +31552,8 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
   border-spacing: 0;
   border-collapse: separate;
   height: auto;
+  width: 100%;
+  height: 100%;
 }
 
 .c8:focus {
@@ -33884,6 +33898,8 @@ exports[`DataTable should show correct page when "show" is { page: # } 1`] = `
   border-spacing: 0;
   border-collapse: separate;
   height: auto;
+  width: 100%;
+  height: 100%;
 }
 
 .c8:focus {

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -21220,8 +21220,6 @@ exports[`DataTable should apply pagination styling 1`] = `
   border-spacing: 0;
   border-collapse: separate;
   height: auto;
-  width: 100%;
-  height: 100%;
 }
 
 .c8:focus {
@@ -23086,8 +23084,6 @@ exports[`DataTable should not show paginate controls when data is empty array 1`
   border-spacing: 0;
   border-collapse: separate;
   height: auto;
-  width: 100%;
-  height: 100%;
 }
 
 .c8:focus {
@@ -23268,8 +23264,6 @@ exports[`DataTable should not show paginate controls when length of data < step 
   border-spacing: 0;
   border-collapse: separate;
   height: auto;
-  width: 100%;
-  height: 100%;
 }
 
 .c8:focus {
@@ -24012,8 +24006,6 @@ exports[`DataTable should paginate 1`] = `
   border-spacing: 0;
   border-collapse: separate;
   height: auto;
-  width: 100%;
-  height: 100%;
 }
 
 .c8:focus {
@@ -26358,8 +26350,6 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
   border-spacing: 0;
   border-collapse: separate;
   height: auto;
-  width: 100%;
-  height: 100%;
 }
 
 .c8:focus {
@@ -27658,8 +27648,6 @@ exports[`DataTable should render new data when page changes 1`] = `
   border-spacing: 0;
   border-collapse: separate;
   height: auto;
-  width: 100%;
-  height: 100%;
 }
 
 .c8:focus {
@@ -29440,7 +29428,7 @@ exports[`DataTable should render new data when page changes 2`] = `
       class="StyledBox-sc-13pk1d4-0 BCyrs"
     >
       <table
-        class="StyledTable-sc-1m3u5g-6 bpywQv StyledDataTable-sc-xrlyjm-0 hJVSAk"
+        class="StyledTable-sc-1m3u5g-6 bpywQv StyledDataTable-sc-xrlyjm-0 gxHxWr"
       >
         <thead
           class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -31552,8 +31540,6 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
   border-spacing: 0;
   border-collapse: separate;
   height: auto;
-  width: 100%;
-  height: 100%;
 }
 
 .c8:focus {
@@ -33898,8 +33884,6 @@ exports[`DataTable should show correct page when "show" is { page: # } 1`] = `
   border-spacing: 0;
   border-collapse: separate;
   height: auto;
-  width: 100%;
-  height: 100%;
 }
 
 .c8:focus {

--- a/src/js/components/DataTable/stories/Test.js
+++ b/src/js/components/DataTable/stories/Test.js
@@ -319,6 +319,7 @@ export const Test = () => {
           sortable
           step={10}
           paginate
+          fill
         />
       </Box>
     </>

--- a/src/js/components/DataTable/stories/Test.js
+++ b/src/js/components/DataTable/stories/Test.js
@@ -1,0 +1,330 @@
+import React from 'react';
+import {
+  Box,
+  DataTable,
+  Heading,
+  Meter,
+  Text,
+  ResponsiveContext,
+} from 'grommet';
+
+const data = [
+  {
+    id: 'mjbpiclthh8y',
+    poolName: 'Asup-array01-lvs (default)',
+    groupName: 'Asup',
+    arrays: 'asup-array01-lvs',
+    size: 16099511627776,
+    pinnable: 2099511627776,
+    pinned: 699511627776,
+    savings: [
+      { unit: 'TiB', value: 12.0 },
+      { unit: 'xGHz', value: 333.2 },
+    ],
+  },
+  {
+    id: 'hx5f2e57phfb',
+    poolName: 'Dev-K8-Sym-R5-3 (default)',
+    groupName: 'Dev',
+    arrays: 'harm-stage-array01',
+    size: 224520271234567,
+    pinnable: 5099511627776,
+    pinned: 2699511627776,
+    savings: [
+      { unit: 'TiB', value: 8.0 },
+      { unit: 'xGHz', value: 333.2 },
+    ],
+  },
+  {
+    id: 'om2hy2z79kyz',
+    poolName: 'Dev36-erray01 (default)',
+    groupName: 'Dev',
+    arrays: 'harm-stage-array02',
+    size: 190655321234567,
+    pinnable: 4099511627776,
+    pinned: 2699511627776,
+    savings: [
+      { unit: 'TiB', value: 8.0 },
+      { unit: 'xGHz', value: 3955.2 },
+    ],
+  },
+  {
+    id: '6d9u4hv95xjq',
+    poolName: 'asup-array1 (default)',
+    groupName: 'Asup',
+    arrays: 'harm-stage-array04',
+    size: 130655321234567,
+    pinnable: 3099511627776,
+    pinned: 699511627776,
+    savings: [
+      { unit: 'TiB', value: 110.6 },
+      { unit: 'xGHz', value: 3.9 },
+    ],
+  },
+  {
+    id: 'qpsidi3ccnpr',
+    poolName: 'Dev-K8-Sym-R5-3 (default)',
+    groupName: 'Dev',
+    arrays: 'Harm-cs-stage-R4-5',
+    size: 68994941234567,
+    pinnable: 3199511627776,
+    pinned: 2699511627776,
+    savings: [
+      { unit: 'TiB', value: 128.5 },
+      { unit: 'xGHz', value: 333.2 },
+    ],
+  },
+  {
+    id: 'l3d8xkm0knx4',
+    poolName: 'asup-array2 (default)',
+    groupName: 'Asup',
+    arrays: 'ds-array02',
+    size: 90655321234567,
+    pinnable: 11199511627776,
+    pinned: 0,
+    savings: [
+      { unit: 'TiB', value: 8.0 },
+      { unit: 'xGHz', value: 3955.2 },
+    ],
+  },
+  {
+    id: 'jsjas87qeqgj',
+    poolName: 'Dev36-varray02 (default)',
+    groupName: 'Dev',
+    arrays: 'ds-array01',
+    size: 101655321234567,
+    pinnable: 12399511627776,
+    pinned: 0,
+    savings: [
+      { unit: 'TiB', value: 8.0 },
+      { unit: 'xGHz', value: 333.2 },
+    ],
+  },
+  {
+    id: '1jrnzxds9419',
+    poolName: 'DevHarmCs2R39',
+    groupName: 'Dev',
+    arrays: 'harm-stage-array03',
+    size: 7900321234567,
+    pinnable: 129511627776,
+    pinned: 7804321432,
+    savings: [
+      { unit: 'TiB', value: 8.0 },
+      { unit: 'xGHz', value: 333.2 },
+    ],
+  },
+  {
+    id: 'lva18ol56t7a',
+    poolName: 'DevStageSymR31 (default)',
+    groupName: 'Dev',
+    arrays: 'rtp-array198',
+    size: 70655321234567,
+    pinnable: 1529511627776,
+    pinned: 0,
+    savings: [
+      { unit: 'TiB', value: 8.0 },
+      { unit: 'xGHz', value: 333.2 },
+    ],
+  },
+  {
+    id: 'g9v1104koten',
+    poolName: 'asup-array2 (default)',
+    groupName: 'Asup',
+    arrays: 'ds-array02',
+    size: 5655321234567,
+    pinnable: 12529511627776,
+    pinned: 0,
+    savings: [
+      { unit: 'TiB', value: 8.0 },
+      { unit: 'xGHz', value: 3955.2 },
+    ],
+  },
+  {
+    id: 'ny13xepj8wyc',
+    poolName: 'Dev36-varray02 (default)',
+    groupName: 'Dev',
+    arrays: 'ds-array01',
+    size: 655321234567,
+    pinnable: 1329511627776,
+    pinned: 0,
+    savings: [
+      { unit: 'TiB', value: 8.0 },
+      { unit: 'xGHz', value: 333.2 },
+    ],
+  },
+  {
+    id: 'vz86u3ll4ai2',
+    poolName: 'DevHarmCs2R39',
+    groupName: 'Dev',
+    arrays: 'harm-stage-array03',
+    size: 52655321234567,
+    pinnable: 2529511627776,
+    pinned: 0,
+    savings: [
+      { unit: 'TiB', value: 8.0 },
+      { unit: 'xGHz', value: 333.2 },
+    ],
+  },
+  {
+    id: 'f1iucu2ybzf3',
+    poolName: 'DevStageSymR31 (default)',
+    groupName: 'Dev',
+    arrays: 'rtp-array198',
+    size: 30655321234567,
+    pinnable: 22529511627776,
+    pinned: 7529511627776,
+    savings: [
+      { unit: 'TiB', value: 8.0 },
+      { unit: 'xGHz', value: 333.2 },
+    ],
+  },
+];
+
+const columns = [
+  {
+    property: 'poolName',
+    header: 'Pool Name',
+    render: (datum) => <Text truncate>{datum.poolName}</Text>,
+    primary: true,
+  },
+  {
+    property: 'groupName',
+    header: 'Group Name',
+  },
+  {
+    property: 'arrays',
+    header: 'Arrays',
+    render: (datum) => <Text truncate>{datum.arrays}</Text>,
+    sortable: false,
+  },
+  {
+    property: 'size',
+    header: (
+      <Text color="text-strong" weight="bold">
+        Size{' '}
+        <Text size="xsmall" weight="normal" color="text">
+          (TiB)
+        </Text>
+      </Text>
+    ),
+    render: (datum) =>
+      // bytes to tebibytes
+      (datum.size / 2 ** 40).toFixed([1]),
+    align: 'end',
+  },
+  {
+    property: 'pinnable',
+    header: (
+      <Text color="text-strong" weight="bold">
+        Pinnable{' '}
+        <Text size="xsmall" weight="normal" color="text">
+          (B)
+        </Text>
+      </Text>
+    ),
+    render: (datum) =>
+      // bytes to tebibytes
+      (datum.pinnable / 2 ** 40).toFixed([1]),
+    align: 'end',
+  },
+  {
+    property: 'pinned',
+    header: (
+      <Text color="text-strong" weight="bold">
+        Pinned{' '}
+        <Text size="xsmall" weight="normal" color="text">
+          %
+        </Text>
+      </Text>
+    ),
+    render: (datum) => (
+      <Box gap="xsmall" direction="row">
+        <Box pad={{ vertical: 'xsmall' }}>
+          <Meter
+            alignSelf="center"
+            values={[
+              { value: datum.pinned / datum.pinnable, color: 'graph-2' },
+            ]}
+            max={1}
+            thickness="small"
+            size="small"
+          />
+        </Box>
+        <Text>{((datum.pinned / datum.pinnable) * 10).toFixed(0)}%</Text>
+      </Box>
+    ),
+    sortable: false,
+  },
+  {
+    property: 'savings',
+    header: (
+      <Text color="text-strong" weight="bold">
+        Savings{' '}
+        <Text size="xsmall" weight="normal" color="text">
+          (xGHz)
+        </Text>
+      </Text>
+    ),
+    align: 'end',
+    render: (datum) => (
+      <Text truncate>{datum.savings[1] && `${datum.savings[1].value}`}</Text>
+    ),
+  },
+];
+
+const handleClickRow = (obj) => {
+  // eslint-disable-next-line no-alert
+  alert(`
+  Record was clicked:
+  { 
+      id: ${obj.id},
+      poolName: ${obj.poolName}
+  }
+  
+  You can use onClickRow() to navigate to a record's detail
+  page, open a panel or modal to edit the record, or perform 
+  other actions as you see fit.
+  `);
+};
+
+// designSystemDemo is used for DS site only, can be removed in production.
+export const Test = () => {
+  const size = React.useContext(ResponsiveContext);
+
+  return (
+    <>
+      <Heading
+        id="storage-pools-heading"
+        level={3}
+        margin={{ bottom: 'small', top: 'none' }}
+      >
+        Storage Pools
+      </Heading>
+      <Box overflow="auto">
+        <DataTable
+          aria-describedby="storage-pools-heading"
+          data={data}
+          columns={[
+            {
+              property: 'id',
+              header: 'Id',
+              primary: true,
+              render: (datum) => datum.id.slice(datum.id.length - 5),
+              pin: ['xsmall', 'small'].includes(size),
+            },
+            ...columns,
+          ]}
+          onClickRow={({ datum }) => handleClickRow(datum)}
+          pin
+          sortable
+          step={10}
+          paginate
+        />
+      </Box>
+    </>
+  );
+};
+
+export default {
+  title: 'Visualizations/DataTable/Test',
+};


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Allows fill prop to be passed through on paginated datatables. This will allow header cells to take the full height of the row. Previously, fill was explicitly set to undefined for paginated data tables which kept the table height at "auto" (meaning the table could never have a defined height).

#### Where should the reviewer start?
DataTable.js

#### What testing has been done on this PR?
Added "Test" storybook. Resize the window until the labels wrap then hover over the DataTable headers. The hoverindicator should fill the full height of the header for both single line and multiline headers.

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

N/A didn't touch.

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #5968

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.