### PR TITLE
Changed Drop to add container inline

### DIFF
--- a/src/js/components/Drop/Drop.js
+++ b/src/js/components/Drop/Drop.js
@@ -11,6 +11,7 @@ import { DropPropTypes } from './propTypes';
 const Drop = forwardRef(
   (
     {
+      container = 'portal',
       restrictFocus,
       target: dropTarget, // avoid DOM leakage
       trapFocus = true,
@@ -24,8 +25,11 @@ const Drop = forwardRef(
     const [dropContainer, setDropContainer] = useState();
     const containerTarget = useContext(ContainerTargetContext);
     useEffect(
-      () => setDropContainer(getNewContainer(containerTarget)),
-      [containerTarget],
+      () =>
+        setDropContainer(
+          container === 'portal' ? getNewContainer(containerTarget) : undefined,
+        ),
+      [container, containerTarget],
     );
 
     // just a few things to clean up when the Drop is unmounted
@@ -49,19 +53,22 @@ const Drop = forwardRef(
       [containerTarget, dropContainer, originalFocusedElement, restrictFocus],
     );
 
-    return dropContainer
-      ? createPortal(
-          <DropContainer
-            ref={ref}
-            dir={theme && theme.dir}
-            dropTarget={dropTarget}
-            restrictFocus={restrictFocus}
-            trapFocus={trapFocus}
-            {...rest}
-          />,
-          dropContainer,
-        )
-      : null;
+    const content = (
+      <DropContainer
+        ref={ref}
+        dir={theme && theme.dir}
+        dropTarget={dropTarget}
+        restrictFocus={restrictFocus}
+        trapFocus={trapFocus}
+        {...rest}
+      />
+    );
+
+    if (container === 'inline') return content;
+
+    if (dropContainer) return createPortal(content, dropContainer);
+
+    return null;
   },
 );
 

--- a/src/js/components/Drop/Drop.js
+++ b/src/js/components/Drop/Drop.js
@@ -11,7 +11,7 @@ import { DropPropTypes } from './propTypes';
 const Drop = forwardRef(
   (
     {
-      container = 'portal',
+      inline,
       restrictFocus,
       target: dropTarget, // avoid DOM leakage
       trapFocus = true,
@@ -27,9 +27,9 @@ const Drop = forwardRef(
     useEffect(
       () =>
         setDropContainer(
-          container === 'portal' ? getNewContainer(containerTarget) : undefined,
+          !inline ? getNewContainer(containerTarget) : undefined,
         ),
-      [container, containerTarget],
+      [containerTarget, inline],
     );
 
     // just a few things to clean up when the Drop is unmounted
@@ -64,7 +64,7 @@ const Drop = forwardRef(
       />
     );
 
-    if (container === 'inline') return content;
+    if (inline) return content;
 
     if (dropContainer) return createPortal(content, dropContainer);
 

--- a/src/js/components/Drop/__tests__/Drop-test.tsx
+++ b/src/js/components/Drop/__tests__/Drop-test.tsx
@@ -60,6 +60,49 @@ const TestInput = ({
   );
 };
 
+interface TestButtonProps extends DropExtendedProps {
+  theme?: ThemeType;
+  containerTarget?: HTMLElement;
+  message?: string;
+}
+const TestButton = ({
+  theme,
+  containerTarget,
+  message = 'this is a test',
+  ...rest
+}: TestButtonProps) => {
+  const [showDrop, setShowDrop] = useState<boolean>(false);
+
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
+
+  useEffect(() => {
+    setShowDrop(true);
+  }, []);
+
+  let drop;
+
+  if (showDrop) {
+    drop = (
+      <Drop
+        id="drop-node"
+        container="inline"
+        target={buttonRef.current || undefined}
+        {...rest}
+      >
+        {message}
+      </Drop>
+    );
+  }
+  return (
+    <Grommet theme={theme} containerTarget={containerTarget}>
+      <button ref={buttonRef} data-testid="drop-button" aria-label="test">
+        <span>click</span>
+        {drop}
+      </button>
+    </Grommet>
+  );
+};
+
 describe('Drop', () => {
   test('should have no accessibility violations', async () => {
     window.scrollTo = jest.fn();
@@ -265,4 +308,10 @@ test('custom containerTarget', () => {
   } finally {
     document.body.removeChild(target);
   }
+});
+
+test('inline', () => {
+  window.scrollTo = jest.fn();
+  const { getByTestId } = render(<TestButton />);
+  expect(getByTestId('drop-button')).toMatchSnapshot();
 });

--- a/src/js/components/Drop/__tests__/Drop-test.tsx
+++ b/src/js/components/Drop/__tests__/Drop-test.tsx
@@ -85,7 +85,7 @@ const TestButton = ({
     drop = (
       <Drop
         id="drop-node"
-        container="inline"
+        inline
         target={buttonRef.current || undefined}
         {...rest}
       >

--- a/src/js/components/Drop/__tests__/__snapshots__/Drop-test.tsx.snap
+++ b/src/js/components/Drop/__tests__/__snapshots__/Drop-test.tsx.snap
@@ -3565,3 +3565,80 @@ exports[`Drop theme elevation renders 2`] = `
   }
 }"
 `;
+
+exports[`inline 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  overflow: auto;
+  box-shadow: 0px 2px 4px rgba(0,0,0,0.20);
+}
+
+.c1 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  border-radius: 0px;
+  position: fixed;
+  z-index: 20;
+  outline: none;
+  background-color: #FFFFFF;
+  color: #444444;
+  opacity: 0;
+  -webkit-transform-origin: top left;
+  -ms-transform-origin: top left;
+  transform-origin: top left;
+  -webkit-animation: kPQHBD 0.1s forwards;
+  animation: kPQHBD 0.1s forwards;
+  -webkit-animation-delay: 0.01s;
+  animation-delay: 0.01s;
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c1 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+  }
+}
+
+<button
+  aria-label="test"
+  data-testid="drop-button"
+>
+  <span>
+    click
+  </span>
+  <div
+    aria-hidden="false"
+  >
+    <div
+      class="c0 c1"
+      data-g-portal-id="0"
+      id="drop-node"
+      style="left: 0px; width: 0.1px; top: 0px; max-height: 1000px;"
+      tabindex="-1"
+    >
+      this is a test
+    </div>
+  </div>
+</button>
+`;

--- a/src/js/components/Drop/index.d.ts
+++ b/src/js/components/Drop/index.d.ts
@@ -15,8 +15,8 @@ export interface DropProps {
     left?: 'left' | 'right';
   };
   background?: BackgroundType;
-  container?: 'inline' | 'portal';
   elevation?: ElevationType;
+  inline?: boolean;
   onClickOutside?: React.MouseEventHandler<HTMLDocument>;
   onEsc?: KeyboardType;
   overflow?:

--- a/src/js/components/Drop/index.d.ts
+++ b/src/js/components/Drop/index.d.ts
@@ -15,6 +15,7 @@ export interface DropProps {
     left?: 'left' | 'right';
   };
   background?: BackgroundType;
+  container?: 'inline' | 'portal';
   elevation?: ElevationType;
   onClickOutside?: React.MouseEventHandler<HTMLDocument>;
   onEsc?: KeyboardType;

--- a/src/js/components/Drop/propTypes.js
+++ b/src/js/components/Drop/propTypes.js
@@ -26,11 +26,11 @@ if (process.env.NODE_ENV !== 'production') {
       left: PropTypes.oneOf(['left', 'right']),
     }),
     background: backgroundDoc,
-    container: PropTypes.oneOf(['inline', 'portal']),
     elevation: PropTypes.oneOfType([
       PropTypes.oneOf(['none', 'xsmall', 'small', 'medium', 'large', 'xlarge']),
       PropTypes.string,
     ]),
+    inline: PropTypes.bool,
     margin: marginProp,
     onClickOutside: PropTypes.func,
     onEsc: PropTypes.func,

--- a/src/js/components/Drop/propTypes.js
+++ b/src/js/components/Drop/propTypes.js
@@ -26,6 +26,7 @@ if (process.env.NODE_ENV !== 'production') {
       left: PropTypes.oneOf(['left', 'right']),
     }),
     background: backgroundDoc,
+    container: PropTypes.oneOf(['inline', 'portal']),
     elevation: PropTypes.oneOfType([
       PropTypes.oneOf(['none', 'xsmall', 'small', 'medium', 'large', 'xlarge']),
       PropTypes.string,

--- a/src/js/components/Drop/stories/Inline.js
+++ b/src/js/components/Drop/stories/Inline.js
@@ -1,0 +1,49 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+import { Box, Drop } from 'grommet';
+
+const align = { top: 'bottom', left: 'left' };
+
+const InlineDrop = () => {
+  const targetRef = useRef();
+
+  // trigger re-render so we have the targetRef
+  const [, setShowDrop] = useState(false);
+  useEffect(() => {
+    setShowDrop(true);
+  }, []);
+
+  return (
+    // Uncomment <Grommet> lines when using outside of storybook
+    // <Grommet theme={...}>
+    <Box fill align="center" justify="center">
+      <Box
+        background="dark-3"
+        pad="medium"
+        align="center"
+        justify="start"
+        ref={targetRef}
+      >
+        Target
+        {targetRef.current && (
+          <Drop container="inline" align={align} target={targetRef.current}>
+            <Box pad="large">Drop Contents</Box>
+          </Drop>
+        )}
+      </Box>
+    </Box>
+    // </Grommet>
+  );
+};
+
+export const Inline = () => <InlineDrop />;
+Inline.parameters = {
+  chromatic: { disable: true },
+};
+Inline.args = {
+  full: true,
+};
+
+export default {
+  title: 'Controls/Drop/Inline',
+};

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -296,6 +296,7 @@ Object {
     "propTypes": Object {
       "align": [Function],
       "background": [Function],
+      "container": [Function],
       "elevation": [Function],
       "margin": [Function],
       "onClickOutside": [Function],

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -296,8 +296,8 @@ Object {
     "propTypes": Object {
       "align": [Function],
       "background": [Function],
-      "container": [Function],
       "elevation": [Function],
+      "inline": [Function],
       "margin": [Function],
       "onClickOutside": [Function],
       "onEsc": [Function],


### PR DESCRIPTION
#### What does this PR do?

Changed Drop to add `container="inline"`. This allows the Drop to be rendered within its parent as opposed to in a React portal.
See the issue for some detail around when this might be useful.

#### Where should the reviewer start?

Inline.js story

#### What testing has been done on this PR?

Added a new Inline story and added a jest test.

#### How should this be manually tested?

Inline story

#### Do Jest tests follow these best practices?

no changes to the unit test patterns already in the file

#### What are the relevant issues?

#6032 

#### Do the grommet docs need to be updated?

yes

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
