### PR TITLE
Bug fix for name attribute in Select Compoenet

### DIFF
--- a/src/js/components/Select/Select.js
+++ b/src/js/components/Select/Select.js
@@ -399,6 +399,7 @@ const Select = forwardRef(
                   {selectValue || displayLabelKey}
                   <HiddenInput
                     type="text"
+                    name={name}
                     id={id ? `${id}__input` : undefined}
                     value={inputValue}
                     ref={inputRef}


### PR DESCRIPTION
- This PR is a fix for issue #6027 
- The `"name"` attribute of `<Select>` component was missing when passed with a `valueLabel`.

#### What does this PR do?
- This PR is a fix for issue #6027 

#### Where should the reviewer start?

- There is only file changed. The reviewer could start reviewing from line number `399` (in the changed file).

#### What testing has been done on this PR?

- `yarn test` tests were performed. All tests had passed

#### How should this be manually tested?
- I have done manual testing using stories ("Value Label" story in "Select") provided in storybook (did a console.log of `event.target.name`)
- 
#### Do Jest tests follow these best practices?

- N/A

#### Any background context you want to provide?

#### What are the relevant issues?
- #6027 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
- Not required

#### Should this PR be mentioned in the release notes?
- Could be mentioned as a bug fix


#### Is this change backwards compatible or is it a breaking change?
- This should be backwards compatible.
