### PR TITLE
Make "as" prop on Box accept any React element

### DIFF
--- a/src/js/components/Box/__tests__/Box-test.tsx
+++ b/src/js/components/Box/__tests__/Box-test.tsx
@@ -486,10 +486,35 @@ describe('Box', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test('as', () => {
+  test('as string', () => {
     const { container } = render(
       <Grommet>
         <Box as="header" />
+      </Grommet>,
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test('as function', () => {
+    const { container } = render(
+      <Grommet>
+        <Box as={(props) => <header className={props.className} />} />
+      </Grommet>,
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test('as component', () => {
+    class Header extends React.Component<any> {
+      render() {
+        return <header className={this.props.className} />;
+      }
+    }
+    const { container } = render(
+      <Grommet>
+        <Box as={Header} />
       </Grommet>,
     );
 

--- a/src/js/components/Box/__tests__/__snapshots__/Box-test.tsx.snap
+++ b/src/js/components/Box/__tests__/__snapshots__/Box-test.tsx.snap
@@ -1076,7 +1076,75 @@ exports[`Box animation 1`] = `
 </div>
 `;
 
-exports[`Box as 1`] = `
+exports[`Box as component 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+<div
+  class="c0"
+>
+  <header
+    class="c1"
+  />
+</div>
+`;
+
+exports[`Box as function 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+<div
+  class="c0"
+>
+  <header
+    class="c1"
+  />
+</div>
+`;
+
+exports[`Box as string 1`] = `
 .c0 {
   font-size: 18px;
   line-height: 24px;

--- a/src/js/components/Box/propTypes.js
+++ b/src/js/components/Box/propTypes.js
@@ -194,7 +194,11 @@ if (process.env.NODE_ENV !== 'production') {
     responsive: PropTypes.bool,
     round: roundPropType,
     tag: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
-    as: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+    as: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.func,
+      PropTypes.elementType,
+    ]),
     width: widthPropType,
     wrap: PropTypes.oneOfType([PropTypes.bool, PropTypes.oneOf(['reverse'])]),
   };


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Very similarly to https://github.com/grommet/grommet/pull/5823, this PR enhances Box to accept any React element for the `as` prop.
When working with legacy code or `styled-components`, I stumbled upon the need for this extension.
Before this PR, a warning like this would appear, but the code would still work like a charm.
<img width="392" alt="image" src="https://user-images.githubusercontent.com/4154003/160928679-65b02cd7-47d2-47bd-a369-dc07528cb454.png">

#### Where should the reviewer start?
At the tests

#### What testing has been done on this PR?
Extensive testing 🧐

#### How should this be manually tested?
Pass a React element such as an old school component as the `as` prop to a Box
#### Do Jest tests follow these best practices?

- [x] `screen` is used for querying.
- [x] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [x] `userEvent` is used in place of `fireEvent`.
- [x] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
They update automatically, right?
#### Should this PR be mentioned in the release notes?
Yes.
#### Is this change backward compatible or is it a breaking change?
This PR does not change Grommet's behavior, but simply removes a useless warning on a specific edge case.