### PR TITLE
Change Calendar/Simple story to only have 1 Calendar

### DIFF
--- a/src/js/components/Calendar/stories/Simple.js
+++ b/src/js/components/Calendar/stories/Simple.js
@@ -16,14 +16,6 @@ export const Simple = () => {
       <Box align="center" pad="large">
         <Calendar
           date={date}
-          onSelect={onSelect}
-          size="small"
-          bounds={['2018-09-08', '2020-12-13']}
-        />
-      </Box>
-      <Box align="center" pad="large">
-        <Calendar
-          date={date}
           daysOfWeek
           onSelect={onSelect}
           size="small"


### PR DESCRIPTION
#### What does this PR do?
Removes one of the Calendars from the Calendar/Simple story. Having two Calendars was causing confusion since they share they same date variable which means in UTC+ timezones the calendar the date was not originally selected on will show one day earlier. See full explanation on why this happens here: https://github.com/grommet/grommet/issues/6023#issuecomment-1079488663

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?
storybook

#### Do Jest tests follow these best practices?
n/a
- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Related to https://github.com/grommet/grommet/issues/6023

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no

#### Should this PR be mentioned in the release notes?
no

#### Is this change backwards compatible or is it a breaking change?
backwards compatible