### PR TITLE
Select - `valueLabel` can be a function & selected option renders when `labelKey` is a function

### DIFF
--- a/src/js/components/Select/Select.js
+++ b/src/js/components/Select/Select.js
@@ -278,13 +278,16 @@ const Select = forwardRef(
     // we should use the labelKey function to display the
     // selected value
     const displayLabelKey = useMemo(() => {
+      const optionLabelKey = applyKey(
+        allOptions[optionIndexesInValue[0]],
+        labelKey,
+      );
       if (
         !selectValue &&
         optionIndexesInValue.length === 1 &&
-        typeof applyKey(allOptions[optionIndexesInValue[0]], labelKey) ===
-          'object'
+        typeof optionLabelKey === 'object'
       )
-        return applyKey(allOptions[optionIndexesInValue[0]], labelKey);
+        return optionLabelKey;
       return undefined;
     }, [labelKey, allOptions, optionIndexesInValue, selectValue]);
 

--- a/src/js/components/Select/Select.js
+++ b/src/js/components/Select/Select.js
@@ -267,10 +267,28 @@ const Select = forwardRef(
 
     // element to show, trumps inputValue
     const selectValue = useMemo(() => {
-      if (valueLabel) return valueLabel;
-      if (React.isValidElement(value)) return value; // deprecated
+      if (valueLabel instanceof Function) {
+        if (value) {
+          return valueLabel(value);
+        }
+      } else if (valueLabel) return valueLabel;
+      else if (React.isValidElement(value)) return value; // deprecated
       return undefined;
     }, [value, valueLabel]);
+
+    // if labelKey is a function and no valueLabel is defined
+    // we should use the labelKey function to display the
+    // selected value
+    const displayLabelKey = useMemo(() => {
+      if (
+        !selectValue &&
+        optionIndexesInValue.length === 1 &&
+        typeof applyKey(allOptions[optionIndexesInValue[0]], labelKey) ===
+          'object'
+      )
+        return applyKey(allOptions[optionIndexesInValue[0]], labelKey);
+      return undefined;
+    }, [labelKey, allOptions, optionIndexesInValue, selectValue]);
 
     // text to show
     // When the options array contains objects, this property indicates how
@@ -375,9 +393,9 @@ const Select = forwardRef(
             background={theme.select.background}
           >
             <Box direction="row" flex basis="auto">
-              {selectValue ? (
+              {selectValue || displayLabelKey ? (
                 <>
-                  {selectValue}
+                  {selectValue || displayLabelKey}
                   <HiddenInput
                     type="text"
                     id={id ? `${id}__input` : undefined}

--- a/src/js/components/Select/Select.js
+++ b/src/js/components/Select/Select.js
@@ -274,7 +274,7 @@ const Select = forwardRef(
       return undefined;
     }, [value, valueLabel]);
 
-    // if labelKey is a function and no valueLabel is defined
+    // if labelKey is a function and valueLabel is not defined
     // we should use the labelKey function to display the
     // selected value
     const displayLabelKey = useMemo(() => {

--- a/src/js/components/Select/Select.js
+++ b/src/js/components/Select/Select.js
@@ -268,9 +268,7 @@ const Select = forwardRef(
     // element to show, trumps inputValue
     const selectValue = useMemo(() => {
       if (valueLabel instanceof Function) {
-        if (value) {
-          return valueLabel(value);
-        }
+        if (value) return valueLabel(value);
       } else if (valueLabel) return valueLabel;
       else if (React.isValidElement(value)) return value; // deprecated
       return undefined;

--- a/src/js/components/Select/index.d.ts
+++ b/src/js/components/Select/index.d.ts
@@ -30,7 +30,7 @@ export interface SelectProps {
   focusIndicator?: boolean;
   icon?: boolean | ((...args: any[]) => any) | React.ReactNode | React.FC;
   id?: string;
-  labelKey?: string | ((...args: any[]) => any);
+  labelKey?: string | ((...args: any[]) => string | React.ReactNode);
   margin?: MarginType;
   messages?: { multiple?: string };
   multiple?: boolean;
@@ -49,11 +49,11 @@ export interface SelectProps {
   selected?: number | number[];
   size?: 'small' | 'medium' | 'large' | 'xlarge' | string;
   value?: string | JSX.Element | object | (string | number | object)[];
-  valueLabel?: React.ReactNode;
+  valueLabel?: React.ReactNode | ((...args: any[]) => string | React.ReactNode);
   valueKey?:
     | string
     | { key: string; reduce?: boolean }
-    | ((...args: any[]) => any);
+    | ((...args: any[]) => string);
   emptySearchMessage?: string | React.ReactNode;
 }
 

--- a/src/js/components/Select/propTypes.js
+++ b/src/js/components/Select/propTypes.js
@@ -106,7 +106,7 @@ if (process.env.NODE_ENV !== 'production') {
         ]),
       ),
     ]),
-    valueLabel: PropTypes.node,
+    valueLabel: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
     valueKey: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.func,


### PR DESCRIPTION
#### What does this PR do?
Select's `valueLabel` prop can now accept a function. This PR also fixes the rendering of the selected option when `labelKey` is a function. Previously no value would display in the textInput area of the select if `labelKey` was a function. Now if `labelKey` is a function, the function will determine how the selected option is displayed. `valueLabel` takes precedence on displaying the selected option when both `valueLabel` and `labelKey` are defined.

#### Where should the reviewer start?

#### What testing has been done on this PR?
Tested with the following story, uncommenting and commenting out various options
```javascript
import React, { useState } from 'react';
import { Box, Select } from 'grommet';

export const Test = () => {
  const options = ['one', 'two'];
  const [value, setValue] = useState('');
  return (
    // Uncomment <Grommet> lines when using outside of storybook
    // <Grommet theme={...}>
    <Box fill align="center" justify="start" pad="small" gap="small">
      <Select
        options={[
          {
            label: 'Hello',
            value: 'hello',
          },
          {
            label: 'World',
            value: 'world',
          },
        ]}
       valueKey="value"
       onChange={({ option }) => console.log(option)}

        // labelKey="label"
        labelKey={(option) => <Box><Text color="red">Test - {option.label}</Text></Box>}
        // labelKey={(option) => `Test - ${option.label}`}

        placeholder="placeholder"
        // placeholder={<Box pad="small"><Text color="green">placeholder</Text></Box>}
        
        valueLabel={(option) => (<Box pad="small"><Text color="green">ValueLabel - {option.label}</Text></Box>)}
        // valueLabel={(option) => `ValueLabel - ${option.label}`}
      />
    </Box>
    // </Grommet>
  );
};

Test.args = {
  full: true,
};

export default {
  title: 'Input/Select/Test',
};
```

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes https://github.com/grommet/grommet/issues/5904

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Yes, working on a pr for this

#### Should this PR be mentioned in the release notes?
Yes

#### Is this change backwards compatible or is it a breaking change?
backwards compatible