### PR TITLE
add disabled to controls in which the video is already playing or paused

### DIFF
--- a/src/js/components/Select/Select.js
+++ b/src/js/components/Select/Select.js
@@ -399,6 +399,7 @@ const Select = forwardRef(
                   {selectValue || displayLabelKey}
                   <HiddenInput
                     type="text"
+                    name={name}
                     id={id ? `${id}__input` : undefined}
                     value={inputValue}
                     ref={inputRef}

--- a/src/js/components/Video/Video.js
+++ b/src/js/components/Video/Video.js
@@ -313,6 +313,7 @@ const Video = forwardRef(
             id: 'video.pauseButton',
             messages,
           }),
+          disabled: !playing,
           onClick: playing ? pause : play,
         },
         play: {
@@ -321,6 +322,7 @@ const Video = forwardRef(
             id: 'video.playButton',
             messages,
           }),
+          disabled: playing,
           onClick: playing ? pause : play,
         },
       };

--- a/src/js/components/Video/Video.js
+++ b/src/js/components/Video/Video.js
@@ -314,7 +314,7 @@ const Video = forwardRef(
             messages,
           }),
           disabled: !playing,
-          onClick: playing ? pause : play,
+          onClick: pause,
         },
         play: {
           icon: <Icons.Play color={iconColor} />,
@@ -323,7 +323,7 @@ const Video = forwardRef(
             messages,
           }),
           disabled: playing,
-          onClick: playing ? pause : play,
+          onClick: play,
         },
       };
 

--- a/src/js/components/Video/index.d.ts
+++ b/src/js/components/Video/index.d.ts
@@ -7,6 +7,18 @@ import {
   Omit,
 } from '../../utils';
 
+type controlsItems =
+  | 'captions'
+  | 'fullScreen'
+  | 'play'
+  | 'pause'
+  | 'volume'
+  | {
+      icon?: React.ReactNode;
+      a11yTitle?: A11yTitleType;
+      onClick?: (...args: any[]) => any;
+    };
+
 export interface VideoProps {
   a11yTitle?: A11yTitleType;
   alignSelf?: AlignSelfType;
@@ -17,14 +29,7 @@ export interface VideoProps {
     | 'below'
     | {
         position?: false | 'over' | 'below';
-        items?: [
-          'captions' | 'fullScreen' | 'play' | 'pause' | 'volume',
-          {
-            icon?: React.ReactNode;
-            a11yTitle?: A11yTitleType;
-            onClick?: () => {};
-          },
-        ];
+        items?: controlsItems[];
       };
   fit?: 'cover' | 'contain';
   gridArea?: GridAreaType;

--- a/src/js/components/Video/propTypes.js
+++ b/src/js/components/Video/propTypes.js
@@ -17,6 +17,7 @@ if (process.env.NODE_ENV !== 'production') {
               icon: PropTypes.element,
               a11yTitle: PropTypes.string,
               onClick: PropTypes.func,
+              disabled: PropTypes.bool,
             }),
           ]),
         ),

--- a/src/js/components/Video/stories/typescript/TheaterMode.tsx
+++ b/src/js/components/Video/stories/typescript/TheaterMode.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import { Box, Video } from 'grommet';
 import { Monitor } from 'grommet-icons/icons/Monitor';
 
-const TheaterMode = (props) => {
+const TheaterMode = () => {
   const [theaterMode, setTheaterMode] = useState(false);
 
   return (
@@ -25,9 +25,9 @@ const TheaterMode = (props) => {
               a11yTitle: 'Toggle theater mode',
             },
             'fullScreen',
+            'pause',
           ],
         }}
-        {...props}
       />
     </Box>
   );

--- a/src/js/components/Video/stories/typescript/TheaterMode.tsx
+++ b/src/js/components/Video/stories/typescript/TheaterMode.tsx
@@ -25,6 +25,8 @@ const TheaterMode = (props) => {
               a11yTitle: 'Toggle theater mode',
             },
             'fullScreen',
+            'pause',
+            'play',
           ],
         }}
         {...props}

--- a/src/js/components/Video/stories/typescript/TheaterMode.tsx
+++ b/src/js/components/Video/stories/typescript/TheaterMode.tsx
@@ -25,8 +25,6 @@ const TheaterMode = (props) => {
               a11yTitle: 'Toggle theater mode',
             },
             'fullScreen',
-            'pause',
-            'play',
           ],
         }}
         {...props}


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR disables `play` button in the control menu when the video is already playing as well as disables the pause button in control menu when the Video is already paused
#### Where should the reviewer start?
video.js
#### What testing has been done on this PR?
storybook 
#### How should this be manually tested?
add `prop` to Video in storybook 

```
controls={{ position: "below", items: ["pause", "play"] }}

```
#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
User plays or pauses the video via the extended "controls" prop. They are able to pause or play with any of the two controls. For example, the video will be playing and the user can go to the extended controls and hit the play icon. This will pause the video.
#### What are the relevant issues?
#6021 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
maybe
#### Is this change backwards compatible or is it a breaking change?
backwards compatible