### PR TITLE
Prevent DateInput from scrolling down the page when opening with space

### DIFF
--- a/src/js/components/DateInput/DateInput.js
+++ b/src/js/components/DateInput/DateInput.js
@@ -229,7 +229,10 @@ Use the icon prop instead.`,
       >
         <Keyboard
           onEsc={open ? () => closeCalendar() : undefined}
-          onSpace={openCalendar}
+          onSpace={(event) => {
+            event.preventDefault();
+            openCalendar();
+          }}
         >
           <Box
             ref={containerRef}


### PR DESCRIPTION
#### What does this PR do?
If you open a DateInput by pressing space it will scroll down the page.

#### Where should the reviewer start?

#### What testing has been done on this PR?
Tested with the following code:
```javascript
<Box width="medium" gap="medium">
  <DateInput format="dd/mm/yyyy" value={value} onChange={onChange} />
</Box>
<Box width="medium" height="xlarge" background ="orange" />
```
I put a colored box below the DateInput so you can see the page scroll down

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes https://github.com/grommet/grommet/issues/5978

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no

#### Should this PR be mentioned in the release notes?
no

#### Is this change backwards compatible or is it a breaking change?
backwards compatible