### PR TITLE
fix(range): enables range wheel event override

### DIFF
--- a/src/js/components/RangeInput/RangeInput.js
+++ b/src/js/components/RangeInput/RangeInput.js
@@ -36,11 +36,11 @@ const RangeInput = forwardRef(
     },
     ref,
   ) => {
-    const themeContext = useContext(ThemeContext) || defaultProps.theme;
+    const theme = useContext(ThemeContext) || defaultProps.theme;
     const formContext = useContext(FormContext);
     const [focus, setFocus] = useState(focusProp);
 
-    const isScrollEnabled = themeContext?.rangeInput?.wheel !== false;
+    const isScrollEnabled = theme?.rangeInput?.wheel !== false;
 
     const [value, setValue] = formContext.useFormInput({
       name,

--- a/src/js/components/RangeInput/RangeInput.js
+++ b/src/js/components/RangeInput/RangeInput.js
@@ -6,6 +6,9 @@ import React, {
   useEffect,
 } from 'react';
 
+import { ThemeContext } from 'styled-components';
+import { defaultProps } from '../../default-props';
+
 import { FormContext } from '../Form/FormContext';
 import { StyledRangeInput } from './StyledRangeInput';
 import { RangeInputPropTypes } from './propTypes';
@@ -33,8 +36,11 @@ const RangeInput = forwardRef(
     },
     ref,
   ) => {
+    const themeContext = useContext(ThemeContext) || defaultProps.theme;
     const formContext = useContext(FormContext);
     const [focus, setFocus] = useState(focusProp);
+
+    const isScrollEnabled = themeContext?.rangeInput?.wheel !== false;
 
     const [value, setValue] = formContext.useFormInput({
       name,
@@ -77,6 +83,9 @@ const RangeInput = forwardRef(
 
     const handleOnWheel = (event) => {
       const newValue = parseFloat(value);
+      if (!isScrollEnabled) {
+        return;
+      }
       if (event.deltaY < 0) {
         setRangeInputValue(newValue + step);
       } else {
@@ -86,8 +95,9 @@ const RangeInput = forwardRef(
     // This is to make sure scrollbar doesn't move
     // when user changes RangeInput value.
     const handleMouseOver = () =>
-      setScroll({ x: window.scrollX, y: window.scrollY });
-    const handleMouseOut = () => setScroll({ x: null, y: null });
+      isScrollEnabled && setScroll({ x: window.scrollX, y: window.scrollY });
+    const handleMouseOut = () =>
+      isScrollEnabled && setScroll({ x: null, y: null });
 
     return (
       <StyledRangeInput

--- a/src/js/components/RangeInput/__tests__/RangeInput-test.tsx
+++ b/src/js/components/RangeInput/__tests__/RangeInput-test.tsx
@@ -7,7 +7,6 @@ import 'regenerator-runtime/runtime';
 
 import { Grommet } from '../../Grommet';
 import { RangeInput } from '..';
-import { ThemeContext } from '../../../contexts/ThemeContext';
 import { ThemeType } from '../../../themes';
 
 describe('RangeInput', () => {
@@ -162,7 +161,7 @@ describe('RangeInput', () => {
     const onChange = jest.fn();
     const { getByDisplayValue } = render(
       <Grommet theme={theme}>
-          <RangeInput min={0} max={10} step={1} value={5} onChange={onChange} />
+        <RangeInput min={0} max={10} step={1} value={5} onChange={onChange} />
       </Grommet>,
     );
 

--- a/src/js/components/RangeInput/__tests__/RangeInput-test.tsx
+++ b/src/js/components/RangeInput/__tests__/RangeInput-test.tsx
@@ -7,6 +7,8 @@ import 'regenerator-runtime/runtime';
 
 import { Grommet } from '../../Grommet';
 import { RangeInput } from '..';
+import { ThemeContext } from '../../../contexts/ThemeContext';
+import { ThemeType } from '../../../themes';
 
 describe('RangeInput', () => {
   test('should have no accessibility violations', async () => {
@@ -137,5 +139,36 @@ describe('RangeInput', () => {
     );
 
     expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test('onWheel should call onChange by default', () => {
+    const onChange = jest.fn();
+    const { getByDisplayValue } = render(
+      <Grommet>
+        <RangeInput min={0} max={10} step={1} value={5} onChange={onChange} />
+      </Grommet>,
+    );
+
+    fireEvent.wheel(getByDisplayValue('5'), {
+      target: {
+        value: '10',
+      },
+    });
+    expect(onChange).toBeCalledTimes(1);
+  });
+
+  test('onWheel overrides should not call onChange', () => {
+    const theme: ThemeType = { rangeInput: { wheel: false } };
+    const onChange = jest.fn();
+    const { getByDisplayValue } = render(
+      <Grommet>
+        <ThemeContext.Extend value={theme}>
+          <RangeInput min={0} max={10} step={1} value={5} onChange={onChange} />
+        </ThemeContext.Extend>
+      </Grommet>,
+    );
+
+    fireEvent.wheel(getByDisplayValue('5'));
+    expect(onChange).not.toBeCalled();
   });
 });

--- a/src/js/components/RangeInput/__tests__/RangeInput-test.tsx
+++ b/src/js/components/RangeInput/__tests__/RangeInput-test.tsx
@@ -161,10 +161,8 @@ describe('RangeInput', () => {
     const theme: ThemeType = { rangeInput: { wheel: false } };
     const onChange = jest.fn();
     const { getByDisplayValue } = render(
-      <Grommet>
-        <ThemeContext.Extend value={theme}>
+      <Grommet theme={theme}>
           <RangeInput min={0} max={10} step={1} value={5} onChange={onChange} />
-        </ThemeContext.Extend>
       </Grommet>,
     );
 

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -1363,6 +1363,7 @@ export interface ThemeType {
       color?: ColorType;
       extend?: ExtendType;
     };
+    wheel?: boolean;
     extend?: ExtendType;
   };
   rangeSelector?: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Enables a user to opt out of the mouse wheel behavior by setting the `onWheel` event on a range input. 

#### Where should the reviewer start?

[This slack conversation](https://grommet.slack.com/archives/C09QQEG69/p1648134314121579) and then the RangeInput test file

#### What testing has been done on this PR?

Added tests for both the overridden and default scroll behavior

#### How should this be manually tested?

Manual testing can be done with the story in storybook

#### Do Jest tests follow these best practices?

- [x] `screen` is used for querying.
- [x] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

^ I used the same patterns already in the file

#### Any background context you want to provide?

This feels to me like it's a less ideal solution than adding a toggle prop for `overrideScrollBehavior` (or something similar)

#### What are the relevant issues?

Closes #6025

#### Do the grommet docs need to be updated?

Yes

#### Should this PR be mentioned in the release notes?

Yes

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible
