### PR TITLE
Add missing type for radioButton.check.color theme

### DIFF
--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -1195,6 +1195,7 @@ export interface ThemeType {
       width?: string;
     };
     check?: {
+      color?: ColorType;
       extend?: ExtendType;
       radius?: string;
       background?: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Adds missing type documented [here][1]. It's a trivial change so I'm leaving the sections below blank.

[1]: https://v2.grommet.io/radiobutton#radioButton.check.color

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
