### PR TITLE
fix(button): hover state lose box-shadow after click

### DIFF
--- a/src/js/components/Accordion/__tests__/__snapshots__/Accordion-test.tsx.snap
+++ b/src/js/components/Accordion/__tests__/__snapshots__/Accordion-test.tsx.snap
@@ -157,43 +157,43 @@ exports[`Accordion AccordionPanel 1`] = `
   text-align: inherit;
 }
 
-.c3:focus {
+.c3:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
+.c3:focus:not(:hover) > circle,
+.c3:focus:not(:hover) > ellipse,
+.c3:focus:not(:hover) > line,
+.c3:focus:not(:hover) > path,
+.c3:focus:not(:hover) > polygon,
+.c3:focus:not(:hover) > polyline,
+.c3:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus::-moz-focus-inner {
+.c3:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c3:focus:not(:focus-visible) {
+.c3:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
+.c3:focus:not(:focus-visible):not(:hover) > circle,
+.c3:focus:not(:focus-visible):not(:hover) > ellipse,
+.c3:focus:not(:focus-visible):not(:hover) > line,
+.c3:focus:not(:focus-visible):not(:hover) > path,
+.c3:focus:not(:focus-visible):not(:hover) > polygon,
+.c3:focus:not(:focus-visible):not(:hover) > polyline,
+.c3:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
+.c3:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -504,43 +504,43 @@ exports[`Accordion accordion border 1`] = `
   text-align: inherit;
 }
 
-.c3:focus {
+.c3:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
+.c3:focus:not(:hover) > circle,
+.c3:focus:not(:hover) > ellipse,
+.c3:focus:not(:hover) > line,
+.c3:focus:not(:hover) > path,
+.c3:focus:not(:hover) > polygon,
+.c3:focus:not(:hover) > polyline,
+.c3:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus::-moz-focus-inner {
+.c3:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c3:focus:not(:focus-visible) {
+.c3:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
+.c3:focus:not(:focus-visible):not(:hover) > circle,
+.c3:focus:not(:focus-visible):not(:hover) > ellipse,
+.c3:focus:not(:focus-visible):not(:hover) > line,
+.c3:focus:not(:focus-visible):not(:hover) > path,
+.c3:focus:not(:focus-visible):not(:hover) > polygon,
+.c3:focus:not(:focus-visible):not(:hover) > polyline,
+.c3:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
+.c3:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -821,43 +821,43 @@ exports[`Accordion backward compatibility of hover.color = undefined 1`] = `
   text-align: inherit;
 }
 
-.c3:focus {
+.c3:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
+.c3:focus:not(:hover) > circle,
+.c3:focus:not(:hover) > ellipse,
+.c3:focus:not(:hover) > line,
+.c3:focus:not(:hover) > path,
+.c3:focus:not(:hover) > polygon,
+.c3:focus:not(:hover) > polyline,
+.c3:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus::-moz-focus-inner {
+.c3:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c3:focus:not(:focus-visible) {
+.c3:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
+.c3:focus:not(:focus-visible):not(:hover) > circle,
+.c3:focus:not(:focus-visible):not(:hover) > ellipse,
+.c3:focus:not(:focus-visible):not(:hover) > line,
+.c3:focus:not(:focus-visible):not(:hover) > path,
+.c3:focus:not(:focus-visible):not(:hover) > polygon,
+.c3:focus:not(:focus-visible):not(:hover) > polyline,
+.c3:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
+.c3:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -1132,43 +1132,43 @@ exports[`Accordion blur styles 1`] = `
   text-align: inherit;
 }
 
-.c3:focus {
+.c3:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
+.c3:focus:not(:hover) > circle,
+.c3:focus:not(:hover) > ellipse,
+.c3:focus:not(:hover) > line,
+.c3:focus:not(:hover) > path,
+.c3:focus:not(:hover) > polygon,
+.c3:focus:not(:hover) > polyline,
+.c3:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus::-moz-focus-inner {
+.c3:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c3:focus:not(:focus-visible) {
+.c3:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
+.c3:focus:not(:focus-visible):not(:hover) > circle,
+.c3:focus:not(:focus-visible):not(:hover) > ellipse,
+.c3:focus:not(:focus-visible):not(:hover) > line,
+.c3:focus:not(:focus-visible):not(:hover) > path,
+.c3:focus:not(:focus-visible):not(:hover) > polygon,
+.c3:focus:not(:focus-visible):not(:hover) > polyline,
+.c3:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
+.c3:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -1448,43 +1448,43 @@ exports[`Accordion change active index 1`] = `
   text-align: inherit;
 }
 
-.c3:focus {
+.c3:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
+.c3:focus:not(:hover) > circle,
+.c3:focus:not(:hover) > ellipse,
+.c3:focus:not(:hover) > line,
+.c3:focus:not(:hover) > path,
+.c3:focus:not(:hover) > polygon,
+.c3:focus:not(:hover) > polyline,
+.c3:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus::-moz-focus-inner {
+.c3:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c3:focus:not(:focus-visible) {
+.c3:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
+.c3:focus:not(:focus-visible):not(:hover) > circle,
+.c3:focus:not(:focus-visible):not(:hover) > ellipse,
+.c3:focus:not(:focus-visible):not(:hover) > line,
+.c3:focus:not(:focus-visible):not(:hover) > path,
+.c3:focus:not(:focus-visible):not(:hover) > polygon,
+.c3:focus:not(:focus-visible):not(:hover) > polyline,
+.c3:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
+.c3:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -1774,64 +1774,6 @@ exports[`Accordion change active index 2`] = `
   flex-direction: column;
 }
 
-.c10 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  color: inherit;
-  outline: none;
-  border: none;
-  padding: 0;
-  text-align: inherit;
-}
-
-.c10:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c10:focus > circle,
-.c10:focus > ellipse,
-.c10:focus > line,
-.c10:focus > path,
-.c10:focus > polygon,
-.c10:focus > polyline,
-.c10:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c10:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c10:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c10:focus:not(:focus-visible) > circle,
-.c10:focus:not(:focus-visible) > ellipse,
-.c10:focus:not(:focus-visible) > line,
-.c10:focus:not(:focus-visible) > path,
-.c10:focus:not(:focus-visible) > polygon,
-.c10:focus:not(:focus-visible) > polyline,
-.c10:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c10:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
 .c3 {
   display: inline-block;
   box-sizing: border-box;
@@ -1850,47 +1792,47 @@ exports[`Accordion change active index 2`] = `
   text-align: inherit;
 }
 
-.c3:focus {
+.c3:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
+.c3:focus:not(:hover) > circle,
+.c3:focus:not(:hover) > ellipse,
+.c3:focus:not(:hover) > line,
+.c3:focus:not(:hover) > path,
+.c3:focus:not(:hover) > polygon,
+.c3:focus:not(:hover) > polyline,
+.c3:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus::-moz-focus-inner {
+.c3:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c3:focus:not(:focus-visible) {
+.c3:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
+.c3:focus:not(:focus-visible):not(:hover) > circle,
+.c3:focus:not(:focus-visible):not(:hover) > ellipse,
+.c3:focus:not(:focus-visible):not(:hover) > line,
+.c3:focus:not(:focus-visible):not(:hover) > path,
+.c3:focus:not(:focus-visible):not(:hover) > polygon,
+.c3:focus:not(:focus-visible):not(:hover) > polyline,
+.c3:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
+.c3:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c11 {
+.c10 {
   font-size: 18px;
   line-height: 24px;
   max-width: 432px;
@@ -1936,7 +1878,7 @@ exports[`Accordion change active index 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c11 {
+  .c10 {
     font-size: 16px;
     line-height: 22px;
     max-width: 384px;
@@ -2009,7 +1951,7 @@ exports[`Accordion change active index 2`] = `
         <button
           aria-expanded="true"
           aria-selected="true"
-          class="c10"
+          class="c3"
           role="tab"
           type="button"
         >
@@ -2020,7 +1962,7 @@ exports[`Accordion change active index 2`] = `
               class="c5"
             >
               <h4
-                class="c11"
+                class="c10"
               >
                 Panel 2
               </h4>
@@ -2211,43 +2153,43 @@ exports[`Accordion change to second Panel 1`] = `
   text-align: inherit;
 }
 
-.c3:focus {
+.c3:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
+.c3:focus:not(:hover) > circle,
+.c3:focus:not(:hover) > ellipse,
+.c3:focus:not(:hover) > line,
+.c3:focus:not(:hover) > path,
+.c3:focus:not(:hover) > polygon,
+.c3:focus:not(:hover) > polyline,
+.c3:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus::-moz-focus-inner {
+.c3:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c3:focus:not(:focus-visible) {
+.c3:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
+.c3:focus:not(:focus-visible):not(:hover) > circle,
+.c3:focus:not(:focus-visible):not(:hover) > ellipse,
+.c3:focus:not(:focus-visible):not(:hover) > line,
+.c3:focus:not(:focus-visible):not(:hover) > path,
+.c3:focus:not(:focus-visible):not(:hover) > polygon,
+.c3:focus:not(:focus-visible):not(:hover) > polyline,
+.c3:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
+.c3:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -2570,101 +2512,43 @@ exports[`Accordion change to second Panel 2`] = `
   text-align: inherit;
 }
 
-.c3:focus {
+.c3:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
+.c3:focus:not(:hover) > circle,
+.c3:focus:not(:hover) > ellipse,
+.c3:focus:not(:hover) > line,
+.c3:focus:not(:hover) > path,
+.c3:focus:not(:hover) > polygon,
+.c3:focus:not(:hover) > polyline,
+.c3:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus::-moz-focus-inner {
+.c3:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c3:focus:not(:focus-visible) {
+.c3:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
+.c3:focus:not(:focus-visible):not(:hover) > circle,
+.c3:focus:not(:focus-visible):not(:hover) > ellipse,
+.c3:focus:not(:focus-visible):not(:hover) > line,
+.c3:focus:not(:focus-visible):not(:hover) > path,
+.c3:focus:not(:focus-visible):not(:hover) > polygon,
+.c3:focus:not(:focus-visible):not(:hover) > polyline,
+.c3:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c11 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  color: inherit;
-  outline: none;
-  border: none;
-  padding: 0;
-  text-align: inherit;
-}
-
-.c11:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c11:focus > circle,
-.c11:focus > ellipse,
-.c11:focus > line,
-.c11:focus > path,
-.c11:focus > polygon,
-.c11:focus > polyline,
-.c11:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c11:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c11:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c11:focus:not(:focus-visible) > circle,
-.c11:focus:not(:focus-visible) > ellipse,
-.c11:focus:not(:focus-visible) > line,
-.c11:focus:not(:focus-visible) > path,
-.c11:focus:not(:focus-visible) > polygon,
-.c11:focus:not(:focus-visible) > polyline,
-.c11:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c11:focus:not(:focus-visible)::-moz-focus-inner {
+.c3:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -2675,7 +2559,7 @@ exports[`Accordion change to second Panel 2`] = `
   overflow: hidden;
 }
 
-.c13 {
+.c12 {
   -webkit-transition: max-height 200ms,opacity 200ms;
   transition: max-height 200ms,opacity 200ms;
   opacity: 1;
@@ -2689,7 +2573,7 @@ exports[`Accordion change to second Panel 2`] = `
   font-weight: 600;
 }
 
-.c12 {
+.c11 {
   font-size: 18px;
   line-height: 24px;
   max-width: 432px;
@@ -2736,7 +2620,7 @@ exports[`Accordion change to second Panel 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c12 {
+  .c11 {
     font-size: 16px;
     line-height: 22px;
     max-width: 384px;
@@ -2805,7 +2689,7 @@ exports[`Accordion change to second Panel 2`] = `
         <button
           aria-expanded="true"
           aria-selected="true"
-          class="c11"
+          class="c3"
           role="tab"
           style="z-index: 1;"
           type="button"
@@ -2817,7 +2701,7 @@ exports[`Accordion change to second Panel 2`] = `
               class="c5"
             >
               <h4
-                class="c12"
+                class="c11"
               >
                 Panel 2
               </h4>
@@ -2846,7 +2730,7 @@ exports[`Accordion change to second Panel 2`] = `
         >
           <div
             aria-hidden="false"
-            class="c1 c13"
+            class="c1 c12"
             open=""
             style="max-height: 0;"
           >
@@ -3016,43 +2900,43 @@ exports[`Accordion change to second Panel without onActive 1`] = `
   text-align: inherit;
 }
 
-.c3:focus {
+.c3:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
+.c3:focus:not(:hover) > circle,
+.c3:focus:not(:hover) > ellipse,
+.c3:focus:not(:hover) > line,
+.c3:focus:not(:hover) > path,
+.c3:focus:not(:hover) > polygon,
+.c3:focus:not(:hover) > polyline,
+.c3:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus::-moz-focus-inner {
+.c3:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c3:focus:not(:focus-visible) {
+.c3:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
+.c3:focus:not(:focus-visible):not(:hover) > circle,
+.c3:focus:not(:focus-visible):not(:hover) > ellipse,
+.c3:focus:not(:focus-visible):not(:hover) > line,
+.c3:focus:not(:focus-visible):not(:hover) > path,
+.c3:focus:not(:focus-visible):not(:hover) > polygon,
+.c3:focus:not(:focus-visible):not(:hover) > polyline,
+.c3:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
+.c3:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -3358,101 +3242,43 @@ exports[`Accordion change to second Panel without onActive 2`] = `
   text-align: inherit;
 }
 
-.c3:focus {
+.c3:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
+.c3:focus:not(:hover) > circle,
+.c3:focus:not(:hover) > ellipse,
+.c3:focus:not(:hover) > line,
+.c3:focus:not(:hover) > path,
+.c3:focus:not(:hover) > polygon,
+.c3:focus:not(:hover) > polyline,
+.c3:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus::-moz-focus-inner {
+.c3:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c3:focus:not(:focus-visible) {
+.c3:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
+.c3:focus:not(:focus-visible):not(:hover) > circle,
+.c3:focus:not(:focus-visible):not(:hover) > ellipse,
+.c3:focus:not(:focus-visible):not(:hover) > line,
+.c3:focus:not(:focus-visible):not(:hover) > path,
+.c3:focus:not(:focus-visible):not(:hover) > polygon,
+.c3:focus:not(:focus-visible):not(:hover) > polyline,
+.c3:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c10 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  color: inherit;
-  outline: none;
-  border: none;
-  padding: 0;
-  text-align: inherit;
-}
-
-.c10:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c10:focus > circle,
-.c10:focus > ellipse,
-.c10:focus > line,
-.c10:focus > path,
-.c10:focus > polygon,
-.c10:focus > polyline,
-.c10:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c10:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c10:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c10:focus:not(:focus-visible) > circle,
-.c10:focus:not(:focus-visible) > ellipse,
-.c10:focus:not(:focus-visible) > line,
-.c10:focus:not(:focus-visible) > path,
-.c10:focus:not(:focus-visible) > polygon,
-.c10:focus:not(:focus-visible) > polyline,
-.c10:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c10:focus:not(:focus-visible)::-moz-focus-inner {
+.c3:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -3463,7 +3289,7 @@ exports[`Accordion change to second Panel without onActive 2`] = `
   font-weight: 600;
 }
 
-.c11 {
+.c10 {
   font-size: 18px;
   line-height: 24px;
   max-width: 432px;
@@ -3510,7 +3336,7 @@ exports[`Accordion change to second Panel without onActive 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c11 {
+  .c10 {
     font-size: 16px;
     line-height: 22px;
     max-width: 384px;
@@ -3574,7 +3400,7 @@ exports[`Accordion change to second Panel without onActive 2`] = `
         <button
           aria-expanded="true"
           aria-selected="true"
-          class="c10"
+          class="c3"
           role="tab"
           style="z-index: 1;"
           type="button"
@@ -3586,7 +3412,7 @@ exports[`Accordion change to second Panel without onActive 2`] = `
               class="c5"
             >
               <h4
-                class="c11"
+                class="c10"
               >
                 Panel 2
               </h4>
@@ -3686,43 +3512,43 @@ exports[`Accordion complex header 1`] = `
   text-align: inherit;
 }
 
-.c3:focus {
+.c3:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
+.c3:focus:not(:hover) > circle,
+.c3:focus:not(:hover) > ellipse,
+.c3:focus:not(:hover) > line,
+.c3:focus:not(:hover) > path,
+.c3:focus:not(:hover) > polygon,
+.c3:focus:not(:hover) > polyline,
+.c3:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus::-moz-focus-inner {
+.c3:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c3:focus:not(:focus-visible) {
+.c3:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
+.c3:focus:not(:focus-visible):not(:hover) > circle,
+.c3:focus:not(:focus-visible):not(:hover) > ellipse,
+.c3:focus:not(:focus-visible):not(:hover) > line,
+.c3:focus:not(:focus-visible):not(:hover) > path,
+.c3:focus:not(:focus-visible):not(:hover) > polygon,
+.c3:focus:not(:focus-visible):not(:hover) > polyline,
+.c3:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
+.c3:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -3949,43 +3775,43 @@ exports[`Accordion complex title 1`] = `
   text-align: inherit;
 }
 
-.c4:focus {
+.c4:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c4:focus > circle,
-.c4:focus > ellipse,
-.c4:focus > line,
-.c4:focus > path,
-.c4:focus > polygon,
-.c4:focus > polyline,
-.c4:focus > rect {
+.c4:focus:not(:hover) > circle,
+.c4:focus:not(:hover) > ellipse,
+.c4:focus:not(:hover) > line,
+.c4:focus:not(:hover) > path,
+.c4:focus:not(:hover) > polygon,
+.c4:focus:not(:hover) > polyline,
+.c4:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c4:focus::-moz-focus-inner {
+.c4:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c4:focus:not(:focus-visible) {
+.c4:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c4:focus:not(:focus-visible) > circle,
-.c4:focus:not(:focus-visible) > ellipse,
-.c4:focus:not(:focus-visible) > line,
-.c4:focus:not(:focus-visible) > path,
-.c4:focus:not(:focus-visible) > polygon,
-.c4:focus:not(:focus-visible) > polyline,
-.c4:focus:not(:focus-visible) > rect {
+.c4:focus:not(:focus-visible):not(:hover) > circle,
+.c4:focus:not(:focus-visible):not(:hover) > ellipse,
+.c4:focus:not(:focus-visible):not(:hover) > line,
+.c4:focus:not(:focus-visible):not(:hover) > path,
+.c4:focus:not(:focus-visible):not(:hover) > polygon,
+.c4:focus:not(:focus-visible):not(:hover) > polyline,
+.c4:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c4:focus:not(:focus-visible)::-moz-focus-inner {
+.c4:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -4278,43 +4104,43 @@ exports[`Accordion custom accordion 1`] = `
   text-align: inherit;
 }
 
-.c3:focus {
+.c3:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
+.c3:focus:not(:hover) > circle,
+.c3:focus:not(:hover) > ellipse,
+.c3:focus:not(:hover) > line,
+.c3:focus:not(:hover) > path,
+.c3:focus:not(:hover) > polygon,
+.c3:focus:not(:hover) > polyline,
+.c3:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus::-moz-focus-inner {
+.c3:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c3:focus:not(:focus-visible) {
+.c3:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
+.c3:focus:not(:focus-visible):not(:hover) > circle,
+.c3:focus:not(:focus-visible):not(:hover) > ellipse,
+.c3:focus:not(:focus-visible):not(:hover) > line,
+.c3:focus:not(:focus-visible):not(:hover) > path,
+.c3:focus:not(:focus-visible):not(:hover) > polygon,
+.c3:focus:not(:focus-visible):not(:hover) > polyline,
+.c3:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
+.c3:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -4588,43 +4414,43 @@ exports[`Accordion focus and hover styles 1`] = `
   text-align: inherit;
 }
 
-.c3:focus {
+.c3:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
+.c3:focus:not(:hover) > circle,
+.c3:focus:not(:hover) > ellipse,
+.c3:focus:not(:hover) > line,
+.c3:focus:not(:hover) > path,
+.c3:focus:not(:hover) > polygon,
+.c3:focus:not(:hover) > polyline,
+.c3:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus::-moz-focus-inner {
+.c3:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c3:focus:not(:focus-visible) {
+.c3:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
+.c3:focus:not(:focus-visible):not(:hover) > circle,
+.c3:focus:not(:focus-visible):not(:hover) > ellipse,
+.c3:focus:not(:focus-visible):not(:hover) > line,
+.c3:focus:not(:focus-visible):not(:hover) > path,
+.c3:focus:not(:focus-visible):not(:hover) > polygon,
+.c3:focus:not(:focus-visible):not(:hover) > polyline,
+.c3:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
+.c3:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -4909,43 +4735,43 @@ exports[`Accordion multiple panels 1`] = `
   text-align: inherit;
 }
 
-.c3:focus {
+.c3:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
+.c3:focus:not(:hover) > circle,
+.c3:focus:not(:hover) > ellipse,
+.c3:focus:not(:hover) > line,
+.c3:focus:not(:hover) > path,
+.c3:focus:not(:hover) > polygon,
+.c3:focus:not(:hover) > polyline,
+.c3:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus::-moz-focus-inner {
+.c3:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c3:focus:not(:focus-visible) {
+.c3:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
+.c3:focus:not(:focus-visible):not(:hover) > circle,
+.c3:focus:not(:focus-visible):not(:hover) > ellipse,
+.c3:focus:not(:focus-visible):not(:hover) > line,
+.c3:focus:not(:focus-visible):not(:hover) > path,
+.c3:focus:not(:focus-visible):not(:hover) > polygon,
+.c3:focus:not(:focus-visible):not(:hover) > polyline,
+.c3:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
+.c3:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -5251,101 +5077,43 @@ exports[`Accordion multiple panels 2`] = `
   text-align: inherit;
 }
 
-.c3:focus {
+.c3:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
+.c3:focus:not(:hover) > circle,
+.c3:focus:not(:hover) > ellipse,
+.c3:focus:not(:hover) > line,
+.c3:focus:not(:hover) > path,
+.c3:focus:not(:hover) > polygon,
+.c3:focus:not(:hover) > polyline,
+.c3:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus::-moz-focus-inner {
+.c3:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c3:focus:not(:focus-visible) {
+.c3:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
+.c3:focus:not(:focus-visible):not(:hover) > circle,
+.c3:focus:not(:focus-visible):not(:hover) > ellipse,
+.c3:focus:not(:focus-visible):not(:hover) > line,
+.c3:focus:not(:focus-visible):not(:hover) > path,
+.c3:focus:not(:focus-visible):not(:hover) > polygon,
+.c3:focus:not(:focus-visible):not(:hover) > polyline,
+.c3:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c10 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  color: inherit;
-  outline: none;
-  border: none;
-  padding: 0;
-  text-align: inherit;
-}
-
-.c10:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c10:focus > circle,
-.c10:focus > ellipse,
-.c10:focus > line,
-.c10:focus > path,
-.c10:focus > polygon,
-.c10:focus > polyline,
-.c10:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c10:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c10:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c10:focus:not(:focus-visible) > circle,
-.c10:focus:not(:focus-visible) > ellipse,
-.c10:focus:not(:focus-visible) > line,
-.c10:focus:not(:focus-visible) > path,
-.c10:focus:not(:focus-visible) > polygon,
-.c10:focus:not(:focus-visible) > polyline,
-.c10:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c10:focus:not(:focus-visible)::-moz-focus-inner {
+.c3:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -5356,7 +5124,7 @@ exports[`Accordion multiple panels 2`] = `
   font-weight: 600;
 }
 
-.c11 {
+.c10 {
   font-size: 18px;
   line-height: 24px;
   max-width: 432px;
@@ -5403,7 +5171,7 @@ exports[`Accordion multiple panels 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c11 {
+  .c10 {
     font-size: 16px;
     line-height: 22px;
     max-width: 384px;
@@ -5467,7 +5235,7 @@ exports[`Accordion multiple panels 2`] = `
         <button
           aria-expanded="true"
           aria-selected="true"
-          class="c10"
+          class="c3"
           role="tab"
           style="z-index: 1;"
           type="button"
@@ -5479,7 +5247,7 @@ exports[`Accordion multiple panels 2`] = `
               class="c5"
             >
               <h4
-                class="c11"
+                class="c10"
               >
                 Panel 2
               </h4>
@@ -5652,64 +5420,6 @@ exports[`Accordion multiple panels 3`] = `
   flex-direction: column;
 }
 
-.c10 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  color: inherit;
-  outline: none;
-  border: none;
-  padding: 0;
-  text-align: inherit;
-}
-
-.c10:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c10:focus > circle,
-.c10:focus > ellipse,
-.c10:focus > line,
-.c10:focus > path,
-.c10:focus > polygon,
-.c10:focus > polyline,
-.c10:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c10:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c10:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c10:focus:not(:focus-visible) > circle,
-.c10:focus:not(:focus-visible) > ellipse,
-.c10:focus:not(:focus-visible) > line,
-.c10:focus:not(:focus-visible) > path,
-.c10:focus:not(:focus-visible) > polygon,
-.c10:focus:not(:focus-visible) > polyline,
-.c10:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c10:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
 .c3 {
   display: inline-block;
   box-sizing: border-box;
@@ -5728,47 +5438,47 @@ exports[`Accordion multiple panels 3`] = `
   text-align: inherit;
 }
 
-.c3:focus {
+.c3:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
+.c3:focus:not(:hover) > circle,
+.c3:focus:not(:hover) > ellipse,
+.c3:focus:not(:hover) > line,
+.c3:focus:not(:hover) > path,
+.c3:focus:not(:hover) > polygon,
+.c3:focus:not(:hover) > polyline,
+.c3:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus::-moz-focus-inner {
+.c3:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c3:focus:not(:focus-visible) {
+.c3:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
+.c3:focus:not(:focus-visible):not(:hover) > circle,
+.c3:focus:not(:focus-visible):not(:hover) > ellipse,
+.c3:focus:not(:focus-visible):not(:hover) > line,
+.c3:focus:not(:focus-visible):not(:hover) > path,
+.c3:focus:not(:focus-visible):not(:hover) > polygon,
+.c3:focus:not(:focus-visible):not(:hover) > polyline,
+.c3:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
+.c3:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c11 {
+.c10 {
   font-size: 18px;
   line-height: 24px;
   max-width: 432px;
@@ -5814,7 +5524,7 @@ exports[`Accordion multiple panels 3`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c11 {
+  .c10 {
     font-size: 16px;
     line-height: 22px;
     max-width: 384px;
@@ -5889,7 +5599,7 @@ exports[`Accordion multiple panels 3`] = `
         <button
           aria-expanded="true"
           aria-selected="true"
-          class="c10"
+          class="c3"
           role="tab"
           style=""
           type="button"
@@ -5901,7 +5611,7 @@ exports[`Accordion multiple panels 3`] = `
               class="c5"
             >
               <h4
-                class="c11"
+                class="c10"
               >
                 Panel 2
               </h4>
@@ -6092,101 +5802,43 @@ exports[`Accordion multiple panels 4`] = `
   text-align: inherit;
 }
 
-.c3:focus {
+.c3:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
+.c3:focus:not(:hover) > circle,
+.c3:focus:not(:hover) > ellipse,
+.c3:focus:not(:hover) > line,
+.c3:focus:not(:hover) > path,
+.c3:focus:not(:hover) > polygon,
+.c3:focus:not(:hover) > polyline,
+.c3:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus::-moz-focus-inner {
+.c3:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c3:focus:not(:focus-visible) {
+.c3:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
+.c3:focus:not(:focus-visible):not(:hover) > circle,
+.c3:focus:not(:focus-visible):not(:hover) > ellipse,
+.c3:focus:not(:focus-visible):not(:hover) > line,
+.c3:focus:not(:focus-visible):not(:hover) > path,
+.c3:focus:not(:focus-visible):not(:hover) > polygon,
+.c3:focus:not(:focus-visible):not(:hover) > polyline,
+.c3:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c10 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  color: inherit;
-  outline: none;
-  border: none;
-  padding: 0;
-  text-align: inherit;
-}
-
-.c10:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c10:focus > circle,
-.c10:focus > ellipse,
-.c10:focus > line,
-.c10:focus > path,
-.c10:focus > polygon,
-.c10:focus > polyline,
-.c10:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c10:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c10:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c10:focus:not(:focus-visible) > circle,
-.c10:focus:not(:focus-visible) > ellipse,
-.c10:focus:not(:focus-visible) > line,
-.c10:focus:not(:focus-visible) > path,
-.c10:focus:not(:focus-visible) > polygon,
-.c10:focus:not(:focus-visible) > polyline,
-.c10:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c10:focus:not(:focus-visible)::-moz-focus-inner {
+.c3:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -6197,7 +5849,7 @@ exports[`Accordion multiple panels 4`] = `
   font-weight: 600;
 }
 
-.c11 {
+.c10 {
   font-size: 18px;
   line-height: 24px;
   max-width: 432px;
@@ -6244,7 +5896,7 @@ exports[`Accordion multiple panels 4`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c11 {
+  .c10 {
     font-size: 16px;
     line-height: 22px;
     max-width: 384px;
@@ -6311,7 +5963,7 @@ exports[`Accordion multiple panels 4`] = `
         <button
           aria-expanded="false"
           aria-selected="false"
-          class="c10"
+          class="c3"
           role="tab"
           style="z-index: 1;"
           type="button"
@@ -6323,7 +5975,7 @@ exports[`Accordion multiple panels 4`] = `
               class="c5"
             >
               <h4
-                class="c11"
+                class="c10"
               >
                 Panel 2
               </h4>
@@ -6494,64 +6146,6 @@ exports[`Accordion multiple panels 5`] = `
   flex-direction: column;
 }
 
-.c10 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  color: inherit;
-  outline: none;
-  border: none;
-  padding: 0;
-  text-align: inherit;
-}
-
-.c10:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c10:focus > circle,
-.c10:focus > ellipse,
-.c10:focus > line,
-.c10:focus > path,
-.c10:focus > polygon,
-.c10:focus > polyline,
-.c10:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c10:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c10:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c10:focus:not(:focus-visible) > circle,
-.c10:focus:not(:focus-visible) > ellipse,
-.c10:focus:not(:focus-visible) > line,
-.c10:focus:not(:focus-visible) > path,
-.c10:focus:not(:focus-visible) > polygon,
-.c10:focus:not(:focus-visible) > polyline,
-.c10:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c10:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
 .c3 {
   display: inline-block;
   box-sizing: border-box;
@@ -6570,47 +6164,47 @@ exports[`Accordion multiple panels 5`] = `
   text-align: inherit;
 }
 
-.c3:focus {
+.c3:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
+.c3:focus:not(:hover) > circle,
+.c3:focus:not(:hover) > ellipse,
+.c3:focus:not(:hover) > line,
+.c3:focus:not(:hover) > path,
+.c3:focus:not(:hover) > polygon,
+.c3:focus:not(:hover) > polyline,
+.c3:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus::-moz-focus-inner {
+.c3:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c3:focus:not(:focus-visible) {
+.c3:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
+.c3:focus:not(:focus-visible):not(:hover) > circle,
+.c3:focus:not(:focus-visible):not(:hover) > ellipse,
+.c3:focus:not(:focus-visible):not(:hover) > line,
+.c3:focus:not(:focus-visible):not(:hover) > path,
+.c3:focus:not(:focus-visible):not(:hover) > polygon,
+.c3:focus:not(:focus-visible):not(:hover) > polyline,
+.c3:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
+.c3:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c11 {
+.c10 {
   font-size: 18px;
   line-height: 24px;
   max-width: 432px;
@@ -6656,7 +6250,7 @@ exports[`Accordion multiple panels 5`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c11 {
+  .c10 {
     font-size: 16px;
     line-height: 22px;
     max-width: 384px;
@@ -6729,7 +6323,7 @@ exports[`Accordion multiple panels 5`] = `
         <button
           aria-expanded="false"
           aria-selected="false"
-          class="c10"
+          class="c3"
           role="tab"
           style=""
           type="button"
@@ -6741,7 +6335,7 @@ exports[`Accordion multiple panels 5`] = `
               class="c5"
             >
               <h4
-                class="c11"
+                class="c10"
               >
                 Panel 2
               </h4>
@@ -6951,43 +6545,43 @@ exports[`Accordion should have no accessibility violations 1`] = `
   text-align: inherit;
 }
 
-.c3:focus {
+.c3:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
+.c3:focus:not(:hover) > circle,
+.c3:focus:not(:hover) > ellipse,
+.c3:focus:not(:hover) > line,
+.c3:focus:not(:hover) > path,
+.c3:focus:not(:hover) > polygon,
+.c3:focus:not(:hover) > polyline,
+.c3:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus::-moz-focus-inner {
+.c3:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c3:focus:not(:focus-visible) {
+.c3:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
+.c3:focus:not(:focus-visible):not(:hover) > circle,
+.c3:focus:not(:focus-visible):not(:hover) > ellipse,
+.c3:focus:not(:focus-visible):not(:hover) > line,
+.c3:focus:not(:focus-visible):not(:hover) > path,
+.c3:focus:not(:focus-visible):not(:hover) > polygon,
+.c3:focus:not(:focus-visible):not(:hover) > polyline,
+.c3:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
+.c3:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -7230,43 +6824,43 @@ exports[`Accordion theme hover of hover.heading.color 1`] = `
   text-align: inherit;
 }
 
-.c3:focus {
+.c3:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
+.c3:focus:not(:hover) > circle,
+.c3:focus:not(:hover) > ellipse,
+.c3:focus:not(:hover) > line,
+.c3:focus:not(:hover) > path,
+.c3:focus:not(:hover) > polygon,
+.c3:focus:not(:hover) > polyline,
+.c3:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus::-moz-focus-inner {
+.c3:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c3:focus:not(:focus-visible) {
+.c3:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
+.c3:focus:not(:focus-visible):not(:hover) > circle,
+.c3:focus:not(:focus-visible):not(:hover) > ellipse,
+.c3:focus:not(:focus-visible):not(:hover) > line,
+.c3:focus:not(:focus-visible):not(:hover) > path,
+.c3:focus:not(:focus-visible):not(:hover) > polygon,
+.c3:focus:not(:focus-visible):not(:hover) > polyline,
+.c3:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
+.c3:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -7546,43 +7140,43 @@ exports[`Accordion wrapped panel 1`] = `
   text-align: inherit;
 }
 
-.c3:focus {
+.c3:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
+.c3:focus:not(:hover) > circle,
+.c3:focus:not(:hover) > ellipse,
+.c3:focus:not(:hover) > line,
+.c3:focus:not(:hover) > path,
+.c3:focus:not(:hover) > polygon,
+.c3:focus:not(:hover) > polyline,
+.c3:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus::-moz-focus-inner {
+.c3:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c3:focus:not(:focus-visible) {
+.c3:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
+.c3:focus:not(:focus-visible):not(:hover) > circle,
+.c3:focus:not(:focus-visible):not(:hover) > ellipse,
+.c3:focus:not(:focus-visible):not(:hover) > line,
+.c3:focus:not(:focus-visible):not(:hover) > path,
+.c3:focus:not(:focus-visible):not(:hover) > polygon,
+.c3:focus:not(:focus-visible):not(:hover) > polyline,
+.c3:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
+.c3:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -7870,64 +7464,6 @@ exports[`Accordion wrapped panel 2`] = `
   flex-direction: column;
 }
 
-.c10 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  color: inherit;
-  outline: none;
-  border: none;
-  padding: 0;
-  text-align: inherit;
-}
-
-.c10:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c10:focus > circle,
-.c10:focus > ellipse,
-.c10:focus > line,
-.c10:focus > path,
-.c10:focus > polygon,
-.c10:focus > polyline,
-.c10:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c10:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c10:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c10:focus:not(:focus-visible) > circle,
-.c10:focus:not(:focus-visible) > ellipse,
-.c10:focus:not(:focus-visible) > line,
-.c10:focus:not(:focus-visible) > path,
-.c10:focus:not(:focus-visible) > polygon,
-.c10:focus:not(:focus-visible) > polyline,
-.c10:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c10:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
 .c3 {
   display: inline-block;
   box-sizing: border-box;
@@ -7946,47 +7482,47 @@ exports[`Accordion wrapped panel 2`] = `
   text-align: inherit;
 }
 
-.c3:focus {
+.c3:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
+.c3:focus:not(:hover) > circle,
+.c3:focus:not(:hover) > ellipse,
+.c3:focus:not(:hover) > line,
+.c3:focus:not(:hover) > path,
+.c3:focus:not(:hover) > polygon,
+.c3:focus:not(:hover) > polyline,
+.c3:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus::-moz-focus-inner {
+.c3:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c3:focus:not(:focus-visible) {
+.c3:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
+.c3:focus:not(:focus-visible):not(:hover) > circle,
+.c3:focus:not(:focus-visible):not(:hover) > ellipse,
+.c3:focus:not(:focus-visible):not(:hover) > line,
+.c3:focus:not(:focus-visible):not(:hover) > path,
+.c3:focus:not(:focus-visible):not(:hover) > polygon,
+.c3:focus:not(:focus-visible):not(:hover) > polyline,
+.c3:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
+.c3:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c11 {
+.c10 {
   font-size: 18px;
   line-height: 24px;
   max-width: 432px;
@@ -8032,7 +7568,7 @@ exports[`Accordion wrapped panel 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c11 {
+  .c10 {
     font-size: 16px;
     line-height: 22px;
     max-width: 384px;
@@ -8107,7 +7643,7 @@ exports[`Accordion wrapped panel 2`] = `
         <button
           aria-expanded="false"
           aria-selected="false"
-          class="c10"
+          class="c3"
           role="tab"
           type="button"
         >
@@ -8118,7 +7654,7 @@ exports[`Accordion wrapped panel 2`] = `
               class="c5"
             >
               <h4
-                class="c11"
+                class="c10"
               >
                 Panel 2
               </h4>

--- a/src/js/components/Button/StyledButton.js
+++ b/src/js/components/Button/StyledButton.js
@@ -199,7 +199,7 @@ const StyledButton = styled.button`
   ${(props) => !props.plain && basicStyle(props)}
   ${(props) => props.primary && primaryStyle(props)}
 
-  ${(props) => !props.disabled && !props.selected && !props.focus && hoverStyle}
+  ${(props) => !props.disabled && !props.selected && hoverStyle}
 
   ${(props) => !props.disabled && props.active && activeButtonStyle(props)}
   ${(props) =>
@@ -208,11 +208,11 @@ const StyledButton = styled.button`
     props.theme.button.disabled &&
     disabledButtonStyle(props)}
 
-  &:focus {
+  &:focus:not(:hover) {
     ${(props) => (!props.plain || props.focusIndicator) && focusStyle()}
   }
 
-  &:focus:not(:focus-visible) {
+  &:focus:not(:focus-visible):not(:hover) {
     ${unfocusStyle()}
   }
 

--- a/src/js/components/Button/__tests__/Button-test.tsx
+++ b/src/js/components/Button/__tests__/Button-test.tsx
@@ -237,7 +237,7 @@ describe('Button', () => {
     expect(document.body).not.toHaveFocus();
 
     expect(button).toHaveStyleRule('box-shadow', '0 0 2px 2px #6FFFB0', {
-      modifier: ':focus',
+      modifier: ':focus:not(:hover)',
     });
     expect(container.firstChild).toMatchSnapshot();
   });

--- a/src/js/components/Button/__tests__/__snapshots__/Button-test.tsx.snap
+++ b/src/js/components/Button/__tests__/__snapshots__/Button-test.tsx.snap
@@ -30,43 +30,43 @@ exports[`Button a11yTitle 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -131,43 +131,43 @@ exports[`Button active + primary 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -225,43 +225,43 @@ exports[`Button active 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -317,43 +317,43 @@ exports[`Button as 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -459,43 +459,43 @@ exports[`Button badge should apply background 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c3:focus {
+.c3:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
+.c3:focus:not(:hover) > circle,
+.c3:focus:not(:hover) > ellipse,
+.c3:focus:not(:hover) > line,
+.c3:focus:not(:hover) > path,
+.c3:focus:not(:hover) > polygon,
+.c3:focus:not(:hover) > polyline,
+.c3:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus::-moz-focus-inner {
+.c3:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c3:focus:not(:focus-visible) {
+.c3:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
+.c3:focus:not(:focus-visible):not(:hover) > circle,
+.c3:focus:not(:focus-visible):not(:hover) > ellipse,
+.c3:focus:not(:focus-visible):not(:hover) > line,
+.c3:focus:not(:focus-visible):not(:hover) > path,
+.c3:focus:not(:focus-visible):not(:hover) > polygon,
+.c3:focus:not(:focus-visible):not(:hover) > polyline,
+.c3:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
+.c3:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -625,43 +625,43 @@ exports[`Button badge should be offset from top-right corner 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c3:focus {
+.c3:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
+.c3:focus:not(:hover) > circle,
+.c3:focus:not(:hover) > ellipse,
+.c3:focus:not(:hover) > line,
+.c3:focus:not(:hover) > path,
+.c3:focus:not(:hover) > polygon,
+.c3:focus:not(:hover) > polyline,
+.c3:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus::-moz-focus-inner {
+.c3:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c3:focus:not(:focus-visible) {
+.c3:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
+.c3:focus:not(:focus-visible):not(:hover) > circle,
+.c3:focus:not(:focus-visible):not(:hover) > ellipse,
+.c3:focus:not(:focus-visible):not(:hover) > line,
+.c3:focus:not(:focus-visible):not(:hover) > path,
+.c3:focus:not(:focus-visible):not(:hover) > polygon,
+.c3:focus:not(:focus-visible):not(:hover) > polyline,
+.c3:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
+.c3:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -792,43 +792,43 @@ exports[`Button badge should display "+" when number is greater than max 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c3:focus {
+.c3:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
+.c3:focus:not(:hover) > circle,
+.c3:focus:not(:hover) > ellipse,
+.c3:focus:not(:hover) > line,
+.c3:focus:not(:hover) > path,
+.c3:focus:not(:hover) > polygon,
+.c3:focus:not(:hover) > polyline,
+.c3:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus::-moz-focus-inner {
+.c3:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c3:focus:not(:focus-visible) {
+.c3:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
+.c3:focus:not(:focus-visible):not(:hover) > circle,
+.c3:focus:not(:focus-visible):not(:hover) > ellipse,
+.c3:focus:not(:focus-visible):not(:hover) > line,
+.c3:focus:not(:focus-visible):not(:hover) > path,
+.c3:focus:not(:focus-visible):not(:hover) > polygon,
+.c3:focus:not(:focus-visible):not(:hover) > polyline,
+.c3:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
+.c3:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -965,43 +965,43 @@ exports[`Button badge should display number content 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c3:focus {
+.c3:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
+.c3:focus:not(:hover) > circle,
+.c3:focus:not(:hover) > ellipse,
+.c3:focus:not(:hover) > line,
+.c3:focus:not(:hover) > path,
+.c3:focus:not(:hover) > polygon,
+.c3:focus:not(:hover) > polyline,
+.c3:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus::-moz-focus-inner {
+.c3:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c3:focus:not(:focus-visible) {
+.c3:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
+.c3:focus:not(:focus-visible):not(:hover) > circle,
+.c3:focus:not(:focus-visible):not(:hover) > ellipse,
+.c3:focus:not(:focus-visible):not(:hover) > line,
+.c3:focus:not(:focus-visible):not(:hover) > path,
+.c3:focus:not(:focus-visible):not(:hover) > polygon,
+.c3:focus:not(:focus-visible):not(:hover) > polyline,
+.c3:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
+.c3:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -1149,43 +1149,43 @@ exports[`Button badge should render custom element 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c3:focus {
+.c3:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
+.c3:focus:not(:hover) > circle,
+.c3:focus:not(:hover) > ellipse,
+.c3:focus:not(:hover) > line,
+.c3:focus:not(:hover) > path,
+.c3:focus:not(:hover) > polygon,
+.c3:focus:not(:hover) > polyline,
+.c3:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus::-moz-focus-inner {
+.c3:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c3:focus:not(:focus-visible) {
+.c3:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
+.c3:focus:not(:focus-visible):not(:hover) > circle,
+.c3:focus:not(:focus-visible):not(:hover) > ellipse,
+.c3:focus:not(:focus-visible):not(:hover) > line,
+.c3:focus:not(:focus-visible):not(:hover) > path,
+.c3:focus:not(:focus-visible):not(:hover) > polygon,
+.c3:focus:not(:focus-visible):not(:hover) > polyline,
+.c3:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
+.c3:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -1343,43 +1343,43 @@ exports[`Button badge should render relative to contents when button has no
   padding: 12px;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -1469,43 +1469,43 @@ exports[`Button basic 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -1561,43 +1561,43 @@ exports[`Button children function 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -1658,43 +1658,43 @@ exports[`Button children function with disabled prop 1`] = `
   transition-timing-function: ease-in-out;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -1727,43 +1727,43 @@ exports[`Button children function with disabled prop 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c3:focus {
+.c3:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
+.c3:focus:not(:hover) > circle,
+.c3:focus:not(:hover) > ellipse,
+.c3:focus:not(:hover) > line,
+.c3:focus:not(:hover) > path,
+.c3:focus:not(:hover) > polygon,
+.c3:focus:not(:hover) > polyline,
+.c3:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus::-moz-focus-inner {
+.c3:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c3:focus:not(:focus-visible) {
+.c3:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
+.c3:focus:not(:focus-visible):not(:hover) > circle,
+.c3:focus:not(:focus-visible):not(:hover) > ellipse,
+.c3:focus:not(:focus-visible):not(:hover) > line,
+.c3:focus:not(:focus-visible):not(:hover) > path,
+.c3:focus:not(:focus-visible):not(:hover) > polygon,
+.c3:focus:not(:focus-visible):not(:hover) > polyline,
+.c3:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
+.c3:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -1834,43 +1834,43 @@ exports[`Button color 1`] = `
   box-shadow: 0px 0px 0px 2px #6FFFB0;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -1906,43 +1906,43 @@ exports[`Button color 1`] = `
   box-shadow: 0px 0px 0px 2px #6FFFB0;
 }
 
-.c2:focus {
+.c2:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c2:focus > circle,
-.c2:focus > ellipse,
-.c2:focus > line,
-.c2:focus > path,
-.c2:focus > polygon,
-.c2:focus > polyline,
-.c2:focus > rect {
+.c2:focus:not(:hover) > circle,
+.c2:focus:not(:hover) > ellipse,
+.c2:focus:not(:hover) > line,
+.c2:focus:not(:hover) > path,
+.c2:focus:not(:hover) > polygon,
+.c2:focus:not(:hover) > polyline,
+.c2:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c2:focus::-moz-focus-inner {
+.c2:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c2:focus:not(:focus-visible) {
+.c2:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c2:focus:not(:focus-visible) > circle,
-.c2:focus:not(:focus-visible) > ellipse,
-.c2:focus:not(:focus-visible) > line,
-.c2:focus:not(:focus-visible) > path,
-.c2:focus:not(:focus-visible) > polygon,
-.c2:focus:not(:focus-visible) > polyline,
-.c2:focus:not(:focus-visible) > rect {
+.c2:focus:not(:focus-visible):not(:hover) > circle,
+.c2:focus:not(:focus-visible):not(:hover) > ellipse,
+.c2:focus:not(:focus-visible):not(:hover) > line,
+.c2:focus:not(:focus-visible):not(:hover) > path,
+.c2:focus:not(:focus-visible):not(:hover) > polygon,
+.c2:focus:not(:focus-visible):not(:hover) > polyline,
+.c2:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c2:focus:not(:focus-visible)::-moz-focus-inner {
+.c2:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -1978,43 +1978,43 @@ exports[`Button color 1`] = `
   box-shadow: 0px 0px 0px 2px #111111;
 }
 
-.c3:focus {
+.c3:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
+.c3:focus:not(:hover) > circle,
+.c3:focus:not(:hover) > ellipse,
+.c3:focus:not(:hover) > line,
+.c3:focus:not(:hover) > path,
+.c3:focus:not(:hover) > polygon,
+.c3:focus:not(:hover) > polyline,
+.c3:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus::-moz-focus-inner {
+.c3:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c3:focus:not(:focus-visible) {
+.c3:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
+.c3:focus:not(:focus-visible):not(:hover) > circle,
+.c3:focus:not(:focus-visible):not(:hover) > ellipse,
+.c3:focus:not(:focus-visible):not(:hover) > line,
+.c3:focus:not(:focus-visible):not(:hover) > path,
+.c3:focus:not(:focus-visible):not(:hover) > polygon,
+.c3:focus:not(:focus-visible):not(:hover) > polyline,
+.c3:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
+.c3:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -2050,43 +2050,43 @@ exports[`Button color 1`] = `
   box-shadow: 0px 0px 0px 2px #123;
 }
 
-.c4:focus {
+.c4:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c4:focus > circle,
-.c4:focus > ellipse,
-.c4:focus > line,
-.c4:focus > path,
-.c4:focus > polygon,
-.c4:focus > polyline,
-.c4:focus > rect {
+.c4:focus:not(:hover) > circle,
+.c4:focus:not(:hover) > ellipse,
+.c4:focus:not(:hover) > line,
+.c4:focus:not(:hover) > path,
+.c4:focus:not(:hover) > polygon,
+.c4:focus:not(:hover) > polyline,
+.c4:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c4:focus::-moz-focus-inner {
+.c4:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c4:focus:not(:focus-visible) {
+.c4:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c4:focus:not(:focus-visible) > circle,
-.c4:focus:not(:focus-visible) > ellipse,
-.c4:focus:not(:focus-visible) > line,
-.c4:focus:not(:focus-visible) > path,
-.c4:focus:not(:focus-visible) > polygon,
-.c4:focus:not(:focus-visible) > polyline,
-.c4:focus:not(:focus-visible) > rect {
+.c4:focus:not(:focus-visible):not(:hover) > circle,
+.c4:focus:not(:focus-visible):not(:hover) > ellipse,
+.c4:focus:not(:focus-visible):not(:hover) > line,
+.c4:focus:not(:focus-visible):not(:hover) > path,
+.c4:focus:not(:focus-visible):not(:hover) > polygon,
+.c4:focus:not(:focus-visible):not(:hover) > polyline,
+.c4:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c4:focus:not(:focus-visible)::-moz-focus-inner {
+.c4:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -2190,43 +2190,43 @@ exports[`Button disabled 1`] = `
   transition-timing-function: ease-in-out;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -2260,43 +2260,43 @@ exports[`Button disabled 1`] = `
   transition-timing-function: ease-in-out;
 }
 
-.c2:focus {
+.c2:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c2:focus > circle,
-.c2:focus > ellipse,
-.c2:focus > line,
-.c2:focus > path,
-.c2:focus > polygon,
-.c2:focus > polyline,
-.c2:focus > rect {
+.c2:focus:not(:hover) > circle,
+.c2:focus:not(:hover) > ellipse,
+.c2:focus:not(:hover) > line,
+.c2:focus:not(:hover) > path,
+.c2:focus:not(:hover) > polygon,
+.c2:focus:not(:hover) > polyline,
+.c2:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c2:focus::-moz-focus-inner {
+.c2:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c2:focus:not(:focus-visible) {
+.c2:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c2:focus:not(:focus-visible) > circle,
-.c2:focus:not(:focus-visible) > ellipse,
-.c2:focus:not(:focus-visible) > line,
-.c2:focus:not(:focus-visible) > path,
-.c2:focus:not(:focus-visible) > polygon,
-.c2:focus:not(:focus-visible) > polyline,
-.c2:focus:not(:focus-visible) > rect {
+.c2:focus:not(:focus-visible):not(:hover) > circle,
+.c2:focus:not(:focus-visible):not(:hover) > ellipse,
+.c2:focus:not(:focus-visible):not(:hover) > line,
+.c2:focus:not(:focus-visible):not(:hover) > path,
+.c2:focus:not(:focus-visible):not(:hover) > polygon,
+.c2:focus:not(:focus-visible):not(:hover) > polyline,
+.c2:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c2:focus:not(:focus-visible)::-moz-focus-inner {
+.c2:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -2320,43 +2320,43 @@ exports[`Button disabled 1`] = `
   cursor: default;
 }
 
-.c3:focus {
+.c3:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
+.c3:focus:not(:hover) > circle,
+.c3:focus:not(:hover) > ellipse,
+.c3:focus:not(:hover) > line,
+.c3:focus:not(:hover) > path,
+.c3:focus:not(:hover) > polygon,
+.c3:focus:not(:hover) > polyline,
+.c3:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus::-moz-focus-inner {
+.c3:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c3:focus:not(:focus-visible) {
+.c3:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
+.c3:focus:not(:focus-visible):not(:hover) > circle,
+.c3:focus:not(:focus-visible):not(:hover) > ellipse,
+.c3:focus:not(:focus-visible):not(:hover) > line,
+.c3:focus:not(:focus-visible):not(:hover) > path,
+.c3:focus:not(:focus-visible):not(:hover) > polygon,
+.c3:focus:not(:focus-visible):not(:hover) > polyline,
+.c3:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
+.c3:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -2382,43 +2382,43 @@ exports[`Button disabled 1`] = `
   padding: 12px;
 }
 
-.c4:focus {
+.c4:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c4:focus > circle,
-.c4:focus > ellipse,
-.c4:focus > line,
-.c4:focus > path,
-.c4:focus > polygon,
-.c4:focus > polyline,
-.c4:focus > rect {
+.c4:focus:not(:hover) > circle,
+.c4:focus:not(:hover) > ellipse,
+.c4:focus:not(:hover) > line,
+.c4:focus:not(:hover) > path,
+.c4:focus:not(:hover) > polygon,
+.c4:focus:not(:hover) > polyline,
+.c4:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c4:focus::-moz-focus-inner {
+.c4:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c4:focus:not(:focus-visible) {
+.c4:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c4:focus:not(:focus-visible) > circle,
-.c4:focus:not(:focus-visible) > ellipse,
-.c4:focus:not(:focus-visible) > line,
-.c4:focus:not(:focus-visible) > path,
-.c4:focus:not(:focus-visible) > polygon,
-.c4:focus:not(:focus-visible) > polyline,
-.c4:focus:not(:focus-visible) > rect {
+.c4:focus:not(:focus-visible):not(:hover) > circle,
+.c4:focus:not(:focus-visible):not(:hover) > ellipse,
+.c4:focus:not(:focus-visible):not(:hover) > line,
+.c4:focus:not(:focus-visible):not(:hover) > path,
+.c4:focus:not(:focus-visible):not(:hover) > polygon,
+.c4:focus:not(:focus-visible):not(:hover) > polyline,
+.c4:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c4:focus:not(:focus-visible)::-moz-focus-inner {
+.c4:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -2443,43 +2443,43 @@ exports[`Button disabled 1`] = `
   line-height: 0;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -2512,43 +2512,43 @@ exports[`Button disabled 1`] = `
   padding: 12px;
 }
 
-.c6:focus {
+.c6:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c6:focus > circle,
-.c6:focus > ellipse,
-.c6:focus > line,
-.c6:focus > path,
-.c6:focus > polygon,
-.c6:focus > polyline,
-.c6:focus > rect {
+.c6:focus:not(:hover) > circle,
+.c6:focus:not(:hover) > ellipse,
+.c6:focus:not(:hover) > line,
+.c6:focus:not(:hover) > path,
+.c6:focus:not(:hover) > polygon,
+.c6:focus:not(:hover) > polyline,
+.c6:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c6:focus::-moz-focus-inner {
+.c6:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c6:focus:not(:focus-visible) {
+.c6:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c6:focus:not(:focus-visible) > circle,
-.c6:focus:not(:focus-visible) > ellipse,
-.c6:focus:not(:focus-visible) > line,
-.c6:focus:not(:focus-visible) > path,
-.c6:focus:not(:focus-visible) > polygon,
-.c6:focus:not(:focus-visible) > polyline,
-.c6:focus:not(:focus-visible) > rect {
+.c6:focus:not(:focus-visible):not(:hover) > circle,
+.c6:focus:not(:focus-visible):not(:hover) > ellipse,
+.c6:focus:not(:focus-visible):not(:hover) > line,
+.c6:focus:not(:focus-visible):not(:hover) > path,
+.c6:focus:not(:focus-visible):not(:hover) > polygon,
+.c6:focus:not(:focus-visible):not(:hover) > polyline,
+.c6:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c6:focus:not(:focus-visible)::-moz-focus-inner {
+.c6:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -2705,43 +2705,43 @@ exports[`Button fill 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -2774,43 +2774,43 @@ exports[`Button fill 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c2:focus {
+.c2:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c2:focus > circle,
-.c2:focus > ellipse,
-.c2:focus > line,
-.c2:focus > path,
-.c2:focus > polygon,
-.c2:focus > polyline,
-.c2:focus > rect {
+.c2:focus:not(:hover) > circle,
+.c2:focus:not(:hover) > ellipse,
+.c2:focus:not(:hover) > line,
+.c2:focus:not(:hover) > path,
+.c2:focus:not(:hover) > polygon,
+.c2:focus:not(:hover) > polyline,
+.c2:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c2:focus::-moz-focus-inner {
+.c2:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c2:focus:not(:focus-visible) {
+.c2:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c2:focus:not(:focus-visible) > circle,
-.c2:focus:not(:focus-visible) > ellipse,
-.c2:focus:not(:focus-visible) > line,
-.c2:focus:not(:focus-visible) > path,
-.c2:focus:not(:focus-visible) > polygon,
-.c2:focus:not(:focus-visible) > polyline,
-.c2:focus:not(:focus-visible) > rect {
+.c2:focus:not(:focus-visible):not(:hover) > circle,
+.c2:focus:not(:focus-visible):not(:hover) > ellipse,
+.c2:focus:not(:focus-visible):not(:hover) > line,
+.c2:focus:not(:focus-visible):not(:hover) > path,
+.c2:focus:not(:focus-visible):not(:hover) > polygon,
+.c2:focus:not(:focus-visible):not(:hover) > polyline,
+.c2:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c2:focus:not(:focus-visible)::-moz-focus-inner {
+.c2:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -2844,43 +2844,43 @@ exports[`Button fill 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c3:focus {
+.c3:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
+.c3:focus:not(:hover) > circle,
+.c3:focus:not(:hover) > ellipse,
+.c3:focus:not(:hover) > line,
+.c3:focus:not(:hover) > path,
+.c3:focus:not(:hover) > polygon,
+.c3:focus:not(:hover) > polyline,
+.c3:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus::-moz-focus-inner {
+.c3:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c3:focus:not(:focus-visible) {
+.c3:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
+.c3:focus:not(:focus-visible):not(:hover) > circle,
+.c3:focus:not(:focus-visible):not(:hover) > ellipse,
+.c3:focus:not(:focus-visible):not(:hover) > line,
+.c3:focus:not(:focus-visible):not(:hover) > path,
+.c3:focus:not(:focus-visible):not(:hover) > polygon,
+.c3:focus:not(:focus-visible):not(:hover) > polyline,
+.c3:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
+.c3:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -2914,43 +2914,43 @@ exports[`Button fill 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c4:focus {
+.c4:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c4:focus > circle,
-.c4:focus > ellipse,
-.c4:focus > line,
-.c4:focus > path,
-.c4:focus > polygon,
-.c4:focus > polyline,
-.c4:focus > rect {
+.c4:focus:not(:hover) > circle,
+.c4:focus:not(:hover) > ellipse,
+.c4:focus:not(:hover) > line,
+.c4:focus:not(:hover) > path,
+.c4:focus:not(:hover) > polygon,
+.c4:focus:not(:hover) > polyline,
+.c4:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c4:focus::-moz-focus-inner {
+.c4:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c4:focus:not(:focus-visible) {
+.c4:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c4:focus:not(:focus-visible) > circle,
-.c4:focus:not(:focus-visible) > ellipse,
-.c4:focus:not(:focus-visible) > line,
-.c4:focus:not(:focus-visible) > path,
-.c4:focus:not(:focus-visible) > polygon,
-.c4:focus:not(:focus-visible) > polyline,
-.c4:focus:not(:focus-visible) > rect {
+.c4:focus:not(:focus-visible):not(:hover) > circle,
+.c4:focus:not(:focus-visible):not(:hover) > ellipse,
+.c4:focus:not(:focus-visible):not(:hover) > line,
+.c4:focus:not(:focus-visible):not(:hover) > path,
+.c4:focus:not(:focus-visible):not(:hover) > polygon,
+.c4:focus:not(:focus-visible):not(:hover) > polyline,
+.c4:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c4:focus:not(:focus-visible)::-moz-focus-inner {
+.c4:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -3020,43 +3020,47 @@ exports[`Button focus 1`] = `
   transition-timing-function: ease-in-out;
 }
 
-.c1:focus {
+.c1:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -3106,43 +3110,43 @@ exports[`Button hoverIndicator as object with color 1`] = `
   color: #FFFFFF;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -3192,43 +3196,43 @@ exports[`Button hoverIndicator as object with invalid color 1`] = `
   color: #000000;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -3278,43 +3282,43 @@ exports[`Button hoverIndicator background 1`] = `
   color: #000000;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -3364,43 +3368,43 @@ exports[`Button hoverIndicator color 1`] = `
   color: #FFFFFF;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -3456,43 +3460,43 @@ exports[`Button href 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -3580,43 +3584,43 @@ exports[`Button icon label 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -3685,43 +3689,43 @@ exports[`Button primary 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -3809,43 +3813,43 @@ exports[`Button reverse icon label 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -4011,43 +4015,43 @@ exports[`Button size 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -4080,43 +4084,43 @@ exports[`Button size 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c2:focus {
+.c2:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c2:focus > circle,
-.c2:focus > ellipse,
-.c2:focus > line,
-.c2:focus > path,
-.c2:focus > polygon,
-.c2:focus > polyline,
-.c2:focus > rect {
+.c2:focus:not(:hover) > circle,
+.c2:focus:not(:hover) > ellipse,
+.c2:focus:not(:hover) > line,
+.c2:focus:not(:hover) > path,
+.c2:focus:not(:hover) > polygon,
+.c2:focus:not(:hover) > polyline,
+.c2:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c2:focus::-moz-focus-inner {
+.c2:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c2:focus:not(:focus-visible) {
+.c2:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c2:focus:not(:focus-visible) > circle,
-.c2:focus:not(:focus-visible) > ellipse,
-.c2:focus:not(:focus-visible) > line,
-.c2:focus:not(:focus-visible) > path,
-.c2:focus:not(:focus-visible) > polygon,
-.c2:focus:not(:focus-visible) > polyline,
-.c2:focus:not(:focus-visible) > rect {
+.c2:focus:not(:focus-visible):not(:hover) > circle,
+.c2:focus:not(:focus-visible):not(:hover) > ellipse,
+.c2:focus:not(:focus-visible):not(:hover) > line,
+.c2:focus:not(:focus-visible):not(:hover) > path,
+.c2:focus:not(:focus-visible):not(:hover) > polygon,
+.c2:focus:not(:focus-visible):not(:hover) > polyline,
+.c2:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c2:focus:not(:focus-visible)::-moz-focus-inner {
+.c2:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -4149,43 +4153,43 @@ exports[`Button size 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c3:focus {
+.c3:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
+.c3:focus:not(:hover) > circle,
+.c3:focus:not(:hover) > ellipse,
+.c3:focus:not(:hover) > line,
+.c3:focus:not(:hover) > path,
+.c3:focus:not(:hover) > polygon,
+.c3:focus:not(:hover) > polyline,
+.c3:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus::-moz-focus-inner {
+.c3:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c3:focus:not(:focus-visible) {
+.c3:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
+.c3:focus:not(:focus-visible):not(:hover) > circle,
+.c3:focus:not(:focus-visible):not(:hover) > ellipse,
+.c3:focus:not(:focus-visible):not(:hover) > line,
+.c3:focus:not(:focus-visible):not(:hover) > path,
+.c3:focus:not(:focus-visible):not(:hover) > polygon,
+.c3:focus:not(:focus-visible):not(:hover) > polyline,
+.c3:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
+.c3:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -4221,43 +4225,43 @@ exports[`Button size 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c4:focus {
+.c4:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c4:focus > circle,
-.c4:focus > ellipse,
-.c4:focus > line,
-.c4:focus > path,
-.c4:focus > polygon,
-.c4:focus > polyline,
-.c4:focus > rect {
+.c4:focus:not(:hover) > circle,
+.c4:focus:not(:hover) > ellipse,
+.c4:focus:not(:hover) > line,
+.c4:focus:not(:hover) > path,
+.c4:focus:not(:hover) > polygon,
+.c4:focus:not(:hover) > polyline,
+.c4:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c4:focus::-moz-focus-inner {
+.c4:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c4:focus:not(:focus-visible) {
+.c4:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c4:focus:not(:focus-visible) > circle,
-.c4:focus:not(:focus-visible) > ellipse,
-.c4:focus:not(:focus-visible) > line,
-.c4:focus:not(:focus-visible) > path,
-.c4:focus:not(:focus-visible) > polygon,
-.c4:focus:not(:focus-visible) > polyline,
-.c4:focus:not(:focus-visible) > rect {
+.c4:focus:not(:focus-visible):not(:hover) > circle,
+.c4:focus:not(:focus-visible):not(:hover) > ellipse,
+.c4:focus:not(:focus-visible):not(:hover) > line,
+.c4:focus:not(:focus-visible):not(:hover) > path,
+.c4:focus:not(:focus-visible):not(:hover) > polygon,
+.c4:focus:not(:focus-visible):not(:hover) > polyline,
+.c4:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c4:focus:not(:focus-visible)::-moz-focus-inner {
+.c4:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -4293,43 +4297,43 @@ exports[`Button size 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -4365,43 +4369,43 @@ exports[`Button size 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c6:focus {
+.c6:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c6:focus > circle,
-.c6:focus > ellipse,
-.c6:focus > line,
-.c6:focus > path,
-.c6:focus > polygon,
-.c6:focus > polyline,
-.c6:focus > rect {
+.c6:focus:not(:hover) > circle,
+.c6:focus:not(:hover) > ellipse,
+.c6:focus:not(:hover) > line,
+.c6:focus:not(:hover) > path,
+.c6:focus:not(:hover) > polygon,
+.c6:focus:not(:hover) > polyline,
+.c6:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c6:focus::-moz-focus-inner {
+.c6:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c6:focus:not(:focus-visible) {
+.c6:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c6:focus:not(:focus-visible) > circle,
-.c6:focus:not(:focus-visible) > ellipse,
-.c6:focus:not(:focus-visible) > line,
-.c6:focus:not(:focus-visible) > path,
-.c6:focus:not(:focus-visible) > polygon,
-.c6:focus:not(:focus-visible) > polyline,
-.c6:focus:not(:focus-visible) > rect {
+.c6:focus:not(:focus-visible):not(:hover) > circle,
+.c6:focus:not(:focus-visible):not(:hover) > ellipse,
+.c6:focus:not(:focus-visible):not(:hover) > line,
+.c6:focus:not(:focus-visible):not(:hover) > path,
+.c6:focus:not(:focus-visible):not(:hover) > polygon,
+.c6:focus:not(:focus-visible):not(:hover) > polyline,
+.c6:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c6:focus:not(:focus-visible)::-moz-focus-inner {
+.c6:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -4428,43 +4432,43 @@ exports[`Button size 1`] = `
   padding: 12px;
 }
 
-.c7:focus {
+.c7:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus > circle,
-.c7:focus > ellipse,
-.c7:focus > line,
-.c7:focus > path,
-.c7:focus > polygon,
-.c7:focus > polyline,
-.c7:focus > rect {
+.c7:focus:not(:hover) > circle,
+.c7:focus:not(:hover) > ellipse,
+.c7:focus:not(:hover) > line,
+.c7:focus:not(:hover) > path,
+.c7:focus:not(:hover) > polygon,
+.c7:focus:not(:hover) > polyline,
+.c7:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus::-moz-focus-inner {
+.c7:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c7:focus:not(:focus-visible) {
+.c7:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c7:focus:not(:focus-visible) > circle,
-.c7:focus:not(:focus-visible) > ellipse,
-.c7:focus:not(:focus-visible) > line,
-.c7:focus:not(:focus-visible) > path,
-.c7:focus:not(:focus-visible) > polygon,
-.c7:focus:not(:focus-visible) > polyline,
-.c7:focus:not(:focus-visible) > rect {
+.c7:focus:not(:focus-visible):not(:hover) > circle,
+.c7:focus:not(:focus-visible):not(:hover) > ellipse,
+.c7:focus:not(:focus-visible):not(:hover) > line,
+.c7:focus:not(:focus-visible):not(:hover) > path,
+.c7:focus:not(:focus-visible):not(:hover) > polygon,
+.c7:focus:not(:focus-visible):not(:hover) > polyline,
+.c7:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c7:focus:not(:focus-visible)::-moz-focus-inner {
+.c7:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -4730,43 +4734,43 @@ exports[`Button tip 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -4838,43 +4842,43 @@ exports[`Button warns about invalid icon 1`] = `
   padding: 12px;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -4919,43 +4923,43 @@ exports[`Button warns about invalid label 1`] = `
   text-align: inherit;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 

--- a/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.tsx.snap
+++ b/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.tsx.snap
@@ -131,43 +131,43 @@ exports[`Calendar change months 1`] = `
   padding: 12px;
 }
 
-.c7:focus {
+.c7:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus > circle,
-.c7:focus > ellipse,
-.c7:focus > line,
-.c7:focus > path,
-.c7:focus > polygon,
-.c7:focus > polyline,
-.c7:focus > rect {
+.c7:focus:not(:hover) > circle,
+.c7:focus:not(:hover) > ellipse,
+.c7:focus:not(:hover) > line,
+.c7:focus:not(:hover) > path,
+.c7:focus:not(:hover) > polygon,
+.c7:focus:not(:hover) > polyline,
+.c7:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus::-moz-focus-inner {
+.c7:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c7:focus:not(:focus-visible) {
+.c7:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c7:focus:not(:focus-visible) > circle,
-.c7:focus:not(:focus-visible) > ellipse,
-.c7:focus:not(:focus-visible) > line,
-.c7:focus:not(:focus-visible) > path,
-.c7:focus:not(:focus-visible) > polygon,
-.c7:focus:not(:focus-visible) > polyline,
-.c7:focus:not(:focus-visible) > rect {
+.c7:focus:not(:focus-visible):not(:hover) > circle,
+.c7:focus:not(:focus-visible):not(:hover) > ellipse,
+.c7:focus:not(:focus-visible):not(:hover) > line,
+.c7:focus:not(:focus-visible):not(:hover) > path,
+.c7:focus:not(:focus-visible):not(:hover) > polygon,
+.c7:focus:not(:focus-visible):not(:hover) > polyline,
+.c7:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c7:focus:not(:focus-visible)::-moz-focus-inner {
+.c7:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -189,43 +189,43 @@ exports[`Calendar change months 1`] = `
   text-align: inherit;
 }
 
-.c13:focus {
+.c13:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus > circle,
-.c13:focus > ellipse,
-.c13:focus > line,
-.c13:focus > path,
-.c13:focus > polygon,
-.c13:focus > polyline,
-.c13:focus > rect {
+.c13:focus:not(:hover) > circle,
+.c13:focus:not(:hover) > ellipse,
+.c13:focus:not(:hover) > line,
+.c13:focus:not(:hover) > path,
+.c13:focus:not(:hover) > polygon,
+.c13:focus:not(:hover) > polyline,
+.c13:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus::-moz-focus-inner {
+.c13:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c13:focus:not(:focus-visible) {
+.c13:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible) > circle,
-.c13:focus:not(:focus-visible) > ellipse,
-.c13:focus:not(:focus-visible) > line,
-.c13:focus:not(:focus-visible) > path,
-.c13:focus:not(:focus-visible) > polygon,
-.c13:focus:not(:focus-visible) > polyline,
-.c13:focus:not(:focus-visible) > rect {
+.c13:focus:not(:focus-visible):not(:hover) > circle,
+.c13:focus:not(:focus-visible):not(:hover) > ellipse,
+.c13:focus:not(:focus-visible):not(:hover) > line,
+.c13:focus:not(:focus-visible):not(:hover) > path,
+.c13:focus:not(:focus-visible):not(:hover) > polygon,
+.c13:focus:not(:focus-visible):not(:hover) > polyline,
+.c13:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible)::-moz-focus-inner {
+.c13:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -1187,7 +1187,7 @@ exports[`Calendar change months 2`] = `
         >
           <button
             aria-label="Go to December 2019"
-            class="StyledButton-sc-323bzc-0 bpsTzm"
+            class="StyledButton-sc-323bzc-0 xRvZe"
             type="button"
           >
             <svg
@@ -1205,7 +1205,7 @@ exports[`Calendar change months 2`] = `
           </button>
           <button
             aria-label="Go to February 2020"
-            class="StyledButton-sc-323bzc-0 bpsTzm"
+            class="StyledButton-sc-323bzc-0 xRvZe"
             type="button"
           >
             <svg
@@ -1245,7 +1245,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Sun Dec 29 2019"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -1262,7 +1262,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Mon Dec 30 2019"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -1279,7 +1279,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Tue Dec 31 2019"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -1296,7 +1296,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Wed Jan 01 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -1313,7 +1313,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Thu Jan 02 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -1330,7 +1330,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Fri Jan 03 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -1347,7 +1347,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Sat Jan 04 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -1369,7 +1369,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Sun Jan 05 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -1386,7 +1386,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Mon Jan 06 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -1403,7 +1403,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Tue Jan 07 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -1420,7 +1420,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Wed Jan 08 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -1437,7 +1437,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Thu Jan 09 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -1454,7 +1454,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Fri Jan 10 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -1471,7 +1471,7 @@ exports[`Calendar change months 2`] = `
             >
               <button
                 aria-label="Sat Jan 11 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -1501,43 +1501,43 @@ exports[`Calendar change months 2`] = `
   text-align: inherit;
 }
 
-.c2:focus {
+.c2:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c2:focus > circle,
-.c2:focus > ellipse,
-.c2:focus > line,
-.c2:focus > path,
-.c2:focus > polygon,
-.c2:focus > polyline,
-.c2:focus > rect {
+.c2:focus:not(:hover) > circle,
+.c2:focus:not(:hover) > ellipse,
+.c2:focus:not(:hover) > line,
+.c2:focus:not(:hover) > path,
+.c2:focus:not(:hover) > polygon,
+.c2:focus:not(:hover) > polyline,
+.c2:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c2:focus::-moz-focus-inner {
+.c2:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c2:focus:not(:focus-visible) {
+.c2:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c2:focus:not(:focus-visible) > circle,
-.c2:focus:not(:focus-visible) > ellipse,
-.c2:focus:not(:focus-visible) > line,
-.c2:focus:not(:focus-visible) > path,
-.c2:focus:not(:focus-visible) > polygon,
-.c2:focus:not(:focus-visible) > polyline,
-.c2:focus:not(:focus-visible) > rect {
+.c2:focus:not(:focus-visible):not(:hover) > circle,
+.c2:focus:not(:focus-visible):not(:hover) > ellipse,
+.c2:focus:not(:focus-visible):not(:hover) > line,
+.c2:focus:not(:focus-visible):not(:hover) > path,
+.c2:focus:not(:focus-visible):not(:hover) > polygon,
+.c2:focus:not(:focus-visible):not(:hover) > polyline,
+.c2:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c2:focus:not(:focus-visible)::-moz-focus-inner {
+.c2:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -1749,43 +1749,43 @@ exports[`Calendar change months 2`] = `
   text-align: inherit;
 }
 
-.c2:focus {
+.c2:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c2:focus > circle,
-.c2:focus > ellipse,
-.c2:focus > line,
-.c2:focus > path,
-.c2:focus > polygon,
-.c2:focus > polyline,
-.c2:focus > rect {
+.c2:focus:not(:hover) > circle,
+.c2:focus:not(:hover) > ellipse,
+.c2:focus:not(:hover) > line,
+.c2:focus:not(:hover) > path,
+.c2:focus:not(:hover) > polygon,
+.c2:focus:not(:hover) > polyline,
+.c2:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c2:focus::-moz-focus-inner {
+.c2:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c2:focus:not(:focus-visible) {
+.c2:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c2:focus:not(:focus-visible) > circle,
-.c2:focus:not(:focus-visible) > ellipse,
-.c2:focus:not(:focus-visible) > line,
-.c2:focus:not(:focus-visible) > path,
-.c2:focus:not(:focus-visible) > polygon,
-.c2:focus:not(:focus-visible) > polyline,
-.c2:focus:not(:focus-visible) > rect {
+.c2:focus:not(:focus-visible):not(:hover) > circle,
+.c2:focus:not(:focus-visible):not(:hover) > ellipse,
+.c2:focus:not(:focus-visible):not(:hover) > line,
+.c2:focus:not(:focus-visible):not(:hover) > path,
+.c2:focus:not(:focus-visible):not(:hover) > polygon,
+.c2:focus:not(:focus-visible):not(:hover) > polyline,
+.c2:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c2:focus:not(:focus-visible)::-moz-focus-inner {
+.c2:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -1977,43 +1977,43 @@ exports[`Calendar change months 2`] = `
   text-align: inherit;
 }
 
-.c2:focus {
+.c2:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c2:focus > circle,
-.c2:focus > ellipse,
-.c2:focus > line,
-.c2:focus > path,
-.c2:focus > polygon,
-.c2:focus > polyline,
-.c2:focus > rect {
+.c2:focus:not(:hover) > circle,
+.c2:focus:not(:hover) > ellipse,
+.c2:focus:not(:hover) > line,
+.c2:focus:not(:hover) > path,
+.c2:focus:not(:hover) > polygon,
+.c2:focus:not(:hover) > polyline,
+.c2:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c2:focus::-moz-focus-inner {
+.c2:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c2:focus:not(:focus-visible) {
+.c2:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c2:focus:not(:focus-visible) > circle,
-.c2:focus:not(:focus-visible) > ellipse,
-.c2:focus:not(:focus-visible) > line,
-.c2:focus:not(:focus-visible) > path,
-.c2:focus:not(:focus-visible) > polygon,
-.c2:focus:not(:focus-visible) > polyline,
-.c2:focus:not(:focus-visible) > rect {
+.c2:focus:not(:focus-visible):not(:hover) > circle,
+.c2:focus:not(:focus-visible):not(:hover) > ellipse,
+.c2:focus:not(:focus-visible):not(:hover) > line,
+.c2:focus:not(:focus-visible):not(:hover) > path,
+.c2:focus:not(:focus-visible):not(:hover) > polygon,
+.c2:focus:not(:focus-visible):not(:hover) > polyline,
+.c2:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c2:focus:not(:focus-visible)::-moz-focus-inner {
+.c2:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -2223,43 +2223,43 @@ exports[`Calendar change months 2`] = `
   text-align: inherit;
 }
 
-.c2:focus {
+.c2:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c2:focus > circle,
-.c2:focus > ellipse,
-.c2:focus > line,
-.c2:focus > path,
-.c2:focus > polygon,
-.c2:focus > polyline,
-.c2:focus > rect {
+.c2:focus:not(:hover) > circle,
+.c2:focus:not(:hover) > ellipse,
+.c2:focus:not(:hover) > line,
+.c2:focus:not(:hover) > path,
+.c2:focus:not(:hover) > polygon,
+.c2:focus:not(:hover) > polyline,
+.c2:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c2:focus::-moz-focus-inner {
+.c2:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c2:focus:not(:focus-visible) {
+.c2:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c2:focus:not(:focus-visible) > circle,
-.c2:focus:not(:focus-visible) > ellipse,
-.c2:focus:not(:focus-visible) > line,
-.c2:focus:not(:focus-visible) > path,
-.c2:focus:not(:focus-visible) > polygon,
-.c2:focus:not(:focus-visible) > polyline,
-.c2:focus:not(:focus-visible) > rect {
+.c2:focus:not(:focus-visible):not(:hover) > circle,
+.c2:focus:not(:focus-visible):not(:hover) > ellipse,
+.c2:focus:not(:focus-visible):not(:hover) > line,
+.c2:focus:not(:focus-visible):not(:hover) > path,
+.c2:focus:not(:focus-visible):not(:hover) > polygon,
+.c2:focus:not(:focus-visible):not(:hover) > polyline,
+.c2:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c2:focus:not(:focus-visible)::-moz-focus-inner {
+.c2:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -2588,43 +2588,43 @@ exports[`Calendar children 1`] = `
   padding: 12px;
 }
 
-.c7:focus {
+.c7:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus > circle,
-.c7:focus > ellipse,
-.c7:focus > line,
-.c7:focus > path,
-.c7:focus > polygon,
-.c7:focus > polyline,
-.c7:focus > rect {
+.c7:focus:not(:hover) > circle,
+.c7:focus:not(:hover) > ellipse,
+.c7:focus:not(:hover) > line,
+.c7:focus:not(:hover) > path,
+.c7:focus:not(:hover) > polygon,
+.c7:focus:not(:hover) > polyline,
+.c7:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus::-moz-focus-inner {
+.c7:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c7:focus:not(:focus-visible) {
+.c7:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c7:focus:not(:focus-visible) > circle,
-.c7:focus:not(:focus-visible) > ellipse,
-.c7:focus:not(:focus-visible) > line,
-.c7:focus:not(:focus-visible) > path,
-.c7:focus:not(:focus-visible) > polygon,
-.c7:focus:not(:focus-visible) > polyline,
-.c7:focus:not(:focus-visible) > rect {
+.c7:focus:not(:focus-visible):not(:hover) > circle,
+.c7:focus:not(:focus-visible):not(:hover) > ellipse,
+.c7:focus:not(:focus-visible):not(:hover) > line,
+.c7:focus:not(:focus-visible):not(:hover) > path,
+.c7:focus:not(:focus-visible):not(:hover) > polygon,
+.c7:focus:not(:focus-visible):not(:hover) > polyline,
+.c7:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c7:focus:not(:focus-visible)::-moz-focus-inner {
+.c7:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -3374,43 +3374,43 @@ exports[`Calendar date 1`] = `
   padding: 12px;
 }
 
-.c7:focus {
+.c7:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus > circle,
-.c7:focus > ellipse,
-.c7:focus > line,
-.c7:focus > path,
-.c7:focus > polygon,
-.c7:focus > polyline,
-.c7:focus > rect {
+.c7:focus:not(:hover) > circle,
+.c7:focus:not(:hover) > ellipse,
+.c7:focus:not(:hover) > line,
+.c7:focus:not(:hover) > path,
+.c7:focus:not(:hover) > polygon,
+.c7:focus:not(:hover) > polyline,
+.c7:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus::-moz-focus-inner {
+.c7:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c7:focus:not(:focus-visible) {
+.c7:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c7:focus:not(:focus-visible) > circle,
-.c7:focus:not(:focus-visible) > ellipse,
-.c7:focus:not(:focus-visible) > line,
-.c7:focus:not(:focus-visible) > path,
-.c7:focus:not(:focus-visible) > polygon,
-.c7:focus:not(:focus-visible) > polyline,
-.c7:focus:not(:focus-visible) > rect {
+.c7:focus:not(:focus-visible):not(:hover) > circle,
+.c7:focus:not(:focus-visible):not(:hover) > ellipse,
+.c7:focus:not(:focus-visible):not(:hover) > line,
+.c7:focus:not(:focus-visible):not(:hover) > path,
+.c7:focus:not(:focus-visible):not(:hover) > polygon,
+.c7:focus:not(:focus-visible):not(:hover) > polyline,
+.c7:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c7:focus:not(:focus-visible)::-moz-focus-inner {
+.c7:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -3432,43 +3432,43 @@ exports[`Calendar date 1`] = `
   text-align: inherit;
 }
 
-.c13:focus {
+.c13:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus > circle,
-.c13:focus > ellipse,
-.c13:focus > line,
-.c13:focus > path,
-.c13:focus > polygon,
-.c13:focus > polyline,
-.c13:focus > rect {
+.c13:focus:not(:hover) > circle,
+.c13:focus:not(:hover) > ellipse,
+.c13:focus:not(:hover) > line,
+.c13:focus:not(:hover) > path,
+.c13:focus:not(:hover) > polygon,
+.c13:focus:not(:hover) > polyline,
+.c13:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus::-moz-focus-inner {
+.c13:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c13:focus:not(:focus-visible) {
+.c13:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible) > circle,
-.c13:focus:not(:focus-visible) > ellipse,
-.c13:focus:not(:focus-visible) > line,
-.c13:focus:not(:focus-visible) > path,
-.c13:focus:not(:focus-visible) > polygon,
-.c13:focus:not(:focus-visible) > polyline,
-.c13:focus:not(:focus-visible) > rect {
+.c13:focus:not(:focus-visible):not(:hover) > circle,
+.c13:focus:not(:focus-visible):not(:hover) > ellipse,
+.c13:focus:not(:focus-visible):not(:hover) > line,
+.c13:focus:not(:focus-visible):not(:hover) > path,
+.c13:focus:not(:focus-visible):not(:hover) > polygon,
+.c13:focus:not(:focus-visible):not(:hover) > polyline,
+.c13:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible)::-moz-focus-inner {
+.c13:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -4554,43 +4554,43 @@ exports[`Calendar dates 1`] = `
   padding: 12px;
 }
 
-.c7:focus {
+.c7:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus > circle,
-.c7:focus > ellipse,
-.c7:focus > line,
-.c7:focus > path,
-.c7:focus > polygon,
-.c7:focus > polyline,
-.c7:focus > rect {
+.c7:focus:not(:hover) > circle,
+.c7:focus:not(:hover) > ellipse,
+.c7:focus:not(:hover) > line,
+.c7:focus:not(:hover) > path,
+.c7:focus:not(:hover) > polygon,
+.c7:focus:not(:hover) > polyline,
+.c7:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus::-moz-focus-inner {
+.c7:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c7:focus:not(:focus-visible) {
+.c7:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c7:focus:not(:focus-visible) > circle,
-.c7:focus:not(:focus-visible) > ellipse,
-.c7:focus:not(:focus-visible) > line,
-.c7:focus:not(:focus-visible) > path,
-.c7:focus:not(:focus-visible) > polygon,
-.c7:focus:not(:focus-visible) > polyline,
-.c7:focus:not(:focus-visible) > rect {
+.c7:focus:not(:focus-visible):not(:hover) > circle,
+.c7:focus:not(:focus-visible):not(:hover) > ellipse,
+.c7:focus:not(:focus-visible):not(:hover) > line,
+.c7:focus:not(:focus-visible):not(:hover) > path,
+.c7:focus:not(:focus-visible):not(:hover) > polygon,
+.c7:focus:not(:focus-visible):not(:hover) > polyline,
+.c7:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c7:focus:not(:focus-visible)::-moz-focus-inner {
+.c7:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -4612,43 +4612,43 @@ exports[`Calendar dates 1`] = `
   text-align: inherit;
 }
 
-.c13:focus {
+.c13:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus > circle,
-.c13:focus > ellipse,
-.c13:focus > line,
-.c13:focus > path,
-.c13:focus > polygon,
-.c13:focus > polyline,
-.c13:focus > rect {
+.c13:focus:not(:hover) > circle,
+.c13:focus:not(:hover) > ellipse,
+.c13:focus:not(:hover) > line,
+.c13:focus:not(:hover) > path,
+.c13:focus:not(:hover) > polygon,
+.c13:focus:not(:hover) > polyline,
+.c13:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus::-moz-focus-inner {
+.c13:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c13:focus:not(:focus-visible) {
+.c13:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible) > circle,
-.c13:focus:not(:focus-visible) > ellipse,
-.c13:focus:not(:focus-visible) > line,
-.c13:focus:not(:focus-visible) > path,
-.c13:focus:not(:focus-visible) > polygon,
-.c13:focus:not(:focus-visible) > polyline,
-.c13:focus:not(:focus-visible) > rect {
+.c13:focus:not(:focus-visible):not(:hover) > circle,
+.c13:focus:not(:focus-visible):not(:hover) > ellipse,
+.c13:focus:not(:focus-visible):not(:hover) > line,
+.c13:focus:not(:focus-visible):not(:hover) > path,
+.c13:focus:not(:focus-visible):not(:hover) > polygon,
+.c13:focus:not(:focus-visible):not(:hover) > polyline,
+.c13:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible)::-moz-focus-inner {
+.c13:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -5753,43 +5753,43 @@ exports[`Calendar daysOfWeek 1`] = `
   padding: 12px;
 }
 
-.c7:focus {
+.c7:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus > circle,
-.c7:focus > ellipse,
-.c7:focus > line,
-.c7:focus > path,
-.c7:focus > polygon,
-.c7:focus > polyline,
-.c7:focus > rect {
+.c7:focus:not(:hover) > circle,
+.c7:focus:not(:hover) > ellipse,
+.c7:focus:not(:hover) > line,
+.c7:focus:not(:hover) > path,
+.c7:focus:not(:hover) > polygon,
+.c7:focus:not(:hover) > polyline,
+.c7:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus::-moz-focus-inner {
+.c7:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c7:focus:not(:focus-visible) {
+.c7:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c7:focus:not(:focus-visible) > circle,
-.c7:focus:not(:focus-visible) > ellipse,
-.c7:focus:not(:focus-visible) > line,
-.c7:focus:not(:focus-visible) > path,
-.c7:focus:not(:focus-visible) > polygon,
-.c7:focus:not(:focus-visible) > polyline,
-.c7:focus:not(:focus-visible) > rect {
+.c7:focus:not(:focus-visible):not(:hover) > circle,
+.c7:focus:not(:focus-visible):not(:hover) > ellipse,
+.c7:focus:not(:focus-visible):not(:hover) > line,
+.c7:focus:not(:focus-visible):not(:hover) > path,
+.c7:focus:not(:focus-visible):not(:hover) > polygon,
+.c7:focus:not(:focus-visible):not(:hover) > polyline,
+.c7:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c7:focus:not(:focus-visible)::-moz-focus-inner {
+.c7:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -5811,43 +5811,43 @@ exports[`Calendar daysOfWeek 1`] = `
   text-align: inherit;
 }
 
-.c14:focus {
+.c14:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c14:focus > circle,
-.c14:focus > ellipse,
-.c14:focus > line,
-.c14:focus > path,
-.c14:focus > polygon,
-.c14:focus > polyline,
-.c14:focus > rect {
+.c14:focus:not(:hover) > circle,
+.c14:focus:not(:hover) > ellipse,
+.c14:focus:not(:hover) > line,
+.c14:focus:not(:hover) > path,
+.c14:focus:not(:hover) > polygon,
+.c14:focus:not(:hover) > polyline,
+.c14:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c14:focus::-moz-focus-inner {
+.c14:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c14:focus:not(:focus-visible) {
+.c14:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c14:focus:not(:focus-visible) > circle,
-.c14:focus:not(:focus-visible) > ellipse,
-.c14:focus:not(:focus-visible) > line,
-.c14:focus:not(:focus-visible) > path,
-.c14:focus:not(:focus-visible) > polygon,
-.c14:focus:not(:focus-visible) > polyline,
-.c14:focus:not(:focus-visible) > rect {
+.c14:focus:not(:focus-visible):not(:hover) > circle,
+.c14:focus:not(:focus-visible):not(:hover) > ellipse,
+.c14:focus:not(:focus-visible):not(:hover) > line,
+.c14:focus:not(:focus-visible):not(:hover) > path,
+.c14:focus:not(:focus-visible):not(:hover) > polygon,
+.c14:focus:not(:focus-visible):not(:hover) > polyline,
+.c14:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c14:focus:not(:focus-visible)::-moz-focus-inner {
+.c14:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -7028,43 +7028,43 @@ exports[`Calendar disabled 1`] = `
   padding: 12px;
 }
 
-.c7:focus {
+.c7:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus > circle,
-.c7:focus > ellipse,
-.c7:focus > line,
-.c7:focus > path,
-.c7:focus > polygon,
-.c7:focus > polyline,
-.c7:focus > rect {
+.c7:focus:not(:hover) > circle,
+.c7:focus:not(:hover) > ellipse,
+.c7:focus:not(:hover) > line,
+.c7:focus:not(:hover) > path,
+.c7:focus:not(:hover) > polygon,
+.c7:focus:not(:hover) > polyline,
+.c7:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus::-moz-focus-inner {
+.c7:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c7:focus:not(:focus-visible) {
+.c7:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c7:focus:not(:focus-visible) > circle,
-.c7:focus:not(:focus-visible) > ellipse,
-.c7:focus:not(:focus-visible) > line,
-.c7:focus:not(:focus-visible) > path,
-.c7:focus:not(:focus-visible) > polygon,
-.c7:focus:not(:focus-visible) > polyline,
-.c7:focus:not(:focus-visible) > rect {
+.c7:focus:not(:focus-visible):not(:hover) > circle,
+.c7:focus:not(:focus-visible):not(:hover) > ellipse,
+.c7:focus:not(:focus-visible):not(:hover) > line,
+.c7:focus:not(:focus-visible):not(:hover) > path,
+.c7:focus:not(:focus-visible):not(:hover) > polygon,
+.c7:focus:not(:focus-visible):not(:hover) > polyline,
+.c7:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c7:focus:not(:focus-visible)::-moz-focus-inner {
+.c7:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -7086,43 +7086,43 @@ exports[`Calendar disabled 1`] = `
   text-align: inherit;
 }
 
-.c13:focus {
+.c13:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus > circle,
-.c13:focus > ellipse,
-.c13:focus > line,
-.c13:focus > path,
-.c13:focus > polygon,
-.c13:focus > polyline,
-.c13:focus > rect {
+.c13:focus:not(:hover) > circle,
+.c13:focus:not(:hover) > ellipse,
+.c13:focus:not(:hover) > line,
+.c13:focus:not(:hover) > path,
+.c13:focus:not(:hover) > polygon,
+.c13:focus:not(:hover) > polyline,
+.c13:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus::-moz-focus-inner {
+.c13:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c13:focus:not(:focus-visible) {
+.c13:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible) > circle,
-.c13:focus:not(:focus-visible) > ellipse,
-.c13:focus:not(:focus-visible) > line,
-.c13:focus:not(:focus-visible) > path,
-.c13:focus:not(:focus-visible) > polygon,
-.c13:focus:not(:focus-visible) > polyline,
-.c13:focus:not(:focus-visible) > rect {
+.c13:focus:not(:focus-visible):not(:hover) > circle,
+.c13:focus:not(:focus-visible):not(:hover) > ellipse,
+.c13:focus:not(:focus-visible):not(:hover) > line,
+.c13:focus:not(:focus-visible):not(:hover) > path,
+.c13:focus:not(:focus-visible):not(:hover) > polygon,
+.c13:focus:not(:focus-visible):not(:hover) > polyline,
+.c13:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible)::-moz-focus-inner {
+.c13:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -7146,43 +7146,43 @@ exports[`Calendar disabled 1`] = `
   cursor: default;
 }
 
-.c17:focus {
+.c17:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus > circle,
-.c17:focus > ellipse,
-.c17:focus > line,
-.c17:focus > path,
-.c17:focus > polygon,
-.c17:focus > polyline,
-.c17:focus > rect {
+.c17:focus:not(:hover) > circle,
+.c17:focus:not(:hover) > ellipse,
+.c17:focus:not(:hover) > line,
+.c17:focus:not(:hover) > path,
+.c17:focus:not(:hover) > polygon,
+.c17:focus:not(:hover) > polyline,
+.c17:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus::-moz-focus-inner {
+.c17:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c17:focus:not(:focus-visible) {
+.c17:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible) > circle,
-.c17:focus:not(:focus-visible) > ellipse,
-.c17:focus:not(:focus-visible) > line,
-.c17:focus:not(:focus-visible) > path,
-.c17:focus:not(:focus-visible) > polygon,
-.c17:focus:not(:focus-visible) > polyline,
-.c17:focus:not(:focus-visible) > rect {
+.c17:focus:not(:focus-visible):not(:hover) > circle,
+.c17:focus:not(:focus-visible):not(:hover) > ellipse,
+.c17:focus:not(:focus-visible):not(:hover) > line,
+.c17:focus:not(:focus-visible):not(:hover) > path,
+.c17:focus:not(:focus-visible):not(:hover) > polygon,
+.c17:focus:not(:focus-visible):not(:hover) > polyline,
+.c17:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible)::-moz-focus-inner {
+.c17:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -8272,43 +8272,43 @@ exports[`Calendar fill 1`] = `
   padding: 12px;
 }
 
-.c7:focus {
+.c7:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus > circle,
-.c7:focus > ellipse,
-.c7:focus > line,
-.c7:focus > path,
-.c7:focus > polygon,
-.c7:focus > polyline,
-.c7:focus > rect {
+.c7:focus:not(:hover) > circle,
+.c7:focus:not(:hover) > ellipse,
+.c7:focus:not(:hover) > line,
+.c7:focus:not(:hover) > path,
+.c7:focus:not(:hover) > polygon,
+.c7:focus:not(:hover) > polyline,
+.c7:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus::-moz-focus-inner {
+.c7:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c7:focus:not(:focus-visible) {
+.c7:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c7:focus:not(:focus-visible) > circle,
-.c7:focus:not(:focus-visible) > ellipse,
-.c7:focus:not(:focus-visible) > line,
-.c7:focus:not(:focus-visible) > path,
-.c7:focus:not(:focus-visible) > polygon,
-.c7:focus:not(:focus-visible) > polyline,
-.c7:focus:not(:focus-visible) > rect {
+.c7:focus:not(:focus-visible):not(:hover) > circle,
+.c7:focus:not(:focus-visible):not(:hover) > ellipse,
+.c7:focus:not(:focus-visible):not(:hover) > line,
+.c7:focus:not(:focus-visible):not(:hover) > path,
+.c7:focus:not(:focus-visible):not(:hover) > polygon,
+.c7:focus:not(:focus-visible):not(:hover) > polyline,
+.c7:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c7:focus:not(:focus-visible)::-moz-focus-inner {
+.c7:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -8336,43 +8336,43 @@ exports[`Calendar fill 1`] = `
   flex: 1 0 auto;
 }
 
-.c13:focus {
+.c13:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus > circle,
-.c13:focus > ellipse,
-.c13:focus > line,
-.c13:focus > path,
-.c13:focus > polygon,
-.c13:focus > polyline,
-.c13:focus > rect {
+.c13:focus:not(:hover) > circle,
+.c13:focus:not(:hover) > ellipse,
+.c13:focus:not(:hover) > line,
+.c13:focus:not(:hover) > path,
+.c13:focus:not(:hover) > polygon,
+.c13:focus:not(:hover) > polyline,
+.c13:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus::-moz-focus-inner {
+.c13:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c13:focus:not(:focus-visible) {
+.c13:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible) > circle,
-.c13:focus:not(:focus-visible) > ellipse,
-.c13:focus:not(:focus-visible) > line,
-.c13:focus:not(:focus-visible) > path,
-.c13:focus:not(:focus-visible) > polygon,
-.c13:focus:not(:focus-visible) > polyline,
-.c13:focus:not(:focus-visible) > rect {
+.c13:focus:not(:focus-visible):not(:hover) > circle,
+.c13:focus:not(:focus-visible):not(:hover) > ellipse,
+.c13:focus:not(:focus-visible):not(:hover) > line,
+.c13:focus:not(:focus-visible):not(:hover) > path,
+.c13:focus:not(:focus-visible):not(:hover) > polygon,
+.c13:focus:not(:focus-visible):not(:hover) > polyline,
+.c13:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible)::-moz-focus-inner {
+.c13:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -9471,43 +9471,43 @@ exports[`Calendar first day sunday week monday 1`] = `
   padding: 12px;
 }
 
-.c7:focus {
+.c7:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus > circle,
-.c7:focus > ellipse,
-.c7:focus > line,
-.c7:focus > path,
-.c7:focus > polygon,
-.c7:focus > polyline,
-.c7:focus > rect {
+.c7:focus:not(:hover) > circle,
+.c7:focus:not(:hover) > ellipse,
+.c7:focus:not(:hover) > line,
+.c7:focus:not(:hover) > path,
+.c7:focus:not(:hover) > polygon,
+.c7:focus:not(:hover) > polyline,
+.c7:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus::-moz-focus-inner {
+.c7:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c7:focus:not(:focus-visible) {
+.c7:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c7:focus:not(:focus-visible) > circle,
-.c7:focus:not(:focus-visible) > ellipse,
-.c7:focus:not(:focus-visible) > line,
-.c7:focus:not(:focus-visible) > path,
-.c7:focus:not(:focus-visible) > polygon,
-.c7:focus:not(:focus-visible) > polyline,
-.c7:focus:not(:focus-visible) > rect {
+.c7:focus:not(:focus-visible):not(:hover) > circle,
+.c7:focus:not(:focus-visible):not(:hover) > ellipse,
+.c7:focus:not(:focus-visible):not(:hover) > line,
+.c7:focus:not(:focus-visible):not(:hover) > path,
+.c7:focus:not(:focus-visible):not(:hover) > polygon,
+.c7:focus:not(:focus-visible):not(:hover) > polyline,
+.c7:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c7:focus:not(:focus-visible)::-moz-focus-inner {
+.c7:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -9529,43 +9529,43 @@ exports[`Calendar first day sunday week monday 1`] = `
   text-align: inherit;
 }
 
-.c13:focus {
+.c13:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus > circle,
-.c13:focus > ellipse,
-.c13:focus > line,
-.c13:focus > path,
-.c13:focus > polygon,
-.c13:focus > polyline,
-.c13:focus > rect {
+.c13:focus:not(:hover) > circle,
+.c13:focus:not(:hover) > ellipse,
+.c13:focus:not(:hover) > line,
+.c13:focus:not(:hover) > path,
+.c13:focus:not(:hover) > polygon,
+.c13:focus:not(:hover) > polyline,
+.c13:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus::-moz-focus-inner {
+.c13:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c13:focus:not(:focus-visible) {
+.c13:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible) > circle,
-.c13:focus:not(:focus-visible) > ellipse,
-.c13:focus:not(:focus-visible) > line,
-.c13:focus:not(:focus-visible) > path,
-.c13:focus:not(:focus-visible) > polygon,
-.c13:focus:not(:focus-visible) > polyline,
-.c13:focus:not(:focus-visible) > rect {
+.c13:focus:not(:focus-visible):not(:hover) > circle,
+.c13:focus:not(:focus-visible):not(:hover) > ellipse,
+.c13:focus:not(:focus-visible):not(:hover) > line,
+.c13:focus:not(:focus-visible):not(:hover) > path,
+.c13:focus:not(:focus-visible):not(:hover) > polygon,
+.c13:focus:not(:focus-visible):not(:hover) > polyline,
+.c13:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible)::-moz-focus-inner {
+.c13:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -10651,43 +10651,43 @@ exports[`Calendar firstDayOfWeek 1`] = `
   padding: 12px;
 }
 
-.c7:focus {
+.c7:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus > circle,
-.c7:focus > ellipse,
-.c7:focus > line,
-.c7:focus > path,
-.c7:focus > polygon,
-.c7:focus > polyline,
-.c7:focus > rect {
+.c7:focus:not(:hover) > circle,
+.c7:focus:not(:hover) > ellipse,
+.c7:focus:not(:hover) > line,
+.c7:focus:not(:hover) > path,
+.c7:focus:not(:hover) > polygon,
+.c7:focus:not(:hover) > polyline,
+.c7:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus::-moz-focus-inner {
+.c7:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c7:focus:not(:focus-visible) {
+.c7:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c7:focus:not(:focus-visible) > circle,
-.c7:focus:not(:focus-visible) > ellipse,
-.c7:focus:not(:focus-visible) > line,
-.c7:focus:not(:focus-visible) > path,
-.c7:focus:not(:focus-visible) > polygon,
-.c7:focus:not(:focus-visible) > polyline,
-.c7:focus:not(:focus-visible) > rect {
+.c7:focus:not(:focus-visible):not(:hover) > circle,
+.c7:focus:not(:focus-visible):not(:hover) > ellipse,
+.c7:focus:not(:focus-visible):not(:hover) > line,
+.c7:focus:not(:focus-visible):not(:hover) > path,
+.c7:focus:not(:focus-visible):not(:hover) > polygon,
+.c7:focus:not(:focus-visible):not(:hover) > polyline,
+.c7:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c7:focus:not(:focus-visible)::-moz-focus-inner {
+.c7:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -10709,43 +10709,43 @@ exports[`Calendar firstDayOfWeek 1`] = `
   text-align: inherit;
 }
 
-.c13:focus {
+.c13:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus > circle,
-.c13:focus > ellipse,
-.c13:focus > line,
-.c13:focus > path,
-.c13:focus > polygon,
-.c13:focus > polyline,
-.c13:focus > rect {
+.c13:focus:not(:hover) > circle,
+.c13:focus:not(:hover) > ellipse,
+.c13:focus:not(:hover) > line,
+.c13:focus:not(:hover) > path,
+.c13:focus:not(:hover) > polygon,
+.c13:focus:not(:hover) > polyline,
+.c13:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus::-moz-focus-inner {
+.c13:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c13:focus:not(:focus-visible) {
+.c13:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible) > circle,
-.c13:focus:not(:focus-visible) > ellipse,
-.c13:focus:not(:focus-visible) > line,
-.c13:focus:not(:focus-visible) > path,
-.c13:focus:not(:focus-visible) > polygon,
-.c13:focus:not(:focus-visible) > polyline,
-.c13:focus:not(:focus-visible) > rect {
+.c13:focus:not(:focus-visible):not(:hover) > circle,
+.c13:focus:not(:focus-visible):not(:hover) > ellipse,
+.c13:focus:not(:focus-visible):not(:hover) > line,
+.c13:focus:not(:focus-visible):not(:hover) > path,
+.c13:focus:not(:focus-visible):not(:hover) > polygon,
+.c13:focus:not(:focus-visible):not(:hover) > polyline,
+.c13:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible)::-moz-focus-inner {
+.c13:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -12613,43 +12613,43 @@ exports[`Calendar header 1`] = `
   text-align: inherit;
 }
 
-.c4:focus {
+.c4:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c4:focus > circle,
-.c4:focus > ellipse,
-.c4:focus > line,
-.c4:focus > path,
-.c4:focus > polygon,
-.c4:focus > polyline,
-.c4:focus > rect {
+.c4:focus:not(:hover) > circle,
+.c4:focus:not(:hover) > ellipse,
+.c4:focus:not(:hover) > line,
+.c4:focus:not(:hover) > path,
+.c4:focus:not(:hover) > polygon,
+.c4:focus:not(:hover) > polyline,
+.c4:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c4:focus::-moz-focus-inner {
+.c4:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c4:focus:not(:focus-visible) {
+.c4:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c4:focus:not(:focus-visible) > circle,
-.c4:focus:not(:focus-visible) > ellipse,
-.c4:focus:not(:focus-visible) > line,
-.c4:focus:not(:focus-visible) > path,
-.c4:focus:not(:focus-visible) > polygon,
-.c4:focus:not(:focus-visible) > polyline,
-.c4:focus:not(:focus-visible) > rect {
+.c4:focus:not(:focus-visible):not(:hover) > circle,
+.c4:focus:not(:focus-visible):not(:hover) > ellipse,
+.c4:focus:not(:focus-visible):not(:hover) > line,
+.c4:focus:not(:focus-visible):not(:hover) > path,
+.c4:focus:not(:focus-visible):not(:hover) > polygon,
+.c4:focus:not(:focus-visible):not(:hover) > polyline,
+.c4:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c4:focus:not(:focus-visible)::-moz-focus-inner {
+.c4:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -12673,43 +12673,43 @@ exports[`Calendar header 1`] = `
   cursor: default;
 }
 
-.c11:focus {
+.c11:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus > circle,
-.c11:focus > ellipse,
-.c11:focus > line,
-.c11:focus > path,
-.c11:focus > polygon,
-.c11:focus > polyline,
-.c11:focus > rect {
+.c11:focus:not(:hover) > circle,
+.c11:focus:not(:hover) > ellipse,
+.c11:focus:not(:hover) > line,
+.c11:focus:not(:hover) > path,
+.c11:focus:not(:hover) > polygon,
+.c11:focus:not(:hover) > polyline,
+.c11:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus::-moz-focus-inner {
+.c11:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c11:focus:not(:focus-visible) {
+.c11:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c11:focus:not(:focus-visible) > circle,
-.c11:focus:not(:focus-visible) > ellipse,
-.c11:focus:not(:focus-visible) > line,
-.c11:focus:not(:focus-visible) > path,
-.c11:focus:not(:focus-visible) > polygon,
-.c11:focus:not(:focus-visible) > polyline,
-.c11:focus:not(:focus-visible) > rect {
+.c11:focus:not(:focus-visible):not(:hover) > circle,
+.c11:focus:not(:focus-visible):not(:hover) > ellipse,
+.c11:focus:not(:focus-visible):not(:hover) > line,
+.c11:focus:not(:focus-visible):not(:hover) > path,
+.c11:focus:not(:focus-visible):not(:hover) > polygon,
+.c11:focus:not(:focus-visible):not(:hover) > polyline,
+.c11:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c11:focus:not(:focus-visible)::-moz-focus-inner {
+.c11:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -13808,43 +13808,43 @@ exports[`Calendar reference 1`] = `
   padding: 12px;
 }
 
-.c7:focus {
+.c7:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus > circle,
-.c7:focus > ellipse,
-.c7:focus > line,
-.c7:focus > path,
-.c7:focus > polygon,
-.c7:focus > polyline,
-.c7:focus > rect {
+.c7:focus:not(:hover) > circle,
+.c7:focus:not(:hover) > ellipse,
+.c7:focus:not(:hover) > line,
+.c7:focus:not(:hover) > path,
+.c7:focus:not(:hover) > polygon,
+.c7:focus:not(:hover) > polyline,
+.c7:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus::-moz-focus-inner {
+.c7:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c7:focus:not(:focus-visible) {
+.c7:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c7:focus:not(:focus-visible) > circle,
-.c7:focus:not(:focus-visible) > ellipse,
-.c7:focus:not(:focus-visible) > line,
-.c7:focus:not(:focus-visible) > path,
-.c7:focus:not(:focus-visible) > polygon,
-.c7:focus:not(:focus-visible) > polyline,
-.c7:focus:not(:focus-visible) > rect {
+.c7:focus:not(:focus-visible):not(:hover) > circle,
+.c7:focus:not(:focus-visible):not(:hover) > ellipse,
+.c7:focus:not(:focus-visible):not(:hover) > line,
+.c7:focus:not(:focus-visible):not(:hover) > path,
+.c7:focus:not(:focus-visible):not(:hover) > polygon,
+.c7:focus:not(:focus-visible):not(:hover) > polyline,
+.c7:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c7:focus:not(:focus-visible)::-moz-focus-inner {
+.c7:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -13866,43 +13866,43 @@ exports[`Calendar reference 1`] = `
   text-align: inherit;
 }
 
-.c13:focus {
+.c13:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus > circle,
-.c13:focus > ellipse,
-.c13:focus > line,
-.c13:focus > path,
-.c13:focus > polygon,
-.c13:focus > polyline,
-.c13:focus > rect {
+.c13:focus:not(:hover) > circle,
+.c13:focus:not(:hover) > ellipse,
+.c13:focus:not(:hover) > line,
+.c13:focus:not(:hover) > path,
+.c13:focus:not(:hover) > polygon,
+.c13:focus:not(:hover) > polyline,
+.c13:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus::-moz-focus-inner {
+.c13:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c13:focus:not(:focus-visible) {
+.c13:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible) > circle,
-.c13:focus:not(:focus-visible) > ellipse,
-.c13:focus:not(:focus-visible) > line,
-.c13:focus:not(:focus-visible) > path,
-.c13:focus:not(:focus-visible) > polygon,
-.c13:focus:not(:focus-visible) > polyline,
-.c13:focus:not(:focus-visible) > rect {
+.c13:focus:not(:focus-visible):not(:hover) > circle,
+.c13:focus:not(:focus-visible):not(:hover) > ellipse,
+.c13:focus:not(:focus-visible):not(:hover) > line,
+.c13:focus:not(:focus-visible):not(:hover) > path,
+.c13:focus:not(:focus-visible):not(:hover) > polygon,
+.c13:focus:not(:focus-visible):not(:hover) > polyline,
+.c13:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible)::-moz-focus-inner {
+.c13:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -14968,43 +14968,43 @@ exports[`Calendar select date 1`] = `
   padding: 12px;
 }
 
-.c7:focus {
+.c7:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus > circle,
-.c7:focus > ellipse,
-.c7:focus > line,
-.c7:focus > path,
-.c7:focus > polygon,
-.c7:focus > polyline,
-.c7:focus > rect {
+.c7:focus:not(:hover) > circle,
+.c7:focus:not(:hover) > ellipse,
+.c7:focus:not(:hover) > line,
+.c7:focus:not(:hover) > path,
+.c7:focus:not(:hover) > polygon,
+.c7:focus:not(:hover) > polyline,
+.c7:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus::-moz-focus-inner {
+.c7:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c7:focus:not(:focus-visible) {
+.c7:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c7:focus:not(:focus-visible) > circle,
-.c7:focus:not(:focus-visible) > ellipse,
-.c7:focus:not(:focus-visible) > line,
-.c7:focus:not(:focus-visible) > path,
-.c7:focus:not(:focus-visible) > polygon,
-.c7:focus:not(:focus-visible) > polyline,
-.c7:focus:not(:focus-visible) > rect {
+.c7:focus:not(:focus-visible):not(:hover) > circle,
+.c7:focus:not(:focus-visible):not(:hover) > ellipse,
+.c7:focus:not(:focus-visible):not(:hover) > line,
+.c7:focus:not(:focus-visible):not(:hover) > path,
+.c7:focus:not(:focus-visible):not(:hover) > polygon,
+.c7:focus:not(:focus-visible):not(:hover) > polyline,
+.c7:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c7:focus:not(:focus-visible)::-moz-focus-inner {
+.c7:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -15026,43 +15026,43 @@ exports[`Calendar select date 1`] = `
   text-align: inherit;
 }
 
-.c13:focus {
+.c13:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus > circle,
-.c13:focus > ellipse,
-.c13:focus > line,
-.c13:focus > path,
-.c13:focus > polygon,
-.c13:focus > polyline,
-.c13:focus > rect {
+.c13:focus:not(:hover) > circle,
+.c13:focus:not(:hover) > ellipse,
+.c13:focus:not(:hover) > line,
+.c13:focus:not(:hover) > path,
+.c13:focus:not(:hover) > polygon,
+.c13:focus:not(:hover) > polyline,
+.c13:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus::-moz-focus-inner {
+.c13:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c13:focus:not(:focus-visible) {
+.c13:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible) > circle,
-.c13:focus:not(:focus-visible) > ellipse,
-.c13:focus:not(:focus-visible) > line,
-.c13:focus:not(:focus-visible) > path,
-.c13:focus:not(:focus-visible) > polygon,
-.c13:focus:not(:focus-visible) > polyline,
-.c13:focus:not(:focus-visible) > rect {
+.c13:focus:not(:focus-visible):not(:hover) > circle,
+.c13:focus:not(:focus-visible):not(:hover) > ellipse,
+.c13:focus:not(:focus-visible):not(:hover) > line,
+.c13:focus:not(:focus-visible):not(:hover) > path,
+.c13:focus:not(:focus-visible):not(:hover) > polygon,
+.c13:focus:not(:focus-visible):not(:hover) > polyline,
+.c13:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible)::-moz-focus-inner {
+.c13:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -16044,7 +16044,7 @@ exports[`Calendar select date 2`] = `
         >
           <button
             aria-label="Go to December 2019"
-            class="StyledButton-sc-323bzc-0 bpsTzm"
+            class="StyledButton-sc-323bzc-0 xRvZe"
             type="button"
           >
             <svg
@@ -16062,7 +16062,7 @@ exports[`Calendar select date 2`] = `
           </button>
           <button
             aria-label="Go to February 2020"
-            class="StyledButton-sc-323bzc-0 bpsTzm"
+            class="StyledButton-sc-323bzc-0 xRvZe"
             type="button"
           >
             <svg
@@ -16102,7 +16102,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Sun Dec 29 2019"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -16119,7 +16119,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Mon Dec 30 2019"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -16136,7 +16136,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Tue Dec 31 2019"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -16153,7 +16153,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Wed Jan 01 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -16170,7 +16170,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Thu Jan 02 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -16187,7 +16187,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Fri Jan 03 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -16204,7 +16204,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Sat Jan 04 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -16226,7 +16226,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Sun Jan 05 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -16243,7 +16243,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Mon Jan 06 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -16260,7 +16260,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Tue Jan 07 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -16277,7 +16277,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Wed Jan 08 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -16294,7 +16294,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Thu Jan 09 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -16311,7 +16311,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Fri Jan 10 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -16328,7 +16328,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Sat Jan 11 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -16350,7 +16350,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Sun Jan 12 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -16367,7 +16367,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Mon Jan 13 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -16384,7 +16384,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Tue Jan 14 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -16401,7 +16401,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Wed Jan 15 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -16418,7 +16418,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Thu Jan 16 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -16435,7 +16435,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Fri Jan 17 2020"
-                class="StyledButton-sc-323bzc-0 kdISIE"
+                class="StyledButton-sc-323bzc-0 btQNHI"
                 tabindex="-1"
                 type="button"
               >
@@ -16452,7 +16452,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Sat Jan 18 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -16474,7 +16474,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Sun Jan 19 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -16491,7 +16491,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Mon Jan 20 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -16508,7 +16508,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Tue Jan 21 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -16525,7 +16525,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Wed Jan 22 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -16542,7 +16542,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Thu Jan 23 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -16559,7 +16559,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Fri Jan 24 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -16576,7 +16576,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Sat Jan 25 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -16598,7 +16598,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Sun Jan 26 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -16615,7 +16615,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Mon Jan 27 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -16632,7 +16632,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Tue Jan 28 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -16649,7 +16649,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Wed Jan 29 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -16666,7 +16666,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Thu Jan 30 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -16683,7 +16683,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Fri Jan 31 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -16700,7 +16700,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Sat Feb 01 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -16722,7 +16722,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Sun Feb 02 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -16739,7 +16739,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Mon Feb 03 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -16756,7 +16756,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Tue Feb 04 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -16773,7 +16773,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Wed Feb 05 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -16790,7 +16790,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Thu Feb 06 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -16807,7 +16807,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Fri Feb 07 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -16824,7 +16824,7 @@ exports[`Calendar select date 2`] = `
             >
               <button
                 aria-label="Sat Feb 08 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -16974,43 +16974,43 @@ exports[`Calendar select dates 1`] = `
   padding: 12px;
 }
 
-.c7:focus {
+.c7:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus > circle,
-.c7:focus > ellipse,
-.c7:focus > line,
-.c7:focus > path,
-.c7:focus > polygon,
-.c7:focus > polyline,
-.c7:focus > rect {
+.c7:focus:not(:hover) > circle,
+.c7:focus:not(:hover) > ellipse,
+.c7:focus:not(:hover) > line,
+.c7:focus:not(:hover) > path,
+.c7:focus:not(:hover) > polygon,
+.c7:focus:not(:hover) > polyline,
+.c7:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus::-moz-focus-inner {
+.c7:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c7:focus:not(:focus-visible) {
+.c7:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c7:focus:not(:focus-visible) > circle,
-.c7:focus:not(:focus-visible) > ellipse,
-.c7:focus:not(:focus-visible) > line,
-.c7:focus:not(:focus-visible) > path,
-.c7:focus:not(:focus-visible) > polygon,
-.c7:focus:not(:focus-visible) > polyline,
-.c7:focus:not(:focus-visible) > rect {
+.c7:focus:not(:focus-visible):not(:hover) > circle,
+.c7:focus:not(:focus-visible):not(:hover) > ellipse,
+.c7:focus:not(:focus-visible):not(:hover) > line,
+.c7:focus:not(:focus-visible):not(:hover) > path,
+.c7:focus:not(:focus-visible):not(:hover) > polygon,
+.c7:focus:not(:focus-visible):not(:hover) > polyline,
+.c7:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c7:focus:not(:focus-visible)::-moz-focus-inner {
+.c7:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -17032,43 +17032,43 @@ exports[`Calendar select dates 1`] = `
   text-align: inherit;
 }
 
-.c13:focus {
+.c13:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus > circle,
-.c13:focus > ellipse,
-.c13:focus > line,
-.c13:focus > path,
-.c13:focus > polygon,
-.c13:focus > polyline,
-.c13:focus > rect {
+.c13:focus:not(:hover) > circle,
+.c13:focus:not(:hover) > ellipse,
+.c13:focus:not(:hover) > line,
+.c13:focus:not(:hover) > path,
+.c13:focus:not(:hover) > polygon,
+.c13:focus:not(:hover) > polyline,
+.c13:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus::-moz-focus-inner {
+.c13:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c13:focus:not(:focus-visible) {
+.c13:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible) > circle,
-.c13:focus:not(:focus-visible) > ellipse,
-.c13:focus:not(:focus-visible) > line,
-.c13:focus:not(:focus-visible) > path,
-.c13:focus:not(:focus-visible) > polygon,
-.c13:focus:not(:focus-visible) > polyline,
-.c13:focus:not(:focus-visible) > rect {
+.c13:focus:not(:focus-visible):not(:hover) > circle,
+.c13:focus:not(:focus-visible):not(:hover) > ellipse,
+.c13:focus:not(:focus-visible):not(:hover) > line,
+.c13:focus:not(:focus-visible):not(:hover) > path,
+.c13:focus:not(:focus-visible):not(:hover) > polygon,
+.c13:focus:not(:focus-visible):not(:hover) > polyline,
+.c13:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible)::-moz-focus-inner {
+.c13:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -18069,7 +18069,7 @@ exports[`Calendar select dates 2`] = `
         >
           <button
             aria-label="Go to December 2019"
-            class="StyledButton-sc-323bzc-0 bpsTzm"
+            class="StyledButton-sc-323bzc-0 xRvZe"
             type="button"
           >
             <svg
@@ -18087,7 +18087,7 @@ exports[`Calendar select dates 2`] = `
           </button>
           <button
             aria-label="Go to February 2020"
-            class="StyledButton-sc-323bzc-0 bpsTzm"
+            class="StyledButton-sc-323bzc-0 xRvZe"
             type="button"
           >
             <svg
@@ -18127,7 +18127,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Sun Dec 29 2019"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -18144,7 +18144,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Mon Dec 30 2019"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -18161,7 +18161,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Tue Dec 31 2019"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -18178,7 +18178,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Wed Jan 01 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -18195,7 +18195,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Thu Jan 02 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -18212,7 +18212,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Fri Jan 03 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -18229,7 +18229,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Sat Jan 04 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -18251,7 +18251,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Sun Jan 05 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -18268,7 +18268,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Mon Jan 06 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -18285,7 +18285,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Tue Jan 07 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -18302,7 +18302,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Wed Jan 08 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -18319,7 +18319,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Thu Jan 09 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -18336,7 +18336,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Fri Jan 10 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -18353,7 +18353,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Sat Jan 11 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -18375,7 +18375,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Sun Jan 12 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -18392,7 +18392,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Mon Jan 13 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -18409,7 +18409,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Tue Jan 14 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -18426,7 +18426,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Wed Jan 15 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -18443,7 +18443,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Thu Jan 16 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -18460,7 +18460,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Fri Jan 17 2020"
-                class="StyledButton-sc-323bzc-0 kdISIE"
+                class="StyledButton-sc-323bzc-0 btQNHI"
                 tabindex="-1"
                 type="button"
               >
@@ -18477,7 +18477,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Sat Jan 18 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -18499,7 +18499,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Sun Jan 19 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -18516,7 +18516,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Mon Jan 20 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -18533,7 +18533,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Tue Jan 21 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -18550,7 +18550,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Wed Jan 22 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -18567,7 +18567,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Thu Jan 23 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -18584,7 +18584,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Fri Jan 24 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -18601,7 +18601,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Sat Jan 25 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -18623,7 +18623,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Sun Jan 26 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -18640,7 +18640,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Mon Jan 27 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -18657,7 +18657,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Tue Jan 28 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -18674,7 +18674,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Wed Jan 29 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -18691,7 +18691,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Thu Jan 30 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -18708,7 +18708,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Fri Jan 31 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -18725,7 +18725,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Sat Feb 01 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -18747,7 +18747,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Sun Feb 02 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -18764,7 +18764,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Mon Feb 03 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -18781,7 +18781,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Tue Feb 04 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -18798,7 +18798,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Wed Feb 05 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -18815,7 +18815,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Thu Feb 06 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -18832,7 +18832,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Fri Feb 07 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -18849,7 +18849,7 @@ exports[`Calendar select dates 2`] = `
             >
               <button
                 aria-label="Sat Feb 08 2020"
-                class="StyledButton-sc-323bzc-0 eiEooU"
+                class="StyledButton-sc-323bzc-0 gsQNSg"
                 tabindex="-1"
                 type="button"
               >
@@ -18999,43 +18999,43 @@ exports[`Calendar showAdjacentDays 1`] = `
   padding: 12px;
 }
 
-.c7:focus {
+.c7:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus > circle,
-.c7:focus > ellipse,
-.c7:focus > line,
-.c7:focus > path,
-.c7:focus > polygon,
-.c7:focus > polyline,
-.c7:focus > rect {
+.c7:focus:not(:hover) > circle,
+.c7:focus:not(:hover) > ellipse,
+.c7:focus:not(:hover) > line,
+.c7:focus:not(:hover) > path,
+.c7:focus:not(:hover) > polygon,
+.c7:focus:not(:hover) > polyline,
+.c7:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus::-moz-focus-inner {
+.c7:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c7:focus:not(:focus-visible) {
+.c7:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c7:focus:not(:focus-visible) > circle,
-.c7:focus:not(:focus-visible) > ellipse,
-.c7:focus:not(:focus-visible) > line,
-.c7:focus:not(:focus-visible) > path,
-.c7:focus:not(:focus-visible) > polygon,
-.c7:focus:not(:focus-visible) > polyline,
-.c7:focus:not(:focus-visible) > rect {
+.c7:focus:not(:focus-visible):not(:hover) > circle,
+.c7:focus:not(:focus-visible):not(:hover) > ellipse,
+.c7:focus:not(:focus-visible):not(:hover) > line,
+.c7:focus:not(:focus-visible):not(:hover) > path,
+.c7:focus:not(:focus-visible):not(:hover) > polygon,
+.c7:focus:not(:focus-visible):not(:hover) > polyline,
+.c7:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c7:focus:not(:focus-visible)::-moz-focus-inner {
+.c7:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -19057,43 +19057,43 @@ exports[`Calendar showAdjacentDays 1`] = `
   text-align: inherit;
 }
 
-.c13:focus {
+.c13:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus > circle,
-.c13:focus > ellipse,
-.c13:focus > line,
-.c13:focus > path,
-.c13:focus > polygon,
-.c13:focus > polyline,
-.c13:focus > rect {
+.c13:focus:not(:hover) > circle,
+.c13:focus:not(:hover) > ellipse,
+.c13:focus:not(:hover) > line,
+.c13:focus:not(:hover) > path,
+.c13:focus:not(:hover) > polygon,
+.c13:focus:not(:hover) > polyline,
+.c13:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus::-moz-focus-inner {
+.c13:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c13:focus:not(:focus-visible) {
+.c13:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible) > circle,
-.c13:focus:not(:focus-visible) > ellipse,
-.c13:focus:not(:focus-visible) > line,
-.c13:focus:not(:focus-visible) > path,
-.c13:focus:not(:focus-visible) > polygon,
-.c13:focus:not(:focus-visible) > polyline,
-.c13:focus:not(:focus-visible) > rect {
+.c13:focus:not(:focus-visible):not(:hover) > circle,
+.c13:focus:not(:focus-visible):not(:hover) > ellipse,
+.c13:focus:not(:focus-visible):not(:hover) > line,
+.c13:focus:not(:focus-visible):not(:hover) > path,
+.c13:focus:not(:focus-visible):not(:hover) > polygon,
+.c13:focus:not(:focus-visible):not(:hover) > polyline,
+.c13:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible)::-moz-focus-inner {
+.c13:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -21707,43 +21707,43 @@ exports[`Calendar size 1`] = `
   padding: 12px;
 }
 
-.c7:focus {
+.c7:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus > circle,
-.c7:focus > ellipse,
-.c7:focus > line,
-.c7:focus > path,
-.c7:focus > polygon,
-.c7:focus > polyline,
-.c7:focus > rect {
+.c7:focus:not(:hover) > circle,
+.c7:focus:not(:hover) > ellipse,
+.c7:focus:not(:hover) > line,
+.c7:focus:not(:hover) > path,
+.c7:focus:not(:hover) > polygon,
+.c7:focus:not(:hover) > polyline,
+.c7:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus::-moz-focus-inner {
+.c7:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c7:focus:not(:focus-visible) {
+.c7:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c7:focus:not(:focus-visible) > circle,
-.c7:focus:not(:focus-visible) > ellipse,
-.c7:focus:not(:focus-visible) > line,
-.c7:focus:not(:focus-visible) > path,
-.c7:focus:not(:focus-visible) > polygon,
-.c7:focus:not(:focus-visible) > polyline,
-.c7:focus:not(:focus-visible) > rect {
+.c7:focus:not(:focus-visible):not(:hover) > circle,
+.c7:focus:not(:focus-visible):not(:hover) > ellipse,
+.c7:focus:not(:focus-visible):not(:hover) > line,
+.c7:focus:not(:focus-visible):not(:hover) > path,
+.c7:focus:not(:focus-visible):not(:hover) > polygon,
+.c7:focus:not(:focus-visible):not(:hover) > polyline,
+.c7:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c7:focus:not(:focus-visible)::-moz-focus-inner {
+.c7:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -21765,43 +21765,43 @@ exports[`Calendar size 1`] = `
   text-align: inherit;
 }
 
-.c13:focus {
+.c13:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus > circle,
-.c13:focus > ellipse,
-.c13:focus > line,
-.c13:focus > path,
-.c13:focus > polygon,
-.c13:focus > polyline,
-.c13:focus > rect {
+.c13:focus:not(:hover) > circle,
+.c13:focus:not(:hover) > ellipse,
+.c13:focus:not(:hover) > line,
+.c13:focus:not(:hover) > path,
+.c13:focus:not(:hover) > polygon,
+.c13:focus:not(:hover) > polyline,
+.c13:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus::-moz-focus-inner {
+.c13:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c13:focus:not(:focus-visible) {
+.c13:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible) > circle,
-.c13:focus:not(:focus-visible) > ellipse,
-.c13:focus:not(:focus-visible) > line,
-.c13:focus:not(:focus-visible) > path,
-.c13:focus:not(:focus-visible) > polygon,
-.c13:focus:not(:focus-visible) > polyline,
-.c13:focus:not(:focus-visible) > rect {
+.c13:focus:not(:focus-visible):not(:hover) > circle,
+.c13:focus:not(:focus-visible):not(:hover) > ellipse,
+.c13:focus:not(:focus-visible):not(:hover) > line,
+.c13:focus:not(:focus-visible):not(:hover) > path,
+.c13:focus:not(:focus-visible):not(:hover) > polygon,
+.c13:focus:not(:focus-visible):not(:hover) > polyline,
+.c13:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible)::-moz-focus-inner {
+.c13:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 

--- a/src/js/components/Carousel/__tests__/__snapshots__/Carousel-test.tsx.snap
+++ b/src/js/components/Carousel/__tests__/__snapshots__/Carousel-test.tsx.snap
@@ -172,43 +172,43 @@ exports[`Carousel basic 1`] = `
   line-height: 0;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -232,43 +232,43 @@ exports[`Carousel basic 1`] = `
   padding: 12px;
 }
 
-.c13:focus {
+.c13:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus > circle,
-.c13:focus > ellipse,
-.c13:focus > line,
-.c13:focus > path,
-.c13:focus > polygon,
-.c13:focus > polyline,
-.c13:focus > rect {
+.c13:focus:not(:hover) > circle,
+.c13:focus:not(:hover) > ellipse,
+.c13:focus:not(:hover) > line,
+.c13:focus:not(:hover) > path,
+.c13:focus:not(:hover) > polygon,
+.c13:focus:not(:hover) > polyline,
+.c13:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus::-moz-focus-inner {
+.c13:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c13:focus:not(:focus-visible) {
+.c13:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible) > circle,
-.c13:focus:not(:focus-visible) > ellipse,
-.c13:focus:not(:focus-visible) > line,
-.c13:focus:not(:focus-visible) > path,
-.c13:focus:not(:focus-visible) > polygon,
-.c13:focus:not(:focus-visible) > polyline,
-.c13:focus:not(:focus-visible) > rect {
+.c13:focus:not(:focus-visible):not(:hover) > circle,
+.c13:focus:not(:focus-visible):not(:hover) > ellipse,
+.c13:focus:not(:focus-visible):not(:hover) > line,
+.c13:focus:not(:focus-visible):not(:hover) > path,
+.c13:focus:not(:focus-visible):not(:hover) > polygon,
+.c13:focus:not(:focus-visible):not(:hover) > polyline,
+.c13:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible)::-moz-focus-inner {
+.c13:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -297,43 +297,43 @@ exports[`Carousel basic 1`] = `
   color: #000000;
 }
 
-.c16:focus {
+.c16:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c16:focus > circle,
-.c16:focus > ellipse,
-.c16:focus > line,
-.c16:focus > path,
-.c16:focus > polygon,
-.c16:focus > polyline,
-.c16:focus > rect {
+.c16:focus:not(:hover) > circle,
+.c16:focus:not(:hover) > ellipse,
+.c16:focus:not(:hover) > line,
+.c16:focus:not(:hover) > path,
+.c16:focus:not(:hover) > polygon,
+.c16:focus:not(:hover) > polyline,
+.c16:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c16:focus::-moz-focus-inner {
+.c16:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c16:focus:not(:focus-visible) {
+.c16:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c16:focus:not(:focus-visible) > circle,
-.c16:focus:not(:focus-visible) > ellipse,
-.c16:focus:not(:focus-visible) > line,
-.c16:focus:not(:focus-visible) > path,
-.c16:focus:not(:focus-visible) > polygon,
-.c16:focus:not(:focus-visible) > polyline,
-.c16:focus:not(:focus-visible) > rect {
+.c16:focus:not(:focus-visible):not(:hover) > circle,
+.c16:focus:not(:focus-visible):not(:hover) > ellipse,
+.c16:focus:not(:focus-visible):not(:hover) > line,
+.c16:focus:not(:focus-visible):not(:hover) > path,
+.c16:focus:not(:focus-visible):not(:hover) > polygon,
+.c16:focus:not(:focus-visible):not(:hover) > polyline,
+.c16:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c16:focus:not(:focus-visible)::-moz-focus-inner {
+.c16:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -630,43 +630,43 @@ exports[`Carousel controlled component 1`] = `
   color: #000000;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -692,43 +692,43 @@ exports[`Carousel controlled component 1`] = `
   line-height: 0;
 }
 
-.c10:focus {
+.c10:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c10:focus > circle,
-.c10:focus > ellipse,
-.c10:focus > line,
-.c10:focus > path,
-.c10:focus > polygon,
-.c10:focus > polyline,
-.c10:focus > rect {
+.c10:focus:not(:hover) > circle,
+.c10:focus:not(:hover) > ellipse,
+.c10:focus:not(:hover) > line,
+.c10:focus:not(:hover) > path,
+.c10:focus:not(:hover) > polygon,
+.c10:focus:not(:hover) > polyline,
+.c10:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c10:focus::-moz-focus-inner {
+.c10:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c10:focus:not(:focus-visible) {
+.c10:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c10:focus:not(:focus-visible) > circle,
-.c10:focus:not(:focus-visible) > ellipse,
-.c10:focus:not(:focus-visible) > line,
-.c10:focus:not(:focus-visible) > path,
-.c10:focus:not(:focus-visible) > polygon,
-.c10:focus:not(:focus-visible) > polyline,
-.c10:focus:not(:focus-visible) > rect {
+.c10:focus:not(:focus-visible):not(:hover) > circle,
+.c10:focus:not(:focus-visible):not(:hover) > ellipse,
+.c10:focus:not(:focus-visible):not(:hover) > line,
+.c10:focus:not(:focus-visible):not(:hover) > path,
+.c10:focus:not(:focus-visible):not(:hover) > polygon,
+.c10:focus:not(:focus-visible):not(:hover) > polyline,
+.c10:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c10:focus:not(:focus-visible)::-moz-focus-inner {
+.c10:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -3020,43 +3020,43 @@ exports[`DataTable custom theme 1`] = `
   height: 100%;
 }
 
-.c7:focus {
+.c7:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus > circle,
-.c7:focus > ellipse,
-.c7:focus > line,
-.c7:focus > path,
-.c7:focus > polygon,
-.c7:focus > polyline,
-.c7:focus > rect {
+.c7:focus:not(:hover) > circle,
+.c7:focus:not(:hover) > ellipse,
+.c7:focus:not(:hover) > line,
+.c7:focus:not(:hover) > path,
+.c7:focus:not(:hover) > polygon,
+.c7:focus:not(:hover) > polyline,
+.c7:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus::-moz-focus-inner {
+.c7:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c7:focus:not(:focus-visible) {
+.c7:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c7:focus:not(:focus-visible) > circle,
-.c7:focus:not(:focus-visible) > ellipse,
-.c7:focus:not(:focus-visible) > line,
-.c7:focus:not(:focus-visible) > path,
-.c7:focus:not(:focus-visible) > polygon,
-.c7:focus:not(:focus-visible) > polyline,
-.c7:focus:not(:focus-visible) > rect {
+.c7:focus:not(:focus-visible):not(:hover) > circle,
+.c7:focus:not(:focus-visible):not(:hover) > ellipse,
+.c7:focus:not(:focus-visible):not(:hover) > line,
+.c7:focus:not(:focus-visible):not(:hover) > path,
+.c7:focus:not(:focus-visible):not(:hover) > polygon,
+.c7:focus:not(:focus-visible):not(:hover) > polyline,
+.c7:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c7:focus:not(:focus-visible)::-moz-focus-inner {
+.c7:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -3449,7 +3449,7 @@ exports[`DataTable custom theme 2`] = `
               class="StyledBox-sc-13pk1d4-0 dLvCRF"
             >
               <button
-                class="StyledButton-sc-323bzc-0 btgWam Header__StyledHeaderCellButton-sc-1baku5q-0 kmeiPn"
+                class="StyledButton-sc-323bzc-0 laoim Header__StyledHeaderCellButton-sc-1baku5q-0 kmeiPn"
                 type="button"
               >
                 <div
@@ -4620,43 +4620,43 @@ exports[`DataTable groupBy 1`] = `
   color: #000000;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -4966,7 +4966,7 @@ exports[`DataTable groupBy 2`] = `
           >
             <button
               aria-label="expand"
-              class="StyledButton-sc-323bzc-0 fpoetD"
+              class="StyledButton-sc-323bzc-0 uzPlT"
               type="button"
             >
               <div
@@ -5033,7 +5033,7 @@ exports[`DataTable groupBy 2`] = `
           >
             <button
               aria-label="expand"
-              class="StyledButton-sc-323bzc-0 fpoetD"
+              class="StyledButton-sc-323bzc-0 uzPlT"
               type="button"
             >
               <div
@@ -5089,7 +5089,7 @@ exports[`DataTable groupBy 2`] = `
           >
             <button
               aria-label="expand"
-              class="StyledButton-sc-323bzc-0 fpoetD"
+              class="StyledButton-sc-323bzc-0 uzPlT"
               type="button"
             >
               <div
@@ -5324,43 +5324,43 @@ exports[`DataTable groupBy expand 1`] = `
   color: #000000;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -5914,43 +5914,43 @@ exports[`DataTable groupBy property 1`] = `
   color: #000000;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -6260,7 +6260,7 @@ exports[`DataTable groupBy property 2`] = `
           >
             <button
               aria-label="expand"
-              class="StyledButton-sc-323bzc-0 fpoetD"
+              class="StyledButton-sc-323bzc-0 uzPlT"
               type="button"
             >
               <div
@@ -6327,7 +6327,7 @@ exports[`DataTable groupBy property 2`] = `
           >
             <button
               aria-label="expand"
-              class="StyledButton-sc-323bzc-0 fpoetD"
+              class="StyledButton-sc-323bzc-0 uzPlT"
               type="button"
             >
               <div
@@ -6383,7 +6383,7 @@ exports[`DataTable groupBy property 2`] = `
           >
             <button
               aria-label="expand"
-              class="StyledButton-sc-323bzc-0 fpoetD"
+              class="StyledButton-sc-323bzc-0 uzPlT"
               type="button"
             >
               <div
@@ -6839,43 +6839,43 @@ exports[`DataTable groupBy toggle 2`] = `
   color: #000000;
 }
 
-.c2:focus {
+.c2:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c2:focus > circle,
-.c2:focus > ellipse,
-.c2:focus > line,
-.c2:focus > path,
-.c2:focus > polygon,
-.c2:focus > polyline,
-.c2:focus > rect {
+.c2:focus:not(:hover) > circle,
+.c2:focus:not(:hover) > ellipse,
+.c2:focus:not(:hover) > line,
+.c2:focus:not(:hover) > path,
+.c2:focus:not(:hover) > polygon,
+.c2:focus:not(:hover) > polyline,
+.c2:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c2:focus::-moz-focus-inner {
+.c2:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c2:focus:not(:focus-visible) {
+.c2:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c2:focus:not(:focus-visible) > circle,
-.c2:focus:not(:focus-visible) > ellipse,
-.c2:focus:not(:focus-visible) > line,
-.c2:focus:not(:focus-visible) > path,
-.c2:focus:not(:focus-visible) > polygon,
-.c2:focus:not(:focus-visible) > polyline,
-.c2:focus:not(:focus-visible) > rect {
+.c2:focus:not(:focus-visible):not(:hover) > circle,
+.c2:focus:not(:focus-visible):not(:hover) > ellipse,
+.c2:focus:not(:focus-visible):not(:hover) > line,
+.c2:focus:not(:focus-visible):not(:hover) > path,
+.c2:focus:not(:focus-visible):not(:hover) > polygon,
+.c2:focus:not(:focus-visible):not(:hover) > polyline,
+.c2:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c2:focus:not(:focus-visible)::-moz-focus-inner {
+.c2:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -7095,43 +7095,43 @@ exports[`DataTable groupBy toggle 2`] = `
   color: #000000;
 }
 
-.c3:focus {
+.c3:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
+.c3:focus:not(:hover) > circle,
+.c3:focus:not(:hover) > ellipse,
+.c3:focus:not(:hover) > line,
+.c3:focus:not(:hover) > path,
+.c3:focus:not(:hover) > polygon,
+.c3:focus:not(:hover) > polyline,
+.c3:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus::-moz-focus-inner {
+.c3:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c3:focus:not(:focus-visible) {
+.c3:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
+.c3:focus:not(:focus-visible):not(:hover) > circle,
+.c3:focus:not(:focus-visible):not(:hover) > ellipse,
+.c3:focus:not(:focus-visible):not(:hover) > line,
+.c3:focus:not(:focus-visible):not(:hover) > path,
+.c3:focus:not(:focus-visible):not(:hover) > polygon,
+.c3:focus:not(:focus-visible):not(:hover) > polyline,
+.c3:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
+.c3:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -7803,43 +7803,43 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
   color: #000000;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -8685,43 +8685,43 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
   color: #000000;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -9415,43 +9415,43 @@ exports[`DataTable onSelect + groupBy should select all items within a group 1`]
   color: #000000;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -10125,43 +10125,43 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 1`
   color: #000000;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -10621,7 +10621,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
           >
             <button
               aria-label="expand"
-              class="StyledButton-sc-323bzc-0 fpoetD"
+              class="StyledButton-sc-323bzc-0 uzPlT"
               type="button"
             >
               <div
@@ -10753,7 +10753,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
           >
             <button
               aria-label="expand"
-              class="StyledButton-sc-323bzc-0 fpoetD"
+              class="StyledButton-sc-323bzc-0 uzPlT"
               type="button"
             >
               <div
@@ -10873,7 +10873,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
           >
             <button
               aria-label="expand"
-              class="StyledButton-sc-323bzc-0 fpoetD"
+              class="StyledButton-sc-323bzc-0 uzPlT"
               type="button"
             >
               <div
@@ -11008,7 +11008,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
           >
             <button
               aria-label="expand"
-              class="StyledButton-sc-323bzc-0 fpoetD"
+              class="StyledButton-sc-323bzc-0 uzPlT"
               type="button"
             >
               <div
@@ -11101,7 +11101,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
           >
             <button
               aria-label="expand"
-              class="StyledButton-sc-323bzc-0 fpoetD"
+              class="StyledButton-sc-323bzc-0 uzPlT"
               type="button"
             >
               <div
@@ -11182,7 +11182,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
           >
             <button
               aria-label="expand"
-              class="StyledButton-sc-323bzc-0 fpoetD"
+              class="StyledButton-sc-323bzc-0 uzPlT"
               type="button"
             >
               <div
@@ -12648,43 +12648,43 @@ exports[`DataTable onSort 1`] = `
   height: 100%;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -12923,7 +12923,7 @@ exports[`DataTable onSort 2`] = `
             class="StyledBox-sc-13pk1d4-0 dLvCRF"
           >
             <button
-              class="StyledButton-sc-323bzc-0 btgWam Header__StyledHeaderCellButton-sc-1baku5q-0 gDJDvV"
+              class="StyledButton-sc-323bzc-0 laoim Header__StyledHeaderCellButton-sc-1baku5q-0 gDJDvV"
               type="button"
             >
               <div
@@ -13023,7 +13023,7 @@ exports[`DataTable onSort 2`] = `
             class="StyledBox-sc-13pk1d4-0 dLvCRF"
           >
             <button
-              class="StyledButton-sc-323bzc-0 btgWam Header__StyledHeaderCellButton-sc-1baku5q-0 gDJDvV"
+              class="StyledButton-sc-323bzc-0 laoim Header__StyledHeaderCellButton-sc-1baku5q-0 gDJDvV"
               type="button"
             >
               <div
@@ -13275,43 +13275,43 @@ exports[`DataTable onSort external 1`] = `
   height: 100%;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -13571,7 +13571,7 @@ exports[`DataTable onSort external 2`] = `
             class="StyledBox-sc-13pk1d4-0 dLvCRF"
           >
             <button
-              class="StyledButton-sc-323bzc-0 btgWam Header__StyledHeaderCellButton-sc-1baku5q-0 gDJDvV"
+              class="StyledButton-sc-323bzc-0 laoim Header__StyledHeaderCellButton-sc-1baku5q-0 gDJDvV"
               type="button"
             >
               <div
@@ -13651,7 +13651,7 @@ exports[`DataTable onSort external 2`] = `
             class="StyledBox-sc-13pk1d4-0 dLvCRF"
           >
             <button
-              class="StyledButton-sc-323bzc-0 btgWam Header__StyledHeaderCellButton-sc-1baku5q-0 gDJDvV"
+              class="StyledButton-sc-323bzc-0 laoim Header__StyledHeaderCellButton-sc-1baku5q-0 gDJDvV"
               type="button"
             >
               <div
@@ -18104,43 +18104,43 @@ exports[`DataTable rowDetails 1`] = `
   color: #000000;
 }
 
-.c10:focus {
+.c10:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c10:focus > circle,
-.c10:focus > ellipse,
-.c10:focus > line,
-.c10:focus > path,
-.c10:focus > polygon,
-.c10:focus > polyline,
-.c10:focus > rect {
+.c10:focus:not(:hover) > circle,
+.c10:focus:not(:hover) > ellipse,
+.c10:focus:not(:hover) > line,
+.c10:focus:not(:hover) > path,
+.c10:focus:not(:hover) > polygon,
+.c10:focus:not(:hover) > polyline,
+.c10:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c10:focus::-moz-focus-inner {
+.c10:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c10:focus:not(:focus-visible) {
+.c10:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c10:focus:not(:focus-visible) > circle,
-.c10:focus:not(:focus-visible) > ellipse,
-.c10:focus:not(:focus-visible) > line,
-.c10:focus:not(:focus-visible) > path,
-.c10:focus:not(:focus-visible) > polygon,
-.c10:focus:not(:focus-visible) > polyline,
-.c10:focus:not(:focus-visible) > rect {
+.c10:focus:not(:focus-visible):not(:hover) > circle,
+.c10:focus:not(:focus-visible):not(:hover) > ellipse,
+.c10:focus:not(:focus-visible):not(:hover) > line,
+.c10:focus:not(:focus-visible):not(:hover) > path,
+.c10:focus:not(:focus-visible):not(:hover) > polygon,
+.c10:focus:not(:focus-visible):not(:hover) > polyline,
+.c10:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c10:focus:not(:focus-visible)::-moz-focus-inner {
+.c10:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -18708,43 +18708,43 @@ exports[`DataTable rowDetails condtional 1`] = `
   color: #000000;
 }
 
-.c10:focus {
+.c10:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c10:focus > circle,
-.c10:focus > ellipse,
-.c10:focus > line,
-.c10:focus > path,
-.c10:focus > polygon,
-.c10:focus > polyline,
-.c10:focus > rect {
+.c10:focus:not(:hover) > circle,
+.c10:focus:not(:hover) > ellipse,
+.c10:focus:not(:hover) > line,
+.c10:focus:not(:hover) > path,
+.c10:focus:not(:hover) > polygon,
+.c10:focus:not(:hover) > polyline,
+.c10:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c10:focus::-moz-focus-inner {
+.c10:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c10:focus:not(:focus-visible) {
+.c10:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c10:focus:not(:focus-visible) > circle,
-.c10:focus:not(:focus-visible) > ellipse,
-.c10:focus:not(:focus-visible) > line,
-.c10:focus:not(:focus-visible) > path,
-.c10:focus:not(:focus-visible) > polygon,
-.c10:focus:not(:focus-visible) > polyline,
-.c10:focus:not(:focus-visible) > rect {
+.c10:focus:not(:focus-visible):not(:hover) > circle,
+.c10:focus:not(:focus-visible):not(:hover) > ellipse,
+.c10:focus:not(:focus-visible):not(:hover) > line,
+.c10:focus:not(:focus-visible):not(:hover) > path,
+.c10:focus:not(:focus-visible):not(:hover) > polygon,
+.c10:focus:not(:focus-visible):not(:hover) > polyline,
+.c10:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c10:focus:not(:focus-visible)::-moz-focus-inner {
+.c10:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -19572,43 +19572,43 @@ exports[`DataTable search 1`] = `
   color: #000000;
 }
 
-.c8:focus {
+.c8:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c8:focus > circle,
-.c8:focus > ellipse,
-.c8:focus > line,
-.c8:focus > path,
-.c8:focus > polygon,
-.c8:focus > polyline,
-.c8:focus > rect {
+.c8:focus:not(:hover) > circle,
+.c8:focus:not(:hover) > ellipse,
+.c8:focus:not(:hover) > line,
+.c8:focus:not(:hover) > path,
+.c8:focus:not(:hover) > polygon,
+.c8:focus:not(:hover) > polyline,
+.c8:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c8:focus::-moz-focus-inner {
+.c8:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c8:focus:not(:focus-visible) {
+.c8:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c8:focus:not(:focus-visible) > circle,
-.c8:focus:not(:focus-visible) > ellipse,
-.c8:focus:not(:focus-visible) > line,
-.c8:focus:not(:focus-visible) > path,
-.c8:focus:not(:focus-visible) > polygon,
-.c8:focus:not(:focus-visible) > polyline,
-.c8:focus:not(:focus-visible) > rect {
+.c8:focus:not(:focus-visible):not(:hover) > circle,
+.c8:focus:not(:focus-visible):not(:hover) > ellipse,
+.c8:focus:not(:focus-visible):not(:hover) > line,
+.c8:focus:not(:focus-visible):not(:hover) > path,
+.c8:focus:not(:focus-visible):not(:hover) > polygon,
+.c8:focus:not(:focus-visible):not(:hover) > polyline,
+.c8:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c8:focus:not(:focus-visible)::-moz-focus-inner {
+.c8:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -35632,43 +35632,43 @@ exports[`DataTable sort 1`] = `
   height: 100%;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -36041,43 +36041,43 @@ exports[`DataTable sort external 1`] = `
   height: 100%;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -36450,43 +36450,43 @@ exports[`DataTable sort nested object 1`] = `
   height: 100%;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -36859,43 +36859,43 @@ exports[`DataTable sort nested object with onSort 1`] = `
   height: 100%;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -37224,43 +37224,43 @@ exports[`DataTable sortable 1`] = `
   height: 100%;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -37499,7 +37499,7 @@ exports[`DataTable sortable 2`] = `
             class="StyledBox-sc-13pk1d4-0 dLvCRF"
           >
             <button
-              class="StyledButton-sc-323bzc-0 btgWam Header__StyledHeaderCellButton-sc-1baku5q-0 gDJDvV"
+              class="StyledButton-sc-323bzc-0 laoim Header__StyledHeaderCellButton-sc-1baku5q-0 gDJDvV"
               type="button"
             >
               <div
@@ -37599,7 +37599,7 @@ exports[`DataTable sortable 2`] = `
             class="StyledBox-sc-13pk1d4-0 dLvCRF"
           >
             <button
-              class="StyledButton-sc-323bzc-0 btgWam Header__StyledHeaderCellButton-sc-1baku5q-0 gDJDvV"
+              class="StyledButton-sc-323bzc-0 laoim Header__StyledHeaderCellButton-sc-1baku5q-0 gDJDvV"
               type="button"
             >
               <div

--- a/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.tsx.snap
+++ b/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.tsx.snap
@@ -65,43 +65,43 @@ exports[`DateInput basic 1`] = `
   padding: 12px;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -198,43 +198,43 @@ exports[`DateInput buttonProps should pass props to Button
   padding: 12px;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -422,43 +422,43 @@ exports[`DateInput controlled format inline 1`] = `
   line-height: 0;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -482,43 +482,43 @@ exports[`DateInput controlled format inline 1`] = `
   padding: 12px;
 }
 
-.c12:focus {
+.c12:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus > circle,
-.c12:focus > ellipse,
-.c12:focus > line,
-.c12:focus > path,
-.c12:focus > polygon,
-.c12:focus > polyline,
-.c12:focus > rect {
+.c12:focus:not(:hover) > circle,
+.c12:focus:not(:hover) > ellipse,
+.c12:focus:not(:hover) > line,
+.c12:focus:not(:hover) > path,
+.c12:focus:not(:hover) > polygon,
+.c12:focus:not(:hover) > polyline,
+.c12:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus::-moz-focus-inner {
+.c12:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c12:focus:not(:focus-visible) {
+.c12:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible) > circle,
-.c12:focus:not(:focus-visible) > ellipse,
-.c12:focus:not(:focus-visible) > line,
-.c12:focus:not(:focus-visible) > path,
-.c12:focus:not(:focus-visible) > polygon,
-.c12:focus:not(:focus-visible) > polyline,
-.c12:focus:not(:focus-visible) > rect {
+.c12:focus:not(:focus-visible):not(:hover) > circle,
+.c12:focus:not(:focus-visible):not(:hover) > ellipse,
+.c12:focus:not(:focus-visible):not(:hover) > line,
+.c12:focus:not(:focus-visible):not(:hover) > path,
+.c12:focus:not(:focus-visible):not(:hover) > polygon,
+.c12:focus:not(:focus-visible):not(:hover) > polyline,
+.c12:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible)::-moz-focus-inner {
+.c12:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -540,43 +540,43 @@ exports[`DateInput controlled format inline 1`] = `
   text-align: inherit;
 }
 
-.c17:focus {
+.c17:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus > circle,
-.c17:focus > ellipse,
-.c17:focus > line,
-.c17:focus > path,
-.c17:focus > polygon,
-.c17:focus > polyline,
-.c17:focus > rect {
+.c17:focus:not(:hover) > circle,
+.c17:focus:not(:hover) > ellipse,
+.c17:focus:not(:hover) > line,
+.c17:focus:not(:hover) > path,
+.c17:focus:not(:hover) > polygon,
+.c17:focus:not(:hover) > polyline,
+.c17:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus::-moz-focus-inner {
+.c17:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c17:focus:not(:focus-visible) {
+.c17:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible) > circle,
-.c17:focus:not(:focus-visible) > ellipse,
-.c17:focus:not(:focus-visible) > line,
-.c17:focus:not(:focus-visible) > path,
-.c17:focus:not(:focus-visible) > polygon,
-.c17:focus:not(:focus-visible) > polyline,
-.c17:focus:not(:focus-visible) > rect {
+.c17:focus:not(:focus-visible):not(:hover) > circle,
+.c17:focus:not(:focus-visible):not(:hover) > ellipse,
+.c17:focus:not(:focus-visible):not(:hover) > line,
+.c17:focus:not(:focus-visible):not(:hover) > path,
+.c17:focus:not(:focus-visible):not(:hover) > polygon,
+.c17:focus:not(:focus-visible):not(:hover) > polyline,
+.c17:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible)::-moz-focus-inner {
+.c17:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -609,43 +609,43 @@ exports[`DateInput controlled format inline 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c21:focus {
+.c21:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c21:focus > circle,
-.c21:focus > ellipse,
-.c21:focus > line,
-.c21:focus > path,
-.c21:focus > polygon,
-.c21:focus > polyline,
-.c21:focus > rect {
+.c21:focus:not(:hover) > circle,
+.c21:focus:not(:hover) > ellipse,
+.c21:focus:not(:hover) > line,
+.c21:focus:not(:hover) > path,
+.c21:focus:not(:hover) > polygon,
+.c21:focus:not(:hover) > polyline,
+.c21:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c21:focus::-moz-focus-inner {
+.c21:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c21:focus:not(:focus-visible) {
+.c21:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c21:focus:not(:focus-visible) > circle,
-.c21:focus:not(:focus-visible) > ellipse,
-.c21:focus:not(:focus-visible) > line,
-.c21:focus:not(:focus-visible) > path,
-.c21:focus:not(:focus-visible) > polygon,
-.c21:focus:not(:focus-visible) > polyline,
-.c21:focus:not(:focus-visible) > rect {
+.c21:focus:not(:focus-visible):not(:hover) > circle,
+.c21:focus:not(:focus-visible):not(:hover) > ellipse,
+.c21:focus:not(:focus-visible):not(:hover) > line,
+.c21:focus:not(:focus-visible):not(:hover) > path,
+.c21:focus:not(:focus-visible):not(:hover) > polygon,
+.c21:focus:not(:focus-visible):not(:hover) > polyline,
+.c21:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c21:focus:not(:focus-visible)::-moz-focus-inner {
+.c21:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -1737,7 +1737,7 @@ exports[`DateInput controlled format inline 2`] = `
         />
       </div>
       <button
-        class="StyledButton-sc-323bzc-0 kHVwhD"
+        class="StyledButton-sc-323bzc-0 eQOfsX"
         type="button"
       >
         <svg
@@ -1777,7 +1777,7 @@ exports[`DateInput controlled format inline 2`] = `
           >
             <button
               aria-label="Go to June 2020"
-              class="StyledButton-sc-323bzc-0 bpsTzm"
+              class="StyledButton-sc-323bzc-0 xRvZe"
               type="button"
             >
               <svg
@@ -1795,7 +1795,7 @@ exports[`DateInput controlled format inline 2`] = `
             </button>
             <button
               aria-label="Go to August 2020"
-              class="StyledButton-sc-323bzc-0 bpsTzm"
+              class="StyledButton-sc-323bzc-0 xRvZe"
               type="button"
             >
               <svg
@@ -1835,7 +1835,7 @@ exports[`DateInput controlled format inline 2`] = `
               >
                 <button
                   aria-label="Sun Jun 28 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -1852,7 +1852,7 @@ exports[`DateInput controlled format inline 2`] = `
               >
                 <button
                   aria-label="Mon Jun 29 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -1869,7 +1869,7 @@ exports[`DateInput controlled format inline 2`] = `
               >
                 <button
                   aria-label="Tue Jun 30 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -1886,7 +1886,7 @@ exports[`DateInput controlled format inline 2`] = `
               >
                 <button
                   aria-label="Wed Jul 01 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -1903,7 +1903,7 @@ exports[`DateInput controlled format inline 2`] = `
               >
                 <button
                   aria-label="Thu Jul 02 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -1920,7 +1920,7 @@ exports[`DateInput controlled format inline 2`] = `
               >
                 <button
                   aria-label="Fri Jul 03 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -1937,7 +1937,7 @@ exports[`DateInput controlled format inline 2`] = `
               >
                 <button
                   aria-label="Sat Jul 04 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -1959,7 +1959,7 @@ exports[`DateInput controlled format inline 2`] = `
               >
                 <button
                   aria-label="Sun Jul 05 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -1976,7 +1976,7 @@ exports[`DateInput controlled format inline 2`] = `
               >
                 <button
                   aria-label="Mon Jul 06 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -1993,7 +1993,7 @@ exports[`DateInput controlled format inline 2`] = `
               >
                 <button
                   aria-label="Tue Jul 07 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -2010,7 +2010,7 @@ exports[`DateInput controlled format inline 2`] = `
               >
                 <button
                   aria-label="Wed Jul 08 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -2027,7 +2027,7 @@ exports[`DateInput controlled format inline 2`] = `
               >
                 <button
                   aria-label="Thu Jul 09 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -2044,7 +2044,7 @@ exports[`DateInput controlled format inline 2`] = `
               >
                 <button
                   aria-label="Fri Jul 10 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -2061,7 +2061,7 @@ exports[`DateInput controlled format inline 2`] = `
               >
                 <button
                   aria-label="Sat Jul 11 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -2083,7 +2083,7 @@ exports[`DateInput controlled format inline 2`] = `
               >
                 <button
                   aria-label="Sun Jul 12 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -2100,7 +2100,7 @@ exports[`DateInput controlled format inline 2`] = `
               >
                 <button
                   aria-label="Mon Jul 13 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -2117,7 +2117,7 @@ exports[`DateInput controlled format inline 2`] = `
               >
                 <button
                   aria-label="Tue Jul 14 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -2134,7 +2134,7 @@ exports[`DateInput controlled format inline 2`] = `
               >
                 <button
                   aria-label="Wed Jul 15 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -2151,7 +2151,7 @@ exports[`DateInput controlled format inline 2`] = `
               >
                 <button
                   aria-label="Thu Jul 16 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -2168,7 +2168,7 @@ exports[`DateInput controlled format inline 2`] = `
               >
                 <button
                   aria-label="Fri Jul 17 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -2185,7 +2185,7 @@ exports[`DateInput controlled format inline 2`] = `
               >
                 <button
                   aria-label="Sat Jul 18 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -2207,7 +2207,7 @@ exports[`DateInput controlled format inline 2`] = `
               >
                 <button
                   aria-label="Sun Jul 19 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -2224,7 +2224,7 @@ exports[`DateInput controlled format inline 2`] = `
               >
                 <button
                   aria-label="Mon Jul 20 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -2241,7 +2241,7 @@ exports[`DateInput controlled format inline 2`] = `
               >
                 <button
                   aria-label="Tue Jul 21 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -2258,7 +2258,7 @@ exports[`DateInput controlled format inline 2`] = `
               >
                 <button
                   aria-label="Wed Jul 22 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -2275,7 +2275,7 @@ exports[`DateInput controlled format inline 2`] = `
               >
                 <button
                   aria-label="Thu Jul 23 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -2292,7 +2292,7 @@ exports[`DateInput controlled format inline 2`] = `
               >
                 <button
                   aria-label="Fri Jul 24 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -2309,7 +2309,7 @@ exports[`DateInput controlled format inline 2`] = `
               >
                 <button
                   aria-label="Sat Jul 25 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -2331,7 +2331,7 @@ exports[`DateInput controlled format inline 2`] = `
               >
                 <button
                   aria-label="Sun Jul 26 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -2348,7 +2348,7 @@ exports[`DateInput controlled format inline 2`] = `
               >
                 <button
                   aria-label="Mon Jul 27 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -2365,7 +2365,7 @@ exports[`DateInput controlled format inline 2`] = `
               >
                 <button
                   aria-label="Tue Jul 28 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -2382,7 +2382,7 @@ exports[`DateInput controlled format inline 2`] = `
               >
                 <button
                   aria-label="Wed Jul 29 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -2399,7 +2399,7 @@ exports[`DateInput controlled format inline 2`] = `
               >
                 <button
                   aria-label="Thu Jul 30 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -2416,7 +2416,7 @@ exports[`DateInput controlled format inline 2`] = `
               >
                 <button
                   aria-label="Fri Jul 31 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -2433,7 +2433,7 @@ exports[`DateInput controlled format inline 2`] = `
               >
                 <button
                   aria-label="Sat Aug 01 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -2455,7 +2455,7 @@ exports[`DateInput controlled format inline 2`] = `
               >
                 <button
                   aria-label="Sun Aug 02 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -2472,7 +2472,7 @@ exports[`DateInput controlled format inline 2`] = `
               >
                 <button
                   aria-label="Mon Aug 03 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -2489,7 +2489,7 @@ exports[`DateInput controlled format inline 2`] = `
               >
                 <button
                   aria-label="Tue Aug 04 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -2506,7 +2506,7 @@ exports[`DateInput controlled format inline 2`] = `
               >
                 <button
                   aria-label="Wed Aug 05 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -2523,7 +2523,7 @@ exports[`DateInput controlled format inline 2`] = `
               >
                 <button
                   aria-label="Thu Aug 06 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -2540,7 +2540,7 @@ exports[`DateInput controlled format inline 2`] = `
               >
                 <button
                   aria-label="Fri Aug 07 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -2557,7 +2557,7 @@ exports[`DateInput controlled format inline 2`] = `
               >
                 <button
                   aria-label="Sat Aug 08 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -2575,7 +2575,7 @@ exports[`DateInput controlled format inline 2`] = `
     </div>
   </div>
   <button
-    class="StyledButton-sc-323bzc-0 LnlOO"
+    class="StyledButton-sc-323bzc-0 dJfmuO"
     type="button"
   >
     first
@@ -2743,43 +2743,43 @@ exports[`DateInput controlled format inline without timezone 1`] = `
   line-height: 0;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -2803,43 +2803,43 @@ exports[`DateInput controlled format inline without timezone 1`] = `
   padding: 12px;
 }
 
-.c12:focus {
+.c12:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus > circle,
-.c12:focus > ellipse,
-.c12:focus > line,
-.c12:focus > path,
-.c12:focus > polygon,
-.c12:focus > polyline,
-.c12:focus > rect {
+.c12:focus:not(:hover) > circle,
+.c12:focus:not(:hover) > ellipse,
+.c12:focus:not(:hover) > line,
+.c12:focus:not(:hover) > path,
+.c12:focus:not(:hover) > polygon,
+.c12:focus:not(:hover) > polyline,
+.c12:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus::-moz-focus-inner {
+.c12:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c12:focus:not(:focus-visible) {
+.c12:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible) > circle,
-.c12:focus:not(:focus-visible) > ellipse,
-.c12:focus:not(:focus-visible) > line,
-.c12:focus:not(:focus-visible) > path,
-.c12:focus:not(:focus-visible) > polygon,
-.c12:focus:not(:focus-visible) > polyline,
-.c12:focus:not(:focus-visible) > rect {
+.c12:focus:not(:focus-visible):not(:hover) > circle,
+.c12:focus:not(:focus-visible):not(:hover) > ellipse,
+.c12:focus:not(:focus-visible):not(:hover) > line,
+.c12:focus:not(:focus-visible):not(:hover) > path,
+.c12:focus:not(:focus-visible):not(:hover) > polygon,
+.c12:focus:not(:focus-visible):not(:hover) > polyline,
+.c12:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible)::-moz-focus-inner {
+.c12:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -2861,43 +2861,43 @@ exports[`DateInput controlled format inline without timezone 1`] = `
   text-align: inherit;
 }
 
-.c17:focus {
+.c17:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus > circle,
-.c17:focus > ellipse,
-.c17:focus > line,
-.c17:focus > path,
-.c17:focus > polygon,
-.c17:focus > polyline,
-.c17:focus > rect {
+.c17:focus:not(:hover) > circle,
+.c17:focus:not(:hover) > ellipse,
+.c17:focus:not(:hover) > line,
+.c17:focus:not(:hover) > path,
+.c17:focus:not(:hover) > polygon,
+.c17:focus:not(:hover) > polyline,
+.c17:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus::-moz-focus-inner {
+.c17:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c17:focus:not(:focus-visible) {
+.c17:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible) > circle,
-.c17:focus:not(:focus-visible) > ellipse,
-.c17:focus:not(:focus-visible) > line,
-.c17:focus:not(:focus-visible) > path,
-.c17:focus:not(:focus-visible) > polygon,
-.c17:focus:not(:focus-visible) > polyline,
-.c17:focus:not(:focus-visible) > rect {
+.c17:focus:not(:focus-visible):not(:hover) > circle,
+.c17:focus:not(:focus-visible):not(:hover) > ellipse,
+.c17:focus:not(:focus-visible):not(:hover) > line,
+.c17:focus:not(:focus-visible):not(:hover) > path,
+.c17:focus:not(:focus-visible):not(:hover) > polygon,
+.c17:focus:not(:focus-visible):not(:hover) > polyline,
+.c17:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible)::-moz-focus-inner {
+.c17:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -2930,43 +2930,43 @@ exports[`DateInput controlled format inline without timezone 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c21:focus {
+.c21:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c21:focus > circle,
-.c21:focus > ellipse,
-.c21:focus > line,
-.c21:focus > path,
-.c21:focus > polygon,
-.c21:focus > polyline,
-.c21:focus > rect {
+.c21:focus:not(:hover) > circle,
+.c21:focus:not(:hover) > ellipse,
+.c21:focus:not(:hover) > line,
+.c21:focus:not(:hover) > path,
+.c21:focus:not(:hover) > polygon,
+.c21:focus:not(:hover) > polyline,
+.c21:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c21:focus::-moz-focus-inner {
+.c21:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c21:focus:not(:focus-visible) {
+.c21:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c21:focus:not(:focus-visible) > circle,
-.c21:focus:not(:focus-visible) > ellipse,
-.c21:focus:not(:focus-visible) > line,
-.c21:focus:not(:focus-visible) > path,
-.c21:focus:not(:focus-visible) > polygon,
-.c21:focus:not(:focus-visible) > polyline,
-.c21:focus:not(:focus-visible) > rect {
+.c21:focus:not(:focus-visible):not(:hover) > circle,
+.c21:focus:not(:focus-visible):not(:hover) > ellipse,
+.c21:focus:not(:focus-visible):not(:hover) > line,
+.c21:focus:not(:focus-visible):not(:hover) > path,
+.c21:focus:not(:focus-visible):not(:hover) > polygon,
+.c21:focus:not(:focus-visible):not(:hover) > polyline,
+.c21:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c21:focus:not(:focus-visible)::-moz-focus-inner {
+.c21:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -4196,43 +4196,43 @@ exports[`DateInput controlled format inline without timezone 2`] = `
   line-height: 0;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -4256,43 +4256,43 @@ exports[`DateInput controlled format inline without timezone 2`] = `
   padding: 12px;
 }
 
-.c12:focus {
+.c12:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus > circle,
-.c12:focus > ellipse,
-.c12:focus > line,
-.c12:focus > path,
-.c12:focus > polygon,
-.c12:focus > polyline,
-.c12:focus > rect {
+.c12:focus:not(:hover) > circle,
+.c12:focus:not(:hover) > ellipse,
+.c12:focus:not(:hover) > line,
+.c12:focus:not(:hover) > path,
+.c12:focus:not(:hover) > polygon,
+.c12:focus:not(:hover) > polyline,
+.c12:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus::-moz-focus-inner {
+.c12:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c12:focus:not(:focus-visible) {
+.c12:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible) > circle,
-.c12:focus:not(:focus-visible) > ellipse,
-.c12:focus:not(:focus-visible) > line,
-.c12:focus:not(:focus-visible) > path,
-.c12:focus:not(:focus-visible) > polygon,
-.c12:focus:not(:focus-visible) > polyline,
-.c12:focus:not(:focus-visible) > rect {
+.c12:focus:not(:focus-visible):not(:hover) > circle,
+.c12:focus:not(:focus-visible):not(:hover) > ellipse,
+.c12:focus:not(:focus-visible):not(:hover) > line,
+.c12:focus:not(:focus-visible):not(:hover) > path,
+.c12:focus:not(:focus-visible):not(:hover) > polygon,
+.c12:focus:not(:focus-visible):not(:hover) > polyline,
+.c12:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible)::-moz-focus-inner {
+.c12:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -4314,43 +4314,43 @@ exports[`DateInput controlled format inline without timezone 2`] = `
   text-align: inherit;
 }
 
-.c17:focus {
+.c17:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus > circle,
-.c17:focus > ellipse,
-.c17:focus > line,
-.c17:focus > path,
-.c17:focus > polygon,
-.c17:focus > polyline,
-.c17:focus > rect {
+.c17:focus:not(:hover) > circle,
+.c17:focus:not(:hover) > ellipse,
+.c17:focus:not(:hover) > line,
+.c17:focus:not(:hover) > path,
+.c17:focus:not(:hover) > polygon,
+.c17:focus:not(:hover) > polyline,
+.c17:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus::-moz-focus-inner {
+.c17:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c17:focus:not(:focus-visible) {
+.c17:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible) > circle,
-.c17:focus:not(:focus-visible) > ellipse,
-.c17:focus:not(:focus-visible) > line,
-.c17:focus:not(:focus-visible) > path,
-.c17:focus:not(:focus-visible) > polygon,
-.c17:focus:not(:focus-visible) > polyline,
-.c17:focus:not(:focus-visible) > rect {
+.c17:focus:not(:focus-visible):not(:hover) > circle,
+.c17:focus:not(:focus-visible):not(:hover) > ellipse,
+.c17:focus:not(:focus-visible):not(:hover) > line,
+.c17:focus:not(:focus-visible):not(:hover) > path,
+.c17:focus:not(:focus-visible):not(:hover) > polygon,
+.c17:focus:not(:focus-visible):not(:hover) > polyline,
+.c17:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible)::-moz-focus-inner {
+.c17:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -4383,43 +4383,43 @@ exports[`DateInput controlled format inline without timezone 2`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c21:focus {
+.c21:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c21:focus > circle,
-.c21:focus > ellipse,
-.c21:focus > line,
-.c21:focus > path,
-.c21:focus > polygon,
-.c21:focus > polyline,
-.c21:focus > rect {
+.c21:focus:not(:hover) > circle,
+.c21:focus:not(:hover) > ellipse,
+.c21:focus:not(:hover) > line,
+.c21:focus:not(:hover) > path,
+.c21:focus:not(:hover) > polygon,
+.c21:focus:not(:hover) > polyline,
+.c21:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c21:focus::-moz-focus-inner {
+.c21:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c21:focus:not(:focus-visible) {
+.c21:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c21:focus:not(:focus-visible) > circle,
-.c21:focus:not(:focus-visible) > ellipse,
-.c21:focus:not(:focus-visible) > line,
-.c21:focus:not(:focus-visible) > path,
-.c21:focus:not(:focus-visible) > polygon,
-.c21:focus:not(:focus-visible) > polyline,
-.c21:focus:not(:focus-visible) > rect {
+.c21:focus:not(:focus-visible):not(:hover) > circle,
+.c21:focus:not(:focus-visible):not(:hover) > ellipse,
+.c21:focus:not(:focus-visible):not(:hover) > line,
+.c21:focus:not(:focus-visible):not(:hover) > path,
+.c21:focus:not(:focus-visible):not(:hover) > polygon,
+.c21:focus:not(:focus-visible):not(:hover) > polyline,
+.c21:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c21:focus:not(:focus-visible)::-moz-focus-inner {
+.c21:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -5554,43 +5554,43 @@ exports[`DateInput disabled 1`] = `
   padding: 12px;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -5702,43 +5702,43 @@ exports[`DateInput dropProps should pass props to Drop
   line-height: 0;
 }
 
-.c4:focus {
+.c4:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c4:focus > circle,
-.c4:focus > ellipse,
-.c4:focus > line,
-.c4:focus > path,
-.c4:focus > polygon,
-.c4:focus > polyline,
-.c4:focus > rect {
+.c4:focus:not(:hover) > circle,
+.c4:focus:not(:hover) > ellipse,
+.c4:focus:not(:hover) > line,
+.c4:focus:not(:hover) > path,
+.c4:focus:not(:hover) > polygon,
+.c4:focus:not(:hover) > polyline,
+.c4:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c4:focus::-moz-focus-inner {
+.c4:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c4:focus:not(:focus-visible) {
+.c4:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c4:focus:not(:focus-visible) > circle,
-.c4:focus:not(:focus-visible) > ellipse,
-.c4:focus:not(:focus-visible) > line,
-.c4:focus:not(:focus-visible) > path,
-.c4:focus:not(:focus-visible) > polygon,
-.c4:focus:not(:focus-visible) > polyline,
-.c4:focus:not(:focus-visible) > rect {
+.c4:focus:not(:focus-visible):not(:hover) > circle,
+.c4:focus:not(:focus-visible):not(:hover) > ellipse,
+.c4:focus:not(:focus-visible):not(:hover) > line,
+.c4:focus:not(:focus-visible):not(:hover) > path,
+.c4:focus:not(:focus-visible):not(:hover) > polygon,
+.c4:focus:not(:focus-visible):not(:hover) > polyline,
+.c4:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c4:focus:not(:focus-visible)::-moz-focus-inner {
+.c4:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -5943,43 +5943,43 @@ exports[`DateInput focus 1`] = `
   line-height: 0;
 }
 
-.c4:focus {
+.c4:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c4:focus > circle,
-.c4:focus > ellipse,
-.c4:focus > line,
-.c4:focus > path,
-.c4:focus > polygon,
-.c4:focus > polyline,
-.c4:focus > rect {
+.c4:focus:not(:hover) > circle,
+.c4:focus:not(:hover) > ellipse,
+.c4:focus:not(:hover) > line,
+.c4:focus:not(:hover) > path,
+.c4:focus:not(:hover) > polygon,
+.c4:focus:not(:hover) > polyline,
+.c4:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c4:focus::-moz-focus-inner {
+.c4:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c4:focus:not(:focus-visible) {
+.c4:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c4:focus:not(:focus-visible) > circle,
-.c4:focus:not(:focus-visible) > ellipse,
-.c4:focus:not(:focus-visible) > line,
-.c4:focus:not(:focus-visible) > path,
-.c4:focus:not(:focus-visible) > polygon,
-.c4:focus:not(:focus-visible) > polyline,
-.c4:focus:not(:focus-visible) > rect {
+.c4:focus:not(:focus-visible):not(:hover) > circle,
+.c4:focus:not(:focus-visible):not(:hover) > ellipse,
+.c4:focus:not(:focus-visible):not(:hover) > line,
+.c4:focus:not(:focus-visible):not(:hover) > path,
+.c4:focus:not(:focus-visible):not(:hover) > polygon,
+.c4:focus:not(:focus-visible):not(:hover) > polyline,
+.c4:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c4:focus:not(:focus-visible)::-moz-focus-inner {
+.c4:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -6186,43 +6186,43 @@ exports[`DateInput format 1`] = `
   line-height: 0;
 }
 
-.c4:focus {
+.c4:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c4:focus > circle,
-.c4:focus > ellipse,
-.c4:focus > line,
-.c4:focus > path,
-.c4:focus > polygon,
-.c4:focus > polyline,
-.c4:focus > rect {
+.c4:focus:not(:hover) > circle,
+.c4:focus:not(:hover) > ellipse,
+.c4:focus:not(:hover) > line,
+.c4:focus:not(:hover) > path,
+.c4:focus:not(:hover) > polygon,
+.c4:focus:not(:hover) > polyline,
+.c4:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c4:focus::-moz-focus-inner {
+.c4:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c4:focus:not(:focus-visible) {
+.c4:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c4:focus:not(:focus-visible) > circle,
-.c4:focus:not(:focus-visible) > ellipse,
-.c4:focus:not(:focus-visible) > line,
-.c4:focus:not(:focus-visible) > path,
-.c4:focus:not(:focus-visible) > polygon,
-.c4:focus:not(:focus-visible) > polyline,
-.c4:focus:not(:focus-visible) > rect {
+.c4:focus:not(:focus-visible):not(:hover) > circle,
+.c4:focus:not(:focus-visible):not(:hover) > ellipse,
+.c4:focus:not(:focus-visible):not(:hover) > line,
+.c4:focus:not(:focus-visible):not(:hover) > path,
+.c4:focus:not(:focus-visible):not(:hover) > polygon,
+.c4:focus:not(:focus-visible):not(:hover) > polyline,
+.c4:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c4:focus:not(:focus-visible)::-moz-focus-inner {
+.c4:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -6429,43 +6429,43 @@ exports[`DateInput format disabled 1`] = `
   line-height: 0;
 }
 
-.c4:focus {
+.c4:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c4:focus > circle,
-.c4:focus > ellipse,
-.c4:focus > line,
-.c4:focus > path,
-.c4:focus > polygon,
-.c4:focus > polyline,
-.c4:focus > rect {
+.c4:focus:not(:hover) > circle,
+.c4:focus:not(:hover) > ellipse,
+.c4:focus:not(:hover) > line,
+.c4:focus:not(:hover) > path,
+.c4:focus:not(:hover) > polygon,
+.c4:focus:not(:hover) > polyline,
+.c4:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c4:focus::-moz-focus-inner {
+.c4:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c4:focus:not(:focus-visible) {
+.c4:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c4:focus:not(:focus-visible) > circle,
-.c4:focus:not(:focus-visible) > ellipse,
-.c4:focus:not(:focus-visible) > line,
-.c4:focus:not(:focus-visible) > path,
-.c4:focus:not(:focus-visible) > polygon,
-.c4:focus:not(:focus-visible) > polyline,
-.c4:focus:not(:focus-visible) > rect {
+.c4:focus:not(:focus-visible):not(:hover) > circle,
+.c4:focus:not(:focus-visible):not(:hover) > ellipse,
+.c4:focus:not(:focus-visible):not(:hover) > line,
+.c4:focus:not(:focus-visible):not(:hover) > path,
+.c4:focus:not(:focus-visible):not(:hover) > polygon,
+.c4:focus:not(:focus-visible):not(:hover) > polyline,
+.c4:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c4:focus:not(:focus-visible)::-moz-focus-inner {
+.c4:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -6751,43 +6751,43 @@ exports[`DateInput format inline 1`] = `
   line-height: 0;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -6811,43 +6811,43 @@ exports[`DateInput format inline 1`] = `
   padding: 12px;
 }
 
-.c12:focus {
+.c12:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus > circle,
-.c12:focus > ellipse,
-.c12:focus > line,
-.c12:focus > path,
-.c12:focus > polygon,
-.c12:focus > polyline,
-.c12:focus > rect {
+.c12:focus:not(:hover) > circle,
+.c12:focus:not(:hover) > ellipse,
+.c12:focus:not(:hover) > line,
+.c12:focus:not(:hover) > path,
+.c12:focus:not(:hover) > polygon,
+.c12:focus:not(:hover) > polyline,
+.c12:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus::-moz-focus-inner {
+.c12:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c12:focus:not(:focus-visible) {
+.c12:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible) > circle,
-.c12:focus:not(:focus-visible) > ellipse,
-.c12:focus:not(:focus-visible) > line,
-.c12:focus:not(:focus-visible) > path,
-.c12:focus:not(:focus-visible) > polygon,
-.c12:focus:not(:focus-visible) > polyline,
-.c12:focus:not(:focus-visible) > rect {
+.c12:focus:not(:focus-visible):not(:hover) > circle,
+.c12:focus:not(:focus-visible):not(:hover) > ellipse,
+.c12:focus:not(:focus-visible):not(:hover) > line,
+.c12:focus:not(:focus-visible):not(:hover) > path,
+.c12:focus:not(:focus-visible):not(:hover) > polygon,
+.c12:focus:not(:focus-visible):not(:hover) > polyline,
+.c12:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible)::-moz-focus-inner {
+.c12:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -6869,43 +6869,43 @@ exports[`DateInput format inline 1`] = `
   text-align: inherit;
 }
 
-.c17:focus {
+.c17:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus > circle,
-.c17:focus > ellipse,
-.c17:focus > line,
-.c17:focus > path,
-.c17:focus > polygon,
-.c17:focus > polyline,
-.c17:focus > rect {
+.c17:focus:not(:hover) > circle,
+.c17:focus:not(:hover) > ellipse,
+.c17:focus:not(:hover) > line,
+.c17:focus:not(:hover) > path,
+.c17:focus:not(:hover) > polygon,
+.c17:focus:not(:hover) > polyline,
+.c17:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus::-moz-focus-inner {
+.c17:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c17:focus:not(:focus-visible) {
+.c17:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible) > circle,
-.c17:focus:not(:focus-visible) > ellipse,
-.c17:focus:not(:focus-visible) > line,
-.c17:focus:not(:focus-visible) > path,
-.c17:focus:not(:focus-visible) > polygon,
-.c17:focus:not(:focus-visible) > polyline,
-.c17:focus:not(:focus-visible) > rect {
+.c17:focus:not(:focus-visible):not(:hover) > circle,
+.c17:focus:not(:focus-visible):not(:hover) > ellipse,
+.c17:focus:not(:focus-visible):not(:hover) > line,
+.c17:focus:not(:focus-visible):not(:hover) > path,
+.c17:focus:not(:focus-visible):not(:hover) > polygon,
+.c17:focus:not(:focus-visible):not(:hover) > polyline,
+.c17:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible)::-moz-focus-inner {
+.c17:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -8081,43 +8081,43 @@ exports[`DateInput handle focus in FormField 1`] = `
   line-height: 0;
 }
 
-.c7:focus {
+.c7:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus > circle,
-.c7:focus > ellipse,
-.c7:focus > line,
-.c7:focus > path,
-.c7:focus > polygon,
-.c7:focus > polyline,
-.c7:focus > rect {
+.c7:focus:not(:hover) > circle,
+.c7:focus:not(:hover) > ellipse,
+.c7:focus:not(:hover) > line,
+.c7:focus:not(:hover) > path,
+.c7:focus:not(:hover) > polygon,
+.c7:focus:not(:hover) > polyline,
+.c7:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus::-moz-focus-inner {
+.c7:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c7:focus:not(:focus-visible) {
+.c7:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c7:focus:not(:focus-visible) > circle,
-.c7:focus:not(:focus-visible) > ellipse,
-.c7:focus:not(:focus-visible) > line,
-.c7:focus:not(:focus-visible) > path,
-.c7:focus:not(:focus-visible) > polygon,
-.c7:focus:not(:focus-visible) > polyline,
-.c7:focus:not(:focus-visible) > rect {
+.c7:focus:not(:focus-visible):not(:hover) > circle,
+.c7:focus:not(:focus-visible):not(:hover) > ellipse,
+.c7:focus:not(:focus-visible):not(:hover) > line,
+.c7:focus:not(:focus-visible):not(:hover) > path,
+.c7:focus:not(:focus-visible):not(:hover) > polygon,
+.c7:focus:not(:focus-visible):not(:hover) > polyline,
+.c7:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c7:focus:not(:focus-visible)::-moz-focus-inner {
+.c7:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -8369,43 +8369,43 @@ exports[`DateInput handle focus in FormField 2`] = `
   line-height: 0;
 }
 
-.c6:focus {
+.c6:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c6:focus > circle,
-.c6:focus > ellipse,
-.c6:focus > line,
-.c6:focus > path,
-.c6:focus > polygon,
-.c6:focus > polyline,
-.c6:focus > rect {
+.c6:focus:not(:hover) > circle,
+.c6:focus:not(:hover) > ellipse,
+.c6:focus:not(:hover) > line,
+.c6:focus:not(:hover) > path,
+.c6:focus:not(:hover) > polygon,
+.c6:focus:not(:hover) > polyline,
+.c6:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c6:focus::-moz-focus-inner {
+.c6:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c6:focus:not(:focus-visible) {
+.c6:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c6:focus:not(:focus-visible) > circle,
-.c6:focus:not(:focus-visible) > ellipse,
-.c6:focus:not(:focus-visible) > line,
-.c6:focus:not(:focus-visible) > path,
-.c6:focus:not(:focus-visible) > polygon,
-.c6:focus:not(:focus-visible) > polyline,
-.c6:focus:not(:focus-visible) > rect {
+.c6:focus:not(:focus-visible):not(:hover) > circle,
+.c6:focus:not(:focus-visible):not(:hover) > ellipse,
+.c6:focus:not(:focus-visible):not(:hover) > line,
+.c6:focus:not(:focus-visible):not(:hover) > path,
+.c6:focus:not(:focus-visible):not(:hover) > polygon,
+.c6:focus:not(:focus-visible):not(:hover) > polyline,
+.c6:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c6:focus:not(:focus-visible)::-moz-focus-inner {
+.c6:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -8579,43 +8579,43 @@ exports[`DateInput icon 1`] = `
   padding: 12px;
 }
 
-.c0:focus {
+.c0:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus > circle,
-.c0:focus > ellipse,
-.c0:focus > line,
-.c0:focus > path,
-.c0:focus > polygon,
-.c0:focus > polyline,
-.c0:focus > rect {
+.c0:focus:not(:hover) > circle,
+.c0:focus:not(:hover) > ellipse,
+.c0:focus:not(:hover) > line,
+.c0:focus:not(:hover) > path,
+.c0:focus:not(:hover) > polygon,
+.c0:focus:not(:hover) > polyline,
+.c0:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus::-moz-focus-inner {
+.c0:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c0:focus:not(:focus-visible) {
+.c0:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible) > circle,
-.c0:focus:not(:focus-visible) > ellipse,
-.c0:focus:not(:focus-visible) > line,
-.c0:focus:not(:focus-visible) > path,
-.c0:focus:not(:focus-visible) > polygon,
-.c0:focus:not(:focus-visible) > polyline,
-.c0:focus:not(:focus-visible) > rect {
+.c0:focus:not(:focus-visible):not(:hover) > circle,
+.c0:focus:not(:focus-visible):not(:hover) > ellipse,
+.c0:focus:not(:focus-visible):not(:hover) > line,
+.c0:focus:not(:focus-visible):not(:hover) > path,
+.c0:focus:not(:focus-visible):not(:hover) > polygon,
+.c0:focus:not(:focus-visible):not(:hover) > polyline,
+.c0:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible)::-moz-focus-inner {
+.c0:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -8780,43 +8780,43 @@ exports[`DateInput inline 1`] = `
   padding: 12px;
 }
 
-.c7:focus {
+.c7:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus > circle,
-.c7:focus > ellipse,
-.c7:focus > line,
-.c7:focus > path,
-.c7:focus > polygon,
-.c7:focus > polyline,
-.c7:focus > rect {
+.c7:focus:not(:hover) > circle,
+.c7:focus:not(:hover) > ellipse,
+.c7:focus:not(:hover) > line,
+.c7:focus:not(:hover) > path,
+.c7:focus:not(:hover) > polygon,
+.c7:focus:not(:hover) > polyline,
+.c7:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus::-moz-focus-inner {
+.c7:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c7:focus:not(:focus-visible) {
+.c7:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c7:focus:not(:focus-visible) > circle,
-.c7:focus:not(:focus-visible) > ellipse,
-.c7:focus:not(:focus-visible) > line,
-.c7:focus:not(:focus-visible) > path,
-.c7:focus:not(:focus-visible) > polygon,
-.c7:focus:not(:focus-visible) > polyline,
-.c7:focus:not(:focus-visible) > rect {
+.c7:focus:not(:focus-visible):not(:hover) > circle,
+.c7:focus:not(:focus-visible):not(:hover) > ellipse,
+.c7:focus:not(:focus-visible):not(:hover) > line,
+.c7:focus:not(:focus-visible):not(:hover) > path,
+.c7:focus:not(:focus-visible):not(:hover) > polygon,
+.c7:focus:not(:focus-visible):not(:hover) > polyline,
+.c7:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c7:focus:not(:focus-visible)::-moz-focus-inner {
+.c7:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -8838,43 +8838,43 @@ exports[`DateInput inline 1`] = `
   text-align: inherit;
 }
 
-.c13:focus {
+.c13:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus > circle,
-.c13:focus > ellipse,
-.c13:focus > line,
-.c13:focus > path,
-.c13:focus > polygon,
-.c13:focus > polyline,
-.c13:focus > rect {
+.c13:focus:not(:hover) > circle,
+.c13:focus:not(:hover) > ellipse,
+.c13:focus:not(:hover) > line,
+.c13:focus:not(:hover) > path,
+.c13:focus:not(:hover) > polygon,
+.c13:focus:not(:hover) > polyline,
+.c13:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus::-moz-focus-inner {
+.c13:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c13:focus:not(:focus-visible) {
+.c13:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible) > circle,
-.c13:focus:not(:focus-visible) > ellipse,
-.c13:focus:not(:focus-visible) > line,
-.c13:focus:not(:focus-visible) > path,
-.c13:focus:not(:focus-visible) > polygon,
-.c13:focus:not(:focus-visible) > polyline,
-.c13:focus:not(:focus-visible) > rect {
+.c13:focus:not(:focus-visible):not(:hover) > circle,
+.c13:focus:not(:focus-visible):not(:hover) > ellipse,
+.c13:focus:not(:focus-visible):not(:hover) > line,
+.c13:focus:not(:focus-visible):not(:hover) > path,
+.c13:focus:not(:focus-visible):not(:hover) > polygon,
+.c13:focus:not(:focus-visible):not(:hover) > polyline,
+.c13:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible)::-moz-focus-inner {
+.c13:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -9885,43 +9885,43 @@ exports[`DateInput range 1`] = `
   padding: 12px;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -10033,43 +10033,43 @@ exports[`DateInput range format 1`] = `
   line-height: 0;
 }
 
-.c4:focus {
+.c4:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c4:focus > circle,
-.c4:focus > ellipse,
-.c4:focus > line,
-.c4:focus > path,
-.c4:focus > polygon,
-.c4:focus > polyline,
-.c4:focus > rect {
+.c4:focus:not(:hover) > circle,
+.c4:focus:not(:hover) > ellipse,
+.c4:focus:not(:hover) > line,
+.c4:focus:not(:hover) > path,
+.c4:focus:not(:hover) > polygon,
+.c4:focus:not(:hover) > polyline,
+.c4:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c4:focus::-moz-focus-inner {
+.c4:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c4:focus:not(:focus-visible) {
+.c4:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c4:focus:not(:focus-visible) > circle,
-.c4:focus:not(:focus-visible) > ellipse,
-.c4:focus:not(:focus-visible) > line,
-.c4:focus:not(:focus-visible) > path,
-.c4:focus:not(:focus-visible) > polygon,
-.c4:focus:not(:focus-visible) > polyline,
-.c4:focus:not(:focus-visible) > rect {
+.c4:focus:not(:focus-visible):not(:hover) > circle,
+.c4:focus:not(:focus-visible):not(:hover) > ellipse,
+.c4:focus:not(:focus-visible):not(:hover) > line,
+.c4:focus:not(:focus-visible):not(:hover) > path,
+.c4:focus:not(:focus-visible):not(:hover) > polygon,
+.c4:focus:not(:focus-visible):not(:hover) > polyline,
+.c4:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c4:focus:not(:focus-visible)::-moz-focus-inner {
+.c4:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -10352,43 +10352,43 @@ exports[`DateInput range format inline 1`] = `
   line-height: 0;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -10412,43 +10412,43 @@ exports[`DateInput range format inline 1`] = `
   padding: 12px;
 }
 
-.c12:focus {
+.c12:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus > circle,
-.c12:focus > ellipse,
-.c12:focus > line,
-.c12:focus > path,
-.c12:focus > polygon,
-.c12:focus > polyline,
-.c12:focus > rect {
+.c12:focus:not(:hover) > circle,
+.c12:focus:not(:hover) > ellipse,
+.c12:focus:not(:hover) > line,
+.c12:focus:not(:hover) > path,
+.c12:focus:not(:hover) > polygon,
+.c12:focus:not(:hover) > polyline,
+.c12:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus::-moz-focus-inner {
+.c12:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c12:focus:not(:focus-visible) {
+.c12:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible) > circle,
-.c12:focus:not(:focus-visible) > ellipse,
-.c12:focus:not(:focus-visible) > line,
-.c12:focus:not(:focus-visible) > path,
-.c12:focus:not(:focus-visible) > polygon,
-.c12:focus:not(:focus-visible) > polyline,
-.c12:focus:not(:focus-visible) > rect {
+.c12:focus:not(:focus-visible):not(:hover) > circle,
+.c12:focus:not(:focus-visible):not(:hover) > ellipse,
+.c12:focus:not(:focus-visible):not(:hover) > line,
+.c12:focus:not(:focus-visible):not(:hover) > path,
+.c12:focus:not(:focus-visible):not(:hover) > polygon,
+.c12:focus:not(:focus-visible):not(:hover) > polyline,
+.c12:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible)::-moz-focus-inner {
+.c12:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -10470,43 +10470,43 @@ exports[`DateInput range format inline 1`] = `
   text-align: inherit;
 }
 
-.c17:focus {
+.c17:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus > circle,
-.c17:focus > ellipse,
-.c17:focus > line,
-.c17:focus > path,
-.c17:focus > polygon,
-.c17:focus > polyline,
-.c17:focus > rect {
+.c17:focus:not(:hover) > circle,
+.c17:focus:not(:hover) > ellipse,
+.c17:focus:not(:hover) > line,
+.c17:focus:not(:hover) > path,
+.c17:focus:not(:hover) > polygon,
+.c17:focus:not(:hover) > polyline,
+.c17:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus::-moz-focus-inner {
+.c17:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c17:focus:not(:focus-visible) {
+.c17:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible) > circle,
-.c17:focus:not(:focus-visible) > ellipse,
-.c17:focus:not(:focus-visible) > line,
-.c17:focus:not(:focus-visible) > path,
-.c17:focus:not(:focus-visible) > polygon,
-.c17:focus:not(:focus-visible) > polyline,
-.c17:focus:not(:focus-visible) > rect {
+.c17:focus:not(:focus-visible):not(:hover) > circle,
+.c17:focus:not(:focus-visible):not(:hover) > ellipse,
+.c17:focus:not(:focus-visible):not(:hover) > line,
+.c17:focus:not(:focus-visible):not(:hover) > path,
+.c17:focus:not(:focus-visible):not(:hover) > polygon,
+.c17:focus:not(:focus-visible):not(:hover) > polyline,
+.c17:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible)::-moz-focus-inner {
+.c17:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -11729,43 +11729,43 @@ exports[`DateInput range inline 1`] = `
   padding: 12px;
 }
 
-.c7:focus {
+.c7:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus > circle,
-.c7:focus > ellipse,
-.c7:focus > line,
-.c7:focus > path,
-.c7:focus > polygon,
-.c7:focus > polyline,
-.c7:focus > rect {
+.c7:focus:not(:hover) > circle,
+.c7:focus:not(:hover) > ellipse,
+.c7:focus:not(:hover) > line,
+.c7:focus:not(:hover) > path,
+.c7:focus:not(:hover) > polygon,
+.c7:focus:not(:hover) > polyline,
+.c7:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus::-moz-focus-inner {
+.c7:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c7:focus:not(:focus-visible) {
+.c7:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c7:focus:not(:focus-visible) > circle,
-.c7:focus:not(:focus-visible) > ellipse,
-.c7:focus:not(:focus-visible) > line,
-.c7:focus:not(:focus-visible) > path,
-.c7:focus:not(:focus-visible) > polygon,
-.c7:focus:not(:focus-visible) > polyline,
-.c7:focus:not(:focus-visible) > rect {
+.c7:focus:not(:focus-visible):not(:hover) > circle,
+.c7:focus:not(:focus-visible):not(:hover) > ellipse,
+.c7:focus:not(:focus-visible):not(:hover) > line,
+.c7:focus:not(:focus-visible):not(:hover) > path,
+.c7:focus:not(:focus-visible):not(:hover) > polygon,
+.c7:focus:not(:focus-visible):not(:hover) > polyline,
+.c7:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c7:focus:not(:focus-visible)::-moz-focus-inner {
+.c7:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -11787,43 +11787,43 @@ exports[`DateInput range inline 1`] = `
   text-align: inherit;
 }
 
-.c13:focus {
+.c13:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus > circle,
-.c13:focus > ellipse,
-.c13:focus > line,
-.c13:focus > path,
-.c13:focus > polygon,
-.c13:focus > polyline,
-.c13:focus > rect {
+.c13:focus:not(:hover) > circle,
+.c13:focus:not(:hover) > ellipse,
+.c13:focus:not(:hover) > line,
+.c13:focus:not(:hover) > path,
+.c13:focus:not(:hover) > polygon,
+.c13:focus:not(:hover) > polyline,
+.c13:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus::-moz-focus-inner {
+.c13:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c13:focus:not(:focus-visible) {
+.c13:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible) > circle,
-.c13:focus:not(:focus-visible) > ellipse,
-.c13:focus:not(:focus-visible) > line,
-.c13:focus:not(:focus-visible) > path,
-.c13:focus:not(:focus-visible) > polygon,
-.c13:focus:not(:focus-visible) > polyline,
-.c13:focus:not(:focus-visible) > rect {
+.c13:focus:not(:focus-visible):not(:hover) > circle,
+.c13:focus:not(:focus-visible):not(:hover) > ellipse,
+.c13:focus:not(:focus-visible):not(:hover) > line,
+.c13:focus:not(:focus-visible):not(:hover) > path,
+.c13:focus:not(:focus-visible):not(:hover) > polygon,
+.c13:focus:not(:focus-visible):not(:hover) > polyline,
+.c13:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible)::-moz-focus-inner {
+.c13:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -12854,43 +12854,43 @@ HTMLCollection [
   padding: 12px;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -13236,43 +13236,43 @@ exports[`DateInput select format 1`] = `
   line-height: 0;
 }
 
-.c4:focus {
+.c4:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c4:focus > circle,
-.c4:focus > ellipse,
-.c4:focus > line,
-.c4:focus > path,
-.c4:focus > polygon,
-.c4:focus > polyline,
-.c4:focus > rect {
+.c4:focus:not(:hover) > circle,
+.c4:focus:not(:hover) > ellipse,
+.c4:focus:not(:hover) > line,
+.c4:focus:not(:hover) > path,
+.c4:focus:not(:hover) > polygon,
+.c4:focus:not(:hover) > polyline,
+.c4:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c4:focus::-moz-focus-inner {
+.c4:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c4:focus:not(:focus-visible) {
+.c4:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c4:focus:not(:focus-visible) > circle,
-.c4:focus:not(:focus-visible) > ellipse,
-.c4:focus:not(:focus-visible) > line,
-.c4:focus:not(:focus-visible) > path,
-.c4:focus:not(:focus-visible) > polygon,
-.c4:focus:not(:focus-visible) > polyline,
-.c4:focus:not(:focus-visible) > rect {
+.c4:focus:not(:focus-visible):not(:hover) > circle,
+.c4:focus:not(:focus-visible):not(:hover) > ellipse,
+.c4:focus:not(:focus-visible):not(:hover) > line,
+.c4:focus:not(:focus-visible):not(:hover) > path,
+.c4:focus:not(:focus-visible):not(:hover) > polygon,
+.c4:focus:not(:focus-visible):not(:hover) > polyline,
+.c4:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c4:focus:not(:focus-visible)::-moz-focus-inner {
+.c4:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -13416,7 +13416,7 @@ exports[`DateInput select format 2`] = `
       />
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 kHVwhD"
+      class="StyledButton-sc-323bzc-0 eQOfsX"
       type="button"
     >
       <svg
@@ -13607,43 +13607,43 @@ exports[`DateInput select format 3`] = `
   padding: 12px;
 }
 
-.c8:focus {
+.c8:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c8:focus > circle,
-.c8:focus > ellipse,
-.c8:focus > line,
-.c8:focus > path,
-.c8:focus > polygon,
-.c8:focus > polyline,
-.c8:focus > rect {
+.c8:focus:not(:hover) > circle,
+.c8:focus:not(:hover) > ellipse,
+.c8:focus:not(:hover) > line,
+.c8:focus:not(:hover) > path,
+.c8:focus:not(:hover) > polygon,
+.c8:focus:not(:hover) > polyline,
+.c8:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c8:focus::-moz-focus-inner {
+.c8:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c8:focus:not(:focus-visible) {
+.c8:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c8:focus:not(:focus-visible) > circle,
-.c8:focus:not(:focus-visible) > ellipse,
-.c8:focus:not(:focus-visible) > line,
-.c8:focus:not(:focus-visible) > path,
-.c8:focus:not(:focus-visible) > polygon,
-.c8:focus:not(:focus-visible) > polyline,
-.c8:focus:not(:focus-visible) > rect {
+.c8:focus:not(:focus-visible):not(:hover) > circle,
+.c8:focus:not(:focus-visible):not(:hover) > ellipse,
+.c8:focus:not(:focus-visible):not(:hover) > line,
+.c8:focus:not(:focus-visible):not(:hover) > path,
+.c8:focus:not(:focus-visible):not(:hover) > polygon,
+.c8:focus:not(:focus-visible):not(:hover) > polyline,
+.c8:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c8:focus:not(:focus-visible)::-moz-focus-inner {
+.c8:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -13665,43 +13665,43 @@ exports[`DateInput select format 3`] = `
   text-align: inherit;
 }
 
-.c14:focus {
+.c14:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c14:focus > circle,
-.c14:focus > ellipse,
-.c14:focus > line,
-.c14:focus > path,
-.c14:focus > polygon,
-.c14:focus > polyline,
-.c14:focus > rect {
+.c14:focus:not(:hover) > circle,
+.c14:focus:not(:hover) > ellipse,
+.c14:focus:not(:hover) > line,
+.c14:focus:not(:hover) > path,
+.c14:focus:not(:hover) > polygon,
+.c14:focus:not(:hover) > polyline,
+.c14:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c14:focus::-moz-focus-inner {
+.c14:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c14:focus:not(:focus-visible) {
+.c14:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c14:focus:not(:focus-visible) > circle,
-.c14:focus:not(:focus-visible) > ellipse,
-.c14:focus:not(:focus-visible) > line,
-.c14:focus:not(:focus-visible) > path,
-.c14:focus:not(:focus-visible) > polygon,
-.c14:focus:not(:focus-visible) > polyline,
-.c14:focus:not(:focus-visible) > rect {
+.c14:focus:not(:focus-visible):not(:hover) > circle,
+.c14:focus:not(:focus-visible):not(:hover) > ellipse,
+.c14:focus:not(:focus-visible):not(:hover) > line,
+.c14:focus:not(:focus-visible):not(:hover) > path,
+.c14:focus:not(:focus-visible):not(:hover) > polygon,
+.c14:focus:not(:focus-visible):not(:hover) > polyline,
+.c14:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c14:focus:not(:focus-visible)::-moz-focus-inner {
+.c14:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -13725,43 +13725,43 @@ exports[`DateInput select format 3`] = `
   color: #000000;
 }
 
-.c16:focus {
+.c16:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c16:focus > circle,
-.c16:focus > ellipse,
-.c16:focus > line,
-.c16:focus > path,
-.c16:focus > polygon,
-.c16:focus > polyline,
-.c16:focus > rect {
+.c16:focus:not(:hover) > circle,
+.c16:focus:not(:hover) > ellipse,
+.c16:focus:not(:hover) > line,
+.c16:focus:not(:hover) > path,
+.c16:focus:not(:hover) > polygon,
+.c16:focus:not(:hover) > polyline,
+.c16:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c16:focus::-moz-focus-inner {
+.c16:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c16:focus:not(:focus-visible) {
+.c16:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c16:focus:not(:focus-visible) > circle,
-.c16:focus:not(:focus-visible) > ellipse,
-.c16:focus:not(:focus-visible) > line,
-.c16:focus:not(:focus-visible) > path,
-.c16:focus:not(:focus-visible) > polygon,
-.c16:focus:not(:focus-visible) > polyline,
-.c16:focus:not(:focus-visible) > rect {
+.c16:focus:not(:focus-visible):not(:hover) > circle,
+.c16:focus:not(:focus-visible):not(:hover) > ellipse,
+.c16:focus:not(:focus-visible):not(:hover) > line,
+.c16:focus:not(:focus-visible):not(:hover) > path,
+.c16:focus:not(:focus-visible):not(:hover) > polygon,
+.c16:focus:not(:focus-visible):not(:hover) > polyline,
+.c16:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c16:focus:not(:focus-visible)::-moz-focus-inner {
+.c16:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -14938,43 +14938,43 @@ exports[`DateInput select format inline 1`] = `
   line-height: 0;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -14998,43 +14998,43 @@ exports[`DateInput select format inline 1`] = `
   padding: 12px;
 }
 
-.c12:focus {
+.c12:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus > circle,
-.c12:focus > ellipse,
-.c12:focus > line,
-.c12:focus > path,
-.c12:focus > polygon,
-.c12:focus > polyline,
-.c12:focus > rect {
+.c12:focus:not(:hover) > circle,
+.c12:focus:not(:hover) > ellipse,
+.c12:focus:not(:hover) > line,
+.c12:focus:not(:hover) > path,
+.c12:focus:not(:hover) > polygon,
+.c12:focus:not(:hover) > polyline,
+.c12:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus::-moz-focus-inner {
+.c12:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c12:focus:not(:focus-visible) {
+.c12:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible) > circle,
-.c12:focus:not(:focus-visible) > ellipse,
-.c12:focus:not(:focus-visible) > line,
-.c12:focus:not(:focus-visible) > path,
-.c12:focus:not(:focus-visible) > polygon,
-.c12:focus:not(:focus-visible) > polyline,
-.c12:focus:not(:focus-visible) > rect {
+.c12:focus:not(:focus-visible):not(:hover) > circle,
+.c12:focus:not(:focus-visible):not(:hover) > ellipse,
+.c12:focus:not(:focus-visible):not(:hover) > line,
+.c12:focus:not(:focus-visible):not(:hover) > path,
+.c12:focus:not(:focus-visible):not(:hover) > polygon,
+.c12:focus:not(:focus-visible):not(:hover) > polyline,
+.c12:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible)::-moz-focus-inner {
+.c12:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -15056,43 +15056,43 @@ exports[`DateInput select format inline 1`] = `
   text-align: inherit;
 }
 
-.c17:focus {
+.c17:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus > circle,
-.c17:focus > ellipse,
-.c17:focus > line,
-.c17:focus > path,
-.c17:focus > polygon,
-.c17:focus > polyline,
-.c17:focus > rect {
+.c17:focus:not(:hover) > circle,
+.c17:focus:not(:hover) > ellipse,
+.c17:focus:not(:hover) > line,
+.c17:focus:not(:hover) > path,
+.c17:focus:not(:hover) > polygon,
+.c17:focus:not(:hover) > polyline,
+.c17:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus::-moz-focus-inner {
+.c17:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c17:focus:not(:focus-visible) {
+.c17:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible) > circle,
-.c17:focus:not(:focus-visible) > ellipse,
-.c17:focus:not(:focus-visible) > line,
-.c17:focus:not(:focus-visible) > path,
-.c17:focus:not(:focus-visible) > polygon,
-.c17:focus:not(:focus-visible) > polyline,
-.c17:focus:not(:focus-visible) > rect {
+.c17:focus:not(:focus-visible):not(:hover) > circle,
+.c17:focus:not(:focus-visible):not(:hover) > ellipse,
+.c17:focus:not(:focus-visible):not(:hover) > line,
+.c17:focus:not(:focus-visible):not(:hover) > path,
+.c17:focus:not(:focus-visible):not(:hover) > polygon,
+.c17:focus:not(:focus-visible):not(:hover) > polyline,
+.c17:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible)::-moz-focus-inner {
+.c17:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -16178,7 +16178,7 @@ exports[`DateInput select format inline 2`] = `
         />
       </div>
       <button
-        class="StyledButton-sc-323bzc-0 kHVwhD"
+        class="StyledButton-sc-323bzc-0 eQOfsX"
         type="button"
       >
         <svg
@@ -16218,7 +16218,7 @@ exports[`DateInput select format inline 2`] = `
           >
             <button
               aria-label="Go to June 2020"
-              class="StyledButton-sc-323bzc-0 bpsTzm"
+              class="StyledButton-sc-323bzc-0 xRvZe"
               type="button"
             >
               <svg
@@ -16236,7 +16236,7 @@ exports[`DateInput select format inline 2`] = `
             </button>
             <button
               aria-label="Go to August 2020"
-              class="StyledButton-sc-323bzc-0 bpsTzm"
+              class="StyledButton-sc-323bzc-0 xRvZe"
               type="button"
             >
               <svg
@@ -16276,7 +16276,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Sun Jun 28 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -16293,7 +16293,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Mon Jun 29 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -16310,7 +16310,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Tue Jun 30 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -16327,7 +16327,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Wed Jul 01 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -16344,7 +16344,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Thu Jul 02 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -16361,7 +16361,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Fri Jul 03 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -16378,7 +16378,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Sat Jul 04 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -16400,7 +16400,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Sun Jul 05 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -16417,7 +16417,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Mon Jul 06 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -16434,7 +16434,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Tue Jul 07 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -16451,7 +16451,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Wed Jul 08 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -16468,7 +16468,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Thu Jul 09 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -16485,7 +16485,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Fri Jul 10 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -16502,7 +16502,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Sat Jul 11 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -16524,7 +16524,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Sun Jul 12 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -16541,7 +16541,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Mon Jul 13 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -16558,7 +16558,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Tue Jul 14 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -16575,7 +16575,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Wed Jul 15 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -16592,7 +16592,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Thu Jul 16 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -16609,7 +16609,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Fri Jul 17 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -16626,7 +16626,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Sat Jul 18 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -16648,7 +16648,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Sun Jul 19 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -16665,7 +16665,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Mon Jul 20 2020"
-                  class="StyledButton-sc-323bzc-0 kdISIE"
+                  class="StyledButton-sc-323bzc-0 btQNHI"
                   tabindex="-1"
                   type="button"
                 >
@@ -16682,7 +16682,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Tue Jul 21 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -16699,7 +16699,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Wed Jul 22 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -16716,7 +16716,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Thu Jul 23 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -16733,7 +16733,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Fri Jul 24 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -16750,7 +16750,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Sat Jul 25 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -16772,7 +16772,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Sun Jul 26 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -16789,7 +16789,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Mon Jul 27 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -16806,7 +16806,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Tue Jul 28 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -16823,7 +16823,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Wed Jul 29 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -16840,7 +16840,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Thu Jul 30 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -16857,7 +16857,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Fri Jul 31 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -16874,7 +16874,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Sat Aug 01 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -16896,7 +16896,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Sun Aug 02 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -16913,7 +16913,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Mon Aug 03 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -16930,7 +16930,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Tue Aug 04 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -16947,7 +16947,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Wed Aug 05 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -16964,7 +16964,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Thu Aug 06 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -16981,7 +16981,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Fri Aug 07 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -16998,7 +16998,7 @@ exports[`DateInput select format inline 2`] = `
               >
                 <button
                   aria-label="Sat Aug 08 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -17178,43 +17178,43 @@ exports[`DateInput select format inline 3`] = `
   line-height: 0;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -17238,43 +17238,43 @@ exports[`DateInput select format inline 3`] = `
   padding: 12px;
 }
 
-.c12:focus {
+.c12:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus > circle,
-.c12:focus > ellipse,
-.c12:focus > line,
-.c12:focus > path,
-.c12:focus > polygon,
-.c12:focus > polyline,
-.c12:focus > rect {
+.c12:focus:not(:hover) > circle,
+.c12:focus:not(:hover) > ellipse,
+.c12:focus:not(:hover) > line,
+.c12:focus:not(:hover) > path,
+.c12:focus:not(:hover) > polygon,
+.c12:focus:not(:hover) > polyline,
+.c12:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus::-moz-focus-inner {
+.c12:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c12:focus:not(:focus-visible) {
+.c12:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible) > circle,
-.c12:focus:not(:focus-visible) > ellipse,
-.c12:focus:not(:focus-visible) > line,
-.c12:focus:not(:focus-visible) > path,
-.c12:focus:not(:focus-visible) > polygon,
-.c12:focus:not(:focus-visible) > polyline,
-.c12:focus:not(:focus-visible) > rect {
+.c12:focus:not(:focus-visible):not(:hover) > circle,
+.c12:focus:not(:focus-visible):not(:hover) > ellipse,
+.c12:focus:not(:focus-visible):not(:hover) > line,
+.c12:focus:not(:focus-visible):not(:hover) > path,
+.c12:focus:not(:focus-visible):not(:hover) > polygon,
+.c12:focus:not(:focus-visible):not(:hover) > polyline,
+.c12:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible)::-moz-focus-inner {
+.c12:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -17296,43 +17296,43 @@ exports[`DateInput select format inline 3`] = `
   text-align: inherit;
 }
 
-.c17:focus {
+.c17:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus > circle,
-.c17:focus > ellipse,
-.c17:focus > line,
-.c17:focus > path,
-.c17:focus > polygon,
-.c17:focus > polyline,
-.c17:focus > rect {
+.c17:focus:not(:hover) > circle,
+.c17:focus:not(:hover) > ellipse,
+.c17:focus:not(:hover) > line,
+.c17:focus:not(:hover) > path,
+.c17:focus:not(:hover) > polygon,
+.c17:focus:not(:hover) > polyline,
+.c17:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus::-moz-focus-inner {
+.c17:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c17:focus:not(:focus-visible) {
+.c17:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible) > circle,
-.c17:focus:not(:focus-visible) > ellipse,
-.c17:focus:not(:focus-visible) > line,
-.c17:focus:not(:focus-visible) > path,
-.c17:focus:not(:focus-visible) > polygon,
-.c17:focus:not(:focus-visible) > polyline,
-.c17:focus:not(:focus-visible) > rect {
+.c17:focus:not(:focus-visible):not(:hover) > circle,
+.c17:focus:not(:focus-visible):not(:hover) > ellipse,
+.c17:focus:not(:focus-visible):not(:hover) > line,
+.c17:focus:not(:focus-visible):not(:hover) > path,
+.c17:focus:not(:focus-visible):not(:hover) > polygon,
+.c17:focus:not(:focus-visible):not(:hover) > polyline,
+.c17:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible)::-moz-focus-inner {
+.c17:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -18556,43 +18556,43 @@ exports[`DateInput select format inline 4`] = `
   line-height: 0;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -18616,43 +18616,43 @@ exports[`DateInput select format inline 4`] = `
   padding: 12px;
 }
 
-.c12:focus {
+.c12:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus > circle,
-.c12:focus > ellipse,
-.c12:focus > line,
-.c12:focus > path,
-.c12:focus > polygon,
-.c12:focus > polyline,
-.c12:focus > rect {
+.c12:focus:not(:hover) > circle,
+.c12:focus:not(:hover) > ellipse,
+.c12:focus:not(:hover) > line,
+.c12:focus:not(:hover) > path,
+.c12:focus:not(:hover) > polygon,
+.c12:focus:not(:hover) > polyline,
+.c12:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus::-moz-focus-inner {
+.c12:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c12:focus:not(:focus-visible) {
+.c12:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible) > circle,
-.c12:focus:not(:focus-visible) > ellipse,
-.c12:focus:not(:focus-visible) > line,
-.c12:focus:not(:focus-visible) > path,
-.c12:focus:not(:focus-visible) > polygon,
-.c12:focus:not(:focus-visible) > polyline,
-.c12:focus:not(:focus-visible) > rect {
+.c12:focus:not(:focus-visible):not(:hover) > circle,
+.c12:focus:not(:focus-visible):not(:hover) > ellipse,
+.c12:focus:not(:focus-visible):not(:hover) > line,
+.c12:focus:not(:focus-visible):not(:hover) > path,
+.c12:focus:not(:focus-visible):not(:hover) > polygon,
+.c12:focus:not(:focus-visible):not(:hover) > polyline,
+.c12:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible)::-moz-focus-inner {
+.c12:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -18674,43 +18674,43 @@ exports[`DateInput select format inline 4`] = `
   text-align: inherit;
 }
 
-.c17:focus {
+.c17:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus > circle,
-.c17:focus > ellipse,
-.c17:focus > line,
-.c17:focus > path,
-.c17:focus > polygon,
-.c17:focus > polyline,
-.c17:focus > rect {
+.c17:focus:not(:hover) > circle,
+.c17:focus:not(:hover) > ellipse,
+.c17:focus:not(:hover) > line,
+.c17:focus:not(:hover) > path,
+.c17:focus:not(:hover) > polygon,
+.c17:focus:not(:hover) > polyline,
+.c17:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus::-moz-focus-inner {
+.c17:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c17:focus:not(:focus-visible) {
+.c17:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible) > circle,
-.c17:focus:not(:focus-visible) > ellipse,
-.c17:focus:not(:focus-visible) > line,
-.c17:focus:not(:focus-visible) > path,
-.c17:focus:not(:focus-visible) > polygon,
-.c17:focus:not(:focus-visible) > polyline,
-.c17:focus:not(:focus-visible) > rect {
+.c17:focus:not(:focus-visible):not(:hover) > circle,
+.c17:focus:not(:focus-visible):not(:hover) > ellipse,
+.c17:focus:not(:focus-visible):not(:hover) > line,
+.c17:focus:not(:focus-visible):not(:hover) > path,
+.c17:focus:not(:focus-visible):not(:hover) > polygon,
+.c17:focus:not(:focus-visible):not(:hover) > polyline,
+.c17:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible)::-moz-focus-inner {
+.c17:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -18734,43 +18734,43 @@ exports[`DateInput select format inline 4`] = `
   color: #000000;
 }
 
-.c20:focus {
+.c20:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c20:focus > circle,
-.c20:focus > ellipse,
-.c20:focus > line,
-.c20:focus > path,
-.c20:focus > polygon,
-.c20:focus > polyline,
-.c20:focus > rect {
+.c20:focus:not(:hover) > circle,
+.c20:focus:not(:hover) > ellipse,
+.c20:focus:not(:hover) > line,
+.c20:focus:not(:hover) > path,
+.c20:focus:not(:hover) > polygon,
+.c20:focus:not(:hover) > polyline,
+.c20:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c20:focus::-moz-focus-inner {
+.c20:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c20:focus:not(:focus-visible) {
+.c20:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c20:focus:not(:focus-visible) > circle,
-.c20:focus:not(:focus-visible) > ellipse,
-.c20:focus:not(:focus-visible) > line,
-.c20:focus:not(:focus-visible) > path,
-.c20:focus:not(:focus-visible) > polygon,
-.c20:focus:not(:focus-visible) > polyline,
-.c20:focus:not(:focus-visible) > rect {
+.c20:focus:not(:focus-visible):not(:hover) > circle,
+.c20:focus:not(:focus-visible):not(:hover) > ellipse,
+.c20:focus:not(:focus-visible):not(:hover) > line,
+.c20:focus:not(:focus-visible):not(:hover) > path,
+.c20:focus:not(:focus-visible):not(:hover) > polygon,
+.c20:focus:not(:focus-visible):not(:hover) > polyline,
+.c20:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c20:focus:not(:focus-visible)::-moz-focus-inner {
+.c20:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -20010,43 +20010,43 @@ exports[`DateInput select format inline range 1`] = `
   line-height: 0;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -20070,43 +20070,43 @@ exports[`DateInput select format inline range 1`] = `
   padding: 12px;
 }
 
-.c12:focus {
+.c12:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus > circle,
-.c12:focus > ellipse,
-.c12:focus > line,
-.c12:focus > path,
-.c12:focus > polygon,
-.c12:focus > polyline,
-.c12:focus > rect {
+.c12:focus:not(:hover) > circle,
+.c12:focus:not(:hover) > ellipse,
+.c12:focus:not(:hover) > line,
+.c12:focus:not(:hover) > path,
+.c12:focus:not(:hover) > polygon,
+.c12:focus:not(:hover) > polyline,
+.c12:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus::-moz-focus-inner {
+.c12:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c12:focus:not(:focus-visible) {
+.c12:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible) > circle,
-.c12:focus:not(:focus-visible) > ellipse,
-.c12:focus:not(:focus-visible) > line,
-.c12:focus:not(:focus-visible) > path,
-.c12:focus:not(:focus-visible) > polygon,
-.c12:focus:not(:focus-visible) > polyline,
-.c12:focus:not(:focus-visible) > rect {
+.c12:focus:not(:focus-visible):not(:hover) > circle,
+.c12:focus:not(:focus-visible):not(:hover) > ellipse,
+.c12:focus:not(:focus-visible):not(:hover) > line,
+.c12:focus:not(:focus-visible):not(:hover) > path,
+.c12:focus:not(:focus-visible):not(:hover) > polygon,
+.c12:focus:not(:focus-visible):not(:hover) > polyline,
+.c12:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible)::-moz-focus-inner {
+.c12:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -20128,43 +20128,43 @@ exports[`DateInput select format inline range 1`] = `
   text-align: inherit;
 }
 
-.c17:focus {
+.c17:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus > circle,
-.c17:focus > ellipse,
-.c17:focus > line,
-.c17:focus > path,
-.c17:focus > polygon,
-.c17:focus > polyline,
-.c17:focus > rect {
+.c17:focus:not(:hover) > circle,
+.c17:focus:not(:hover) > ellipse,
+.c17:focus:not(:hover) > line,
+.c17:focus:not(:hover) > path,
+.c17:focus:not(:hover) > polygon,
+.c17:focus:not(:hover) > polyline,
+.c17:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus::-moz-focus-inner {
+.c17:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c17:focus:not(:focus-visible) {
+.c17:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible) > circle,
-.c17:focus:not(:focus-visible) > ellipse,
-.c17:focus:not(:focus-visible) > line,
-.c17:focus:not(:focus-visible) > path,
-.c17:focus:not(:focus-visible) > polygon,
-.c17:focus:not(:focus-visible) > polyline,
-.c17:focus:not(:focus-visible) > rect {
+.c17:focus:not(:focus-visible):not(:hover) > circle,
+.c17:focus:not(:focus-visible):not(:hover) > ellipse,
+.c17:focus:not(:focus-visible):not(:hover) > line,
+.c17:focus:not(:focus-visible):not(:hover) > path,
+.c17:focus:not(:focus-visible):not(:hover) > polygon,
+.c17:focus:not(:focus-visible):not(:hover) > polyline,
+.c17:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible)::-moz-focus-inner {
+.c17:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -21269,7 +21269,7 @@ exports[`DateInput select format inline range 2`] = `
         />
       </div>
       <button
-        class="StyledButton-sc-323bzc-0 kHVwhD"
+        class="StyledButton-sc-323bzc-0 eQOfsX"
         type="button"
       >
         <svg
@@ -21309,7 +21309,7 @@ exports[`DateInput select format inline range 2`] = `
           >
             <button
               aria-label="Go to June 2020"
-              class="StyledButton-sc-323bzc-0 bpsTzm"
+              class="StyledButton-sc-323bzc-0 xRvZe"
               type="button"
             >
               <svg
@@ -21327,7 +21327,7 @@ exports[`DateInput select format inline range 2`] = `
             </button>
             <button
               aria-label="Go to August 2020"
-              class="StyledButton-sc-323bzc-0 bpsTzm"
+              class="StyledButton-sc-323bzc-0 xRvZe"
               type="button"
             >
               <svg
@@ -21368,7 +21368,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Sun Jun 28 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -21385,7 +21385,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Mon Jun 29 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -21402,7 +21402,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Tue Jun 30 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -21419,7 +21419,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Wed Jul 01 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -21436,7 +21436,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Thu Jul 02 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -21453,7 +21453,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Fri Jul 03 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -21470,7 +21470,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Sat Jul 04 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -21492,7 +21492,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Sun Jul 05 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -21509,7 +21509,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Mon Jul 06 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -21526,7 +21526,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Tue Jul 07 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -21543,7 +21543,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Wed Jul 08 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -21560,7 +21560,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Thu Jul 09 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -21577,7 +21577,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Fri Jul 10 2020"
-                  class="StyledButton-sc-323bzc-0 kdISIE"
+                  class="StyledButton-sc-323bzc-0 btQNHI"
                   tabindex="-1"
                   type="button"
                 >
@@ -21594,7 +21594,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Sat Jul 11 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -21616,7 +21616,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Sun Jul 12 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -21633,7 +21633,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Mon Jul 13 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -21650,7 +21650,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Tue Jul 14 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -21667,7 +21667,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Wed Jul 15 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -21684,7 +21684,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Thu Jul 16 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -21701,7 +21701,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Fri Jul 17 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -21718,7 +21718,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Sat Jul 18 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -21740,7 +21740,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Sun Jul 19 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -21757,7 +21757,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Mon Jul 20 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -21774,7 +21774,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Tue Jul 21 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -21791,7 +21791,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Wed Jul 22 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -21808,7 +21808,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Thu Jul 23 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -21825,7 +21825,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Fri Jul 24 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -21842,7 +21842,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Sat Jul 25 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -21864,7 +21864,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Sun Jul 26 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -21881,7 +21881,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Mon Jul 27 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -21898,7 +21898,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Tue Jul 28 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -21915,7 +21915,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Wed Jul 29 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -21932,7 +21932,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Thu Jul 30 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -21949,7 +21949,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Fri Jul 31 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -21966,7 +21966,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Sat Aug 01 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -21988,7 +21988,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Sun Aug 02 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -22005,7 +22005,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Mon Aug 03 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -22022,7 +22022,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Tue Aug 04 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -22039,7 +22039,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Wed Aug 05 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -22056,7 +22056,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Thu Aug 06 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -22073,7 +22073,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Fri Aug 07 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -22090,7 +22090,7 @@ exports[`DateInput select format inline range 2`] = `
               >
                 <button
                   aria-label="Sat Aug 08 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -22270,43 +22270,43 @@ exports[`DateInput select format inline range without timezone 1`] = `
   line-height: 0;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -22330,43 +22330,43 @@ exports[`DateInput select format inline range without timezone 1`] = `
   padding: 12px;
 }
 
-.c12:focus {
+.c12:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus > circle,
-.c12:focus > ellipse,
-.c12:focus > line,
-.c12:focus > path,
-.c12:focus > polygon,
-.c12:focus > polyline,
-.c12:focus > rect {
+.c12:focus:not(:hover) > circle,
+.c12:focus:not(:hover) > ellipse,
+.c12:focus:not(:hover) > line,
+.c12:focus:not(:hover) > path,
+.c12:focus:not(:hover) > polygon,
+.c12:focus:not(:hover) > polyline,
+.c12:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus::-moz-focus-inner {
+.c12:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c12:focus:not(:focus-visible) {
+.c12:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible) > circle,
-.c12:focus:not(:focus-visible) > ellipse,
-.c12:focus:not(:focus-visible) > line,
-.c12:focus:not(:focus-visible) > path,
-.c12:focus:not(:focus-visible) > polygon,
-.c12:focus:not(:focus-visible) > polyline,
-.c12:focus:not(:focus-visible) > rect {
+.c12:focus:not(:focus-visible):not(:hover) > circle,
+.c12:focus:not(:focus-visible):not(:hover) > ellipse,
+.c12:focus:not(:focus-visible):not(:hover) > line,
+.c12:focus:not(:focus-visible):not(:hover) > path,
+.c12:focus:not(:focus-visible):not(:hover) > polygon,
+.c12:focus:not(:focus-visible):not(:hover) > polyline,
+.c12:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible)::-moz-focus-inner {
+.c12:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -22388,43 +22388,43 @@ exports[`DateInput select format inline range without timezone 1`] = `
   text-align: inherit;
 }
 
-.c17:focus {
+.c17:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus > circle,
-.c17:focus > ellipse,
-.c17:focus > line,
-.c17:focus > path,
-.c17:focus > polygon,
-.c17:focus > polyline,
-.c17:focus > rect {
+.c17:focus:not(:hover) > circle,
+.c17:focus:not(:hover) > ellipse,
+.c17:focus:not(:hover) > line,
+.c17:focus:not(:hover) > path,
+.c17:focus:not(:hover) > polygon,
+.c17:focus:not(:hover) > polyline,
+.c17:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus::-moz-focus-inner {
+.c17:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c17:focus:not(:focus-visible) {
+.c17:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible) > circle,
-.c17:focus:not(:focus-visible) > ellipse,
-.c17:focus:not(:focus-visible) > line,
-.c17:focus:not(:focus-visible) > path,
-.c17:focus:not(:focus-visible) > polygon,
-.c17:focus:not(:focus-visible) > polyline,
-.c17:focus:not(:focus-visible) > rect {
+.c17:focus:not(:focus-visible):not(:hover) > circle,
+.c17:focus:not(:focus-visible):not(:hover) > ellipse,
+.c17:focus:not(:focus-visible):not(:hover) > line,
+.c17:focus:not(:focus-visible):not(:hover) > path,
+.c17:focus:not(:focus-visible):not(:hover) > polygon,
+.c17:focus:not(:focus-visible):not(:hover) > polyline,
+.c17:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible)::-moz-focus-inner {
+.c17:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -23667,43 +23667,43 @@ exports[`DateInput select format inline range without timezone 2`] = `
   line-height: 0;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -23727,43 +23727,43 @@ exports[`DateInput select format inline range without timezone 2`] = `
   padding: 12px;
 }
 
-.c12:focus {
+.c12:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus > circle,
-.c12:focus > ellipse,
-.c12:focus > line,
-.c12:focus > path,
-.c12:focus > polygon,
-.c12:focus > polyline,
-.c12:focus > rect {
+.c12:focus:not(:hover) > circle,
+.c12:focus:not(:hover) > ellipse,
+.c12:focus:not(:hover) > line,
+.c12:focus:not(:hover) > path,
+.c12:focus:not(:hover) > polygon,
+.c12:focus:not(:hover) > polyline,
+.c12:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus::-moz-focus-inner {
+.c12:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c12:focus:not(:focus-visible) {
+.c12:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible) > circle,
-.c12:focus:not(:focus-visible) > ellipse,
-.c12:focus:not(:focus-visible) > line,
-.c12:focus:not(:focus-visible) > path,
-.c12:focus:not(:focus-visible) > polygon,
-.c12:focus:not(:focus-visible) > polyline,
-.c12:focus:not(:focus-visible) > rect {
+.c12:focus:not(:focus-visible):not(:hover) > circle,
+.c12:focus:not(:focus-visible):not(:hover) > ellipse,
+.c12:focus:not(:focus-visible):not(:hover) > line,
+.c12:focus:not(:focus-visible):not(:hover) > path,
+.c12:focus:not(:focus-visible):not(:hover) > polygon,
+.c12:focus:not(:focus-visible):not(:hover) > polyline,
+.c12:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible)::-moz-focus-inner {
+.c12:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -23785,43 +23785,43 @@ exports[`DateInput select format inline range without timezone 2`] = `
   text-align: inherit;
 }
 
-.c17:focus {
+.c17:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus > circle,
-.c17:focus > ellipse,
-.c17:focus > line,
-.c17:focus > path,
-.c17:focus > polygon,
-.c17:focus > polyline,
-.c17:focus > rect {
+.c17:focus:not(:hover) > circle,
+.c17:focus:not(:hover) > ellipse,
+.c17:focus:not(:hover) > line,
+.c17:focus:not(:hover) > path,
+.c17:focus:not(:hover) > polygon,
+.c17:focus:not(:hover) > polyline,
+.c17:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus::-moz-focus-inner {
+.c17:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c17:focus:not(:focus-visible) {
+.c17:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible) > circle,
-.c17:focus:not(:focus-visible) > ellipse,
-.c17:focus:not(:focus-visible) > line,
-.c17:focus:not(:focus-visible) > path,
-.c17:focus:not(:focus-visible) > polygon,
-.c17:focus:not(:focus-visible) > polyline,
-.c17:focus:not(:focus-visible) > rect {
+.c17:focus:not(:focus-visible):not(:hover) > circle,
+.c17:focus:not(:focus-visible):not(:hover) > ellipse,
+.c17:focus:not(:focus-visible):not(:hover) > line,
+.c17:focus:not(:focus-visible):not(:hover) > path,
+.c17:focus:not(:focus-visible):not(:hover) > polygon,
+.c17:focus:not(:focus-visible):not(:hover) > polyline,
+.c17:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible)::-moz-focus-inner {
+.c17:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -23845,43 +23845,43 @@ exports[`DateInput select format inline range without timezone 2`] = `
   color: #000000;
 }
 
-.c20:focus {
+.c20:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c20:focus > circle,
-.c20:focus > ellipse,
-.c20:focus > line,
-.c20:focus > path,
-.c20:focus > polygon,
-.c20:focus > polyline,
-.c20:focus > rect {
+.c20:focus:not(:hover) > circle,
+.c20:focus:not(:hover) > ellipse,
+.c20:focus:not(:hover) > line,
+.c20:focus:not(:hover) > path,
+.c20:focus:not(:hover) > polygon,
+.c20:focus:not(:hover) > polyline,
+.c20:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c20:focus::-moz-focus-inner {
+.c20:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c20:focus:not(:focus-visible) {
+.c20:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c20:focus:not(:focus-visible) > circle,
-.c20:focus:not(:focus-visible) > ellipse,
-.c20:focus:not(:focus-visible) > line,
-.c20:focus:not(:focus-visible) > path,
-.c20:focus:not(:focus-visible) > polygon,
-.c20:focus:not(:focus-visible) > polyline,
-.c20:focus:not(:focus-visible) > rect {
+.c20:focus:not(:focus-visible):not(:hover) > circle,
+.c20:focus:not(:focus-visible):not(:hover) > ellipse,
+.c20:focus:not(:focus-visible):not(:hover) > line,
+.c20:focus:not(:focus-visible):not(:hover) > path,
+.c20:focus:not(:focus-visible):not(:hover) > polygon,
+.c20:focus:not(:focus-visible):not(:hover) > polyline,
+.c20:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c20:focus:not(:focus-visible)::-moz-focus-inner {
+.c20:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -25047,43 +25047,43 @@ exports[`DateInput select format no timezone 1`] = `
   line-height: 0;
 }
 
-.c4:focus {
+.c4:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c4:focus > circle,
-.c4:focus > ellipse,
-.c4:focus > line,
-.c4:focus > path,
-.c4:focus > polygon,
-.c4:focus > polyline,
-.c4:focus > rect {
+.c4:focus:not(:hover) > circle,
+.c4:focus:not(:hover) > ellipse,
+.c4:focus:not(:hover) > line,
+.c4:focus:not(:hover) > path,
+.c4:focus:not(:hover) > polygon,
+.c4:focus:not(:hover) > polyline,
+.c4:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c4:focus::-moz-focus-inner {
+.c4:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c4:focus:not(:focus-visible) {
+.c4:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c4:focus:not(:focus-visible) > circle,
-.c4:focus:not(:focus-visible) > ellipse,
-.c4:focus:not(:focus-visible) > line,
-.c4:focus:not(:focus-visible) > path,
-.c4:focus:not(:focus-visible) > polygon,
-.c4:focus:not(:focus-visible) > polyline,
-.c4:focus:not(:focus-visible) > rect {
+.c4:focus:not(:focus-visible):not(:hover) > circle,
+.c4:focus:not(:focus-visible):not(:hover) > ellipse,
+.c4:focus:not(:focus-visible):not(:hover) > line,
+.c4:focus:not(:focus-visible):not(:hover) > path,
+.c4:focus:not(:focus-visible):not(:hover) > polygon,
+.c4:focus:not(:focus-visible):not(:hover) > polyline,
+.c4:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c4:focus:not(:focus-visible)::-moz-focus-inner {
+.c4:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -25292,43 +25292,43 @@ exports[`DateInput select format no timezone 2`] = `
   line-height: 0;
 }
 
-.c4:focus {
+.c4:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c4:focus > circle,
-.c4:focus > ellipse,
-.c4:focus > line,
-.c4:focus > path,
-.c4:focus > polygon,
-.c4:focus > polyline,
-.c4:focus > rect {
+.c4:focus:not(:hover) > circle,
+.c4:focus:not(:hover) > ellipse,
+.c4:focus:not(:hover) > line,
+.c4:focus:not(:hover) > path,
+.c4:focus:not(:hover) > polygon,
+.c4:focus:not(:hover) > polyline,
+.c4:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c4:focus::-moz-focus-inner {
+.c4:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c4:focus:not(:focus-visible) {
+.c4:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c4:focus:not(:focus-visible) > circle,
-.c4:focus:not(:focus-visible) > ellipse,
-.c4:focus:not(:focus-visible) > line,
-.c4:focus:not(:focus-visible) > path,
-.c4:focus:not(:focus-visible) > polygon,
-.c4:focus:not(:focus-visible) > polyline,
-.c4:focus:not(:focus-visible) > rect {
+.c4:focus:not(:focus-visible):not(:hover) > circle,
+.c4:focus:not(:focus-visible):not(:hover) > ellipse,
+.c4:focus:not(:focus-visible):not(:hover) > line,
+.c4:focus:not(:focus-visible):not(:hover) > path,
+.c4:focus:not(:focus-visible):not(:hover) > polygon,
+.c4:focus:not(:focus-visible):not(:hover) > polyline,
+.c4:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c4:focus:not(:focus-visible)::-moz-focus-inner {
+.c4:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -25624,43 +25624,43 @@ exports[`DateInput select format no timezone 3`] = `
   padding: 12px;
 }
 
-.c8:focus {
+.c8:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c8:focus > circle,
-.c8:focus > ellipse,
-.c8:focus > line,
-.c8:focus > path,
-.c8:focus > polygon,
-.c8:focus > polyline,
-.c8:focus > rect {
+.c8:focus:not(:hover) > circle,
+.c8:focus:not(:hover) > ellipse,
+.c8:focus:not(:hover) > line,
+.c8:focus:not(:hover) > path,
+.c8:focus:not(:hover) > polygon,
+.c8:focus:not(:hover) > polyline,
+.c8:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c8:focus::-moz-focus-inner {
+.c8:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c8:focus:not(:focus-visible) {
+.c8:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c8:focus:not(:focus-visible) > circle,
-.c8:focus:not(:focus-visible) > ellipse,
-.c8:focus:not(:focus-visible) > line,
-.c8:focus:not(:focus-visible) > path,
-.c8:focus:not(:focus-visible) > polygon,
-.c8:focus:not(:focus-visible) > polyline,
-.c8:focus:not(:focus-visible) > rect {
+.c8:focus:not(:focus-visible):not(:hover) > circle,
+.c8:focus:not(:focus-visible):not(:hover) > ellipse,
+.c8:focus:not(:focus-visible):not(:hover) > line,
+.c8:focus:not(:focus-visible):not(:hover) > path,
+.c8:focus:not(:focus-visible):not(:hover) > polygon,
+.c8:focus:not(:focus-visible):not(:hover) > polyline,
+.c8:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c8:focus:not(:focus-visible)::-moz-focus-inner {
+.c8:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -25682,43 +25682,43 @@ exports[`DateInput select format no timezone 3`] = `
   text-align: inherit;
 }
 
-.c14:focus {
+.c14:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c14:focus > circle,
-.c14:focus > ellipse,
-.c14:focus > line,
-.c14:focus > path,
-.c14:focus > polygon,
-.c14:focus > polyline,
-.c14:focus > rect {
+.c14:focus:not(:hover) > circle,
+.c14:focus:not(:hover) > ellipse,
+.c14:focus:not(:hover) > line,
+.c14:focus:not(:hover) > path,
+.c14:focus:not(:hover) > polygon,
+.c14:focus:not(:hover) > polyline,
+.c14:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c14:focus::-moz-focus-inner {
+.c14:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c14:focus:not(:focus-visible) {
+.c14:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c14:focus:not(:focus-visible) > circle,
-.c14:focus:not(:focus-visible) > ellipse,
-.c14:focus:not(:focus-visible) > line,
-.c14:focus:not(:focus-visible) > path,
-.c14:focus:not(:focus-visible) > polygon,
-.c14:focus:not(:focus-visible) > polyline,
-.c14:focus:not(:focus-visible) > rect {
+.c14:focus:not(:focus-visible):not(:hover) > circle,
+.c14:focus:not(:focus-visible):not(:hover) > ellipse,
+.c14:focus:not(:focus-visible):not(:hover) > line,
+.c14:focus:not(:focus-visible):not(:hover) > path,
+.c14:focus:not(:focus-visible):not(:hover) > polygon,
+.c14:focus:not(:focus-visible):not(:hover) > polyline,
+.c14:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c14:focus:not(:focus-visible)::-moz-focus-inner {
+.c14:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -25742,43 +25742,43 @@ exports[`DateInput select format no timezone 3`] = `
   color: #000000;
 }
 
-.c16:focus {
+.c16:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c16:focus > circle,
-.c16:focus > ellipse,
-.c16:focus > line,
-.c16:focus > path,
-.c16:focus > polygon,
-.c16:focus > polyline,
-.c16:focus > rect {
+.c16:focus:not(:hover) > circle,
+.c16:focus:not(:hover) > ellipse,
+.c16:focus:not(:hover) > line,
+.c16:focus:not(:hover) > path,
+.c16:focus:not(:hover) > polygon,
+.c16:focus:not(:hover) > polyline,
+.c16:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c16:focus::-moz-focus-inner {
+.c16:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c16:focus:not(:focus-visible) {
+.c16:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c16:focus:not(:focus-visible) > circle,
-.c16:focus:not(:focus-visible) > ellipse,
-.c16:focus:not(:focus-visible) > line,
-.c16:focus:not(:focus-visible) > path,
-.c16:focus:not(:focus-visible) > polygon,
-.c16:focus:not(:focus-visible) > polyline,
-.c16:focus:not(:focus-visible) > rect {
+.c16:focus:not(:focus-visible):not(:hover) > circle,
+.c16:focus:not(:focus-visible):not(:hover) > ellipse,
+.c16:focus:not(:focus-visible):not(:hover) > line,
+.c16:focus:not(:focus-visible):not(:hover) > path,
+.c16:focus:not(:focus-visible):not(:hover) > polygon,
+.c16:focus:not(:focus-visible):not(:hover) > polyline,
+.c16:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c16:focus:not(:focus-visible)::-moz-focus-inner {
+.c16:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -26937,43 +26937,43 @@ exports[`DateInput select inline 1`] = `
   padding: 12px;
 }
 
-.c7:focus {
+.c7:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus > circle,
-.c7:focus > ellipse,
-.c7:focus > line,
-.c7:focus > path,
-.c7:focus > polygon,
-.c7:focus > polyline,
-.c7:focus > rect {
+.c7:focus:not(:hover) > circle,
+.c7:focus:not(:hover) > ellipse,
+.c7:focus:not(:hover) > line,
+.c7:focus:not(:hover) > path,
+.c7:focus:not(:hover) > polygon,
+.c7:focus:not(:hover) > polyline,
+.c7:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus::-moz-focus-inner {
+.c7:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c7:focus:not(:focus-visible) {
+.c7:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c7:focus:not(:focus-visible) > circle,
-.c7:focus:not(:focus-visible) > ellipse,
-.c7:focus:not(:focus-visible) > line,
-.c7:focus:not(:focus-visible) > path,
-.c7:focus:not(:focus-visible) > polygon,
-.c7:focus:not(:focus-visible) > polyline,
-.c7:focus:not(:focus-visible) > rect {
+.c7:focus:not(:focus-visible):not(:hover) > circle,
+.c7:focus:not(:focus-visible):not(:hover) > ellipse,
+.c7:focus:not(:focus-visible):not(:hover) > line,
+.c7:focus:not(:focus-visible):not(:hover) > path,
+.c7:focus:not(:focus-visible):not(:hover) > polygon,
+.c7:focus:not(:focus-visible):not(:hover) > polyline,
+.c7:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c7:focus:not(:focus-visible)::-moz-focus-inner {
+.c7:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -26995,43 +26995,43 @@ exports[`DateInput select inline 1`] = `
   text-align: inherit;
 }
 
-.c13:focus {
+.c13:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus > circle,
-.c13:focus > ellipse,
-.c13:focus > line,
-.c13:focus > path,
-.c13:focus > polygon,
-.c13:focus > polyline,
-.c13:focus > rect {
+.c13:focus:not(:hover) > circle,
+.c13:focus:not(:hover) > ellipse,
+.c13:focus:not(:hover) > line,
+.c13:focus:not(:hover) > path,
+.c13:focus:not(:hover) > polygon,
+.c13:focus:not(:hover) > polyline,
+.c13:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus::-moz-focus-inner {
+.c13:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c13:focus:not(:focus-visible) {
+.c13:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible) > circle,
-.c13:focus:not(:focus-visible) > ellipse,
-.c13:focus:not(:focus-visible) > line,
-.c13:focus:not(:focus-visible) > path,
-.c13:focus:not(:focus-visible) > polygon,
-.c13:focus:not(:focus-visible) > polyline,
-.c13:focus:not(:focus-visible) > rect {
+.c13:focus:not(:focus-visible):not(:hover) > circle,
+.c13:focus:not(:focus-visible):not(:hover) > ellipse,
+.c13:focus:not(:focus-visible):not(:hover) > line,
+.c13:focus:not(:focus-visible):not(:hover) > path,
+.c13:focus:not(:focus-visible):not(:hover) > polygon,
+.c13:focus:not(:focus-visible):not(:hover) > polyline,
+.c13:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible)::-moz-focus-inner {
+.c13:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -28118,43 +28118,43 @@ exports[`DateInput select inline without timezone 1`] = `
   padding: 12px;
 }
 
-.c7:focus {
+.c7:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus > circle,
-.c7:focus > ellipse,
-.c7:focus > line,
-.c7:focus > path,
-.c7:focus > polygon,
-.c7:focus > polyline,
-.c7:focus > rect {
+.c7:focus:not(:hover) > circle,
+.c7:focus:not(:hover) > ellipse,
+.c7:focus:not(:hover) > line,
+.c7:focus:not(:hover) > path,
+.c7:focus:not(:hover) > polygon,
+.c7:focus:not(:hover) > polyline,
+.c7:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus::-moz-focus-inner {
+.c7:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c7:focus:not(:focus-visible) {
+.c7:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c7:focus:not(:focus-visible) > circle,
-.c7:focus:not(:focus-visible) > ellipse,
-.c7:focus:not(:focus-visible) > line,
-.c7:focus:not(:focus-visible) > path,
-.c7:focus:not(:focus-visible) > polygon,
-.c7:focus:not(:focus-visible) > polyline,
-.c7:focus:not(:focus-visible) > rect {
+.c7:focus:not(:focus-visible):not(:hover) > circle,
+.c7:focus:not(:focus-visible):not(:hover) > ellipse,
+.c7:focus:not(:focus-visible):not(:hover) > line,
+.c7:focus:not(:focus-visible):not(:hover) > path,
+.c7:focus:not(:focus-visible):not(:hover) > polygon,
+.c7:focus:not(:focus-visible):not(:hover) > polyline,
+.c7:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c7:focus:not(:focus-visible)::-moz-focus-inner {
+.c7:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -28176,43 +28176,43 @@ exports[`DateInput select inline without timezone 1`] = `
   text-align: inherit;
 }
 
-.c13:focus {
+.c13:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus > circle,
-.c13:focus > ellipse,
-.c13:focus > line,
-.c13:focus > path,
-.c13:focus > polygon,
-.c13:focus > polyline,
-.c13:focus > rect {
+.c13:focus:not(:hover) > circle,
+.c13:focus:not(:hover) > ellipse,
+.c13:focus:not(:hover) > line,
+.c13:focus:not(:hover) > path,
+.c13:focus:not(:hover) > polygon,
+.c13:focus:not(:hover) > polyline,
+.c13:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus::-moz-focus-inner {
+.c13:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c13:focus:not(:focus-visible) {
+.c13:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible) > circle,
-.c13:focus:not(:focus-visible) > ellipse,
-.c13:focus:not(:focus-visible) > line,
-.c13:focus:not(:focus-visible) > path,
-.c13:focus:not(:focus-visible) > polygon,
-.c13:focus:not(:focus-visible) > polyline,
-.c13:focus:not(:focus-visible) > rect {
+.c13:focus:not(:focus-visible):not(:hover) > circle,
+.c13:focus:not(:focus-visible):not(:hover) > ellipse,
+.c13:focus:not(:focus-visible):not(:hover) > line,
+.c13:focus:not(:focus-visible):not(:hover) > path,
+.c13:focus:not(:focus-visible):not(:hover) > polygon,
+.c13:focus:not(:focus-visible):not(:hover) > polyline,
+.c13:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible)::-moz-focus-inner {
+.c13:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -29317,43 +29317,43 @@ exports[`DateInput type format inline 1`] = `
   line-height: 0;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -29377,43 +29377,43 @@ exports[`DateInput type format inline 1`] = `
   padding: 12px;
 }
 
-.c12:focus {
+.c12:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus > circle,
-.c12:focus > ellipse,
-.c12:focus > line,
-.c12:focus > path,
-.c12:focus > polygon,
-.c12:focus > polyline,
-.c12:focus > rect {
+.c12:focus:not(:hover) > circle,
+.c12:focus:not(:hover) > ellipse,
+.c12:focus:not(:hover) > line,
+.c12:focus:not(:hover) > path,
+.c12:focus:not(:hover) > polygon,
+.c12:focus:not(:hover) > polyline,
+.c12:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus::-moz-focus-inner {
+.c12:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c12:focus:not(:focus-visible) {
+.c12:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible) > circle,
-.c12:focus:not(:focus-visible) > ellipse,
-.c12:focus:not(:focus-visible) > line,
-.c12:focus:not(:focus-visible) > path,
-.c12:focus:not(:focus-visible) > polygon,
-.c12:focus:not(:focus-visible) > polyline,
-.c12:focus:not(:focus-visible) > rect {
+.c12:focus:not(:focus-visible):not(:hover) > circle,
+.c12:focus:not(:focus-visible):not(:hover) > ellipse,
+.c12:focus:not(:focus-visible):not(:hover) > line,
+.c12:focus:not(:focus-visible):not(:hover) > path,
+.c12:focus:not(:focus-visible):not(:hover) > polygon,
+.c12:focus:not(:focus-visible):not(:hover) > polyline,
+.c12:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible)::-moz-focus-inner {
+.c12:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -29435,43 +29435,43 @@ exports[`DateInput type format inline 1`] = `
   text-align: inherit;
 }
 
-.c17:focus {
+.c17:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus > circle,
-.c17:focus > ellipse,
-.c17:focus > line,
-.c17:focus > path,
-.c17:focus > polygon,
-.c17:focus > polyline,
-.c17:focus > rect {
+.c17:focus:not(:hover) > circle,
+.c17:focus:not(:hover) > ellipse,
+.c17:focus:not(:hover) > line,
+.c17:focus:not(:hover) > path,
+.c17:focus:not(:hover) > polygon,
+.c17:focus:not(:hover) > polyline,
+.c17:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus::-moz-focus-inner {
+.c17:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c17:focus:not(:focus-visible) {
+.c17:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible) > circle,
-.c17:focus:not(:focus-visible) > ellipse,
-.c17:focus:not(:focus-visible) > line,
-.c17:focus:not(:focus-visible) > path,
-.c17:focus:not(:focus-visible) > polygon,
-.c17:focus:not(:focus-visible) > polyline,
-.c17:focus:not(:focus-visible) > rect {
+.c17:focus:not(:focus-visible):not(:hover) > circle,
+.c17:focus:not(:focus-visible):not(:hover) > ellipse,
+.c17:focus:not(:focus-visible):not(:hover) > line,
+.c17:focus:not(:focus-visible):not(:hover) > path,
+.c17:focus:not(:focus-visible):not(:hover) > polygon,
+.c17:focus:not(:focus-visible):not(:hover) > polyline,
+.c17:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible)::-moz-focus-inner {
+.c17:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -30557,7 +30557,7 @@ exports[`DateInput type format inline 2`] = `
         />
       </div>
       <button
-        class="StyledButton-sc-323bzc-0 kHVwhD"
+        class="StyledButton-sc-323bzc-0 eQOfsX"
         type="button"
       >
         <svg
@@ -30597,7 +30597,7 @@ exports[`DateInput type format inline 2`] = `
           >
             <button
               aria-label="Go to June 2020"
-              class="StyledButton-sc-323bzc-0 bpsTzm"
+              class="StyledButton-sc-323bzc-0 xRvZe"
               type="button"
             >
               <svg
@@ -30615,7 +30615,7 @@ exports[`DateInput type format inline 2`] = `
             </button>
             <button
               aria-label="Go to August 2020"
-              class="StyledButton-sc-323bzc-0 bpsTzm"
+              class="StyledButton-sc-323bzc-0 xRvZe"
               type="button"
             >
               <svg
@@ -30655,7 +30655,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Sun Jun 28 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -30672,7 +30672,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Mon Jun 29 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -30689,7 +30689,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Tue Jun 30 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -30706,7 +30706,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Wed Jul 01 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -30723,7 +30723,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Thu Jul 02 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -30740,7 +30740,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Fri Jul 03 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -30757,7 +30757,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Sat Jul 04 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -30779,7 +30779,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Sun Jul 05 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -30796,7 +30796,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Mon Jul 06 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -30813,7 +30813,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Tue Jul 07 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -30830,7 +30830,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Wed Jul 08 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -30847,7 +30847,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Thu Jul 09 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -30864,7 +30864,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Fri Jul 10 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -30881,7 +30881,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Sat Jul 11 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -30903,7 +30903,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Sun Jul 12 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -30920,7 +30920,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Mon Jul 13 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -30937,7 +30937,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Tue Jul 14 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -30954,7 +30954,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Wed Jul 15 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -30971,7 +30971,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Thu Jul 16 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -30988,7 +30988,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Fri Jul 17 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -31005,7 +31005,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Sat Jul 18 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -31027,7 +31027,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Sun Jul 19 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -31044,7 +31044,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Mon Jul 20 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -31061,7 +31061,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Tue Jul 21 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -31078,7 +31078,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Wed Jul 22 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -31095,7 +31095,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Thu Jul 23 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -31112,7 +31112,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Fri Jul 24 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -31129,7 +31129,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Sat Jul 25 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -31151,7 +31151,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Sun Jul 26 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -31168,7 +31168,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Mon Jul 27 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -31185,7 +31185,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Tue Jul 28 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -31202,7 +31202,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Wed Jul 29 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -31219,7 +31219,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Thu Jul 30 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -31236,7 +31236,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Fri Jul 31 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -31253,7 +31253,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Sat Aug 01 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -31275,7 +31275,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Sun Aug 02 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -31292,7 +31292,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Mon Aug 03 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -31309,7 +31309,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Tue Aug 04 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -31326,7 +31326,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Wed Aug 05 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -31343,7 +31343,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Thu Aug 06 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -31360,7 +31360,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Fri Aug 07 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -31377,7 +31377,7 @@ exports[`DateInput type format inline 2`] = `
               >
                 <button
                   aria-label="Sat Aug 08 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -31556,43 +31556,43 @@ exports[`DateInput type format inline partial 1`] = `
   line-height: 0;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -31616,43 +31616,43 @@ exports[`DateInput type format inline partial 1`] = `
   padding: 12px;
 }
 
-.c12:focus {
+.c12:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus > circle,
-.c12:focus > ellipse,
-.c12:focus > line,
-.c12:focus > path,
-.c12:focus > polygon,
-.c12:focus > polyline,
-.c12:focus > rect {
+.c12:focus:not(:hover) > circle,
+.c12:focus:not(:hover) > ellipse,
+.c12:focus:not(:hover) > line,
+.c12:focus:not(:hover) > path,
+.c12:focus:not(:hover) > polygon,
+.c12:focus:not(:hover) > polyline,
+.c12:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus::-moz-focus-inner {
+.c12:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c12:focus:not(:focus-visible) {
+.c12:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible) > circle,
-.c12:focus:not(:focus-visible) > ellipse,
-.c12:focus:not(:focus-visible) > line,
-.c12:focus:not(:focus-visible) > path,
-.c12:focus:not(:focus-visible) > polygon,
-.c12:focus:not(:focus-visible) > polyline,
-.c12:focus:not(:focus-visible) > rect {
+.c12:focus:not(:focus-visible):not(:hover) > circle,
+.c12:focus:not(:focus-visible):not(:hover) > ellipse,
+.c12:focus:not(:focus-visible):not(:hover) > line,
+.c12:focus:not(:focus-visible):not(:hover) > path,
+.c12:focus:not(:focus-visible):not(:hover) > polygon,
+.c12:focus:not(:focus-visible):not(:hover) > polyline,
+.c12:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible)::-moz-focus-inner {
+.c12:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -31674,43 +31674,43 @@ exports[`DateInput type format inline partial 1`] = `
   text-align: inherit;
 }
 
-.c17:focus {
+.c17:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus > circle,
-.c17:focus > ellipse,
-.c17:focus > line,
-.c17:focus > path,
-.c17:focus > polygon,
-.c17:focus > polyline,
-.c17:focus > rect {
+.c17:focus:not(:hover) > circle,
+.c17:focus:not(:hover) > ellipse,
+.c17:focus:not(:hover) > line,
+.c17:focus:not(:hover) > path,
+.c17:focus:not(:hover) > polygon,
+.c17:focus:not(:hover) > polyline,
+.c17:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus::-moz-focus-inner {
+.c17:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c17:focus:not(:focus-visible) {
+.c17:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible) > circle,
-.c17:focus:not(:focus-visible) > ellipse,
-.c17:focus:not(:focus-visible) > line,
-.c17:focus:not(:focus-visible) > path,
-.c17:focus:not(:focus-visible) > polygon,
-.c17:focus:not(:focus-visible) > polyline,
-.c17:focus:not(:focus-visible) > rect {
+.c17:focus:not(:focus-visible):not(:hover) > circle,
+.c17:focus:not(:focus-visible):not(:hover) > ellipse,
+.c17:focus:not(:focus-visible):not(:hover) > line,
+.c17:focus:not(:focus-visible):not(:hover) > path,
+.c17:focus:not(:focus-visible):not(:hover) > polygon,
+.c17:focus:not(:focus-visible):not(:hover) > polyline,
+.c17:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible)::-moz-focus-inner {
+.c17:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -32933,43 +32933,43 @@ exports[`DateInput type format inline partial without timezone 1`] = `
   line-height: 0;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -32993,43 +32993,43 @@ exports[`DateInput type format inline partial without timezone 1`] = `
   padding: 12px;
 }
 
-.c12:focus {
+.c12:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus > circle,
-.c12:focus > ellipse,
-.c12:focus > line,
-.c12:focus > path,
-.c12:focus > polygon,
-.c12:focus > polyline,
-.c12:focus > rect {
+.c12:focus:not(:hover) > circle,
+.c12:focus:not(:hover) > ellipse,
+.c12:focus:not(:hover) > line,
+.c12:focus:not(:hover) > path,
+.c12:focus:not(:hover) > polygon,
+.c12:focus:not(:hover) > polyline,
+.c12:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus::-moz-focus-inner {
+.c12:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c12:focus:not(:focus-visible) {
+.c12:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible) > circle,
-.c12:focus:not(:focus-visible) > ellipse,
-.c12:focus:not(:focus-visible) > line,
-.c12:focus:not(:focus-visible) > path,
-.c12:focus:not(:focus-visible) > polygon,
-.c12:focus:not(:focus-visible) > polyline,
-.c12:focus:not(:focus-visible) > rect {
+.c12:focus:not(:focus-visible):not(:hover) > circle,
+.c12:focus:not(:focus-visible):not(:hover) > ellipse,
+.c12:focus:not(:focus-visible):not(:hover) > line,
+.c12:focus:not(:focus-visible):not(:hover) > path,
+.c12:focus:not(:focus-visible):not(:hover) > polygon,
+.c12:focus:not(:focus-visible):not(:hover) > polyline,
+.c12:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible)::-moz-focus-inner {
+.c12:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -33051,43 +33051,43 @@ exports[`DateInput type format inline partial without timezone 1`] = `
   text-align: inherit;
 }
 
-.c17:focus {
+.c17:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus > circle,
-.c17:focus > ellipse,
-.c17:focus > line,
-.c17:focus > path,
-.c17:focus > polygon,
-.c17:focus > polyline,
-.c17:focus > rect {
+.c17:focus:not(:hover) > circle,
+.c17:focus:not(:hover) > ellipse,
+.c17:focus:not(:hover) > line,
+.c17:focus:not(:hover) > path,
+.c17:focus:not(:hover) > polygon,
+.c17:focus:not(:hover) > polyline,
+.c17:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus::-moz-focus-inner {
+.c17:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c17:focus:not(:focus-visible) {
+.c17:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible) > circle,
-.c17:focus:not(:focus-visible) > ellipse,
-.c17:focus:not(:focus-visible) > line,
-.c17:focus:not(:focus-visible) > path,
-.c17:focus:not(:focus-visible) > polygon,
-.c17:focus:not(:focus-visible) > polyline,
-.c17:focus:not(:focus-visible) > rect {
+.c17:focus:not(:focus-visible):not(:hover) > circle,
+.c17:focus:not(:focus-visible):not(:hover) > ellipse,
+.c17:focus:not(:focus-visible):not(:hover) > line,
+.c17:focus:not(:focus-visible):not(:hover) > path,
+.c17:focus:not(:focus-visible):not(:hover) > polygon,
+.c17:focus:not(:focus-visible):not(:hover) > polyline,
+.c17:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible)::-moz-focus-inner {
+.c17:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -34310,43 +34310,43 @@ exports[`DateInput type format inline range 1`] = `
   line-height: 0;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -34370,43 +34370,43 @@ exports[`DateInput type format inline range 1`] = `
   padding: 12px;
 }
 
-.c12:focus {
+.c12:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus > circle,
-.c12:focus > ellipse,
-.c12:focus > line,
-.c12:focus > path,
-.c12:focus > polygon,
-.c12:focus > polyline,
-.c12:focus > rect {
+.c12:focus:not(:hover) > circle,
+.c12:focus:not(:hover) > ellipse,
+.c12:focus:not(:hover) > line,
+.c12:focus:not(:hover) > path,
+.c12:focus:not(:hover) > polygon,
+.c12:focus:not(:hover) > polyline,
+.c12:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus::-moz-focus-inner {
+.c12:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c12:focus:not(:focus-visible) {
+.c12:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible) > circle,
-.c12:focus:not(:focus-visible) > ellipse,
-.c12:focus:not(:focus-visible) > line,
-.c12:focus:not(:focus-visible) > path,
-.c12:focus:not(:focus-visible) > polygon,
-.c12:focus:not(:focus-visible) > polyline,
-.c12:focus:not(:focus-visible) > rect {
+.c12:focus:not(:focus-visible):not(:hover) > circle,
+.c12:focus:not(:focus-visible):not(:hover) > ellipse,
+.c12:focus:not(:focus-visible):not(:hover) > line,
+.c12:focus:not(:focus-visible):not(:hover) > path,
+.c12:focus:not(:focus-visible):not(:hover) > polygon,
+.c12:focus:not(:focus-visible):not(:hover) > polyline,
+.c12:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible)::-moz-focus-inner {
+.c12:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -34428,43 +34428,43 @@ exports[`DateInput type format inline range 1`] = `
   text-align: inherit;
 }
 
-.c17:focus {
+.c17:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus > circle,
-.c17:focus > ellipse,
-.c17:focus > line,
-.c17:focus > path,
-.c17:focus > polygon,
-.c17:focus > polyline,
-.c17:focus > rect {
+.c17:focus:not(:hover) > circle,
+.c17:focus:not(:hover) > ellipse,
+.c17:focus:not(:hover) > line,
+.c17:focus:not(:hover) > path,
+.c17:focus:not(:hover) > polygon,
+.c17:focus:not(:hover) > polyline,
+.c17:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus::-moz-focus-inner {
+.c17:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c17:focus:not(:focus-visible) {
+.c17:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible) > circle,
-.c17:focus:not(:focus-visible) > ellipse,
-.c17:focus:not(:focus-visible) > line,
-.c17:focus:not(:focus-visible) > path,
-.c17:focus:not(:focus-visible) > polygon,
-.c17:focus:not(:focus-visible) > polyline,
-.c17:focus:not(:focus-visible) > rect {
+.c17:focus:not(:focus-visible):not(:hover) > circle,
+.c17:focus:not(:focus-visible):not(:hover) > ellipse,
+.c17:focus:not(:focus-visible):not(:hover) > line,
+.c17:focus:not(:focus-visible):not(:hover) > path,
+.c17:focus:not(:focus-visible):not(:hover) > polygon,
+.c17:focus:not(:focus-visible):not(:hover) > polyline,
+.c17:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible)::-moz-focus-inner {
+.c17:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -35569,7 +35569,7 @@ exports[`DateInput type format inline range 2`] = `
         />
       </div>
       <button
-        class="StyledButton-sc-323bzc-0 kHVwhD"
+        class="StyledButton-sc-323bzc-0 eQOfsX"
         type="button"
       >
         <svg
@@ -35609,7 +35609,7 @@ exports[`DateInput type format inline range 2`] = `
           >
             <button
               aria-label="Go to June 2020"
-              class="StyledButton-sc-323bzc-0 bpsTzm"
+              class="StyledButton-sc-323bzc-0 xRvZe"
               type="button"
             >
               <svg
@@ -35627,7 +35627,7 @@ exports[`DateInput type format inline range 2`] = `
             </button>
             <button
               aria-label="Go to August 2020"
-              class="StyledButton-sc-323bzc-0 bpsTzm"
+              class="StyledButton-sc-323bzc-0 xRvZe"
               type="button"
             >
               <svg
@@ -35668,7 +35668,7 @@ exports[`DateInput type format inline range 2`] = `
               >
                 <button
                   aria-label="Sun Jun 28 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -35685,7 +35685,7 @@ exports[`DateInput type format inline range 2`] = `
               >
                 <button
                   aria-label="Mon Jun 29 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -35702,7 +35702,7 @@ exports[`DateInput type format inline range 2`] = `
               >
                 <button
                   aria-label="Tue Jun 30 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -35719,7 +35719,7 @@ exports[`DateInput type format inline range 2`] = `
               >
                 <button
                   aria-label="Wed Jul 01 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -35736,7 +35736,7 @@ exports[`DateInput type format inline range 2`] = `
               >
                 <button
                   aria-label="Thu Jul 02 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -35753,7 +35753,7 @@ exports[`DateInput type format inline range 2`] = `
               >
                 <button
                   aria-label="Fri Jul 03 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -35770,7 +35770,7 @@ exports[`DateInput type format inline range 2`] = `
               >
                 <button
                   aria-label="Sat Jul 04 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -35792,7 +35792,7 @@ exports[`DateInput type format inline range 2`] = `
               >
                 <button
                   aria-label="Sun Jul 05 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -35809,7 +35809,7 @@ exports[`DateInput type format inline range 2`] = `
               >
                 <button
                   aria-label="Mon Jul 06 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -35826,7 +35826,7 @@ exports[`DateInput type format inline range 2`] = `
               >
                 <button
                   aria-label="Tue Jul 07 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -35843,7 +35843,7 @@ exports[`DateInput type format inline range 2`] = `
               >
                 <button
                   aria-label="Wed Jul 08 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -35860,7 +35860,7 @@ exports[`DateInput type format inline range 2`] = `
               >
                 <button
                   aria-label="Thu Jul 09 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -35877,7 +35877,7 @@ exports[`DateInput type format inline range 2`] = `
               >
                 <button
                   aria-label="Fri Jul 10 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -35894,7 +35894,7 @@ exports[`DateInput type format inline range 2`] = `
               >
                 <button
                   aria-label="Sat Jul 11 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -35916,7 +35916,7 @@ exports[`DateInput type format inline range 2`] = `
               >
                 <button
                   aria-label="Sun Jul 12 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -35933,7 +35933,7 @@ exports[`DateInput type format inline range 2`] = `
               >
                 <button
                   aria-label="Mon Jul 13 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -35950,7 +35950,7 @@ exports[`DateInput type format inline range 2`] = `
               >
                 <button
                   aria-label="Tue Jul 14 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -35967,7 +35967,7 @@ exports[`DateInput type format inline range 2`] = `
               >
                 <button
                   aria-label="Wed Jul 15 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -35984,7 +35984,7 @@ exports[`DateInput type format inline range 2`] = `
               >
                 <button
                   aria-label="Thu Jul 16 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -36001,7 +36001,7 @@ exports[`DateInput type format inline range 2`] = `
               >
                 <button
                   aria-label="Fri Jul 17 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -36018,7 +36018,7 @@ exports[`DateInput type format inline range 2`] = `
               >
                 <button
                   aria-label="Sat Jul 18 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -36040,7 +36040,7 @@ exports[`DateInput type format inline range 2`] = `
               >
                 <button
                   aria-label="Sun Jul 19 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -36057,7 +36057,7 @@ exports[`DateInput type format inline range 2`] = `
               >
                 <button
                   aria-label="Mon Jul 20 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -36074,7 +36074,7 @@ exports[`DateInput type format inline range 2`] = `
               >
                 <button
                   aria-label="Tue Jul 21 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -36091,7 +36091,7 @@ exports[`DateInput type format inline range 2`] = `
               >
                 <button
                   aria-label="Wed Jul 22 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -36108,7 +36108,7 @@ exports[`DateInput type format inline range 2`] = `
               >
                 <button
                   aria-label="Thu Jul 23 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -36125,7 +36125,7 @@ exports[`DateInput type format inline range 2`] = `
               >
                 <button
                   aria-label="Fri Jul 24 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -36142,7 +36142,7 @@ exports[`DateInput type format inline range 2`] = `
               >
                 <button
                   aria-label="Sat Jul 25 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -36164,7 +36164,7 @@ exports[`DateInput type format inline range 2`] = `
               >
                 <button
                   aria-label="Sun Jul 26 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -36181,7 +36181,7 @@ exports[`DateInput type format inline range 2`] = `
               >
                 <button
                   aria-label="Mon Jul 27 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -36198,7 +36198,7 @@ exports[`DateInput type format inline range 2`] = `
               >
                 <button
                   aria-label="Tue Jul 28 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -36215,7 +36215,7 @@ exports[`DateInput type format inline range 2`] = `
               >
                 <button
                   aria-label="Wed Jul 29 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -36232,7 +36232,7 @@ exports[`DateInput type format inline range 2`] = `
               >
                 <button
                   aria-label="Thu Jul 30 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -36249,7 +36249,7 @@ exports[`DateInput type format inline range 2`] = `
               >
                 <button
                   aria-label="Fri Jul 31 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -36266,7 +36266,7 @@ exports[`DateInput type format inline range 2`] = `
               >
                 <button
                   aria-label="Sat Aug 01 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -36288,7 +36288,7 @@ exports[`DateInput type format inline range 2`] = `
               >
                 <button
                   aria-label="Sun Aug 02 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -36305,7 +36305,7 @@ exports[`DateInput type format inline range 2`] = `
               >
                 <button
                   aria-label="Mon Aug 03 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -36322,7 +36322,7 @@ exports[`DateInput type format inline range 2`] = `
               >
                 <button
                   aria-label="Tue Aug 04 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -36339,7 +36339,7 @@ exports[`DateInput type format inline range 2`] = `
               >
                 <button
                   aria-label="Wed Aug 05 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -36356,7 +36356,7 @@ exports[`DateInput type format inline range 2`] = `
               >
                 <button
                   aria-label="Thu Aug 06 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -36373,7 +36373,7 @@ exports[`DateInput type format inline range 2`] = `
               >
                 <button
                   aria-label="Fri Aug 07 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -36390,7 +36390,7 @@ exports[`DateInput type format inline range 2`] = `
               >
                 <button
                   aria-label="Sat Aug 08 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -36569,43 +36569,43 @@ exports[`DateInput type format inline range partial 1`] = `
   line-height: 0;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -36629,43 +36629,43 @@ exports[`DateInput type format inline range partial 1`] = `
   padding: 12px;
 }
 
-.c12:focus {
+.c12:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus > circle,
-.c12:focus > ellipse,
-.c12:focus > line,
-.c12:focus > path,
-.c12:focus > polygon,
-.c12:focus > polyline,
-.c12:focus > rect {
+.c12:focus:not(:hover) > circle,
+.c12:focus:not(:hover) > ellipse,
+.c12:focus:not(:hover) > line,
+.c12:focus:not(:hover) > path,
+.c12:focus:not(:hover) > polygon,
+.c12:focus:not(:hover) > polyline,
+.c12:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus::-moz-focus-inner {
+.c12:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c12:focus:not(:focus-visible) {
+.c12:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible) > circle,
-.c12:focus:not(:focus-visible) > ellipse,
-.c12:focus:not(:focus-visible) > line,
-.c12:focus:not(:focus-visible) > path,
-.c12:focus:not(:focus-visible) > polygon,
-.c12:focus:not(:focus-visible) > polyline,
-.c12:focus:not(:focus-visible) > rect {
+.c12:focus:not(:focus-visible):not(:hover) > circle,
+.c12:focus:not(:focus-visible):not(:hover) > ellipse,
+.c12:focus:not(:focus-visible):not(:hover) > line,
+.c12:focus:not(:focus-visible):not(:hover) > path,
+.c12:focus:not(:focus-visible):not(:hover) > polygon,
+.c12:focus:not(:focus-visible):not(:hover) > polyline,
+.c12:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible)::-moz-focus-inner {
+.c12:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -36687,43 +36687,43 @@ exports[`DateInput type format inline range partial 1`] = `
   text-align: inherit;
 }
 
-.c17:focus {
+.c17:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus > circle,
-.c17:focus > ellipse,
-.c17:focus > line,
-.c17:focus > path,
-.c17:focus > polygon,
-.c17:focus > polyline,
-.c17:focus > rect {
+.c17:focus:not(:hover) > circle,
+.c17:focus:not(:hover) > ellipse,
+.c17:focus:not(:hover) > line,
+.c17:focus:not(:hover) > path,
+.c17:focus:not(:hover) > polygon,
+.c17:focus:not(:hover) > polyline,
+.c17:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus::-moz-focus-inner {
+.c17:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c17:focus:not(:focus-visible) {
+.c17:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible) > circle,
-.c17:focus:not(:focus-visible) > ellipse,
-.c17:focus:not(:focus-visible) > line,
-.c17:focus:not(:focus-visible) > path,
-.c17:focus:not(:focus-visible) > polygon,
-.c17:focus:not(:focus-visible) > polyline,
-.c17:focus:not(:focus-visible) > rect {
+.c17:focus:not(:focus-visible):not(:hover) > circle,
+.c17:focus:not(:focus-visible):not(:hover) > ellipse,
+.c17:focus:not(:focus-visible):not(:hover) > line,
+.c17:focus:not(:focus-visible):not(:hover) > path,
+.c17:focus:not(:focus-visible):not(:hover) > polygon,
+.c17:focus:not(:focus-visible):not(:hover) > polyline,
+.c17:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible)::-moz-focus-inner {
+.c17:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -37828,7 +37828,7 @@ exports[`DateInput type format inline range partial 2`] = `
         />
       </div>
       <button
-        class="StyledButton-sc-323bzc-0 kHVwhD"
+        class="StyledButton-sc-323bzc-0 eQOfsX"
         type="button"
       >
         <svg
@@ -37868,7 +37868,7 @@ exports[`DateInput type format inline range partial 2`] = `
           >
             <button
               aria-label="Go to June 2020"
-              class="StyledButton-sc-323bzc-0 bpsTzm"
+              class="StyledButton-sc-323bzc-0 xRvZe"
               type="button"
             >
               <svg
@@ -37886,7 +37886,7 @@ exports[`DateInput type format inline range partial 2`] = `
             </button>
             <button
               aria-label="Go to August 2020"
-              class="StyledButton-sc-323bzc-0 bpsTzm"
+              class="StyledButton-sc-323bzc-0 xRvZe"
               type="button"
             >
               <svg
@@ -37927,7 +37927,7 @@ exports[`DateInput type format inline range partial 2`] = `
               >
                 <button
                   aria-label="Sun Jun 28 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -37944,7 +37944,7 @@ exports[`DateInput type format inline range partial 2`] = `
               >
                 <button
                   aria-label="Mon Jun 29 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -37961,7 +37961,7 @@ exports[`DateInput type format inline range partial 2`] = `
               >
                 <button
                   aria-label="Tue Jun 30 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -37978,7 +37978,7 @@ exports[`DateInput type format inline range partial 2`] = `
               >
                 <button
                   aria-label="Wed Jul 01 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -37995,7 +37995,7 @@ exports[`DateInput type format inline range partial 2`] = `
               >
                 <button
                   aria-label="Thu Jul 02 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -38012,7 +38012,7 @@ exports[`DateInput type format inline range partial 2`] = `
               >
                 <button
                   aria-label="Fri Jul 03 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -38029,7 +38029,7 @@ exports[`DateInput type format inline range partial 2`] = `
               >
                 <button
                   aria-label="Sat Jul 04 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -38051,7 +38051,7 @@ exports[`DateInput type format inline range partial 2`] = `
               >
                 <button
                   aria-label="Sun Jul 05 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -38068,7 +38068,7 @@ exports[`DateInput type format inline range partial 2`] = `
               >
                 <button
                   aria-label="Mon Jul 06 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -38085,7 +38085,7 @@ exports[`DateInput type format inline range partial 2`] = `
               >
                 <button
                   aria-label="Tue Jul 07 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -38102,7 +38102,7 @@ exports[`DateInput type format inline range partial 2`] = `
               >
                 <button
                   aria-label="Wed Jul 08 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -38119,7 +38119,7 @@ exports[`DateInput type format inline range partial 2`] = `
               >
                 <button
                   aria-label="Thu Jul 09 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -38136,7 +38136,7 @@ exports[`DateInput type format inline range partial 2`] = `
               >
                 <button
                   aria-label="Fri Jul 10 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -38153,7 +38153,7 @@ exports[`DateInput type format inline range partial 2`] = `
               >
                 <button
                   aria-label="Sat Jul 11 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -38175,7 +38175,7 @@ exports[`DateInput type format inline range partial 2`] = `
               >
                 <button
                   aria-label="Sun Jul 12 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -38192,7 +38192,7 @@ exports[`DateInput type format inline range partial 2`] = `
               >
                 <button
                   aria-label="Mon Jul 13 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -38209,7 +38209,7 @@ exports[`DateInput type format inline range partial 2`] = `
               >
                 <button
                   aria-label="Tue Jul 14 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -38226,7 +38226,7 @@ exports[`DateInput type format inline range partial 2`] = `
               >
                 <button
                   aria-label="Wed Jul 15 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -38243,7 +38243,7 @@ exports[`DateInput type format inline range partial 2`] = `
               >
                 <button
                   aria-label="Thu Jul 16 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -38260,7 +38260,7 @@ exports[`DateInput type format inline range partial 2`] = `
               >
                 <button
                   aria-label="Fri Jul 17 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -38277,7 +38277,7 @@ exports[`DateInput type format inline range partial 2`] = `
               >
                 <button
                   aria-label="Sat Jul 18 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -38299,7 +38299,7 @@ exports[`DateInput type format inline range partial 2`] = `
               >
                 <button
                   aria-label="Sun Jul 19 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -38316,7 +38316,7 @@ exports[`DateInput type format inline range partial 2`] = `
               >
                 <button
                   aria-label="Mon Jul 20 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -38333,7 +38333,7 @@ exports[`DateInput type format inline range partial 2`] = `
               >
                 <button
                   aria-label="Tue Jul 21 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -38350,7 +38350,7 @@ exports[`DateInput type format inline range partial 2`] = `
               >
                 <button
                   aria-label="Wed Jul 22 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -38367,7 +38367,7 @@ exports[`DateInput type format inline range partial 2`] = `
               >
                 <button
                   aria-label="Thu Jul 23 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -38384,7 +38384,7 @@ exports[`DateInput type format inline range partial 2`] = `
               >
                 <button
                   aria-label="Fri Jul 24 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -38401,7 +38401,7 @@ exports[`DateInput type format inline range partial 2`] = `
               >
                 <button
                   aria-label="Sat Jul 25 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -38423,7 +38423,7 @@ exports[`DateInput type format inline range partial 2`] = `
               >
                 <button
                   aria-label="Sun Jul 26 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -38440,7 +38440,7 @@ exports[`DateInput type format inline range partial 2`] = `
               >
                 <button
                   aria-label="Mon Jul 27 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -38457,7 +38457,7 @@ exports[`DateInput type format inline range partial 2`] = `
               >
                 <button
                   aria-label="Tue Jul 28 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -38474,7 +38474,7 @@ exports[`DateInput type format inline range partial 2`] = `
               >
                 <button
                   aria-label="Wed Jul 29 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -38491,7 +38491,7 @@ exports[`DateInput type format inline range partial 2`] = `
               >
                 <button
                   aria-label="Thu Jul 30 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -38508,7 +38508,7 @@ exports[`DateInput type format inline range partial 2`] = `
               >
                 <button
                   aria-label="Fri Jul 31 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -38525,7 +38525,7 @@ exports[`DateInput type format inline range partial 2`] = `
               >
                 <button
                   aria-label="Sat Aug 01 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -38547,7 +38547,7 @@ exports[`DateInput type format inline range partial 2`] = `
               >
                 <button
                   aria-label="Sun Aug 02 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -38564,7 +38564,7 @@ exports[`DateInput type format inline range partial 2`] = `
               >
                 <button
                   aria-label="Mon Aug 03 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -38581,7 +38581,7 @@ exports[`DateInput type format inline range partial 2`] = `
               >
                 <button
                   aria-label="Tue Aug 04 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -38598,7 +38598,7 @@ exports[`DateInput type format inline range partial 2`] = `
               >
                 <button
                   aria-label="Wed Aug 05 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -38615,7 +38615,7 @@ exports[`DateInput type format inline range partial 2`] = `
               >
                 <button
                   aria-label="Thu Aug 06 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -38632,7 +38632,7 @@ exports[`DateInput type format inline range partial 2`] = `
               >
                 <button
                   aria-label="Fri Aug 07 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -38649,7 +38649,7 @@ exports[`DateInput type format inline range partial 2`] = `
               >
                 <button
                   aria-label="Sat Aug 08 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -38692,7 +38692,7 @@ exports[`DateInput type format inline range partial 3`] = `
         />
       </div>
       <button
-        class="StyledButton-sc-323bzc-0 kHVwhD"
+        class="StyledButton-sc-323bzc-0 eQOfsX"
         type="button"
       >
         <svg
@@ -38732,7 +38732,7 @@ exports[`DateInput type format inline range partial 3`] = `
           >
             <button
               aria-label="Go to June 2020"
-              class="StyledButton-sc-323bzc-0 bpsTzm"
+              class="StyledButton-sc-323bzc-0 xRvZe"
               type="button"
             >
               <svg
@@ -38750,7 +38750,7 @@ exports[`DateInput type format inline range partial 3`] = `
             </button>
             <button
               aria-label="Go to August 2020"
-              class="StyledButton-sc-323bzc-0 bpsTzm"
+              class="StyledButton-sc-323bzc-0 xRvZe"
               type="button"
             >
               <svg
@@ -38791,7 +38791,7 @@ exports[`DateInput type format inline range partial 3`] = `
               >
                 <button
                   aria-label="Sun Jun 28 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -38808,7 +38808,7 @@ exports[`DateInput type format inline range partial 3`] = `
               >
                 <button
                   aria-label="Mon Jun 29 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -38825,7 +38825,7 @@ exports[`DateInput type format inline range partial 3`] = `
               >
                 <button
                   aria-label="Tue Jun 30 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -38842,7 +38842,7 @@ exports[`DateInput type format inline range partial 3`] = `
               >
                 <button
                   aria-label="Wed Jul 01 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -38859,7 +38859,7 @@ exports[`DateInput type format inline range partial 3`] = `
               >
                 <button
                   aria-label="Thu Jul 02 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -38876,7 +38876,7 @@ exports[`DateInput type format inline range partial 3`] = `
               >
                 <button
                   aria-label="Fri Jul 03 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -38893,7 +38893,7 @@ exports[`DateInput type format inline range partial 3`] = `
               >
                 <button
                   aria-label="Sat Jul 04 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -38915,7 +38915,7 @@ exports[`DateInput type format inline range partial 3`] = `
               >
                 <button
                   aria-label="Sun Jul 05 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -38932,7 +38932,7 @@ exports[`DateInput type format inline range partial 3`] = `
               >
                 <button
                   aria-label="Mon Jul 06 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -38949,7 +38949,7 @@ exports[`DateInput type format inline range partial 3`] = `
               >
                 <button
                   aria-label="Tue Jul 07 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -38966,7 +38966,7 @@ exports[`DateInput type format inline range partial 3`] = `
               >
                 <button
                   aria-label="Wed Jul 08 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -38983,7 +38983,7 @@ exports[`DateInput type format inline range partial 3`] = `
               >
                 <button
                   aria-label="Thu Jul 09 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -39000,7 +39000,7 @@ exports[`DateInput type format inline range partial 3`] = `
               >
                 <button
                   aria-label="Fri Jul 10 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -39017,7 +39017,7 @@ exports[`DateInput type format inline range partial 3`] = `
               >
                 <button
                   aria-label="Sat Jul 11 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -39039,7 +39039,7 @@ exports[`DateInput type format inline range partial 3`] = `
               >
                 <button
                   aria-label="Sun Jul 12 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -39056,7 +39056,7 @@ exports[`DateInput type format inline range partial 3`] = `
               >
                 <button
                   aria-label="Mon Jul 13 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -39073,7 +39073,7 @@ exports[`DateInput type format inline range partial 3`] = `
               >
                 <button
                   aria-label="Tue Jul 14 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -39090,7 +39090,7 @@ exports[`DateInput type format inline range partial 3`] = `
               >
                 <button
                   aria-label="Wed Jul 15 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -39107,7 +39107,7 @@ exports[`DateInput type format inline range partial 3`] = `
               >
                 <button
                   aria-label="Thu Jul 16 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -39124,7 +39124,7 @@ exports[`DateInput type format inline range partial 3`] = `
               >
                 <button
                   aria-label="Fri Jul 17 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -39141,7 +39141,7 @@ exports[`DateInput type format inline range partial 3`] = `
               >
                 <button
                   aria-label="Sat Jul 18 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -39163,7 +39163,7 @@ exports[`DateInput type format inline range partial 3`] = `
               >
                 <button
                   aria-label="Sun Jul 19 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -39180,7 +39180,7 @@ exports[`DateInput type format inline range partial 3`] = `
               >
                 <button
                   aria-label="Mon Jul 20 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -39197,7 +39197,7 @@ exports[`DateInput type format inline range partial 3`] = `
               >
                 <button
                   aria-label="Tue Jul 21 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -39214,7 +39214,7 @@ exports[`DateInput type format inline range partial 3`] = `
               >
                 <button
                   aria-label="Wed Jul 22 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -39231,7 +39231,7 @@ exports[`DateInput type format inline range partial 3`] = `
               >
                 <button
                   aria-label="Thu Jul 23 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -39248,7 +39248,7 @@ exports[`DateInput type format inline range partial 3`] = `
               >
                 <button
                   aria-label="Fri Jul 24 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -39265,7 +39265,7 @@ exports[`DateInput type format inline range partial 3`] = `
               >
                 <button
                   aria-label="Sat Jul 25 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -39287,7 +39287,7 @@ exports[`DateInput type format inline range partial 3`] = `
               >
                 <button
                   aria-label="Sun Jul 26 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -39304,7 +39304,7 @@ exports[`DateInput type format inline range partial 3`] = `
               >
                 <button
                   aria-label="Mon Jul 27 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -39321,7 +39321,7 @@ exports[`DateInput type format inline range partial 3`] = `
               >
                 <button
                   aria-label="Tue Jul 28 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -39338,7 +39338,7 @@ exports[`DateInput type format inline range partial 3`] = `
               >
                 <button
                   aria-label="Wed Jul 29 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -39355,7 +39355,7 @@ exports[`DateInput type format inline range partial 3`] = `
               >
                 <button
                   aria-label="Thu Jul 30 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -39372,7 +39372,7 @@ exports[`DateInput type format inline range partial 3`] = `
               >
                 <button
                   aria-label="Fri Jul 31 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -39389,7 +39389,7 @@ exports[`DateInput type format inline range partial 3`] = `
               >
                 <button
                   aria-label="Sat Aug 01 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -39411,7 +39411,7 @@ exports[`DateInput type format inline range partial 3`] = `
               >
                 <button
                   aria-label="Sun Aug 02 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -39428,7 +39428,7 @@ exports[`DateInput type format inline range partial 3`] = `
               >
                 <button
                   aria-label="Mon Aug 03 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -39445,7 +39445,7 @@ exports[`DateInput type format inline range partial 3`] = `
               >
                 <button
                   aria-label="Tue Aug 04 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -39462,7 +39462,7 @@ exports[`DateInput type format inline range partial 3`] = `
               >
                 <button
                   aria-label="Wed Aug 05 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -39479,7 +39479,7 @@ exports[`DateInput type format inline range partial 3`] = `
               >
                 <button
                   aria-label="Thu Aug 06 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -39496,7 +39496,7 @@ exports[`DateInput type format inline range partial 3`] = `
               >
                 <button
                   aria-label="Fri Aug 07 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -39513,7 +39513,7 @@ exports[`DateInput type format inline range partial 3`] = `
               >
                 <button
                   aria-label="Sat Aug 08 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -39693,43 +39693,43 @@ exports[`DateInput type format inline range partial without timezone 1`] = `
   line-height: 0;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -39753,43 +39753,43 @@ exports[`DateInput type format inline range partial without timezone 1`] = `
   padding: 12px;
 }
 
-.c12:focus {
+.c12:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus > circle,
-.c12:focus > ellipse,
-.c12:focus > line,
-.c12:focus > path,
-.c12:focus > polygon,
-.c12:focus > polyline,
-.c12:focus > rect {
+.c12:focus:not(:hover) > circle,
+.c12:focus:not(:hover) > ellipse,
+.c12:focus:not(:hover) > line,
+.c12:focus:not(:hover) > path,
+.c12:focus:not(:hover) > polygon,
+.c12:focus:not(:hover) > polyline,
+.c12:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus::-moz-focus-inner {
+.c12:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c12:focus:not(:focus-visible) {
+.c12:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible) > circle,
-.c12:focus:not(:focus-visible) > ellipse,
-.c12:focus:not(:focus-visible) > line,
-.c12:focus:not(:focus-visible) > path,
-.c12:focus:not(:focus-visible) > polygon,
-.c12:focus:not(:focus-visible) > polyline,
-.c12:focus:not(:focus-visible) > rect {
+.c12:focus:not(:focus-visible):not(:hover) > circle,
+.c12:focus:not(:focus-visible):not(:hover) > ellipse,
+.c12:focus:not(:focus-visible):not(:hover) > line,
+.c12:focus:not(:focus-visible):not(:hover) > path,
+.c12:focus:not(:focus-visible):not(:hover) > polygon,
+.c12:focus:not(:focus-visible):not(:hover) > polyline,
+.c12:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible)::-moz-focus-inner {
+.c12:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -39811,43 +39811,43 @@ exports[`DateInput type format inline range partial without timezone 1`] = `
   text-align: inherit;
 }
 
-.c17:focus {
+.c17:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus > circle,
-.c17:focus > ellipse,
-.c17:focus > line,
-.c17:focus > path,
-.c17:focus > polygon,
-.c17:focus > polyline,
-.c17:focus > rect {
+.c17:focus:not(:hover) > circle,
+.c17:focus:not(:hover) > ellipse,
+.c17:focus:not(:hover) > line,
+.c17:focus:not(:hover) > path,
+.c17:focus:not(:hover) > polygon,
+.c17:focus:not(:hover) > polyline,
+.c17:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus::-moz-focus-inner {
+.c17:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c17:focus:not(:focus-visible) {
+.c17:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible) > circle,
-.c17:focus:not(:focus-visible) > ellipse,
-.c17:focus:not(:focus-visible) > line,
-.c17:focus:not(:focus-visible) > path,
-.c17:focus:not(:focus-visible) > polygon,
-.c17:focus:not(:focus-visible) > polyline,
-.c17:focus:not(:focus-visible) > rect {
+.c17:focus:not(:focus-visible):not(:hover) > circle,
+.c17:focus:not(:focus-visible):not(:hover) > ellipse,
+.c17:focus:not(:focus-visible):not(:hover) > line,
+.c17:focus:not(:focus-visible):not(:hover) > path,
+.c17:focus:not(:focus-visible):not(:hover) > polygon,
+.c17:focus:not(:focus-visible):not(:hover) > polyline,
+.c17:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible)::-moz-focus-inner {
+.c17:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -41090,43 +41090,43 @@ exports[`DateInput type format inline range partial without timezone 2`] = `
   line-height: 0;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -41150,43 +41150,43 @@ exports[`DateInput type format inline range partial without timezone 2`] = `
   padding: 12px;
 }
 
-.c12:focus {
+.c12:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus > circle,
-.c12:focus > ellipse,
-.c12:focus > line,
-.c12:focus > path,
-.c12:focus > polygon,
-.c12:focus > polyline,
-.c12:focus > rect {
+.c12:focus:not(:hover) > circle,
+.c12:focus:not(:hover) > ellipse,
+.c12:focus:not(:hover) > line,
+.c12:focus:not(:hover) > path,
+.c12:focus:not(:hover) > polygon,
+.c12:focus:not(:hover) > polyline,
+.c12:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus::-moz-focus-inner {
+.c12:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c12:focus:not(:focus-visible) {
+.c12:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible) > circle,
-.c12:focus:not(:focus-visible) > ellipse,
-.c12:focus:not(:focus-visible) > line,
-.c12:focus:not(:focus-visible) > path,
-.c12:focus:not(:focus-visible) > polygon,
-.c12:focus:not(:focus-visible) > polyline,
-.c12:focus:not(:focus-visible) > rect {
+.c12:focus:not(:focus-visible):not(:hover) > circle,
+.c12:focus:not(:focus-visible):not(:hover) > ellipse,
+.c12:focus:not(:focus-visible):not(:hover) > line,
+.c12:focus:not(:focus-visible):not(:hover) > path,
+.c12:focus:not(:focus-visible):not(:hover) > polygon,
+.c12:focus:not(:focus-visible):not(:hover) > polyline,
+.c12:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible)::-moz-focus-inner {
+.c12:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -41208,43 +41208,43 @@ exports[`DateInput type format inline range partial without timezone 2`] = `
   text-align: inherit;
 }
 
-.c17:focus {
+.c17:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus > circle,
-.c17:focus > ellipse,
-.c17:focus > line,
-.c17:focus > path,
-.c17:focus > polygon,
-.c17:focus > polyline,
-.c17:focus > rect {
+.c17:focus:not(:hover) > circle,
+.c17:focus:not(:hover) > ellipse,
+.c17:focus:not(:hover) > line,
+.c17:focus:not(:hover) > path,
+.c17:focus:not(:hover) > polygon,
+.c17:focus:not(:hover) > polyline,
+.c17:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus::-moz-focus-inner {
+.c17:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c17:focus:not(:focus-visible) {
+.c17:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible) > circle,
-.c17:focus:not(:focus-visible) > ellipse,
-.c17:focus:not(:focus-visible) > line,
-.c17:focus:not(:focus-visible) > path,
-.c17:focus:not(:focus-visible) > polygon,
-.c17:focus:not(:focus-visible) > polyline,
-.c17:focus:not(:focus-visible) > rect {
+.c17:focus:not(:focus-visible):not(:hover) > circle,
+.c17:focus:not(:focus-visible):not(:hover) > ellipse,
+.c17:focus:not(:focus-visible):not(:hover) > line,
+.c17:focus:not(:focus-visible):not(:hover) > path,
+.c17:focus:not(:focus-visible):not(:hover) > polygon,
+.c17:focus:not(:focus-visible):not(:hover) > polyline,
+.c17:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible)::-moz-focus-inner {
+.c17:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -42469,43 +42469,43 @@ exports[`DateInput type format inline range partial without timezone 3`] = `
   line-height: 0;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -42529,43 +42529,43 @@ exports[`DateInput type format inline range partial without timezone 3`] = `
   padding: 12px;
 }
 
-.c12:focus {
+.c12:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus > circle,
-.c12:focus > ellipse,
-.c12:focus > line,
-.c12:focus > path,
-.c12:focus > polygon,
-.c12:focus > polyline,
-.c12:focus > rect {
+.c12:focus:not(:hover) > circle,
+.c12:focus:not(:hover) > ellipse,
+.c12:focus:not(:hover) > line,
+.c12:focus:not(:hover) > path,
+.c12:focus:not(:hover) > polygon,
+.c12:focus:not(:hover) > polyline,
+.c12:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus::-moz-focus-inner {
+.c12:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c12:focus:not(:focus-visible) {
+.c12:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible) > circle,
-.c12:focus:not(:focus-visible) > ellipse,
-.c12:focus:not(:focus-visible) > line,
-.c12:focus:not(:focus-visible) > path,
-.c12:focus:not(:focus-visible) > polygon,
-.c12:focus:not(:focus-visible) > polyline,
-.c12:focus:not(:focus-visible) > rect {
+.c12:focus:not(:focus-visible):not(:hover) > circle,
+.c12:focus:not(:focus-visible):not(:hover) > ellipse,
+.c12:focus:not(:focus-visible):not(:hover) > line,
+.c12:focus:not(:focus-visible):not(:hover) > path,
+.c12:focus:not(:focus-visible):not(:hover) > polygon,
+.c12:focus:not(:focus-visible):not(:hover) > polyline,
+.c12:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible)::-moz-focus-inner {
+.c12:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -42587,43 +42587,43 @@ exports[`DateInput type format inline range partial without timezone 3`] = `
   text-align: inherit;
 }
 
-.c17:focus {
+.c17:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus > circle,
-.c17:focus > ellipse,
-.c17:focus > line,
-.c17:focus > path,
-.c17:focus > polygon,
-.c17:focus > polyline,
-.c17:focus > rect {
+.c17:focus:not(:hover) > circle,
+.c17:focus:not(:hover) > ellipse,
+.c17:focus:not(:hover) > line,
+.c17:focus:not(:hover) > path,
+.c17:focus:not(:hover) > polygon,
+.c17:focus:not(:hover) > polyline,
+.c17:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus::-moz-focus-inner {
+.c17:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c17:focus:not(:focus-visible) {
+.c17:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible) > circle,
-.c17:focus:not(:focus-visible) > ellipse,
-.c17:focus:not(:focus-visible) > line,
-.c17:focus:not(:focus-visible) > path,
-.c17:focus:not(:focus-visible) > polygon,
-.c17:focus:not(:focus-visible) > polyline,
-.c17:focus:not(:focus-visible) > rect {
+.c17:focus:not(:focus-visible):not(:hover) > circle,
+.c17:focus:not(:focus-visible):not(:hover) > ellipse,
+.c17:focus:not(:focus-visible):not(:hover) > line,
+.c17:focus:not(:focus-visible):not(:hover) > path,
+.c17:focus:not(:focus-visible):not(:hover) > polygon,
+.c17:focus:not(:focus-visible):not(:hover) > polyline,
+.c17:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible)::-moz-focus-inner {
+.c17:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -43848,43 +43848,43 @@ exports[`DateInput type format inline range without timezone 1`] = `
   line-height: 0;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -43908,43 +43908,43 @@ exports[`DateInput type format inline range without timezone 1`] = `
   padding: 12px;
 }
 
-.c12:focus {
+.c12:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus > circle,
-.c12:focus > ellipse,
-.c12:focus > line,
-.c12:focus > path,
-.c12:focus > polygon,
-.c12:focus > polyline,
-.c12:focus > rect {
+.c12:focus:not(:hover) > circle,
+.c12:focus:not(:hover) > ellipse,
+.c12:focus:not(:hover) > line,
+.c12:focus:not(:hover) > path,
+.c12:focus:not(:hover) > polygon,
+.c12:focus:not(:hover) > polyline,
+.c12:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus::-moz-focus-inner {
+.c12:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c12:focus:not(:focus-visible) {
+.c12:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible) > circle,
-.c12:focus:not(:focus-visible) > ellipse,
-.c12:focus:not(:focus-visible) > line,
-.c12:focus:not(:focus-visible) > path,
-.c12:focus:not(:focus-visible) > polygon,
-.c12:focus:not(:focus-visible) > polyline,
-.c12:focus:not(:focus-visible) > rect {
+.c12:focus:not(:focus-visible):not(:hover) > circle,
+.c12:focus:not(:focus-visible):not(:hover) > ellipse,
+.c12:focus:not(:focus-visible):not(:hover) > line,
+.c12:focus:not(:focus-visible):not(:hover) > path,
+.c12:focus:not(:focus-visible):not(:hover) > polygon,
+.c12:focus:not(:focus-visible):not(:hover) > polyline,
+.c12:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible)::-moz-focus-inner {
+.c12:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -43966,43 +43966,43 @@ exports[`DateInput type format inline range without timezone 1`] = `
   text-align: inherit;
 }
 
-.c17:focus {
+.c17:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus > circle,
-.c17:focus > ellipse,
-.c17:focus > line,
-.c17:focus > path,
-.c17:focus > polygon,
-.c17:focus > polyline,
-.c17:focus > rect {
+.c17:focus:not(:hover) > circle,
+.c17:focus:not(:hover) > ellipse,
+.c17:focus:not(:hover) > line,
+.c17:focus:not(:hover) > path,
+.c17:focus:not(:hover) > polygon,
+.c17:focus:not(:hover) > polyline,
+.c17:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus::-moz-focus-inner {
+.c17:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c17:focus:not(:focus-visible) {
+.c17:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible) > circle,
-.c17:focus:not(:focus-visible) > ellipse,
-.c17:focus:not(:focus-visible) > line,
-.c17:focus:not(:focus-visible) > path,
-.c17:focus:not(:focus-visible) > polygon,
-.c17:focus:not(:focus-visible) > polyline,
-.c17:focus:not(:focus-visible) > rect {
+.c17:focus:not(:focus-visible):not(:hover) > circle,
+.c17:focus:not(:focus-visible):not(:hover) > ellipse,
+.c17:focus:not(:focus-visible):not(:hover) > line,
+.c17:focus:not(:focus-visible):not(:hover) > path,
+.c17:focus:not(:focus-visible):not(:hover) > polygon,
+.c17:focus:not(:focus-visible):not(:hover) > polyline,
+.c17:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible)::-moz-focus-inner {
+.c17:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -45245,43 +45245,43 @@ exports[`DateInput type format inline range without timezone 2`] = `
   line-height: 0;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -45305,43 +45305,43 @@ exports[`DateInput type format inline range without timezone 2`] = `
   padding: 12px;
 }
 
-.c12:focus {
+.c12:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus > circle,
-.c12:focus > ellipse,
-.c12:focus > line,
-.c12:focus > path,
-.c12:focus > polygon,
-.c12:focus > polyline,
-.c12:focus > rect {
+.c12:focus:not(:hover) > circle,
+.c12:focus:not(:hover) > ellipse,
+.c12:focus:not(:hover) > line,
+.c12:focus:not(:hover) > path,
+.c12:focus:not(:hover) > polygon,
+.c12:focus:not(:hover) > polyline,
+.c12:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus::-moz-focus-inner {
+.c12:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c12:focus:not(:focus-visible) {
+.c12:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible) > circle,
-.c12:focus:not(:focus-visible) > ellipse,
-.c12:focus:not(:focus-visible) > line,
-.c12:focus:not(:focus-visible) > path,
-.c12:focus:not(:focus-visible) > polygon,
-.c12:focus:not(:focus-visible) > polyline,
-.c12:focus:not(:focus-visible) > rect {
+.c12:focus:not(:focus-visible):not(:hover) > circle,
+.c12:focus:not(:focus-visible):not(:hover) > ellipse,
+.c12:focus:not(:focus-visible):not(:hover) > line,
+.c12:focus:not(:focus-visible):not(:hover) > path,
+.c12:focus:not(:focus-visible):not(:hover) > polygon,
+.c12:focus:not(:focus-visible):not(:hover) > polyline,
+.c12:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible)::-moz-focus-inner {
+.c12:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -45363,43 +45363,43 @@ exports[`DateInput type format inline range without timezone 2`] = `
   text-align: inherit;
 }
 
-.c17:focus {
+.c17:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus > circle,
-.c17:focus > ellipse,
-.c17:focus > line,
-.c17:focus > path,
-.c17:focus > polygon,
-.c17:focus > polyline,
-.c17:focus > rect {
+.c17:focus:not(:hover) > circle,
+.c17:focus:not(:hover) > ellipse,
+.c17:focus:not(:hover) > line,
+.c17:focus:not(:hover) > path,
+.c17:focus:not(:hover) > polygon,
+.c17:focus:not(:hover) > polyline,
+.c17:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus::-moz-focus-inner {
+.c17:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c17:focus:not(:focus-visible) {
+.c17:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible) > circle,
-.c17:focus:not(:focus-visible) > ellipse,
-.c17:focus:not(:focus-visible) > line,
-.c17:focus:not(:focus-visible) > path,
-.c17:focus:not(:focus-visible) > polygon,
-.c17:focus:not(:focus-visible) > polyline,
-.c17:focus:not(:focus-visible) > rect {
+.c17:focus:not(:focus-visible):not(:hover) > circle,
+.c17:focus:not(:focus-visible):not(:hover) > ellipse,
+.c17:focus:not(:focus-visible):not(:hover) > line,
+.c17:focus:not(:focus-visible):not(:hover) > path,
+.c17:focus:not(:focus-visible):not(:hover) > polygon,
+.c17:focus:not(:focus-visible):not(:hover) > polyline,
+.c17:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible)::-moz-focus-inner {
+.c17:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -46641,43 +46641,43 @@ exports[`DateInput type format inline short 1`] = `
   line-height: 0;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -46701,43 +46701,43 @@ exports[`DateInput type format inline short 1`] = `
   padding: 12px;
 }
 
-.c12:focus {
+.c12:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus > circle,
-.c12:focus > ellipse,
-.c12:focus > line,
-.c12:focus > path,
-.c12:focus > polygon,
-.c12:focus > polyline,
-.c12:focus > rect {
+.c12:focus:not(:hover) > circle,
+.c12:focus:not(:hover) > ellipse,
+.c12:focus:not(:hover) > line,
+.c12:focus:not(:hover) > path,
+.c12:focus:not(:hover) > polygon,
+.c12:focus:not(:hover) > polyline,
+.c12:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus::-moz-focus-inner {
+.c12:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c12:focus:not(:focus-visible) {
+.c12:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible) > circle,
-.c12:focus:not(:focus-visible) > ellipse,
-.c12:focus:not(:focus-visible) > line,
-.c12:focus:not(:focus-visible) > path,
-.c12:focus:not(:focus-visible) > polygon,
-.c12:focus:not(:focus-visible) > polyline,
-.c12:focus:not(:focus-visible) > rect {
+.c12:focus:not(:focus-visible):not(:hover) > circle,
+.c12:focus:not(:focus-visible):not(:hover) > ellipse,
+.c12:focus:not(:focus-visible):not(:hover) > line,
+.c12:focus:not(:focus-visible):not(:hover) > path,
+.c12:focus:not(:focus-visible):not(:hover) > polygon,
+.c12:focus:not(:focus-visible):not(:hover) > polyline,
+.c12:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible)::-moz-focus-inner {
+.c12:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -46759,43 +46759,43 @@ exports[`DateInput type format inline short 1`] = `
   text-align: inherit;
 }
 
-.c17:focus {
+.c17:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus > circle,
-.c17:focus > ellipse,
-.c17:focus > line,
-.c17:focus > path,
-.c17:focus > polygon,
-.c17:focus > polyline,
-.c17:focus > rect {
+.c17:focus:not(:hover) > circle,
+.c17:focus:not(:hover) > ellipse,
+.c17:focus:not(:hover) > line,
+.c17:focus:not(:hover) > path,
+.c17:focus:not(:hover) > polygon,
+.c17:focus:not(:hover) > polyline,
+.c17:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus::-moz-focus-inner {
+.c17:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c17:focus:not(:focus-visible) {
+.c17:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible) > circle,
-.c17:focus:not(:focus-visible) > ellipse,
-.c17:focus:not(:focus-visible) > line,
-.c17:focus:not(:focus-visible) > path,
-.c17:focus:not(:focus-visible) > polygon,
-.c17:focus:not(:focus-visible) > polyline,
-.c17:focus:not(:focus-visible) > rect {
+.c17:focus:not(:focus-visible):not(:hover) > circle,
+.c17:focus:not(:focus-visible):not(:hover) > ellipse,
+.c17:focus:not(:focus-visible):not(:hover) > line,
+.c17:focus:not(:focus-visible):not(:hover) > path,
+.c17:focus:not(:focus-visible):not(:hover) > polygon,
+.c17:focus:not(:focus-visible):not(:hover) > polyline,
+.c17:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible)::-moz-focus-inner {
+.c17:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -47881,7 +47881,7 @@ exports[`DateInput type format inline short 2`] = `
         />
       </div>
       <button
-        class="StyledButton-sc-323bzc-0 kHVwhD"
+        class="StyledButton-sc-323bzc-0 eQOfsX"
         type="button"
       >
         <svg
@@ -47921,7 +47921,7 @@ exports[`DateInput type format inline short 2`] = `
           >
             <button
               aria-label="Go to June 2020"
-              class="StyledButton-sc-323bzc-0 bpsTzm"
+              class="StyledButton-sc-323bzc-0 xRvZe"
               type="button"
             >
               <svg
@@ -47939,7 +47939,7 @@ exports[`DateInput type format inline short 2`] = `
             </button>
             <button
               aria-label="Go to August 2020"
-              class="StyledButton-sc-323bzc-0 bpsTzm"
+              class="StyledButton-sc-323bzc-0 xRvZe"
               type="button"
             >
               <svg
@@ -47979,7 +47979,7 @@ exports[`DateInput type format inline short 2`] = `
               >
                 <button
                   aria-label="Sun Jun 28 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -47996,7 +47996,7 @@ exports[`DateInput type format inline short 2`] = `
               >
                 <button
                   aria-label="Mon Jun 29 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -48013,7 +48013,7 @@ exports[`DateInput type format inline short 2`] = `
               >
                 <button
                   aria-label="Tue Jun 30 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -48030,7 +48030,7 @@ exports[`DateInput type format inline short 2`] = `
               >
                 <button
                   aria-label="Wed Jul 01 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -48047,7 +48047,7 @@ exports[`DateInput type format inline short 2`] = `
               >
                 <button
                   aria-label="Thu Jul 02 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -48064,7 +48064,7 @@ exports[`DateInput type format inline short 2`] = `
               >
                 <button
                   aria-label="Fri Jul 03 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -48081,7 +48081,7 @@ exports[`DateInput type format inline short 2`] = `
               >
                 <button
                   aria-label="Sat Jul 04 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -48103,7 +48103,7 @@ exports[`DateInput type format inline short 2`] = `
               >
                 <button
                   aria-label="Sun Jul 05 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -48120,7 +48120,7 @@ exports[`DateInput type format inline short 2`] = `
               >
                 <button
                   aria-label="Mon Jul 06 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -48137,7 +48137,7 @@ exports[`DateInput type format inline short 2`] = `
               >
                 <button
                   aria-label="Tue Jul 07 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -48154,7 +48154,7 @@ exports[`DateInput type format inline short 2`] = `
               >
                 <button
                   aria-label="Wed Jul 08 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -48171,7 +48171,7 @@ exports[`DateInput type format inline short 2`] = `
               >
                 <button
                   aria-label="Thu Jul 09 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -48188,7 +48188,7 @@ exports[`DateInput type format inline short 2`] = `
               >
                 <button
                   aria-label="Fri Jul 10 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -48205,7 +48205,7 @@ exports[`DateInput type format inline short 2`] = `
               >
                 <button
                   aria-label="Sat Jul 11 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -48227,7 +48227,7 @@ exports[`DateInput type format inline short 2`] = `
               >
                 <button
                   aria-label="Sun Jul 12 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -48244,7 +48244,7 @@ exports[`DateInput type format inline short 2`] = `
               >
                 <button
                   aria-label="Mon Jul 13 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -48261,7 +48261,7 @@ exports[`DateInput type format inline short 2`] = `
               >
                 <button
                   aria-label="Tue Jul 14 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -48278,7 +48278,7 @@ exports[`DateInput type format inline short 2`] = `
               >
                 <button
                   aria-label="Wed Jul 15 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -48295,7 +48295,7 @@ exports[`DateInput type format inline short 2`] = `
               >
                 <button
                   aria-label="Thu Jul 16 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -48312,7 +48312,7 @@ exports[`DateInput type format inline short 2`] = `
               >
                 <button
                   aria-label="Fri Jul 17 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -48329,7 +48329,7 @@ exports[`DateInput type format inline short 2`] = `
               >
                 <button
                   aria-label="Sat Jul 18 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -48351,7 +48351,7 @@ exports[`DateInput type format inline short 2`] = `
               >
                 <button
                   aria-label="Sun Jul 19 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -48368,7 +48368,7 @@ exports[`DateInput type format inline short 2`] = `
               >
                 <button
                   aria-label="Mon Jul 20 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -48385,7 +48385,7 @@ exports[`DateInput type format inline short 2`] = `
               >
                 <button
                   aria-label="Tue Jul 21 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -48402,7 +48402,7 @@ exports[`DateInput type format inline short 2`] = `
               >
                 <button
                   aria-label="Wed Jul 22 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -48419,7 +48419,7 @@ exports[`DateInput type format inline short 2`] = `
               >
                 <button
                   aria-label="Thu Jul 23 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -48436,7 +48436,7 @@ exports[`DateInput type format inline short 2`] = `
               >
                 <button
                   aria-label="Fri Jul 24 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -48453,7 +48453,7 @@ exports[`DateInput type format inline short 2`] = `
               >
                 <button
                   aria-label="Sat Jul 25 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -48475,7 +48475,7 @@ exports[`DateInput type format inline short 2`] = `
               >
                 <button
                   aria-label="Sun Jul 26 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -48492,7 +48492,7 @@ exports[`DateInput type format inline short 2`] = `
               >
                 <button
                   aria-label="Mon Jul 27 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -48509,7 +48509,7 @@ exports[`DateInput type format inline short 2`] = `
               >
                 <button
                   aria-label="Tue Jul 28 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -48526,7 +48526,7 @@ exports[`DateInput type format inline short 2`] = `
               >
                 <button
                   aria-label="Wed Jul 29 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -48543,7 +48543,7 @@ exports[`DateInput type format inline short 2`] = `
               >
                 <button
                   aria-label="Thu Jul 30 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -48560,7 +48560,7 @@ exports[`DateInput type format inline short 2`] = `
               >
                 <button
                   aria-label="Fri Jul 31 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -48577,7 +48577,7 @@ exports[`DateInput type format inline short 2`] = `
               >
                 <button
                   aria-label="Sat Aug 01 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -48599,7 +48599,7 @@ exports[`DateInput type format inline short 2`] = `
               >
                 <button
                   aria-label="Sun Aug 02 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -48616,7 +48616,7 @@ exports[`DateInput type format inline short 2`] = `
               >
                 <button
                   aria-label="Mon Aug 03 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -48633,7 +48633,7 @@ exports[`DateInput type format inline short 2`] = `
               >
                 <button
                   aria-label="Tue Aug 04 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -48650,7 +48650,7 @@ exports[`DateInput type format inline short 2`] = `
               >
                 <button
                   aria-label="Wed Aug 05 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -48667,7 +48667,7 @@ exports[`DateInput type format inline short 2`] = `
               >
                 <button
                   aria-label="Thu Aug 06 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -48684,7 +48684,7 @@ exports[`DateInput type format inline short 2`] = `
               >
                 <button
                   aria-label="Fri Aug 07 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -48701,7 +48701,7 @@ exports[`DateInput type format inline short 2`] = `
               >
                 <button
                   aria-label="Sat Aug 08 2020"
-                  class="StyledButton-sc-323bzc-0 eiEooU"
+                  class="StyledButton-sc-323bzc-0 gsQNSg"
                   tabindex="-1"
                   type="button"
                 >
@@ -48881,43 +48881,43 @@ exports[`DateInput type format inline short without timezone 1`] = `
   line-height: 0;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -48941,43 +48941,43 @@ exports[`DateInput type format inline short without timezone 1`] = `
   padding: 12px;
 }
 
-.c12:focus {
+.c12:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus > circle,
-.c12:focus > ellipse,
-.c12:focus > line,
-.c12:focus > path,
-.c12:focus > polygon,
-.c12:focus > polyline,
-.c12:focus > rect {
+.c12:focus:not(:hover) > circle,
+.c12:focus:not(:hover) > ellipse,
+.c12:focus:not(:hover) > line,
+.c12:focus:not(:hover) > path,
+.c12:focus:not(:hover) > polygon,
+.c12:focus:not(:hover) > polyline,
+.c12:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus::-moz-focus-inner {
+.c12:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c12:focus:not(:focus-visible) {
+.c12:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible) > circle,
-.c12:focus:not(:focus-visible) > ellipse,
-.c12:focus:not(:focus-visible) > line,
-.c12:focus:not(:focus-visible) > path,
-.c12:focus:not(:focus-visible) > polygon,
-.c12:focus:not(:focus-visible) > polyline,
-.c12:focus:not(:focus-visible) > rect {
+.c12:focus:not(:focus-visible):not(:hover) > circle,
+.c12:focus:not(:focus-visible):not(:hover) > ellipse,
+.c12:focus:not(:focus-visible):not(:hover) > line,
+.c12:focus:not(:focus-visible):not(:hover) > path,
+.c12:focus:not(:focus-visible):not(:hover) > polygon,
+.c12:focus:not(:focus-visible):not(:hover) > polyline,
+.c12:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible)::-moz-focus-inner {
+.c12:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -48999,43 +48999,43 @@ exports[`DateInput type format inline short without timezone 1`] = `
   text-align: inherit;
 }
 
-.c17:focus {
+.c17:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus > circle,
-.c17:focus > ellipse,
-.c17:focus > line,
-.c17:focus > path,
-.c17:focus > polygon,
-.c17:focus > polyline,
-.c17:focus > rect {
+.c17:focus:not(:hover) > circle,
+.c17:focus:not(:hover) > ellipse,
+.c17:focus:not(:hover) > line,
+.c17:focus:not(:hover) > path,
+.c17:focus:not(:hover) > polygon,
+.c17:focus:not(:hover) > polyline,
+.c17:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus::-moz-focus-inner {
+.c17:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c17:focus:not(:focus-visible) {
+.c17:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible) > circle,
-.c17:focus:not(:focus-visible) > ellipse,
-.c17:focus:not(:focus-visible) > line,
-.c17:focus:not(:focus-visible) > path,
-.c17:focus:not(:focus-visible) > polygon,
-.c17:focus:not(:focus-visible) > polyline,
-.c17:focus:not(:focus-visible) > rect {
+.c17:focus:not(:focus-visible):not(:hover) > circle,
+.c17:focus:not(:focus-visible):not(:hover) > ellipse,
+.c17:focus:not(:focus-visible):not(:hover) > line,
+.c17:focus:not(:focus-visible):not(:hover) > path,
+.c17:focus:not(:focus-visible):not(:hover) > polygon,
+.c17:focus:not(:focus-visible):not(:hover) > polyline,
+.c17:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible)::-moz-focus-inner {
+.c17:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -50259,43 +50259,43 @@ exports[`DateInput type format inline short without timezone 2`] = `
   line-height: 0;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -50319,43 +50319,43 @@ exports[`DateInput type format inline short without timezone 2`] = `
   padding: 12px;
 }
 
-.c12:focus {
+.c12:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus > circle,
-.c12:focus > ellipse,
-.c12:focus > line,
-.c12:focus > path,
-.c12:focus > polygon,
-.c12:focus > polyline,
-.c12:focus > rect {
+.c12:focus:not(:hover) > circle,
+.c12:focus:not(:hover) > ellipse,
+.c12:focus:not(:hover) > line,
+.c12:focus:not(:hover) > path,
+.c12:focus:not(:hover) > polygon,
+.c12:focus:not(:hover) > polyline,
+.c12:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus::-moz-focus-inner {
+.c12:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c12:focus:not(:focus-visible) {
+.c12:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible) > circle,
-.c12:focus:not(:focus-visible) > ellipse,
-.c12:focus:not(:focus-visible) > line,
-.c12:focus:not(:focus-visible) > path,
-.c12:focus:not(:focus-visible) > polygon,
-.c12:focus:not(:focus-visible) > polyline,
-.c12:focus:not(:focus-visible) > rect {
+.c12:focus:not(:focus-visible):not(:hover) > circle,
+.c12:focus:not(:focus-visible):not(:hover) > ellipse,
+.c12:focus:not(:focus-visible):not(:hover) > line,
+.c12:focus:not(:focus-visible):not(:hover) > path,
+.c12:focus:not(:focus-visible):not(:hover) > polygon,
+.c12:focus:not(:focus-visible):not(:hover) > polyline,
+.c12:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible)::-moz-focus-inner {
+.c12:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -50377,43 +50377,43 @@ exports[`DateInput type format inline short without timezone 2`] = `
   text-align: inherit;
 }
 
-.c17:focus {
+.c17:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus > circle,
-.c17:focus > ellipse,
-.c17:focus > line,
-.c17:focus > path,
-.c17:focus > polygon,
-.c17:focus > polyline,
-.c17:focus > rect {
+.c17:focus:not(:hover) > circle,
+.c17:focus:not(:hover) > ellipse,
+.c17:focus:not(:hover) > line,
+.c17:focus:not(:hover) > path,
+.c17:focus:not(:hover) > polygon,
+.c17:focus:not(:hover) > polyline,
+.c17:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus::-moz-focus-inner {
+.c17:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c17:focus:not(:focus-visible) {
+.c17:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible) > circle,
-.c17:focus:not(:focus-visible) > ellipse,
-.c17:focus:not(:focus-visible) > line,
-.c17:focus:not(:focus-visible) > path,
-.c17:focus:not(:focus-visible) > polygon,
-.c17:focus:not(:focus-visible) > polyline,
-.c17:focus:not(:focus-visible) > rect {
+.c17:focus:not(:focus-visible):not(:hover) > circle,
+.c17:focus:not(:focus-visible):not(:hover) > ellipse,
+.c17:focus:not(:focus-visible):not(:hover) > line,
+.c17:focus:not(:focus-visible):not(:hover) > path,
+.c17:focus:not(:focus-visible):not(:hover) > polygon,
+.c17:focus:not(:focus-visible):not(:hover) > polyline,
+.c17:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible)::-moz-focus-inner {
+.c17:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -51637,43 +51637,43 @@ exports[`DateInput type format inline without timezone 1`] = `
   line-height: 0;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -51697,43 +51697,43 @@ exports[`DateInput type format inline without timezone 1`] = `
   padding: 12px;
 }
 
-.c12:focus {
+.c12:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus > circle,
-.c12:focus > ellipse,
-.c12:focus > line,
-.c12:focus > path,
-.c12:focus > polygon,
-.c12:focus > polyline,
-.c12:focus > rect {
+.c12:focus:not(:hover) > circle,
+.c12:focus:not(:hover) > ellipse,
+.c12:focus:not(:hover) > line,
+.c12:focus:not(:hover) > path,
+.c12:focus:not(:hover) > polygon,
+.c12:focus:not(:hover) > polyline,
+.c12:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus::-moz-focus-inner {
+.c12:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c12:focus:not(:focus-visible) {
+.c12:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible) > circle,
-.c12:focus:not(:focus-visible) > ellipse,
-.c12:focus:not(:focus-visible) > line,
-.c12:focus:not(:focus-visible) > path,
-.c12:focus:not(:focus-visible) > polygon,
-.c12:focus:not(:focus-visible) > polyline,
-.c12:focus:not(:focus-visible) > rect {
+.c12:focus:not(:focus-visible):not(:hover) > circle,
+.c12:focus:not(:focus-visible):not(:hover) > ellipse,
+.c12:focus:not(:focus-visible):not(:hover) > line,
+.c12:focus:not(:focus-visible):not(:hover) > path,
+.c12:focus:not(:focus-visible):not(:hover) > polygon,
+.c12:focus:not(:focus-visible):not(:hover) > polyline,
+.c12:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible)::-moz-focus-inner {
+.c12:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -51755,43 +51755,43 @@ exports[`DateInput type format inline without timezone 1`] = `
   text-align: inherit;
 }
 
-.c17:focus {
+.c17:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus > circle,
-.c17:focus > ellipse,
-.c17:focus > line,
-.c17:focus > path,
-.c17:focus > polygon,
-.c17:focus > polyline,
-.c17:focus > rect {
+.c17:focus:not(:hover) > circle,
+.c17:focus:not(:hover) > ellipse,
+.c17:focus:not(:hover) > line,
+.c17:focus:not(:hover) > path,
+.c17:focus:not(:hover) > polygon,
+.c17:focus:not(:hover) > polyline,
+.c17:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus::-moz-focus-inner {
+.c17:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c17:focus:not(:focus-visible) {
+.c17:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible) > circle,
-.c17:focus:not(:focus-visible) > ellipse,
-.c17:focus:not(:focus-visible) > line,
-.c17:focus:not(:focus-visible) > path,
-.c17:focus:not(:focus-visible) > polygon,
-.c17:focus:not(:focus-visible) > polyline,
-.c17:focus:not(:focus-visible) > rect {
+.c17:focus:not(:focus-visible):not(:hover) > circle,
+.c17:focus:not(:focus-visible):not(:hover) > ellipse,
+.c17:focus:not(:focus-visible):not(:hover) > line,
+.c17:focus:not(:focus-visible):not(:hover) > path,
+.c17:focus:not(:focus-visible):not(:hover) > polygon,
+.c17:focus:not(:focus-visible):not(:hover) > polyline,
+.c17:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible)::-moz-focus-inner {
+.c17:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -53015,43 +53015,43 @@ exports[`DateInput type format inline without timezone 2`] = `
   line-height: 0;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -53075,43 +53075,43 @@ exports[`DateInput type format inline without timezone 2`] = `
   padding: 12px;
 }
 
-.c12:focus {
+.c12:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus > circle,
-.c12:focus > ellipse,
-.c12:focus > line,
-.c12:focus > path,
-.c12:focus > polygon,
-.c12:focus > polyline,
-.c12:focus > rect {
+.c12:focus:not(:hover) > circle,
+.c12:focus:not(:hover) > ellipse,
+.c12:focus:not(:hover) > line,
+.c12:focus:not(:hover) > path,
+.c12:focus:not(:hover) > polygon,
+.c12:focus:not(:hover) > polyline,
+.c12:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus::-moz-focus-inner {
+.c12:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c12:focus:not(:focus-visible) {
+.c12:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible) > circle,
-.c12:focus:not(:focus-visible) > ellipse,
-.c12:focus:not(:focus-visible) > line,
-.c12:focus:not(:focus-visible) > path,
-.c12:focus:not(:focus-visible) > polygon,
-.c12:focus:not(:focus-visible) > polyline,
-.c12:focus:not(:focus-visible) > rect {
+.c12:focus:not(:focus-visible):not(:hover) > circle,
+.c12:focus:not(:focus-visible):not(:hover) > ellipse,
+.c12:focus:not(:focus-visible):not(:hover) > line,
+.c12:focus:not(:focus-visible):not(:hover) > path,
+.c12:focus:not(:focus-visible):not(:hover) > polygon,
+.c12:focus:not(:focus-visible):not(:hover) > polyline,
+.c12:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible)::-moz-focus-inner {
+.c12:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -53133,43 +53133,43 @@ exports[`DateInput type format inline without timezone 2`] = `
   text-align: inherit;
 }
 
-.c17:focus {
+.c17:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus > circle,
-.c17:focus > ellipse,
-.c17:focus > line,
-.c17:focus > path,
-.c17:focus > polygon,
-.c17:focus > polyline,
-.c17:focus > rect {
+.c17:focus:not(:hover) > circle,
+.c17:focus:not(:hover) > ellipse,
+.c17:focus:not(:hover) > line,
+.c17:focus:not(:hover) > path,
+.c17:focus:not(:hover) > polygon,
+.c17:focus:not(:hover) > polyline,
+.c17:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus::-moz-focus-inner {
+.c17:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c17:focus:not(:focus-visible) {
+.c17:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible) > circle,
-.c17:focus:not(:focus-visible) > ellipse,
-.c17:focus:not(:focus-visible) > line,
-.c17:focus:not(:focus-visible) > path,
-.c17:focus:not(:focus-visible) > polygon,
-.c17:focus:not(:focus-visible) > polyline,
-.c17:focus:not(:focus-visible) > rect {
+.c17:focus:not(:focus-visible):not(:hover) > circle,
+.c17:focus:not(:focus-visible):not(:hover) > ellipse,
+.c17:focus:not(:focus-visible):not(:hover) > line,
+.c17:focus:not(:focus-visible):not(:hover) > path,
+.c17:focus:not(:focus-visible):not(:hover) > polygon,
+.c17:focus:not(:focus-visible):not(:hover) > polyline,
+.c17:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible)::-moz-focus-inner {
+.c17:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 

--- a/src/js/components/DropButton/__tests__/__snapshots__/DropButton-test.js.snap
+++ b/src/js/components/DropButton/__tests__/__snapshots__/DropButton-test.js.snap
@@ -30,43 +30,43 @@ exports[`DropButton close by clicking outside 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c0:focus {
+.c0:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus > circle,
-.c0:focus > ellipse,
-.c0:focus > line,
-.c0:focus > path,
-.c0:focus > polygon,
-.c0:focus > polyline,
-.c0:focus > rect {
+.c0:focus:not(:hover) > circle,
+.c0:focus:not(:hover) > ellipse,
+.c0:focus:not(:hover) > line,
+.c0:focus:not(:hover) > path,
+.c0:focus:not(:hover) > polygon,
+.c0:focus:not(:hover) > polyline,
+.c0:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus::-moz-focus-inner {
+.c0:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c0:focus:not(:focus-visible) {
+.c0:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible) > circle,
-.c0:focus:not(:focus-visible) > ellipse,
-.c0:focus:not(:focus-visible) > line,
-.c0:focus:not(:focus-visible) > path,
-.c0:focus:not(:focus-visible) > polygon,
-.c0:focus:not(:focus-visible) > polyline,
-.c0:focus:not(:focus-visible) > rect {
+.c0:focus:not(:focus-visible):not(:hover) > circle,
+.c0:focus:not(:focus-visible):not(:hover) > ellipse,
+.c0:focus:not(:focus-visible):not(:hover) > line,
+.c0:focus:not(:focus-visible):not(:hover) > path,
+.c0:focus:not(:focus-visible):not(:hover) > polygon,
+.c0:focus:not(:focus-visible):not(:hover) > polyline,
+.c0:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible)::-moz-focus-inner {
+.c0:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -123,43 +123,43 @@ exports[`DropButton closed 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c0:focus {
+.c0:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus > circle,
-.c0:focus > ellipse,
-.c0:focus > line,
-.c0:focus > path,
-.c0:focus > polygon,
-.c0:focus > polyline,
-.c0:focus > rect {
+.c0:focus:not(:hover) > circle,
+.c0:focus:not(:hover) > ellipse,
+.c0:focus:not(:hover) > line,
+.c0:focus:not(:hover) > path,
+.c0:focus:not(:hover) > polygon,
+.c0:focus:not(:hover) > polyline,
+.c0:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus::-moz-focus-inner {
+.c0:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c0:focus:not(:focus-visible) {
+.c0:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible) > circle,
-.c0:focus:not(:focus-visible) > ellipse,
-.c0:focus:not(:focus-visible) > line,
-.c0:focus:not(:focus-visible) > path,
-.c0:focus:not(:focus-visible) > polygon,
-.c0:focus:not(:focus-visible) > polyline,
-.c0:focus:not(:focus-visible) > rect {
+.c0:focus:not(:focus-visible):not(:hover) > circle,
+.c0:focus:not(:focus-visible):not(:hover) > ellipse,
+.c0:focus:not(:focus-visible):not(:hover) > line,
+.c0:focus:not(:focus-visible):not(:hover) > path,
+.c0:focus:not(:focus-visible):not(:hover) > polygon,
+.c0:focus:not(:focus-visible):not(:hover) > polyline,
+.c0:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible)::-moz-focus-inner {
+.c0:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -200,43 +200,43 @@ exports[`DropButton disabled 1`] = `
   transition-timing-function: ease-in-out;
 }
 
-.c0:focus {
+.c0:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus > circle,
-.c0:focus > ellipse,
-.c0:focus > line,
-.c0:focus > path,
-.c0:focus > polygon,
-.c0:focus > polyline,
-.c0:focus > rect {
+.c0:focus:not(:hover) > circle,
+.c0:focus:not(:hover) > ellipse,
+.c0:focus:not(:hover) > line,
+.c0:focus:not(:hover) > path,
+.c0:focus:not(:hover) > polygon,
+.c0:focus:not(:hover) > polyline,
+.c0:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus::-moz-focus-inner {
+.c0:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c0:focus:not(:focus-visible) {
+.c0:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible) > circle,
-.c0:focus:not(:focus-visible) > ellipse,
-.c0:focus:not(:focus-visible) > line,
-.c0:focus:not(:focus-visible) > path,
-.c0:focus:not(:focus-visible) > polygon,
-.c0:focus:not(:focus-visible) > polyline,
-.c0:focus:not(:focus-visible) > rect {
+.c0:focus:not(:focus-visible):not(:hover) > circle,
+.c0:focus:not(:focus-visible):not(:hover) > ellipse,
+.c0:focus:not(:focus-visible):not(:hover) > line,
+.c0:focus:not(:focus-visible):not(:hover) > path,
+.c0:focus:not(:focus-visible):not(:hover) > polygon,
+.c0:focus:not(:focus-visible):not(:hover) > polyline,
+.c0:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible)::-moz-focus-inner {
+.c0:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -280,43 +280,43 @@ exports[`DropButton open and close 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c0:focus {
+.c0:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus > circle,
-.c0:focus > ellipse,
-.c0:focus > line,
-.c0:focus > path,
-.c0:focus > polygon,
-.c0:focus > polyline,
-.c0:focus > rect {
+.c0:focus:not(:hover) > circle,
+.c0:focus:not(:hover) > ellipse,
+.c0:focus:not(:hover) > line,
+.c0:focus:not(:hover) > path,
+.c0:focus:not(:hover) > polygon,
+.c0:focus:not(:hover) > polyline,
+.c0:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus::-moz-focus-inner {
+.c0:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c0:focus:not(:focus-visible) {
+.c0:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible) > circle,
-.c0:focus:not(:focus-visible) > ellipse,
-.c0:focus:not(:focus-visible) > line,
-.c0:focus:not(:focus-visible) > path,
-.c0:focus:not(:focus-visible) > polygon,
-.c0:focus:not(:focus-visible) > polyline,
-.c0:focus:not(:focus-visible) > rect {
+.c0:focus:not(:focus-visible):not(:hover) > circle,
+.c0:focus:not(:focus-visible):not(:hover) > ellipse,
+.c0:focus:not(:focus-visible):not(:hover) > line,
+.c0:focus:not(:focus-visible):not(:hover) > path,
+.c0:focus:not(:focus-visible):not(:hover) > polygon,
+.c0:focus:not(:focus-visible):not(:hover) > polyline,
+.c0:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible)::-moz-focus-inner {
+.c0:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -373,43 +373,43 @@ exports[`DropButton opened 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c0:focus {
+.c0:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus > circle,
-.c0:focus > ellipse,
-.c0:focus > line,
-.c0:focus > path,
-.c0:focus > polygon,
-.c0:focus > polyline,
-.c0:focus > rect {
+.c0:focus:not(:hover) > circle,
+.c0:focus:not(:hover) > ellipse,
+.c0:focus:not(:hover) > line,
+.c0:focus:not(:hover) > path,
+.c0:focus:not(:hover) > polygon,
+.c0:focus:not(:hover) > polyline,
+.c0:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus::-moz-focus-inner {
+.c0:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c0:focus:not(:focus-visible) {
+.c0:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible) > circle,
-.c0:focus:not(:focus-visible) > ellipse,
-.c0:focus:not(:focus-visible) > line,
-.c0:focus:not(:focus-visible) > path,
-.c0:focus:not(:focus-visible) > polygon,
-.c0:focus:not(:focus-visible) > polyline,
-.c0:focus:not(:focus-visible) > rect {
+.c0:focus:not(:focus-visible):not(:hover) > circle,
+.c0:focus:not(:focus-visible):not(:hover) > ellipse,
+.c0:focus:not(:focus-visible):not(:hover) > line,
+.c0:focus:not(:focus-visible):not(:hover) > path,
+.c0:focus:not(:focus-visible):not(:hover) > polygon,
+.c0:focus:not(:focus-visible):not(:hover) > polyline,
+.c0:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible)::-moz-focus-inner {
+.c0:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -456,43 +456,43 @@ exports[`DropButton opened ref 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c0:focus {
+.c0:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus > circle,
-.c0:focus > ellipse,
-.c0:focus > line,
-.c0:focus > path,
-.c0:focus > polygon,
-.c0:focus > polyline,
-.c0:focus > rect {
+.c0:focus:not(:hover) > circle,
+.c0:focus:not(:hover) > ellipse,
+.c0:focus:not(:hover) > line,
+.c0:focus:not(:hover) > path,
+.c0:focus:not(:hover) > polygon,
+.c0:focus:not(:hover) > polyline,
+.c0:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus::-moz-focus-inner {
+.c0:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c0:focus:not(:focus-visible) {
+.c0:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible) > circle,
-.c0:focus:not(:focus-visible) > ellipse,
-.c0:focus:not(:focus-visible) > line,
-.c0:focus:not(:focus-visible) > path,
-.c0:focus:not(:focus-visible) > polygon,
-.c0:focus:not(:focus-visible) > polyline,
-.c0:focus:not(:focus-visible) > rect {
+.c0:focus:not(:focus-visible):not(:hover) > circle,
+.c0:focus:not(:focus-visible):not(:hover) > ellipse,
+.c0:focus:not(:focus-visible):not(:hover) > line,
+.c0:focus:not(:focus-visible):not(:hover) > path,
+.c0:focus:not(:focus-visible):not(:hover) > polygon,
+.c0:focus:not(:focus-visible):not(:hover) > polyline,
+.c0:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible)::-moz-focus-inner {
+.c0:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -553,43 +553,43 @@ exports[`DropButton ref function 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c0:focus {
+.c0:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus > circle,
-.c0:focus > ellipse,
-.c0:focus > line,
-.c0:focus > path,
-.c0:focus > polygon,
-.c0:focus > polyline,
-.c0:focus > rect {
+.c0:focus:not(:hover) > circle,
+.c0:focus:not(:hover) > ellipse,
+.c0:focus:not(:hover) > line,
+.c0:focus:not(:hover) > path,
+.c0:focus:not(:hover) > polygon,
+.c0:focus:not(:hover) > polyline,
+.c0:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus::-moz-focus-inner {
+.c0:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c0:focus:not(:focus-visible) {
+.c0:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible) > circle,
-.c0:focus:not(:focus-visible) > ellipse,
-.c0:focus:not(:focus-visible) > line,
-.c0:focus:not(:focus-visible) > path,
-.c0:focus:not(:focus-visible) > polygon,
-.c0:focus:not(:focus-visible) > polyline,
-.c0:focus:not(:focus-visible) > rect {
+.c0:focus:not(:focus-visible):not(:hover) > circle,
+.c0:focus:not(:focus-visible):not(:hover) > ellipse,
+.c0:focus:not(:focus-visible):not(:hover) > line,
+.c0:focus:not(:focus-visible):not(:hover) > path,
+.c0:focus:not(:focus-visible):not(:hover) > polygon,
+.c0:focus:not(:focus-visible):not(:hover) > polyline,
+.c0:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible)::-moz-focus-inner {
+.c0:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -660,43 +660,43 @@ exports[`DropButton rendersr a11yTitle and aria-label 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -750,43 +750,43 @@ exports[`DropButton should have no accessibility violations 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c0:focus {
+.c0:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus > circle,
-.c0:focus > ellipse,
-.c0:focus > line,
-.c0:focus > path,
-.c0:focus > polygon,
-.c0:focus > polyline,
-.c0:focus > rect {
+.c0:focus:not(:hover) > circle,
+.c0:focus:not(:hover) > ellipse,
+.c0:focus:not(:hover) > line,
+.c0:focus:not(:hover) > path,
+.c0:focus:not(:hover) > polygon,
+.c0:focus:not(:hover) > polyline,
+.c0:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus::-moz-focus-inner {
+.c0:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c0:focus:not(:focus-visible) {
+.c0:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible) > circle,
-.c0:focus:not(:focus-visible) > ellipse,
-.c0:focus:not(:focus-visible) > line,
-.c0:focus:not(:focus-visible) > path,
-.c0:focus:not(:focus-visible) > polygon,
-.c0:focus:not(:focus-visible) > polyline,
-.c0:focus:not(:focus-visible) > rect {
+.c0:focus:not(:focus-visible):not(:hover) > circle,
+.c0:focus:not(:focus-visible):not(:hover) > ellipse,
+.c0:focus:not(:focus-visible):not(:hover) > line,
+.c0:focus:not(:focus-visible):not(:hover) > path,
+.c0:focus:not(:focus-visible):not(:hover) > polygon,
+.c0:focus:not(:focus-visible):not(:hover) > polyline,
+.c0:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible)::-moz-focus-inner {
+.c0:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-controlled.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-controlled.js.snap
@@ -73,43 +73,43 @@ exports[`Form controlled controlled 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -232,7 +232,7 @@ exports[`Form controlled controlled 2`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 dBcUrk"
+      class="StyledButton-sc-323bzc-0 hkSdsg"
       type="submit"
     >
       Submit
@@ -266,7 +266,7 @@ exports[`Form controlled controlled 3`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 dBcUrk"
+      class="StyledButton-sc-323bzc-0 hkSdsg"
       type="submit"
     >
       Submit
@@ -370,43 +370,43 @@ exports[`Form controlled controlled Array of Form Fields 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c6:focus {
+.c6:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c6:focus > circle,
-.c6:focus > ellipse,
-.c6:focus > line,
-.c6:focus > path,
-.c6:focus > polygon,
-.c6:focus > polyline,
-.c6:focus > rect {
+.c6:focus:not(:hover) > circle,
+.c6:focus:not(:hover) > ellipse,
+.c6:focus:not(:hover) > line,
+.c6:focus:not(:hover) > path,
+.c6:focus:not(:hover) > polygon,
+.c6:focus:not(:hover) > polyline,
+.c6:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c6:focus::-moz-focus-inner {
+.c6:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c6:focus:not(:focus-visible) {
+.c6:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c6:focus:not(:focus-visible) > circle,
-.c6:focus:not(:focus-visible) > ellipse,
-.c6:focus:not(:focus-visible) > line,
-.c6:focus:not(:focus-visible) > path,
-.c6:focus:not(:focus-visible) > polygon,
-.c6:focus:not(:focus-visible) > polyline,
-.c6:focus:not(:focus-visible) > rect {
+.c6:focus:not(:focus-visible):not(:hover) > circle,
+.c6:focus:not(:focus-visible):not(:hover) > ellipse,
+.c6:focus:not(:focus-visible):not(:hover) > line,
+.c6:focus:not(:focus-visible):not(:hover) > path,
+.c6:focus:not(:focus-visible):not(:hover) > polygon,
+.c6:focus:not(:focus-visible):not(:hover) > polyline,
+.c6:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c6:focus:not(:focus-visible)::-moz-focus-inner {
+.c6:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -743,7 +743,7 @@ exports[`Form controlled controlled Array of Form Fields 2`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 dBcUrk"
+      class="StyledButton-sc-323bzc-0 hkSdsg"
       type="submit"
     >
       Submit
@@ -884,7 +884,7 @@ exports[`Form controlled controlled Array of Form Fields 3`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 dBcUrk"
+      class="StyledButton-sc-323bzc-0 hkSdsg"
       type="submit"
     >
       Submit
@@ -988,43 +988,43 @@ exports[`Form controlled controlled Array of Form Fields onValidate 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c6:focus {
+.c6:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c6:focus > circle,
-.c6:focus > ellipse,
-.c6:focus > line,
-.c6:focus > path,
-.c6:focus > polygon,
-.c6:focus > polyline,
-.c6:focus > rect {
+.c6:focus:not(:hover) > circle,
+.c6:focus:not(:hover) > ellipse,
+.c6:focus:not(:hover) > line,
+.c6:focus:not(:hover) > path,
+.c6:focus:not(:hover) > polygon,
+.c6:focus:not(:hover) > polyline,
+.c6:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c6:focus::-moz-focus-inner {
+.c6:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c6:focus:not(:focus-visible) {
+.c6:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c6:focus:not(:focus-visible) > circle,
-.c6:focus:not(:focus-visible) > ellipse,
-.c6:focus:not(:focus-visible) > line,
-.c6:focus:not(:focus-visible) > path,
-.c6:focus:not(:focus-visible) > polygon,
-.c6:focus:not(:focus-visible) > polyline,
-.c6:focus:not(:focus-visible) > rect {
+.c6:focus:not(:focus-visible):not(:hover) > circle,
+.c6:focus:not(:focus-visible):not(:hover) > ellipse,
+.c6:focus:not(:focus-visible):not(:hover) > line,
+.c6:focus:not(:focus-visible):not(:hover) > path,
+.c6:focus:not(:focus-visible):not(:hover) > polygon,
+.c6:focus:not(:focus-visible):not(:hover) > polyline,
+.c6:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c6:focus:not(:focus-visible)::-moz-focus-inner {
+.c6:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -1331,7 +1331,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate 2`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 dBcUrk"
+      class="StyledButton-sc-323bzc-0 hkSdsg"
       type="submit"
     >
       Submit
@@ -1435,43 +1435,43 @@ exports[`Form controlled controlled Array of Form Fields onValidate custom error
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c6:focus {
+.c6:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c6:focus > circle,
-.c6:focus > ellipse,
-.c6:focus > line,
-.c6:focus > path,
-.c6:focus > polygon,
-.c6:focus > polyline,
-.c6:focus > rect {
+.c6:focus:not(:hover) > circle,
+.c6:focus:not(:hover) > ellipse,
+.c6:focus:not(:hover) > line,
+.c6:focus:not(:hover) > path,
+.c6:focus:not(:hover) > polygon,
+.c6:focus:not(:hover) > polyline,
+.c6:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c6:focus::-moz-focus-inner {
+.c6:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c6:focus:not(:focus-visible) {
+.c6:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c6:focus:not(:focus-visible) > circle,
-.c6:focus:not(:focus-visible) > ellipse,
-.c6:focus:not(:focus-visible) > line,
-.c6:focus:not(:focus-visible) > path,
-.c6:focus:not(:focus-visible) > polygon,
-.c6:focus:not(:focus-visible) > polyline,
-.c6:focus:not(:focus-visible) > rect {
+.c6:focus:not(:focus-visible):not(:hover) > circle,
+.c6:focus:not(:focus-visible):not(:hover) > ellipse,
+.c6:focus:not(:focus-visible):not(:hover) > line,
+.c6:focus:not(:focus-visible):not(:hover) > path,
+.c6:focus:not(:focus-visible):not(:hover) > polygon,
+.c6:focus:not(:focus-visible):not(:hover) > polyline,
+.c6:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c6:focus:not(:focus-visible)::-moz-focus-inner {
+.c6:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -1751,7 +1751,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate custom error
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 dBcUrk"
+      class="StyledButton-sc-323bzc-0 hkSdsg"
       type="submit"
     >
       Submit
@@ -1842,43 +1842,43 @@ exports[`Form controlled controlled FormField deprecated 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c6:focus {
+.c6:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c6:focus > circle,
-.c6:focus > ellipse,
-.c6:focus > line,
-.c6:focus > path,
-.c6:focus > polygon,
-.c6:focus > polyline,
-.c6:focus > rect {
+.c6:focus:not(:hover) > circle,
+.c6:focus:not(:hover) > ellipse,
+.c6:focus:not(:hover) > line,
+.c6:focus:not(:hover) > path,
+.c6:focus:not(:hover) > polygon,
+.c6:focus:not(:hover) > polyline,
+.c6:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c6:focus::-moz-focus-inner {
+.c6:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c6:focus:not(:focus-visible) {
+.c6:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c6:focus:not(:focus-visible) > circle,
-.c6:focus:not(:focus-visible) > ellipse,
-.c6:focus:not(:focus-visible) > line,
-.c6:focus:not(:focus-visible) > path,
-.c6:focus:not(:focus-visible) > polygon,
-.c6:focus:not(:focus-visible) > polyline,
-.c6:focus:not(:focus-visible) > rect {
+.c6:focus:not(:focus-visible):not(:hover) > circle,
+.c6:focus:not(:focus-visible):not(:hover) > ellipse,
+.c6:focus:not(:focus-visible):not(:hover) > line,
+.c6:focus:not(:focus-visible):not(:hover) > path,
+.c6:focus:not(:focus-visible):not(:hover) > polygon,
+.c6:focus:not(:focus-visible):not(:hover) > polyline,
+.c6:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c6:focus:not(:focus-visible)::-moz-focus-inner {
+.c6:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -2013,7 +2013,7 @@ exports[`Form controlled controlled FormField deprecated 2`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 dBcUrk"
+      class="StyledButton-sc-323bzc-0 hkSdsg"
       type="submit"
     >
       Submit
@@ -2053,7 +2053,7 @@ exports[`Form controlled controlled FormField deprecated 3`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 dBcUrk"
+      class="StyledButton-sc-323bzc-0 hkSdsg"
       type="submit"
     >
       Submit
@@ -2135,43 +2135,43 @@ exports[`Form controlled controlled input 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -2294,7 +2294,7 @@ exports[`Form controlled controlled input 2`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 dBcUrk"
+      class="StyledButton-sc-323bzc-0 hkSdsg"
       type="submit"
     >
       Submit
@@ -2328,7 +2328,7 @@ exports[`Form controlled controlled input 3`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 dBcUrk"
+      class="StyledButton-sc-323bzc-0 hkSdsg"
       type="submit"
     >
       Submit
@@ -2410,43 +2410,43 @@ exports[`Form controlled controlled input lazy 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -2569,7 +2569,7 @@ exports[`Form controlled controlled input lazy 2`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 dBcUrk"
+      class="StyledButton-sc-323bzc-0 hkSdsg"
       type="submit"
     >
       Submit
@@ -2603,7 +2603,7 @@ exports[`Form controlled controlled input lazy 3`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 dBcUrk"
+      class="StyledButton-sc-323bzc-0 hkSdsg"
       type="submit"
     >
       Submit
@@ -2685,43 +2685,43 @@ exports[`Form controlled controlled lazy 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -2844,7 +2844,7 @@ exports[`Form controlled controlled lazy 2`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 dBcUrk"
+      class="StyledButton-sc-323bzc-0 hkSdsg"
       type="submit"
     >
       Submit
@@ -2878,7 +2878,7 @@ exports[`Form controlled controlled lazy 3`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 dBcUrk"
+      class="StyledButton-sc-323bzc-0 hkSdsg"
       type="submit"
     >
       Submit
@@ -2960,43 +2960,43 @@ exports[`Form controlled controlled onChange touched 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -3167,43 +3167,43 @@ exports[`Form controlled controlled onValidate 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -3353,7 +3353,7 @@ exports[`Form controlled controlled onValidate 2`] = `
       </span>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 dBcUrk"
+      class="StyledButton-sc-323bzc-0 hkSdsg"
       type="submit"
     >
       Submit
@@ -3435,43 +3435,43 @@ exports[`Form controlled controlled onValidate custom error 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -3621,7 +3621,7 @@ exports[`Form controlled controlled onValidate custom error 2`] = `
       </span>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 dBcUrk"
+      class="StyledButton-sc-323bzc-0 hkSdsg"
       type="submit"
     >
       Submit
@@ -3703,43 +3703,43 @@ exports[`Form controlled controlled onValidate custom info 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -3885,7 +3885,7 @@ exports[`Form controlled controlled onValidate custom info 2`] = `
       </span>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 dBcUrk"
+      class="StyledButton-sc-323bzc-0 hkSdsg"
       type="submit"
     >
       Submit
@@ -4080,43 +4080,43 @@ exports[`Form controlled dynamicly removed fields using blur validation
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c11:focus {
+.c11:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus > circle,
-.c11:focus > ellipse,
-.c11:focus > line,
-.c11:focus > path,
-.c11:focus > polygon,
-.c11:focus > polyline,
-.c11:focus > rect {
+.c11:focus:not(:hover) > circle,
+.c11:focus:not(:hover) > ellipse,
+.c11:focus:not(:hover) > line,
+.c11:focus:not(:hover) > path,
+.c11:focus:not(:hover) > polygon,
+.c11:focus:not(:hover) > polyline,
+.c11:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus::-moz-focus-inner {
+.c11:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c11:focus:not(:focus-visible) {
+.c11:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c11:focus:not(:focus-visible) > circle,
-.c11:focus:not(:focus-visible) > ellipse,
-.c11:focus:not(:focus-visible) > line,
-.c11:focus:not(:focus-visible) > path,
-.c11:focus:not(:focus-visible) > polygon,
-.c11:focus:not(:focus-visible) > polyline,
-.c11:focus:not(:focus-visible) > rect {
+.c11:focus:not(:focus-visible):not(:hover) > circle,
+.c11:focus:not(:focus-visible):not(:hover) > ellipse,
+.c11:focus:not(:focus-visible):not(:hover) > line,
+.c11:focus:not(:focus-visible):not(:hover) > path,
+.c11:focus:not(:focus-visible):not(:hover) > polygon,
+.c11:focus:not(:focus-visible):not(:hover) > polyline,
+.c11:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c11:focus:not(:focus-visible)::-moz-focus-inner {
+.c11:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -4497,7 +4497,7 @@ exports[`Form controlled dynamicly removed fields using blur validation
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 dBcUrk"
+      class="StyledButton-sc-323bzc-0 hkSdsg"
       type="submit"
     >
       Submit
@@ -4560,7 +4560,7 @@ exports[`Form controlled dynamicly removed fields using blur validation
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 dBcUrk"
+      class="StyledButton-sc-323bzc-0 hkSdsg"
       type="submit"
     >
       Submit
@@ -4609,43 +4609,43 @@ exports[`Form controlled lazy value 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c3:focus {
+.c3:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
+.c3:focus:not(:hover) > circle,
+.c3:focus:not(:hover) > ellipse,
+.c3:focus:not(:hover) > line,
+.c3:focus:not(:hover) > path,
+.c3:focus:not(:hover) > polygon,
+.c3:focus:not(:hover) > polyline,
+.c3:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus::-moz-focus-inner {
+.c3:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c3:focus:not(:focus-visible) {
+.c3:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
+.c3:focus:not(:focus-visible):not(:hover) > circle,
+.c3:focus:not(:focus-visible):not(:hover) > ellipse,
+.c3:focus:not(:focus-visible):not(:hover) > line,
+.c3:focus:not(:focus-visible):not(:hover) > path,
+.c3:focus:not(:focus-visible):not(:hover) > polygon,
+.c3:focus:not(:focus-visible):not(:hover) > polyline,
+.c3:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
+.c3:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
@@ -650,23 +650,23 @@ exports[`Form accessibility Select in Form should have no accessibility violatio
   text-align: inherit;
 }
 
-.c3:focus:not(:focus-visible) {
+.c3:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
+.c3:focus:not(:focus-visible):not(:hover) > circle,
+.c3:focus:not(:focus-visible):not(:hover) > ellipse,
+.c3:focus:not(:focus-visible):not(:hover) > line,
+.c3:focus:not(:focus-visible):not(:hover) > path,
+.c3:focus:not(:focus-visible):not(:hover) > polygon,
+.c3:focus:not(:focus-visible):not(:hover) > polyline,
+.c3:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
+.c3:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -1118,43 +1118,43 @@ exports[`Form uncontrolled dynamicly removed fields should be removed from form 
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c11:focus {
+.c11:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus > circle,
-.c11:focus > ellipse,
-.c11:focus > line,
-.c11:focus > path,
-.c11:focus > polygon,
-.c11:focus > polyline,
-.c11:focus > rect {
+.c11:focus:not(:hover) > circle,
+.c11:focus:not(:hover) > ellipse,
+.c11:focus:not(:hover) > line,
+.c11:focus:not(:hover) > path,
+.c11:focus:not(:hover) > polygon,
+.c11:focus:not(:hover) > polyline,
+.c11:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus::-moz-focus-inner {
+.c11:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c11:focus:not(:focus-visible) {
+.c11:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c11:focus:not(:focus-visible) > circle,
-.c11:focus:not(:focus-visible) > ellipse,
-.c11:focus:not(:focus-visible) > line,
-.c11:focus:not(:focus-visible) > path,
-.c11:focus:not(:focus-visible) > polygon,
-.c11:focus:not(:focus-visible) > polyline,
-.c11:focus:not(:focus-visible) > rect {
+.c11:focus:not(:focus-visible):not(:hover) > circle,
+.c11:focus:not(:focus-visible):not(:hover) > ellipse,
+.c11:focus:not(:focus-visible):not(:hover) > line,
+.c11:focus:not(:focus-visible):not(:hover) > path,
+.c11:focus:not(:focus-visible):not(:hover) > polygon,
+.c11:focus:not(:focus-visible):not(:hover) > polyline,
+.c11:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c11:focus:not(:focus-visible)::-moz-focus-inner {
+.c11:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -1357,7 +1357,7 @@ exports[`Form uncontrolled dynamicly removed fields should be removed from form 
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 dBcUrk"
+      class="StyledButton-sc-323bzc-0 hkSdsg"
       type="submit"
     >
       Submit
@@ -1552,43 +1552,43 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c11:focus {
+.c11:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus > circle,
-.c11:focus > ellipse,
-.c11:focus > line,
-.c11:focus > path,
-.c11:focus > polygon,
-.c11:focus > polyline,
-.c11:focus > rect {
+.c11:focus:not(:hover) > circle,
+.c11:focus:not(:hover) > ellipse,
+.c11:focus:not(:hover) > line,
+.c11:focus:not(:hover) > path,
+.c11:focus:not(:hover) > polygon,
+.c11:focus:not(:hover) > polyline,
+.c11:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus::-moz-focus-inner {
+.c11:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c11:focus:not(:focus-visible) {
+.c11:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c11:focus:not(:focus-visible) > circle,
-.c11:focus:not(:focus-visible) > ellipse,
-.c11:focus:not(:focus-visible) > line,
-.c11:focus:not(:focus-visible) > path,
-.c11:focus:not(:focus-visible) > polygon,
-.c11:focus:not(:focus-visible) > polyline,
-.c11:focus:not(:focus-visible) > rect {
+.c11:focus:not(:focus-visible):not(:hover) > circle,
+.c11:focus:not(:focus-visible):not(:hover) > ellipse,
+.c11:focus:not(:focus-visible):not(:hover) > line,
+.c11:focus:not(:focus-visible):not(:hover) > path,
+.c11:focus:not(:focus-visible):not(:hover) > polygon,
+.c11:focus:not(:focus-visible):not(:hover) > polyline,
+.c11:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c11:focus:not(:focus-visible)::-moz-focus-inner {
+.c11:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -1969,7 +1969,7 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 dBcUrk"
+      class="StyledButton-sc-323bzc-0 hkSdsg"
       type="submit"
     >
       Submit
@@ -2032,7 +2032,7 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 dBcUrk"
+      class="StyledButton-sc-323bzc-0 hkSdsg"
       type="submit"
     >
       Submit
@@ -2876,23 +2876,23 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 1`] =
   text-align: inherit;
 }
 
-.c4:focus:not(:focus-visible) {
+.c4:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c4:focus:not(:focus-visible) > circle,
-.c4:focus:not(:focus-visible) > ellipse,
-.c4:focus:not(:focus-visible) > line,
-.c4:focus:not(:focus-visible) > path,
-.c4:focus:not(:focus-visible) > polygon,
-.c4:focus:not(:focus-visible) > polyline,
-.c4:focus:not(:focus-visible) > rect {
+.c4:focus:not(:focus-visible):not(:hover) > circle,
+.c4:focus:not(:focus-visible):not(:hover) > ellipse,
+.c4:focus:not(:focus-visible):not(:hover) > line,
+.c4:focus:not(:focus-visible):not(:hover) > path,
+.c4:focus:not(:focus-visible):not(:hover) > polygon,
+.c4:focus:not(:focus-visible):not(:hover) > polyline,
+.c4:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c4:focus:not(:focus-visible)::-moz-focus-inner {
+.c4:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -2928,43 +2928,43 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 1`] =
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c27:focus {
+.c27:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c27:focus > circle,
-.c27:focus > ellipse,
-.c27:focus > line,
-.c27:focus > path,
-.c27:focus > polygon,
-.c27:focus > polyline,
-.c27:focus > rect {
+.c27:focus:not(:hover) > circle,
+.c27:focus:not(:hover) > ellipse,
+.c27:focus:not(:hover) > line,
+.c27:focus:not(:hover) > path,
+.c27:focus:not(:hover) > polygon,
+.c27:focus:not(:hover) > polyline,
+.c27:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c27:focus::-moz-focus-inner {
+.c27:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c27:focus:not(:focus-visible) {
+.c27:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c27:focus:not(:focus-visible) > circle,
-.c27:focus:not(:focus-visible) > ellipse,
-.c27:focus:not(:focus-visible) > line,
-.c27:focus:not(:focus-visible) > path,
-.c27:focus:not(:focus-visible) > polygon,
-.c27:focus:not(:focus-visible) > polyline,
-.c27:focus:not(:focus-visible) > rect {
+.c27:focus:not(:focus-visible):not(:hover) > circle,
+.c27:focus:not(:focus-visible):not(:hover) > ellipse,
+.c27:focus:not(:focus-visible):not(:hover) > line,
+.c27:focus:not(:focus-visible):not(:hover) > path,
+.c27:focus:not(:focus-visible):not(:hover) > polygon,
+.c27:focus:not(:focus-visible):not(:hover) > polyline,
+.c27:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c27:focus:not(:focus-visible)::-moz-focus-inner {
+.c27:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -3362,7 +3362,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="test select"
-          class="StyledButton-sc-323bzc-0 fhAZId Select__StyledSelectDropButton-sc-17idtfo-2 fJfYtd"
+          class="StyledButton-sc-323bzc-0 foEeCR Select__StyledSelectDropButton-sc-17idtfo-2 fJfYtd"
           id="test-select"
           type="button"
         >
@@ -3547,7 +3547,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 dBcUrk"
+      class="StyledButton-sc-323bzc-0 hkSdsg"
       type="reset"
     >
       Reset
@@ -3629,43 +3629,43 @@ exports[`Form uncontrolled uncontrolled 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -3788,7 +3788,7 @@ exports[`Form uncontrolled uncontrolled 2`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 dBcUrk"
+      class="StyledButton-sc-323bzc-0 hkSdsg"
       type="submit"
     >
       Submit
@@ -3822,7 +3822,7 @@ exports[`Form uncontrolled uncontrolled 3`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 dBcUrk"
+      class="StyledButton-sc-323bzc-0 hkSdsg"
       type="submit"
     >
       Submit
@@ -3904,43 +3904,43 @@ exports[`Form uncontrolled uncontrolled onValidate 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -4090,7 +4090,7 @@ exports[`Form uncontrolled uncontrolled onValidate 2`] = `
       </span>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 dBcUrk"
+      class="StyledButton-sc-323bzc-0 hkSdsg"
       type="submit"
     >
       Submit
@@ -4172,43 +4172,43 @@ exports[`Form uncontrolled uncontrolled onValidate custom error 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -4358,7 +4358,7 @@ exports[`Form uncontrolled uncontrolled onValidate custom error 2`] = `
       </span>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 dBcUrk"
+      class="StyledButton-sc-323bzc-0 hkSdsg"
       type="submit"
     >
       Submit
@@ -4440,43 +4440,43 @@ exports[`Form uncontrolled uncontrolled onValidate custom info 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -4622,7 +4622,7 @@ exports[`Form uncontrolled uncontrolled onValidate custom info 2`] = `
       </span>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 dBcUrk"
+      class="StyledButton-sc-323bzc-0 hkSdsg"
       type="submit"
     >
       Submit
@@ -4704,43 +4704,43 @@ exports[`Form uncontrolled update 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 

--- a/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
+++ b/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
@@ -2049,43 +2049,43 @@ exports[`Layer invokes onEsc when modal={false} 1`] = `
   text-align: inherit;
 }
 
-.c3:focus {
+.c3:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
+.c3:focus:not(:hover) > circle,
+.c3:focus:not(:hover) > ellipse,
+.c3:focus:not(:hover) > line,
+.c3:focus:not(:hover) > path,
+.c3:focus:not(:hover) > polygon,
+.c3:focus:not(:hover) > polyline,
+.c3:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus::-moz-focus-inner {
+.c3:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c3:focus:not(:focus-visible) {
+.c3:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
+.c3:focus:not(:focus-visible):not(:hover) > circle,
+.c3:focus:not(:focus-visible):not(:hover) > ellipse,
+.c3:focus:not(:focus-visible):not(:hover) > line,
+.c3:focus:not(:focus-visible):not(:hover) > path,
+.c3:focus:not(:focus-visible):not(:hover) > polygon,
+.c3:focus:not(:focus-visible):not(:hover) > polyline,
+.c3:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
+.c3:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 

--- a/src/js/components/List/__tests__/__snapshots__/List-test.js.snap
+++ b/src/js/components/List/__tests__/__snapshots__/List-test.js.snap
@@ -12682,23 +12682,23 @@ exports[`List onOrder Keyboard move down 1`] = `
   padding: 12px;
 }
 
-.c9:focus:not(:focus-visible) {
+.c9:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c9:focus:not(:focus-visible) > circle,
-.c9:focus:not(:focus-visible) > ellipse,
-.c9:focus:not(:focus-visible) > line,
-.c9:focus:not(:focus-visible) > path,
-.c9:focus:not(:focus-visible) > polygon,
-.c9:focus:not(:focus-visible) > polyline,
-.c9:focus:not(:focus-visible) > rect {
+.c9:focus:not(:focus-visible):not(:hover) > circle,
+.c9:focus:not(:focus-visible):not(:hover) > ellipse,
+.c9:focus:not(:focus-visible):not(:hover) > line,
+.c9:focus:not(:focus-visible):not(:hover) > path,
+.c9:focus:not(:focus-visible):not(:hover) > polygon,
+.c9:focus:not(:focus-visible):not(:hover) > polyline,
+.c9:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c9:focus:not(:focus-visible)::-moz-focus-inner {
+.c9:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -12727,23 +12727,23 @@ exports[`List onOrder Keyboard move down 1`] = `
   color: #000000;
 }
 
-.c11:focus:not(:focus-visible) {
+.c11:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c11:focus:not(:focus-visible) > circle,
-.c11:focus:not(:focus-visible) > ellipse,
-.c11:focus:not(:focus-visible) > line,
-.c11:focus:not(:focus-visible) > path,
-.c11:focus:not(:focus-visible) > polygon,
-.c11:focus:not(:focus-visible) > polyline,
-.c11:focus:not(:focus-visible) > rect {
+.c11:focus:not(:focus-visible):not(:hover) > circle,
+.c11:focus:not(:focus-visible):not(:hover) > ellipse,
+.c11:focus:not(:focus-visible):not(:hover) > line,
+.c11:focus:not(:focus-visible):not(:hover) > path,
+.c11:focus:not(:focus-visible):not(:hover) > polygon,
+.c11:focus:not(:focus-visible):not(:hover) > polyline,
+.c11:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c11:focus:not(:focus-visible)::-moz-focus-inner {
+.c11:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -13003,7 +13003,7 @@ exports[`List onOrder Keyboard move down 2`] = `
       >
         <button
           aria-label="1 alpha move up"
-          class="StyledButton-sc-323bzc-0 eHnmvB"
+          class="StyledButton-sc-323bzc-0 fXOaHR"
           disabled=""
           id="alphaMoveUp"
           tabindex="-1"
@@ -13024,7 +13024,7 @@ exports[`List onOrder Keyboard move down 2`] = `
         </button>
         <button
           aria-label="1 alpha move down"
-          class="StyledButton-sc-323bzc-0 hkDZmn"
+          class="StyledButton-sc-323bzc-0 cAHECD"
           id="alphaMoveDown"
           tabindex="-1"
           type="button"
@@ -13073,7 +13073,7 @@ exports[`List onOrder Keyboard move down 2`] = `
       >
         <button
           aria-label="2 beta move up"
-          class="StyledButton-sc-323bzc-0 cbFwAL"
+          class="StyledButton-sc-323bzc-0 hALuyT"
           id="betaMoveUp"
           tabindex="-1"
           type="button"
@@ -13093,7 +13093,7 @@ exports[`List onOrder Keyboard move down 2`] = `
         </button>
         <button
           aria-label="2 beta move down"
-          class="StyledButton-sc-323bzc-0 eHnmvB"
+          class="StyledButton-sc-323bzc-0 fXOaHR"
           disabled=""
           id="betaMoveDown"
           tabindex="-1"
@@ -13157,7 +13157,7 @@ exports[`List onOrder Keyboard move down 3`] = `
       >
         <button
           aria-label="1 beta move up"
-          class="StyledButton-sc-323bzc-0 eHnmvB"
+          class="StyledButton-sc-323bzc-0 fXOaHR"
           disabled=""
           id="betaMoveUp"
           tabindex="-1"
@@ -13178,7 +13178,7 @@ exports[`List onOrder Keyboard move down 3`] = `
         </button>
         <button
           aria-label="1 beta move down"
-          class="StyledButton-sc-323bzc-0 cbFwAL"
+          class="StyledButton-sc-323bzc-0 hALuyT"
           id="betaMoveDown"
           tabindex="-1"
           type="button"
@@ -13227,7 +13227,7 @@ exports[`List onOrder Keyboard move down 3`] = `
       >
         <button
           aria-label="2 alpha move up"
-          class="StyledButton-sc-323bzc-0 hkDZmn"
+          class="StyledButton-sc-323bzc-0 cAHECD"
           id="alphaMoveUp"
           tabindex="-1"
           type="button"
@@ -13247,7 +13247,7 @@ exports[`List onOrder Keyboard move down 3`] = `
         </button>
         <button
           aria-label="2 alpha move down"
-          class="StyledButton-sc-323bzc-0 eHnmvB"
+          class="StyledButton-sc-323bzc-0 fXOaHR"
           disabled=""
           id="alphaMoveDown"
           tabindex="-1"
@@ -13452,23 +13452,23 @@ exports[`List onOrder Keyboard move up 1`] = `
   padding: 12px;
 }
 
-.c9:focus:not(:focus-visible) {
+.c9:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c9:focus:not(:focus-visible) > circle,
-.c9:focus:not(:focus-visible) > ellipse,
-.c9:focus:not(:focus-visible) > line,
-.c9:focus:not(:focus-visible) > path,
-.c9:focus:not(:focus-visible) > polygon,
-.c9:focus:not(:focus-visible) > polyline,
-.c9:focus:not(:focus-visible) > rect {
+.c9:focus:not(:focus-visible):not(:hover) > circle,
+.c9:focus:not(:focus-visible):not(:hover) > ellipse,
+.c9:focus:not(:focus-visible):not(:hover) > line,
+.c9:focus:not(:focus-visible):not(:hover) > path,
+.c9:focus:not(:focus-visible):not(:hover) > polygon,
+.c9:focus:not(:focus-visible):not(:hover) > polyline,
+.c9:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c9:focus:not(:focus-visible)::-moz-focus-inner {
+.c9:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -13497,23 +13497,23 @@ exports[`List onOrder Keyboard move up 1`] = `
   color: #000000;
 }
 
-.c11:focus:not(:focus-visible) {
+.c11:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c11:focus:not(:focus-visible) > circle,
-.c11:focus:not(:focus-visible) > ellipse,
-.c11:focus:not(:focus-visible) > line,
-.c11:focus:not(:focus-visible) > path,
-.c11:focus:not(:focus-visible) > polygon,
-.c11:focus:not(:focus-visible) > polyline,
-.c11:focus:not(:focus-visible) > rect {
+.c11:focus:not(:focus-visible):not(:hover) > circle,
+.c11:focus:not(:focus-visible):not(:hover) > ellipse,
+.c11:focus:not(:focus-visible):not(:hover) > line,
+.c11:focus:not(:focus-visible):not(:hover) > path,
+.c11:focus:not(:focus-visible):not(:hover) > polygon,
+.c11:focus:not(:focus-visible):not(:hover) > polyline,
+.c11:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c11:focus:not(:focus-visible)::-moz-focus-inner {
+.c11:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -13773,7 +13773,7 @@ exports[`List onOrder Keyboard move up 2`] = `
       >
         <button
           aria-label="1 alpha move up"
-          class="StyledButton-sc-323bzc-0 eHnmvB"
+          class="StyledButton-sc-323bzc-0 fXOaHR"
           disabled=""
           id="alphaMoveUp"
           tabindex="-1"
@@ -13794,7 +13794,7 @@ exports[`List onOrder Keyboard move up 2`] = `
         </button>
         <button
           aria-label="1 alpha move down"
-          class="StyledButton-sc-323bzc-0 cbFwAL"
+          class="StyledButton-sc-323bzc-0 hALuyT"
           id="alphaMoveDown"
           tabindex="-1"
           type="button"
@@ -13843,7 +13843,7 @@ exports[`List onOrder Keyboard move up 2`] = `
       >
         <button
           aria-label="2 beta move up"
-          class="StyledButton-sc-323bzc-0 hkDZmn"
+          class="StyledButton-sc-323bzc-0 cAHECD"
           id="betaMoveUp"
           tabindex="-1"
           type="button"
@@ -13863,7 +13863,7 @@ exports[`List onOrder Keyboard move up 2`] = `
         </button>
         <button
           aria-label="2 beta move down"
-          class="StyledButton-sc-323bzc-0 eHnmvB"
+          class="StyledButton-sc-323bzc-0 fXOaHR"
           disabled=""
           id="betaMoveDown"
           tabindex="-1"
@@ -13927,7 +13927,7 @@ exports[`List onOrder Keyboard move up 3`] = `
       >
         <button
           aria-label="1 beta move up"
-          class="StyledButton-sc-323bzc-0 eHnmvB"
+          class="StyledButton-sc-323bzc-0 fXOaHR"
           disabled=""
           id="betaMoveUp"
           tabindex="-1"
@@ -13948,7 +13948,7 @@ exports[`List onOrder Keyboard move up 3`] = `
         </button>
         <button
           aria-label="1 beta move down"
-          class="StyledButton-sc-323bzc-0 hkDZmn"
+          class="StyledButton-sc-323bzc-0 cAHECD"
           id="betaMoveDown"
           tabindex="-1"
           type="button"
@@ -13997,7 +13997,7 @@ exports[`List onOrder Keyboard move up 3`] = `
       >
         <button
           aria-label="2 alpha move up"
-          class="StyledButton-sc-323bzc-0 cbFwAL"
+          class="StyledButton-sc-323bzc-0 hALuyT"
           id="alphaMoveUp"
           tabindex="-1"
           type="button"
@@ -14017,7 +14017,7 @@ exports[`List onOrder Keyboard move up 3`] = `
         </button>
         <button
           aria-label="2 alpha move down"
-          class="StyledButton-sc-323bzc-0 eHnmvB"
+          class="StyledButton-sc-323bzc-0 fXOaHR"
           disabled=""
           id="alphaMoveDown"
           tabindex="-1"
@@ -14222,23 +14222,23 @@ exports[`List onOrder Mouse move down 1`] = `
   padding: 12px;
 }
 
-.c9:focus:not(:focus-visible) {
+.c9:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c9:focus:not(:focus-visible) > circle,
-.c9:focus:not(:focus-visible) > ellipse,
-.c9:focus:not(:focus-visible) > line,
-.c9:focus:not(:focus-visible) > path,
-.c9:focus:not(:focus-visible) > polygon,
-.c9:focus:not(:focus-visible) > polyline,
-.c9:focus:not(:focus-visible) > rect {
+.c9:focus:not(:focus-visible):not(:hover) > circle,
+.c9:focus:not(:focus-visible):not(:hover) > ellipse,
+.c9:focus:not(:focus-visible):not(:hover) > line,
+.c9:focus:not(:focus-visible):not(:hover) > path,
+.c9:focus:not(:focus-visible):not(:hover) > polygon,
+.c9:focus:not(:focus-visible):not(:hover) > polyline,
+.c9:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c9:focus:not(:focus-visible)::-moz-focus-inner {
+.c9:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -14267,23 +14267,23 @@ exports[`List onOrder Mouse move down 1`] = `
   color: #000000;
 }
 
-.c11:focus:not(:focus-visible) {
+.c11:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c11:focus:not(:focus-visible) > circle,
-.c11:focus:not(:focus-visible) > ellipse,
-.c11:focus:not(:focus-visible) > line,
-.c11:focus:not(:focus-visible) > path,
-.c11:focus:not(:focus-visible) > polygon,
-.c11:focus:not(:focus-visible) > polyline,
-.c11:focus:not(:focus-visible) > rect {
+.c11:focus:not(:focus-visible):not(:hover) > circle,
+.c11:focus:not(:focus-visible):not(:hover) > ellipse,
+.c11:focus:not(:focus-visible):not(:hover) > line,
+.c11:focus:not(:focus-visible):not(:hover) > path,
+.c11:focus:not(:focus-visible):not(:hover) > polygon,
+.c11:focus:not(:focus-visible):not(:hover) > polyline,
+.c11:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c11:focus:not(:focus-visible)::-moz-focus-inner {
+.c11:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -14542,7 +14542,7 @@ exports[`List onOrder Mouse move down 2`] = `
       >
         <button
           aria-label="1 beta move up"
-          class="StyledButton-sc-323bzc-0 eHnmvB"
+          class="StyledButton-sc-323bzc-0 fXOaHR"
           disabled=""
           id="betaMoveUp"
           tabindex="-1"
@@ -14563,7 +14563,7 @@ exports[`List onOrder Mouse move down 2`] = `
         </button>
         <button
           aria-label="1 beta move down"
-          class="StyledButton-sc-323bzc-0 cbFwAL"
+          class="StyledButton-sc-323bzc-0 hALuyT"
           id="betaMoveDown"
           tabindex="-1"
           type="button"
@@ -14612,7 +14612,7 @@ exports[`List onOrder Mouse move down 2`] = `
       >
         <button
           aria-label="2 alpha move up"
-          class="StyledButton-sc-323bzc-0 cbFwAL"
+          class="StyledButton-sc-323bzc-0 hALuyT"
           id="alphaMoveUp"
           tabindex="-1"
           type="button"
@@ -14632,7 +14632,7 @@ exports[`List onOrder Mouse move down 2`] = `
         </button>
         <button
           aria-label="2 alpha move down"
-          class="StyledButton-sc-323bzc-0 eHnmvB"
+          class="StyledButton-sc-323bzc-0 fXOaHR"
           disabled=""
           id="alphaMoveDown"
           tabindex="-1"

--- a/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.js.snap
+++ b/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.js.snap
@@ -145,43 +145,43 @@ exports[`MaskedInput applies custom global.hover theme to options 2`] = `
   color: #7D4CDB;
 }
 
-.c0:focus {
+.c0:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus > circle,
-.c0:focus > ellipse,
-.c0:focus > line,
-.c0:focus > path,
-.c0:focus > polygon,
-.c0:focus > polyline,
-.c0:focus > rect {
+.c0:focus:not(:hover) > circle,
+.c0:focus:not(:hover) > ellipse,
+.c0:focus:not(:hover) > line,
+.c0:focus:not(:hover) > path,
+.c0:focus:not(:hover) > polygon,
+.c0:focus:not(:hover) > polyline,
+.c0:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus::-moz-focus-inner {
+.c0:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c0:focus:not(:focus-visible) {
+.c0:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible) > circle,
-.c0:focus:not(:focus-visible) > ellipse,
-.c0:focus:not(:focus-visible) > line,
-.c0:focus:not(:focus-visible) > path,
-.c0:focus:not(:focus-visible) > polygon,
-.c0:focus:not(:focus-visible) > polyline,
-.c0:focus:not(:focus-visible) > rect {
+.c0:focus:not(:focus-visible):not(:hover) > circle,
+.c0:focus:not(:focus-visible):not(:hover) > ellipse,
+.c0:focus:not(:focus-visible):not(:hover) > line,
+.c0:focus:not(:focus-visible):not(:hover) > path,
+.c0:focus:not(:focus-visible):not(:hover) > polygon,
+.c0:focus:not(:focus-visible):not(:hover) > polyline,
+.c0:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible)::-moz-focus-inner {
+.c0:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -938,43 +938,43 @@ exports[`MaskedInput event target props are available option via mouse 2`] = `
   color: #000000;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -1574,43 +1574,43 @@ exports[`MaskedInput mask 2`] = `
   color: #000000;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -2163,43 +2163,43 @@ exports[`MaskedInput option via mouse 2`] = `
   color: #000000;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 

--- a/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
+++ b/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
@@ -57,43 +57,43 @@ exports[`Menu basic 1`] = `
   text-align: inherit;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -238,43 +238,43 @@ exports[`Menu close by clicking outside 1`] = `
   text-align: inherit;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -540,23 +540,23 @@ exports[`Menu close by clicking outside 2`] = `
   color: #000000;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -791,43 +791,43 @@ exports[`Menu close on tab 1`] = `
   text-align: inherit;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -983,43 +983,43 @@ exports[`Menu custom a11yTitle or aria-label 1`] = `
   text-align: inherit;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -1208,43 +1208,43 @@ exports[`Menu custom message 1`] = `
   text-align: inherit;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -1399,43 +1399,43 @@ exports[`Menu custom theme icon color 1`] = `
   text-align: inherit;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -1781,43 +1781,43 @@ exports[`Menu disabled 1`] = `
   cursor: default;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -1974,43 +1974,43 @@ exports[`Menu gap between icon and label 1`] = `
   text-align: inherit;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -2294,43 +2294,43 @@ exports[`Menu justify content 1`] = `
   text-align: inherit;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -2768,43 +2768,43 @@ exports[`Menu navigate through suggestions and select 1`] = `
   text-align: inherit;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -2960,43 +2960,43 @@ exports[`Menu open and close on click 1`] = `
   text-align: inherit;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -3069,7 +3069,7 @@ exports[`Menu open and close on click 2`] = `
     aria-expanded="true"
     aria-haspopup="menu"
     aria-label="Open Menu"
-    class="StyledButton-sc-323bzc-0 eiEooU"
+    class="StyledButton-sc-323bzc-0 gsQNSg"
     id="test-menu"
     type="button"
   >
@@ -3302,23 +3302,23 @@ exports[`Menu open and close on click 3`] = `
   color: #000000;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -3569,43 +3569,43 @@ exports[`Menu open on down close on esc 1`] = `
   text-align: inherit;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -3761,43 +3761,43 @@ exports[`Menu open on up close on esc 1`] = `
   text-align: inherit;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -4063,23 +4063,23 @@ exports[`Menu open on up close on esc 2`] = `
   color: #000000;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -4314,43 +4314,43 @@ exports[`Menu reverse icon and label 1`] = `
   text-align: inherit;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -4519,43 +4519,43 @@ exports[`Menu select an item 1`] = `
   text-align: inherit;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -4711,43 +4711,43 @@ exports[`Menu shift + tab through menu until it closes 1`] = `
   text-align: inherit;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -4903,43 +4903,43 @@ exports[`Menu should apply themed drop props 1`] = `
   text-align: inherit;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -5096,43 +5096,43 @@ exports[`Menu should have no accessibility violations 1`] = `
   text-align: inherit;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -5278,43 +5278,43 @@ exports[`Menu tab through menu until it closes 1`] = `
   text-align: inherit;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -5470,43 +5470,43 @@ exports[`Menu with dropAlign bottom renders 1`] = `
   text-align: inherit;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -5772,23 +5772,23 @@ exports[`Menu with dropAlign bottom renders 2`] = `
   color: #000000;
 }
 
-.c6:focus:not(:focus-visible) {
+.c6:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c6:focus:not(:focus-visible) > circle,
-.c6:focus:not(:focus-visible) > ellipse,
-.c6:focus:not(:focus-visible) > line,
-.c6:focus:not(:focus-visible) > path,
-.c6:focus:not(:focus-visible) > polygon,
-.c6:focus:not(:focus-visible) > polyline,
-.c6:focus:not(:focus-visible) > rect {
+.c6:focus:not(:focus-visible):not(:hover) > circle,
+.c6:focus:not(:focus-visible):not(:hover) > ellipse,
+.c6:focus:not(:focus-visible):not(:hover) > line,
+.c6:focus:not(:focus-visible):not(:hover) > path,
+.c6:focus:not(:focus-visible):not(:hover) > polygon,
+.c6:focus:not(:focus-visible):not(:hover) > polyline,
+.c6:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c6:focus:not(:focus-visible)::-moz-focus-inner {
+.c6:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -6023,43 +6023,43 @@ exports[`Menu with dropAlign top renders 1`] = `
   text-align: inherit;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -6325,23 +6325,23 @@ exports[`Menu with dropAlign top renders 2`] = `
   color: #000000;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 

--- a/src/js/components/RoutedButton/__tests__/__snapshots__/RoutedButton-test.js.snap
+++ b/src/js/components/RoutedButton/__tests__/__snapshots__/RoutedButton-test.js.snap
@@ -30,43 +30,43 @@ exports[`RoutedButton renders 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -113,43 +113,43 @@ exports[`Select 0 value 1`] = `
   text-align: inherit;
 }
 
-.c0:focus {
+.c0:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus > circle,
-.c0:focus > ellipse,
-.c0:focus > line,
-.c0:focus > path,
-.c0:focus > polygon,
-.c0:focus > polyline,
-.c0:focus > rect {
+.c0:focus:not(:hover) > circle,
+.c0:focus:not(:hover) > ellipse,
+.c0:focus:not(:hover) > line,
+.c0:focus:not(:hover) > path,
+.c0:focus:not(:hover) > polygon,
+.c0:focus:not(:hover) > polyline,
+.c0:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus::-moz-focus-inner {
+.c0:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c0:focus:not(:focus-visible) {
+.c0:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible) > circle,
-.c0:focus:not(:focus-visible) > ellipse,
-.c0:focus:not(:focus-visible) > line,
-.c0:focus:not(:focus-visible) > path,
-.c0:focus:not(:focus-visible) > polygon,
-.c0:focus:not(:focus-visible) > polyline,
-.c0:focus:not(:focus-visible) > rect {
+.c0:focus:not(:focus-visible):not(:hover) > circle,
+.c0:focus:not(:focus-visible):not(:hover) > ellipse,
+.c0:focus:not(:focus-visible):not(:hover) > line,
+.c0:focus:not(:focus-visible):not(:hover) > path,
+.c0:focus:not(:focus-visible):not(:hover) > polygon,
+.c0:focus:not(:focus-visible):not(:hover) > polyline,
+.c0:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible)::-moz-focus-inner {
+.c0:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -389,23 +389,23 @@ exports[`Select Clear option renders - bottom 1`] = `
   color: #000000;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -650,23 +650,23 @@ exports[`Select Clear option renders correct label when wrapped in FormField 1`]
   color: #000000;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -919,23 +919,23 @@ exports[`Select Clear option renders custom label 1`] = `
   color: #000000;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -1180,23 +1180,23 @@ exports[`Select Clear option renders- top 1`] = `
   color: #000000;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -1433,43 +1433,43 @@ exports[`Select Search timeout 1`] = `
   text-align: inherit;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -1828,43 +1828,43 @@ exports[`Select applies custom global.hover theme to options 1`] = `
   text-align: inherit;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -2044,23 +2044,28 @@ exports[`Select applies custom global.hover theme to options 2`] = `
   color: #000000;
 }
 
-.c0:focus:not(:focus-visible) {
+.c0:hover {
+  background-color: lightgreen;
+  color: #7D4CDB;
+}
+
+.c0:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible) > circle,
-.c0:focus:not(:focus-visible) > ellipse,
-.c0:focus:not(:focus-visible) > line,
-.c0:focus:not(:focus-visible) > path,
-.c0:focus:not(:focus-visible) > polygon,
-.c0:focus:not(:focus-visible) > polyline,
-.c0:focus:not(:focus-visible) > rect {
+.c0:focus:not(:focus-visible):not(:hover) > circle,
+.c0:focus:not(:focus-visible):not(:hover) > ellipse,
+.c0:focus:not(:focus-visible):not(:hover) > line,
+.c0:focus:not(:focus-visible):not(:hover) > path,
+.c0:focus:not(:focus-visible):not(:hover) > polygon,
+.c0:focus:not(:focus-visible):not(:hover) > polyline,
+.c0:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible)::-moz-focus-inner {
+.c0:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -2221,43 +2226,43 @@ exports[`Select basic 1`] = `
   text-align: inherit;
 }
 
-.c0:focus {
+.c0:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus > circle,
-.c0:focus > ellipse,
-.c0:focus > line,
-.c0:focus > path,
-.c0:focus > polygon,
-.c0:focus > polyline,
-.c0:focus > rect {
+.c0:focus:not(:hover) > circle,
+.c0:focus:not(:hover) > ellipse,
+.c0:focus:not(:hover) > line,
+.c0:focus:not(:hover) > path,
+.c0:focus:not(:hover) > polygon,
+.c0:focus:not(:hover) > polyline,
+.c0:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus::-moz-focus-inner {
+.c0:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c0:focus:not(:focus-visible) {
+.c0:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible) > circle,
-.c0:focus:not(:focus-visible) > ellipse,
-.c0:focus:not(:focus-visible) > line,
-.c0:focus:not(:focus-visible) > path,
-.c0:focus:not(:focus-visible) > polygon,
-.c0:focus:not(:focus-visible) > polyline,
-.c0:focus:not(:focus-visible) > rect {
+.c0:focus:not(:focus-visible):not(:hover) > circle,
+.c0:focus:not(:focus-visible):not(:hover) > ellipse,
+.c0:focus:not(:focus-visible):not(:hover) > line,
+.c0:focus:not(:focus-visible):not(:hover) > path,
+.c0:focus:not(:focus-visible):not(:hover) > polygon,
+.c0:focus:not(:focus-visible):not(:hover) > polyline,
+.c0:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible)::-moz-focus-inner {
+.c0:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -2489,43 +2494,43 @@ exports[`Select complex options and children 1`] = `
   text-align: inherit;
 }
 
-.c0:focus {
+.c0:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus > circle,
-.c0:focus > ellipse,
-.c0:focus > line,
-.c0:focus > path,
-.c0:focus > polygon,
-.c0:focus > polyline,
-.c0:focus > rect {
+.c0:focus:not(:hover) > circle,
+.c0:focus:not(:hover) > ellipse,
+.c0:focus:not(:hover) > line,
+.c0:focus:not(:hover) > path,
+.c0:focus:not(:hover) > polygon,
+.c0:focus:not(:hover) > polyline,
+.c0:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus::-moz-focus-inner {
+.c0:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c0:focus:not(:focus-visible) {
+.c0:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible) > circle,
-.c0:focus:not(:focus-visible) > ellipse,
-.c0:focus:not(:focus-visible) > line,
-.c0:focus:not(:focus-visible) > path,
-.c0:focus:not(:focus-visible) > polygon,
-.c0:focus:not(:focus-visible) > polyline,
-.c0:focus:not(:focus-visible) > rect {
+.c0:focus:not(:focus-visible):not(:hover) > circle,
+.c0:focus:not(:focus-visible):not(:hover) > ellipse,
+.c0:focus:not(:focus-visible):not(:hover) > line,
+.c0:focus:not(:focus-visible):not(:hover) > path,
+.c0:focus:not(:focus-visible):not(:hover) > polygon,
+.c0:focus:not(:focus-visible):not(:hover) > polyline,
+.c0:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible)::-moz-focus-inner {
+.c0:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -2649,7 +2654,7 @@ exports[`Select complex options and children 2`] = `
   aria-expanded="true"
   aria-haspopup="listbox"
   aria-label="test select"
-  class="StyledButton-sc-323bzc-0 eiEooU Select__StyledSelectDropButton-sc-17idtfo-2 ktDhrd"
+  class="StyledButton-sc-323bzc-0 gsQNSg Select__StyledSelectDropButton-sc-17idtfo-2 ktDhrd"
   id="test-select"
   type="button"
 >
@@ -2791,23 +2796,23 @@ exports[`Select complex options and children 3`] = `
   color: #000000;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -3051,43 +3056,43 @@ exports[`Select dark 1`] = `
   text-align: inherit;
 }
 
-.c2:focus {
+.c2:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c2:focus > circle,
-.c2:focus > ellipse,
-.c2:focus > line,
-.c2:focus > path,
-.c2:focus > polygon,
-.c2:focus > polyline,
-.c2:focus > rect {
+.c2:focus:not(:hover) > circle,
+.c2:focus:not(:hover) > ellipse,
+.c2:focus:not(:hover) > line,
+.c2:focus:not(:hover) > path,
+.c2:focus:not(:hover) > polygon,
+.c2:focus:not(:hover) > polyline,
+.c2:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c2:focus::-moz-focus-inner {
+.c2:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c2:focus:not(:focus-visible) {
+.c2:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c2:focus:not(:focus-visible) > circle,
-.c2:focus:not(:focus-visible) > ellipse,
-.c2:focus:not(:focus-visible) > line,
-.c2:focus:not(:focus-visible) > path,
-.c2:focus:not(:focus-visible) > polygon,
-.c2:focus:not(:focus-visible) > polyline,
-.c2:focus:not(:focus-visible) > rect {
+.c2:focus:not(:focus-visible):not(:hover) > circle,
+.c2:focus:not(:focus-visible):not(:hover) > ellipse,
+.c2:focus:not(:focus-visible):not(:hover) > line,
+.c2:focus:not(:focus-visible):not(:hover) > path,
+.c2:focus:not(:focus-visible):not(:hover) > polygon,
+.c2:focus:not(:focus-visible):not(:hover) > polyline,
+.c2:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c2:focus:not(:focus-visible)::-moz-focus-inner {
+.c2:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -3335,43 +3340,43 @@ exports[`Select default value 1`] = `
   text-align: inherit;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -3652,23 +3657,23 @@ exports[`Select default value clear 1`] = `
   flex: 1 0 auto;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -3695,23 +3700,23 @@ exports[`Select default value clear 1`] = `
   color: #000000;
 }
 
-.c8:focus:not(:focus-visible) {
+.c8:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c8:focus:not(:focus-visible) > circle,
-.c8:focus:not(:focus-visible) > ellipse,
-.c8:focus:not(:focus-visible) > line,
-.c8:focus:not(:focus-visible) > path,
-.c8:focus:not(:focus-visible) > polygon,
-.c8:focus:not(:focus-visible) > polyline,
-.c8:focus:not(:focus-visible) > rect {
+.c8:focus:not(:focus-visible):not(:hover) > circle,
+.c8:focus:not(:focus-visible):not(:hover) > ellipse,
+.c8:focus:not(:focus-visible):not(:hover) > line,
+.c8:focus:not(:focus-visible):not(:hover) > path,
+.c8:focus:not(:focus-visible):not(:hover) > polygon,
+.c8:focus:not(:focus-visible):not(:hover) > polyline,
+.c8:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c8:focus:not(:focus-visible)::-moz-focus-inner {
+.c8:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -3733,23 +3738,23 @@ exports[`Select default value clear 1`] = `
   text-align: inherit;
 }
 
-.c12:focus:not(:focus-visible) {
+.c12:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible) > circle,
-.c12:focus:not(:focus-visible) > ellipse,
-.c12:focus:not(:focus-visible) > line,
-.c12:focus:not(:focus-visible) > path,
-.c12:focus:not(:focus-visible) > polygon,
-.c12:focus:not(:focus-visible) > polyline,
-.c12:focus:not(:focus-visible) > rect {
+.c12:focus:not(:focus-visible):not(:hover) > circle,
+.c12:focus:not(:focus-visible):not(:hover) > ellipse,
+.c12:focus:not(:focus-visible):not(:hover) > line,
+.c12:focus:not(:focus-visible):not(:hover) > path,
+.c12:focus:not(:focus-visible):not(:hover) > polygon,
+.c12:focus:not(:focus-visible):not(:hover) > polyline,
+.c12:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible)::-moz-focus-inner {
+.c12:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -4012,43 +4017,43 @@ exports[`Select default value object options 1`] = `
   text-align: inherit;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -4296,43 +4301,43 @@ exports[`Select disabled 1`] = `
   cursor: default;
 }
 
-.c0:focus {
+.c0:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus > circle,
-.c0:focus > ellipse,
-.c0:focus > line,
-.c0:focus > path,
-.c0:focus > polygon,
-.c0:focus > polyline,
-.c0:focus > rect {
+.c0:focus:not(:hover) > circle,
+.c0:focus:not(:hover) > ellipse,
+.c0:focus:not(:hover) > line,
+.c0:focus:not(:hover) > path,
+.c0:focus:not(:hover) > polygon,
+.c0:focus:not(:hover) > polyline,
+.c0:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus::-moz-focus-inner {
+.c0:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c0:focus:not(:focus-visible) {
+.c0:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible) > circle,
-.c0:focus:not(:focus-visible) > ellipse,
-.c0:focus:not(:focus-visible) > line,
-.c0:focus:not(:focus-visible) > path,
-.c0:focus:not(:focus-visible) > polygon,
-.c0:focus:not(:focus-visible) > polyline,
-.c0:focus:not(:focus-visible) > rect {
+.c0:focus:not(:focus-visible):not(:hover) > circle,
+.c0:focus:not(:focus-visible):not(:hover) > ellipse,
+.c0:focus:not(:focus-visible):not(:hover) > line,
+.c0:focus:not(:focus-visible):not(:hover) > path,
+.c0:focus:not(:focus-visible):not(:hover) > polygon,
+.c0:focus:not(:focus-visible):not(:hover) > polyline,
+.c0:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible)::-moz-focus-inner {
+.c0:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -4457,7 +4462,7 @@ exports[`Select disabled 2`] = `
   aria-expanded="false"
   aria-haspopup="listbox"
   aria-label="test select"
-  class="StyledButton-sc-323bzc-0 ijdOBy Select__StyledSelectDropButton-sc-17idtfo-2 ktDhrd"
+  class="StyledButton-sc-323bzc-0 irUKSK Select__StyledSelectDropButton-sc-17idtfo-2 ktDhrd"
   disabled=""
   id="test-select"
   type="button"
@@ -4617,43 +4622,43 @@ exports[`Select disabled key 1`] = `
   text-align: inherit;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -4904,23 +4909,23 @@ exports[`Select disabled key 2`] = `
   cursor: default;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -4947,23 +4952,23 @@ exports[`Select disabled key 2`] = `
   color: #000000;
 }
 
-.c9:focus:not(:focus-visible) {
+.c9:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c9:focus:not(:focus-visible) > circle,
-.c9:focus:not(:focus-visible) > ellipse,
-.c9:focus:not(:focus-visible) > line,
-.c9:focus:not(:focus-visible) > path,
-.c9:focus:not(:focus-visible) > polygon,
-.c9:focus:not(:focus-visible) > polyline,
-.c9:focus:not(:focus-visible) > rect {
+.c9:focus:not(:focus-visible):not(:hover) > circle,
+.c9:focus:not(:focus-visible):not(:hover) > ellipse,
+.c9:focus:not(:focus-visible):not(:hover) > line,
+.c9:focus:not(:focus-visible):not(:hover) > path,
+.c9:focus:not(:focus-visible):not(:hover) > polygon,
+.c9:focus:not(:focus-visible):not(:hover) > polyline,
+.c9:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c9:focus:not(:focus-visible)::-moz-focus-inner {
+.c9:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -5206,23 +5211,23 @@ exports[`Select disabled option value 1`] = `
   cursor: default;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -5249,23 +5254,23 @@ exports[`Select disabled option value 1`] = `
   color: #000000;
 }
 
-.c9:focus:not(:focus-visible) {
+.c9:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c9:focus:not(:focus-visible) > circle,
-.c9:focus:not(:focus-visible) > ellipse,
-.c9:focus:not(:focus-visible) > line,
-.c9:focus:not(:focus-visible) > path,
-.c9:focus:not(:focus-visible) > polygon,
-.c9:focus:not(:focus-visible) > polyline,
-.c9:focus:not(:focus-visible) > rect {
+.c9:focus:not(:focus-visible):not(:hover) > circle,
+.c9:focus:not(:focus-visible):not(:hover) > ellipse,
+.c9:focus:not(:focus-visible):not(:hover) > line,
+.c9:focus:not(:focus-visible):not(:hover) > path,
+.c9:focus:not(:focus-visible):not(:hover) > polygon,
+.c9:focus:not(:focus-visible):not(:hover) > polyline,
+.c9:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c9:focus:not(:focus-visible)::-moz-focus-inner {
+.c9:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -5596,43 +5601,43 @@ exports[`Select keyboard navigation timeout 1`] = `
   text-align: inherit;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -5902,23 +5907,23 @@ exports[`Select large drop container height 1`] = `
   color: #000000;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -6153,23 +6158,23 @@ exports[`Select medium drop container height 1`] = `
   color: #000000;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -6396,43 +6401,43 @@ exports[`Select modifies select control style on open 1`] = `
   text-align: inherit;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -6680,43 +6685,43 @@ exports[`Select onChange with valueKey string 1`] = `
   text-align: inherit;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -6970,23 +6975,23 @@ exports[`Select onChange with valueKey string 2`] = `
   color: #000000;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -7222,43 +7227,43 @@ exports[`Select onChange with valueLabel 1`] = `
   text-align: inherit;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -7459,23 +7464,23 @@ exports[`Select onChange with valueLabel 2`] = `
   color: #000000;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -7711,43 +7716,43 @@ exports[`Select onChange without valueKey 1`] = `
   text-align: inherit;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -8001,23 +8006,23 @@ exports[`Select onChange without valueKey 2`] = `
   color: #000000;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -8253,43 +8258,43 @@ exports[`Select prop: onClose 1`] = `
   text-align: inherit;
 }
 
-.c0:focus {
+.c0:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus > circle,
-.c0:focus > ellipse,
-.c0:focus > line,
-.c0:focus > path,
-.c0:focus > polygon,
-.c0:focus > polyline,
-.c0:focus > rect {
+.c0:focus:not(:hover) > circle,
+.c0:focus:not(:hover) > ellipse,
+.c0:focus:not(:hover) > line,
+.c0:focus:not(:hover) > path,
+.c0:focus:not(:hover) > polygon,
+.c0:focus:not(:hover) > polyline,
+.c0:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus::-moz-focus-inner {
+.c0:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c0:focus:not(:focus-visible) {
+.c0:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible) > circle,
-.c0:focus:not(:focus-visible) > ellipse,
-.c0:focus:not(:focus-visible) > line,
-.c0:focus:not(:focus-visible) > path,
-.c0:focus:not(:focus-visible) > polygon,
-.c0:focus:not(:focus-visible) > polyline,
-.c0:focus:not(:focus-visible) > rect {
+.c0:focus:not(:focus-visible):not(:hover) > circle,
+.c0:focus:not(:focus-visible):not(:hover) > ellipse,
+.c0:focus:not(:focus-visible):not(:hover) > line,
+.c0:focus:not(:focus-visible):not(:hover) > path,
+.c0:focus:not(:focus-visible):not(:hover) > polygon,
+.c0:focus:not(:focus-visible):not(:hover) > polyline,
+.c0:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible)::-moz-focus-inner {
+.c0:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -8533,43 +8538,43 @@ exports[`Select prop: onClose 2`] = `
   text-align: inherit;
 }
 
-.c0:focus {
+.c0:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus > circle,
-.c0:focus > ellipse,
-.c0:focus > line,
-.c0:focus > path,
-.c0:focus > polygon,
-.c0:focus > polyline,
-.c0:focus > rect {
+.c0:focus:not(:hover) > circle,
+.c0:focus:not(:hover) > ellipse,
+.c0:focus:not(:hover) > line,
+.c0:focus:not(:hover) > path,
+.c0:focus:not(:hover) > polygon,
+.c0:focus:not(:hover) > polyline,
+.c0:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus::-moz-focus-inner {
+.c0:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c0:focus:not(:focus-visible) {
+.c0:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible) > circle,
-.c0:focus:not(:focus-visible) > ellipse,
-.c0:focus:not(:focus-visible) > line,
-.c0:focus:not(:focus-visible) > path,
-.c0:focus:not(:focus-visible) > polygon,
-.c0:focus:not(:focus-visible) > polyline,
-.c0:focus:not(:focus-visible) > rect {
+.c0:focus:not(:focus-visible):not(:hover) > circle,
+.c0:focus:not(:focus-visible):not(:hover) > ellipse,
+.c0:focus:not(:focus-visible):not(:hover) > line,
+.c0:focus:not(:focus-visible):not(:hover) > path,
+.c0:focus:not(:focus-visible):not(:hover) > polygon,
+.c0:focus:not(:focus-visible):not(:hover) > polyline,
+.c0:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible)::-moz-focus-inner {
+.c0:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -8818,43 +8823,43 @@ exports[`Select prop: onOpen 1`] = `
   text-align: inherit;
 }
 
-.c0:focus {
+.c0:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus > circle,
-.c0:focus > ellipse,
-.c0:focus > line,
-.c0:focus > path,
-.c0:focus > polygon,
-.c0:focus > polyline,
-.c0:focus > rect {
+.c0:focus:not(:hover) > circle,
+.c0:focus:not(:hover) > ellipse,
+.c0:focus:not(:hover) > line,
+.c0:focus:not(:hover) > path,
+.c0:focus:not(:hover) > polygon,
+.c0:focus:not(:hover) > polyline,
+.c0:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus::-moz-focus-inner {
+.c0:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c0:focus:not(:focus-visible) {
+.c0:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible) > circle,
-.c0:focus:not(:focus-visible) > ellipse,
-.c0:focus:not(:focus-visible) > line,
-.c0:focus:not(:focus-visible) > path,
-.c0:focus:not(:focus-visible) > polygon,
-.c0:focus:not(:focus-visible) > polyline,
-.c0:focus:not(:focus-visible) > rect {
+.c0:focus:not(:focus-visible):not(:hover) > circle,
+.c0:focus:not(:focus-visible):not(:hover) > ellipse,
+.c0:focus:not(:focus-visible):not(:hover) > line,
+.c0:focus:not(:focus-visible):not(:hover) > path,
+.c0:focus:not(:focus-visible):not(:hover) > polygon,
+.c0:focus:not(:focus-visible):not(:hover) > polyline,
+.c0:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible)::-moz-focus-inner {
+.c0:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -8978,7 +8983,7 @@ exports[`Select prop: onOpen 2`] = `
   aria-expanded="true"
   aria-haspopup="listbox"
   aria-label="test select"
-  class="StyledButton-sc-323bzc-0 eiEooU Select__StyledSelectDropButton-sc-17idtfo-2 ktDhrd"
+  class="StyledButton-sc-323bzc-0 gsQNSg Select__StyledSelectDropButton-sc-17idtfo-2 ktDhrd"
   id="test-select"
   type="button"
 >
@@ -9145,23 +9150,23 @@ exports[`Select prop: onOpen 3`] = `
   color: #000000;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -9294,7 +9299,7 @@ exports[`Select prop: onOpen 5`] = `
     aria-posinset="1"
     aria-selected="false"
     aria-setsize="2"
-    class="StyledButton-sc-323bzc-0 cOvmzN SelectContainer__SelectOption-sc-1wi0ul8-1 jRnsyM"
+    class="StyledButton-sc-323bzc-0 jEHcxV SelectContainer__SelectOption-sc-1wi0ul8-1 jRnsyM"
     role="option"
     tabindex="-1"
     type="button"
@@ -9313,7 +9318,7 @@ exports[`Select prop: onOpen 5`] = `
     aria-posinset="2"
     aria-selected="false"
     aria-setsize="2"
-    class="StyledButton-sc-323bzc-0 cOvmzN SelectContainer__SelectOption-sc-1wi0ul8-1 jRnsyM"
+    class="StyledButton-sc-323bzc-0 jEHcxV SelectContainer__SelectOption-sc-1wi0ul8-1 jRnsyM"
     role="option"
     tabindex="-1"
     type="button"
@@ -9447,43 +9452,43 @@ exports[`Select renders custom icon 1`] = `
   text-align: inherit;
 }
 
-.c0:focus {
+.c0:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus > circle,
-.c0:focus > ellipse,
-.c0:focus > line,
-.c0:focus > path,
-.c0:focus > polygon,
-.c0:focus > polyline,
-.c0:focus > rect {
+.c0:focus:not(:hover) > circle,
+.c0:focus:not(:hover) > ellipse,
+.c0:focus:not(:hover) > line,
+.c0:focus:not(:hover) > path,
+.c0:focus:not(:hover) > polygon,
+.c0:focus:not(:hover) > polyline,
+.c0:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus::-moz-focus-inner {
+.c0:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c0:focus:not(:focus-visible) {
+.c0:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible) > circle,
-.c0:focus:not(:focus-visible) > ellipse,
-.c0:focus:not(:focus-visible) > line,
-.c0:focus:not(:focus-visible) > path,
-.c0:focus:not(:focus-visible) > polygon,
-.c0:focus:not(:focus-visible) > polyline,
-.c0:focus:not(:focus-visible) > rect {
+.c0:focus:not(:focus-visible):not(:hover) > circle,
+.c0:focus:not(:focus-visible):not(:hover) > ellipse,
+.c0:focus:not(:focus-visible):not(:hover) > line,
+.c0:focus:not(:focus-visible):not(:hover) > path,
+.c0:focus:not(:focus-visible):not(:hover) > polygon,
+.c0:focus:not(:focus-visible):not(:hover) > polyline,
+.c0:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible)::-moz-focus-inner {
+.c0:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -9714,43 +9719,43 @@ exports[`Select renders custom up and down icons 1`] = `
   text-align: inherit;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -9889,7 +9894,7 @@ exports[`Select renders custom up and down icons 2`] = `
     aria-expanded="true"
     aria-haspopup="listbox"
     aria-label="Select..."
-    class="StyledButton-sc-323bzc-0 eiEooU Select__StyledSelectDropButton-sc-17idtfo-2 ktDhrd"
+    class="StyledButton-sc-323bzc-0 gsQNSg Select__StyledSelectDropButton-sc-17idtfo-2 ktDhrd"
     type="button"
   >
     <div
@@ -10097,43 +10102,43 @@ exports[`Select renders default icon 1`] = `
   text-align: inherit;
 }
 
-.c0:focus {
+.c0:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus > circle,
-.c0:focus > ellipse,
-.c0:focus > line,
-.c0:focus > path,
-.c0:focus > polygon,
-.c0:focus > polyline,
-.c0:focus > rect {
+.c0:focus:not(:hover) > circle,
+.c0:focus:not(:hover) > ellipse,
+.c0:focus:not(:hover) > line,
+.c0:focus:not(:hover) > path,
+.c0:focus:not(:hover) > polygon,
+.c0:focus:not(:hover) > polyline,
+.c0:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus::-moz-focus-inner {
+.c0:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c0:focus:not(:focus-visible) {
+.c0:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible) > circle,
-.c0:focus:not(:focus-visible) > ellipse,
-.c0:focus:not(:focus-visible) > line,
-.c0:focus:not(:focus-visible) > path,
-.c0:focus:not(:focus-visible) > polygon,
-.c0:focus:not(:focus-visible) > polyline,
-.c0:focus:not(:focus-visible) > rect {
+.c0:focus:not(:focus-visible):not(:hover) > circle,
+.c0:focus:not(:focus-visible):not(:hover) > ellipse,
+.c0:focus:not(:focus-visible):not(:hover) > line,
+.c0:focus:not(:focus-visible):not(:hover) > path,
+.c0:focus:not(:focus-visible):not(:hover) > polygon,
+.c0:focus:not(:focus-visible):not(:hover) > polyline,
+.c0:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible)::-moz-focus-inner {
+.c0:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -10365,43 +10370,43 @@ exports[`Select renders styled select options backwards compatible with legacy
   text-align: inherit;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -10650,43 +10655,43 @@ exports[`Select renders styled select options combining select.options.box &&
   text-align: inherit;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -10933,43 +10938,43 @@ exports[`Select renders styled select options using select.options.container 1`]
   text-align: inherit;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -11163,43 +11168,43 @@ exports[`Select renders without icon 1`] = `
   text-align: inherit;
 }
 
-.c0:focus {
+.c0:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus > circle,
-.c0:focus > ellipse,
-.c0:focus > line,
-.c0:focus > path,
-.c0:focus > polygon,
-.c0:focus > polyline,
-.c0:focus > rect {
+.c0:focus:not(:hover) > circle,
+.c0:focus:not(:hover) > ellipse,
+.c0:focus:not(:hover) > line,
+.c0:focus:not(:hover) > path,
+.c0:focus:not(:hover) > polygon,
+.c0:focus:not(:hover) > polyline,
+.c0:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus::-moz-focus-inner {
+.c0:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c0:focus:not(:focus-visible) {
+.c0:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible) > circle,
-.c0:focus:not(:focus-visible) > ellipse,
-.c0:focus:not(:focus-visible) > line,
-.c0:focus:not(:focus-visible) > path,
-.c0:focus:not(:focus-visible) > polygon,
-.c0:focus:not(:focus-visible) > polyline,
-.c0:focus:not(:focus-visible) > rect {
+.c0:focus:not(:focus-visible):not(:hover) > circle,
+.c0:focus:not(:focus-visible):not(:hover) > ellipse,
+.c0:focus:not(:focus-visible):not(:hover) > line,
+.c0:focus:not(:focus-visible):not(:hover) > path,
+.c0:focus:not(:focus-visible):not(:hover) > polygon,
+.c0:focus:not(:focus-visible):not(:hover) > polyline,
+.c0:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible)::-moz-focus-inner {
+.c0:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -11406,43 +11411,43 @@ exports[`Select search 1`] = `
   text-align: inherit;
 }
 
-.c0:focus {
+.c0:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus > circle,
-.c0:focus > ellipse,
-.c0:focus > line,
-.c0:focus > path,
-.c0:focus > polygon,
-.c0:focus > polyline,
-.c0:focus > rect {
+.c0:focus:not(:hover) > circle,
+.c0:focus:not(:hover) > ellipse,
+.c0:focus:not(:hover) > line,
+.c0:focus:not(:hover) > path,
+.c0:focus:not(:hover) > polygon,
+.c0:focus:not(:hover) > polyline,
+.c0:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus::-moz-focus-inner {
+.c0:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c0:focus:not(:focus-visible) {
+.c0:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible) > circle,
-.c0:focus:not(:focus-visible) > ellipse,
-.c0:focus:not(:focus-visible) > line,
-.c0:focus:not(:focus-visible) > path,
-.c0:focus:not(:focus-visible) > polygon,
-.c0:focus:not(:focus-visible) > polyline,
-.c0:focus:not(:focus-visible) > rect {
+.c0:focus:not(:focus-visible):not(:hover) > circle,
+.c0:focus:not(:focus-visible):not(:hover) > ellipse,
+.c0:focus:not(:focus-visible):not(:hover) > line,
+.c0:focus:not(:focus-visible):not(:hover) > path,
+.c0:focus:not(:focus-visible):not(:hover) > polygon,
+.c0:focus:not(:focus-visible):not(:hover) > polyline,
+.c0:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible)::-moz-focus-inner {
+.c0:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -11700,23 +11705,23 @@ exports[`Select search 2`] = `
   color: #000000;
 }
 
-.c8:focus:not(:focus-visible) {
+.c8:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c8:focus:not(:focus-visible) > circle,
-.c8:focus:not(:focus-visible) > ellipse,
-.c8:focus:not(:focus-visible) > line,
-.c8:focus:not(:focus-visible) > path,
-.c8:focus:not(:focus-visible) > polygon,
-.c8:focus:not(:focus-visible) > polyline,
-.c8:focus:not(:focus-visible) > rect {
+.c8:focus:not(:focus-visible):not(:hover) > circle,
+.c8:focus:not(:focus-visible):not(:hover) > ellipse,
+.c8:focus:not(:focus-visible):not(:hover) > line,
+.c8:focus:not(:focus-visible):not(:hover) > path,
+.c8:focus:not(:focus-visible):not(:hover) > polygon,
+.c8:focus:not(:focus-visible):not(:hover) > polyline,
+.c8:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c8:focus:not(:focus-visible)::-moz-focus-inner {
+.c8:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -11738,23 +11743,23 @@ exports[`Select search 2`] = `
   text-align: inherit;
 }
 
-.c12:focus:not(:focus-visible) {
+.c12:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible) > circle,
-.c12:focus:not(:focus-visible) > ellipse,
-.c12:focus:not(:focus-visible) > line,
-.c12:focus:not(:focus-visible) > path,
-.c12:focus:not(:focus-visible) > polygon,
-.c12:focus:not(:focus-visible) > polyline,
-.c12:focus:not(:focus-visible) > rect {
+.c12:focus:not(:focus-visible):not(:hover) > circle,
+.c12:focus:not(:focus-visible):not(:hover) > ellipse,
+.c12:focus:not(:focus-visible):not(:hover) > line,
+.c12:focus:not(:focus-visible):not(:hover) > path,
+.c12:focus:not(:focus-visible):not(:hover) > polygon,
+.c12:focus:not(:focus-visible):not(:hover) > polyline,
+.c12:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible)::-moz-focus-inner {
+.c12:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -11987,7 +11992,7 @@ exports[`Select search 5`] = `
   aria-posinset="2"
   aria-selected="true"
   aria-setsize="2"
-  class="StyledButton-sc-323bzc-0 jXGGBG SelectContainer__SelectOption-sc-1wi0ul8-1 fFhDhl"
+  class="StyledButton-sc-323bzc-0 beEhEu SelectContainer__SelectOption-sc-1wi0ul8-1 fFhDhl"
   role="option"
   tabindex="0"
   type="button"
@@ -12117,43 +12122,43 @@ exports[`Select search and select 1`] = `
   text-align: inherit;
 }
 
-.c0:focus {
+.c0:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus > circle,
-.c0:focus > ellipse,
-.c0:focus > line,
-.c0:focus > path,
-.c0:focus > polygon,
-.c0:focus > polyline,
-.c0:focus > rect {
+.c0:focus:not(:hover) > circle,
+.c0:focus:not(:hover) > ellipse,
+.c0:focus:not(:hover) > line,
+.c0:focus:not(:hover) > path,
+.c0:focus:not(:hover) > polygon,
+.c0:focus:not(:hover) > polyline,
+.c0:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus::-moz-focus-inner {
+.c0:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c0:focus:not(:focus-visible) {
+.c0:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible) > circle,
-.c0:focus:not(:focus-visible) > ellipse,
-.c0:focus:not(:focus-visible) > line,
-.c0:focus:not(:focus-visible) > path,
-.c0:focus:not(:focus-visible) > polygon,
-.c0:focus:not(:focus-visible) > polyline,
-.c0:focus:not(:focus-visible) > rect {
+.c0:focus:not(:focus-visible):not(:hover) > circle,
+.c0:focus:not(:focus-visible):not(:hover) > ellipse,
+.c0:focus:not(:focus-visible):not(:hover) > line,
+.c0:focus:not(:focus-visible):not(:hover) > path,
+.c0:focus:not(:focus-visible):not(:hover) > polygon,
+.c0:focus:not(:focus-visible):not(:hover) > polyline,
+.c0:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible)::-moz-focus-inner {
+.c0:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -12411,23 +12416,23 @@ exports[`Select search and select 2`] = `
   color: #000000;
 }
 
-.c8:focus:not(:focus-visible) {
+.c8:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c8:focus:not(:focus-visible) > circle,
-.c8:focus:not(:focus-visible) > ellipse,
-.c8:focus:not(:focus-visible) > line,
-.c8:focus:not(:focus-visible) > path,
-.c8:focus:not(:focus-visible) > polygon,
-.c8:focus:not(:focus-visible) > polyline,
-.c8:focus:not(:focus-visible) > rect {
+.c8:focus:not(:focus-visible):not(:hover) > circle,
+.c8:focus:not(:focus-visible):not(:hover) > ellipse,
+.c8:focus:not(:focus-visible):not(:hover) > line,
+.c8:focus:not(:focus-visible):not(:hover) > path,
+.c8:focus:not(:focus-visible):not(:hover) > polygon,
+.c8:focus:not(:focus-visible):not(:hover) > polyline,
+.c8:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c8:focus:not(:focus-visible)::-moz-focus-inner {
+.c8:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -12770,43 +12775,43 @@ exports[`Select select an object with label key specific with keypress 1`] = `
   text-align: inherit;
 }
 
-.c0:focus {
+.c0:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus > circle,
-.c0:focus > ellipse,
-.c0:focus > line,
-.c0:focus > path,
-.c0:focus > polygon,
-.c0:focus > polyline,
-.c0:focus > rect {
+.c0:focus:not(:hover) > circle,
+.c0:focus:not(:hover) > ellipse,
+.c0:focus:not(:hover) > line,
+.c0:focus:not(:hover) > path,
+.c0:focus:not(:hover) > polygon,
+.c0:focus:not(:hover) > polyline,
+.c0:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus::-moz-focus-inner {
+.c0:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c0:focus:not(:focus-visible) {
+.c0:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible) > circle,
-.c0:focus:not(:focus-visible) > ellipse,
-.c0:focus:not(:focus-visible) > line,
-.c0:focus:not(:focus-visible) > path,
-.c0:focus:not(:focus-visible) > polygon,
-.c0:focus:not(:focus-visible) > polyline,
-.c0:focus:not(:focus-visible) > rect {
+.c0:focus:not(:focus-visible):not(:hover) > circle,
+.c0:focus:not(:focus-visible):not(:hover) > ellipse,
+.c0:focus:not(:focus-visible):not(:hover) > line,
+.c0:focus:not(:focus-visible):not(:hover) > path,
+.c0:focus:not(:focus-visible):not(:hover) > polygon,
+.c0:focus:not(:focus-visible):not(:hover) > polyline,
+.c0:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible)::-moz-focus-inner {
+.c0:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -13038,43 +13043,43 @@ exports[`Select select an option 1`] = `
   text-align: inherit;
 }
 
-.c0:focus {
+.c0:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus > circle,
-.c0:focus > ellipse,
-.c0:focus > line,
-.c0:focus > path,
-.c0:focus > polygon,
-.c0:focus > polyline,
-.c0:focus > rect {
+.c0:focus:not(:hover) > circle,
+.c0:focus:not(:hover) > ellipse,
+.c0:focus:not(:hover) > line,
+.c0:focus:not(:hover) > path,
+.c0:focus:not(:hover) > polygon,
+.c0:focus:not(:hover) > polyline,
+.c0:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus::-moz-focus-inner {
+.c0:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c0:focus:not(:focus-visible) {
+.c0:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible) > circle,
-.c0:focus:not(:focus-visible) > ellipse,
-.c0:focus:not(:focus-visible) > line,
-.c0:focus:not(:focus-visible) > path,
-.c0:focus:not(:focus-visible) > polygon,
-.c0:focus:not(:focus-visible) > polyline,
-.c0:focus:not(:focus-visible) > rect {
+.c0:focus:not(:focus-visible):not(:hover) > circle,
+.c0:focus:not(:focus-visible):not(:hover) > ellipse,
+.c0:focus:not(:focus-visible):not(:hover) > line,
+.c0:focus:not(:focus-visible):not(:hover) > path,
+.c0:focus:not(:focus-visible):not(:hover) > polygon,
+.c0:focus:not(:focus-visible):not(:hover) > polyline,
+.c0:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible)::-moz-focus-inner {
+.c0:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -13306,43 +13311,43 @@ exports[`Select select an option with complex options 1`] = `
   text-align: inherit;
 }
 
-.c0:focus {
+.c0:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus > circle,
-.c0:focus > ellipse,
-.c0:focus > line,
-.c0:focus > path,
-.c0:focus > polygon,
-.c0:focus > polyline,
-.c0:focus > rect {
+.c0:focus:not(:hover) > circle,
+.c0:focus:not(:hover) > ellipse,
+.c0:focus:not(:hover) > line,
+.c0:focus:not(:hover) > path,
+.c0:focus:not(:hover) > polygon,
+.c0:focus:not(:hover) > polyline,
+.c0:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus::-moz-focus-inner {
+.c0:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c0:focus:not(:focus-visible) {
+.c0:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible) > circle,
-.c0:focus:not(:focus-visible) > ellipse,
-.c0:focus:not(:focus-visible) > line,
-.c0:focus:not(:focus-visible) > path,
-.c0:focus:not(:focus-visible) > polygon,
-.c0:focus:not(:focus-visible) > polyline,
-.c0:focus:not(:focus-visible) > rect {
+.c0:focus:not(:focus-visible):not(:hover) > circle,
+.c0:focus:not(:focus-visible):not(:hover) > ellipse,
+.c0:focus:not(:focus-visible):not(:hover) > line,
+.c0:focus:not(:focus-visible):not(:hover) > path,
+.c0:focus:not(:focus-visible):not(:hover) > polygon,
+.c0:focus:not(:focus-visible):not(:hover) > polyline,
+.c0:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible)::-moz-focus-inner {
+.c0:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -13516,43 +13521,43 @@ exports[`Select select an option with enter 1`] = `
   text-align: inherit;
 }
 
-.c0:focus {
+.c0:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus > circle,
-.c0:focus > ellipse,
-.c0:focus > line,
-.c0:focus > path,
-.c0:focus > polygon,
-.c0:focus > polyline,
-.c0:focus > rect {
+.c0:focus:not(:hover) > circle,
+.c0:focus:not(:hover) > ellipse,
+.c0:focus:not(:hover) > line,
+.c0:focus:not(:hover) > path,
+.c0:focus:not(:hover) > polygon,
+.c0:focus:not(:hover) > polyline,
+.c0:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus::-moz-focus-inner {
+.c0:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c0:focus:not(:focus-visible) {
+.c0:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible) > circle,
-.c0:focus:not(:focus-visible) > ellipse,
-.c0:focus:not(:focus-visible) > line,
-.c0:focus:not(:focus-visible) > path,
-.c0:focus:not(:focus-visible) > polygon,
-.c0:focus:not(:focus-visible) > polyline,
-.c0:focus:not(:focus-visible) > rect {
+.c0:focus:not(:focus-visible):not(:hover) > circle,
+.c0:focus:not(:focus-visible):not(:hover) > ellipse,
+.c0:focus:not(:focus-visible):not(:hover) > line,
+.c0:focus:not(:focus-visible):not(:hover) > path,
+.c0:focus:not(:focus-visible):not(:hover) > polygon,
+.c0:focus:not(:focus-visible):not(:hover) > polyline,
+.c0:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible)::-moz-focus-inner {
+.c0:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -13784,43 +13789,43 @@ exports[`Select select an option with keypress 1`] = `
   text-align: inherit;
 }
 
-.c0:focus {
+.c0:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus > circle,
-.c0:focus > ellipse,
-.c0:focus > line,
-.c0:focus > path,
-.c0:focus > polygon,
-.c0:focus > polyline,
-.c0:focus > rect {
+.c0:focus:not(:hover) > circle,
+.c0:focus:not(:hover) > ellipse,
+.c0:focus:not(:hover) > line,
+.c0:focus:not(:hover) > path,
+.c0:focus:not(:hover) > polygon,
+.c0:focus:not(:hover) > polyline,
+.c0:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus::-moz-focus-inner {
+.c0:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c0:focus:not(:focus-visible) {
+.c0:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible) > circle,
-.c0:focus:not(:focus-visible) > ellipse,
-.c0:focus:not(:focus-visible) > line,
-.c0:focus:not(:focus-visible) > path,
-.c0:focus:not(:focus-visible) > polygon,
-.c0:focus:not(:focus-visible) > polyline,
-.c0:focus:not(:focus-visible) > rect {
+.c0:focus:not(:focus-visible):not(:hover) > circle,
+.c0:focus:not(:focus-visible):not(:hover) > ellipse,
+.c0:focus:not(:focus-visible):not(:hover) > line,
+.c0:focus:not(:focus-visible):not(:hover) > path,
+.c0:focus:not(:focus-visible):not(:hover) > polygon,
+.c0:focus:not(:focus-visible):not(:hover) > polyline,
+.c0:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible)::-moz-focus-inner {
+.c0:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -14052,43 +14057,43 @@ exports[`Select select on multiple keydown always picks first enabled option 1`]
   text-align: inherit;
 }
 
-.c0:focus {
+.c0:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus > circle,
-.c0:focus > ellipse,
-.c0:focus > line,
-.c0:focus > path,
-.c0:focus > polygon,
-.c0:focus > polyline,
-.c0:focus > rect {
+.c0:focus:not(:hover) > circle,
+.c0:focus:not(:hover) > ellipse,
+.c0:focus:not(:hover) > line,
+.c0:focus:not(:hover) > path,
+.c0:focus:not(:hover) > polygon,
+.c0:focus:not(:hover) > polyline,
+.c0:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus::-moz-focus-inner {
+.c0:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c0:focus:not(:focus-visible) {
+.c0:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible) > circle,
-.c0:focus:not(:focus-visible) > ellipse,
-.c0:focus:not(:focus-visible) > line,
-.c0:focus:not(:focus-visible) > path,
-.c0:focus:not(:focus-visible) > polygon,
-.c0:focus:not(:focus-visible) > polyline,
-.c0:focus:not(:focus-visible) > rect {
+.c0:focus:not(:focus-visible):not(:hover) > circle,
+.c0:focus:not(:focus-visible):not(:hover) > ellipse,
+.c0:focus:not(:focus-visible):not(:hover) > line,
+.c0:focus:not(:focus-visible):not(:hover) > path,
+.c0:focus:not(:focus-visible):not(:hover) > polygon,
+.c0:focus:not(:focus-visible):not(:hover) > polyline,
+.c0:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible)::-moz-focus-inner {
+.c0:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -14320,43 +14325,43 @@ exports[`Select select option by typing should not break if caller passes JSX 1`
   text-align: inherit;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -14497,7 +14502,7 @@ exports[`Select select option by typing should not break if caller passes JSX 2`
     aria-expanded="false"
     aria-haspopup="listbox"
     aria-label="test select; Selected: two"
-    class="StyledButton-sc-323bzc-0 eiEooU Select__StyledSelectDropButton-sc-17idtfo-2 ktDhrd"
+    class="StyledButton-sc-323bzc-0 gsQNSg Select__StyledSelectDropButton-sc-17idtfo-2 ktDhrd"
     id="test-select"
     type="button"
   >
@@ -14657,43 +14662,43 @@ exports[`Select selected 1`] = `
   text-align: inherit;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -14939,43 +14944,43 @@ exports[`Select should apply a11yTitle or aria-label 1`] = `
   text-align: inherit;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -15265,43 +15270,43 @@ exports[`Select should not have accessibility violations 1`] = `
   text-align: inherit;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -15545,43 +15550,43 @@ exports[`Select size 1`] = `
   text-align: inherit;
 }
 
-.c0:focus {
+.c0:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus > circle,
-.c0:focus > ellipse,
-.c0:focus > line,
-.c0:focus > path,
-.c0:focus > polygon,
-.c0:focus > polyline,
-.c0:focus > rect {
+.c0:focus:not(:hover) > circle,
+.c0:focus:not(:hover) > ellipse,
+.c0:focus:not(:hover) > line,
+.c0:focus:not(:hover) > path,
+.c0:focus:not(:hover) > polygon,
+.c0:focus:not(:hover) > polyline,
+.c0:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus::-moz-focus-inner {
+.c0:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c0:focus:not(:focus-visible) {
+.c0:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible) > circle,
-.c0:focus:not(:focus-visible) > ellipse,
-.c0:focus:not(:focus-visible) > line,
-.c0:focus:not(:focus-visible) > path,
-.c0:focus:not(:focus-visible) > polygon,
-.c0:focus:not(:focus-visible) > polyline,
-.c0:focus:not(:focus-visible) > rect {
+.c0:focus:not(:focus-visible):not(:hover) > circle,
+.c0:focus:not(:focus-visible):not(:hover) > ellipse,
+.c0:focus:not(:focus-visible):not(:hover) > line,
+.c0:focus:not(:focus-visible):not(:hover) > path,
+.c0:focus:not(:focus-visible):not(:hover) > polygon,
+.c0:focus:not(:focus-visible):not(:hover) > polyline,
+.c0:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible)::-moz-focus-inner {
+.c0:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -15822,23 +15827,23 @@ exports[`Select small drop container height 1`] = `
   color: #000000;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 

--- a/src/js/components/Select/__tests__/__snapshots__/SelectMultiple-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/SelectMultiple-test.js.snap
@@ -113,43 +113,43 @@ exports[`Select Controlled deselect an option 1`] = `
   text-align: inherit;
 }
 
-.c0:focus {
+.c0:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus > circle,
-.c0:focus > ellipse,
-.c0:focus > line,
-.c0:focus > path,
-.c0:focus > polygon,
-.c0:focus > polyline,
-.c0:focus > rect {
+.c0:focus:not(:hover) > circle,
+.c0:focus:not(:hover) > ellipse,
+.c0:focus:not(:hover) > line,
+.c0:focus:not(:hover) > path,
+.c0:focus:not(:hover) > polygon,
+.c0:focus:not(:hover) > polyline,
+.c0:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus::-moz-focus-inner {
+.c0:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c0:focus:not(:focus-visible) {
+.c0:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible) > circle,
-.c0:focus:not(:focus-visible) > ellipse,
-.c0:focus:not(:focus-visible) > line,
-.c0:focus:not(:focus-visible) > path,
-.c0:focus:not(:focus-visible) > polygon,
-.c0:focus:not(:focus-visible) > polyline,
-.c0:focus:not(:focus-visible) > rect {
+.c0:focus:not(:focus-visible):not(:hover) > circle,
+.c0:focus:not(:focus-visible):not(:hover) > ellipse,
+.c0:focus:not(:focus-visible):not(:hover) > line,
+.c0:focus:not(:focus-visible):not(:hover) > path,
+.c0:focus:not(:focus-visible):not(:hover) > polygon,
+.c0:focus:not(:focus-visible):not(:hover) > polyline,
+.c0:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible)::-moz-focus-inner {
+.c0:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -381,43 +381,43 @@ exports[`Select Controlled multiple 1`] = `
   text-align: inherit;
 }
 
-.c0:focus {
+.c0:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus > circle,
-.c0:focus > ellipse,
-.c0:focus > line,
-.c0:focus > path,
-.c0:focus > polygon,
-.c0:focus > polyline,
-.c0:focus > rect {
+.c0:focus:not(:hover) > circle,
+.c0:focus:not(:hover) > ellipse,
+.c0:focus:not(:hover) > line,
+.c0:focus:not(:hover) > path,
+.c0:focus:not(:hover) > polygon,
+.c0:focus:not(:hover) > polyline,
+.c0:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus::-moz-focus-inner {
+.c0:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c0:focus:not(:focus-visible) {
+.c0:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible) > circle,
-.c0:focus:not(:focus-visible) > ellipse,
-.c0:focus:not(:focus-visible) > line,
-.c0:focus:not(:focus-visible) > path,
-.c0:focus:not(:focus-visible) > polygon,
-.c0:focus:not(:focus-visible) > polyline,
-.c0:focus:not(:focus-visible) > rect {
+.c0:focus:not(:focus-visible):not(:hover) > circle,
+.c0:focus:not(:focus-visible):not(:hover) > ellipse,
+.c0:focus:not(:focus-visible):not(:hover) > line,
+.c0:focus:not(:focus-visible):not(:hover) > path,
+.c0:focus:not(:focus-visible):not(:hover) > polygon,
+.c0:focus:not(:focus-visible):not(:hover) > polyline,
+.c0:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible)::-moz-focus-inner {
+.c0:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -648,43 +648,43 @@ exports[`Select Controlled multiple onChange toggle with valueKey reduce 1`] = `
   text-align: inherit;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -933,23 +933,23 @@ exports[`Select Controlled multiple onChange toggle with valueKey reduce 2`] = `
   text-align: inherit;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -976,23 +976,23 @@ exports[`Select Controlled multiple onChange toggle with valueKey reduce 2`] = `
   color: #000000;
 }
 
-.c9:focus:not(:focus-visible) {
+.c9:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c9:focus:not(:focus-visible) > circle,
-.c9:focus:not(:focus-visible) > ellipse,
-.c9:focus:not(:focus-visible) > line,
-.c9:focus:not(:focus-visible) > path,
-.c9:focus:not(:focus-visible) > polygon,
-.c9:focus:not(:focus-visible) > polyline,
-.c9:focus:not(:focus-visible) > rect {
+.c9:focus:not(:focus-visible):not(:hover) > circle,
+.c9:focus:not(:focus-visible):not(:hover) > ellipse,
+.c9:focus:not(:focus-visible):not(:hover) > line,
+.c9:focus:not(:focus-visible):not(:hover) > path,
+.c9:focus:not(:focus-visible):not(:hover) > polygon,
+.c9:focus:not(:focus-visible):not(:hover) > polyline,
+.c9:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c9:focus:not(:focus-visible)::-moz-focus-inner {
+.c9:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -1236,43 +1236,43 @@ exports[`Select Controlled multiple onChange with valueKey reduce 1`] = `
   text-align: inherit;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -1526,23 +1526,23 @@ exports[`Select Controlled multiple onChange with valueKey reduce 2`] = `
   color: #000000;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -1779,43 +1779,43 @@ exports[`Select Controlled multiple onChange with valueKey string 1`] = `
   text-align: inherit;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -2069,23 +2069,23 @@ exports[`Select Controlled multiple onChange with valueKey string 2`] = `
   color: #000000;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -2322,43 +2322,43 @@ exports[`Select Controlled multiple onChange without valueKey 1`] = `
   text-align: inherit;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -2612,23 +2612,23 @@ exports[`Select Controlled multiple onChange without valueKey 2`] = `
   color: #000000;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -2773,7 +2773,7 @@ exports[`Select Controlled multiple onChange without valueKey 4`] = `
       <button
         aria-posinset="1"
         aria-setsize="2"
-        class="StyledButton-sc-323bzc-0 cOvmzN SelectContainer__SelectOption-sc-1wi0ul8-1 jRnsyM"
+        class="StyledButton-sc-323bzc-0 jEHcxV SelectContainer__SelectOption-sc-1wi0ul8-1 jRnsyM"
         role="option"
         tabindex="-1"
         type="button"
@@ -2791,7 +2791,7 @@ exports[`Select Controlled multiple onChange without valueKey 4`] = `
       <button
         aria-posinset="2"
         aria-setsize="2"
-        class="StyledButton-sc-323bzc-0 cOvmzN SelectContainer__SelectOption-sc-1wi0ul8-1 jRnsyM"
+        class="StyledButton-sc-323bzc-0 jEHcxV SelectContainer__SelectOption-sc-1wi0ul8-1 jRnsyM"
         role="option"
         tabindex="-1"
         type="button"
@@ -2936,43 +2936,43 @@ exports[`Select Controlled multiple values 1`] = `
   text-align: inherit;
 }
 
-.c0:focus {
+.c0:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus > circle,
-.c0:focus > ellipse,
-.c0:focus > line,
-.c0:focus > path,
-.c0:focus > polygon,
-.c0:focus > polyline,
-.c0:focus > rect {
+.c0:focus:not(:hover) > circle,
+.c0:focus:not(:hover) > ellipse,
+.c0:focus:not(:hover) > line,
+.c0:focus:not(:hover) > path,
+.c0:focus:not(:hover) > polygon,
+.c0:focus:not(:hover) > polyline,
+.c0:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus::-moz-focus-inner {
+.c0:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c0:focus:not(:focus-visible) {
+.c0:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible) > circle,
-.c0:focus:not(:focus-visible) > ellipse,
-.c0:focus:not(:focus-visible) > line,
-.c0:focus:not(:focus-visible) > path,
-.c0:focus:not(:focus-visible) > polygon,
-.c0:focus:not(:focus-visible) > polyline,
-.c0:focus:not(:focus-visible) > rect {
+.c0:focus:not(:focus-visible):not(:hover) > circle,
+.c0:focus:not(:focus-visible):not(:hover) > ellipse,
+.c0:focus:not(:focus-visible):not(:hover) > line,
+.c0:focus:not(:focus-visible):not(:hover) > path,
+.c0:focus:not(:focus-visible):not(:hover) > polygon,
+.c0:focus:not(:focus-visible):not(:hover) > polyline,
+.c0:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible)::-moz-focus-inner {
+.c0:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -3096,7 +3096,7 @@ exports[`Select Controlled multiple values 2`] = `
   aria-expanded="true"
   aria-haspopup="listbox"
   aria-label="test select; Selected: one,two"
-  class="StyledButton-sc-323bzc-0 eiEooU Select__StyledSelectDropButton-sc-17idtfo-2 ktDhrd"
+  class="StyledButton-sc-323bzc-0 gsQNSg Select__StyledSelectDropButton-sc-17idtfo-2 ktDhrd"
   id="test-select"
   type="button"
 >
@@ -3258,23 +3258,23 @@ exports[`Select Controlled multiple values 3`] = `
   text-align: inherit;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -3513,43 +3513,43 @@ exports[`Select Controlled multiple with empty results 1`] = `
   text-align: inherit;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -3803,23 +3803,23 @@ exports[`Select Controlled multiple with empty results 2`] = `
   color: #000000;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -4056,43 +4056,43 @@ exports[`Select Controlled select another option 1`] = `
   text-align: inherit;
 }
 
-.c0:focus {
+.c0:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus > circle,
-.c0:focus > ellipse,
-.c0:focus > line,
-.c0:focus > path,
-.c0:focus > polygon,
-.c0:focus > polyline,
-.c0:focus > rect {
+.c0:focus:not(:hover) > circle,
+.c0:focus:not(:hover) > ellipse,
+.c0:focus:not(:hover) > line,
+.c0:focus:not(:hover) > path,
+.c0:focus:not(:hover) > polygon,
+.c0:focus:not(:hover) > polyline,
+.c0:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c0:focus::-moz-focus-inner {
+.c0:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c0:focus:not(:focus-visible) {
+.c0:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible) > circle,
-.c0:focus:not(:focus-visible) > ellipse,
-.c0:focus:not(:focus-visible) > line,
-.c0:focus:not(:focus-visible) > path,
-.c0:focus:not(:focus-visible) > polygon,
-.c0:focus:not(:focus-visible) > polyline,
-.c0:focus:not(:focus-visible) > rect {
+.c0:focus:not(:focus-visible):not(:hover) > circle,
+.c0:focus:not(:focus-visible):not(:hover) > ellipse,
+.c0:focus:not(:focus-visible):not(:hover) > line,
+.c0:focus:not(:focus-visible):not(:hover) > path,
+.c0:focus:not(:focus-visible):not(:hover) > polygon,
+.c0:focus:not(:focus-visible):not(:hover) > polyline,
+.c0:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c0:focus:not(:focus-visible)::-moz-focus-inner {
+.c0:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -4324,43 +4324,43 @@ exports[`Select Controlled should not have accessibility violations 1`] = `
   text-align: inherit;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 

--- a/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.tsx.snap
+++ b/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.tsx.snap
@@ -109,43 +109,43 @@ exports[`Tabs Custom Tab component 1`] = `
   text-align: inherit;
 }
 
-.c3:focus {
+.c3:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
+.c3:focus:not(:hover) > circle,
+.c3:focus:not(:hover) > ellipse,
+.c3:focus:not(:hover) > line,
+.c3:focus:not(:hover) > path,
+.c3:focus:not(:hover) > polygon,
+.c3:focus:not(:hover) > polyline,
+.c3:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus::-moz-focus-inner {
+.c3:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c3:focus:not(:focus-visible) {
+.c3:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
+.c3:focus:not(:focus-visible):not(:hover) > circle,
+.c3:focus:not(:focus-visible):not(:hover) > ellipse,
+.c3:focus:not(:focus-visible):not(:hover) > line,
+.c3:focus:not(:focus-visible):not(:hover) > path,
+.c3:focus:not(:focus-visible):not(:hover) > polygon,
+.c3:focus:not(:focus-visible):not(:hover) > polyline,
+.c3:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
+.c3:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -391,43 +391,43 @@ exports[`Tabs Tab 1`] = `
   text-align: inherit;
 }
 
-.c3:focus {
+.c3:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
+.c3:focus:not(:hover) > circle,
+.c3:focus:not(:hover) > ellipse,
+.c3:focus:not(:hover) > line,
+.c3:focus:not(:hover) > path,
+.c3:focus:not(:hover) > polygon,
+.c3:focus:not(:hover) > polyline,
+.c3:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus::-moz-focus-inner {
+.c3:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c3:focus:not(:focus-visible) {
+.c3:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
+.c3:focus:not(:focus-visible):not(:hover) > circle,
+.c3:focus:not(:focus-visible):not(:hover) > ellipse,
+.c3:focus:not(:focus-visible):not(:hover) > line,
+.c3:focus:not(:focus-visible):not(:hover) > path,
+.c3:focus:not(:focus-visible):not(:hover) > polygon,
+.c3:focus:not(:focus-visible):not(:hover) > polyline,
+.c3:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
+.c3:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -676,43 +676,43 @@ exports[`Tabs alignControls 1`] = `
   text-align: inherit;
 }
 
-.c3:focus {
+.c3:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
+.c3:focus:not(:hover) > circle,
+.c3:focus:not(:hover) > ellipse,
+.c3:focus:not(:hover) > line,
+.c3:focus:not(:hover) > path,
+.c3:focus:not(:hover) > polygon,
+.c3:focus:not(:hover) > polyline,
+.c3:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus::-moz-focus-inner {
+.c3:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c3:focus:not(:focus-visible) {
+.c3:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
+.c3:focus:not(:focus-visible):not(:hover) > circle,
+.c3:focus:not(:focus-visible):not(:hover) > ellipse,
+.c3:focus:not(:focus-visible):not(:hover) > line,
+.c3:focus:not(:focus-visible):not(:hover) > path,
+.c3:focus:not(:focus-visible):not(:hover) > polygon,
+.c3:focus:not(:focus-visible):not(:hover) > polyline,
+.c3:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
+.c3:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -961,43 +961,43 @@ exports[`Tabs change to second tab 1`] = `
   text-align: inherit;
 }
 
-.c3:focus {
+.c3:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
+.c3:focus:not(:hover) > circle,
+.c3:focus:not(:hover) > ellipse,
+.c3:focus:not(:hover) > line,
+.c3:focus:not(:hover) > path,
+.c3:focus:not(:hover) > polygon,
+.c3:focus:not(:hover) > polyline,
+.c3:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus::-moz-focus-inner {
+.c3:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c3:focus:not(:focus-visible) {
+.c3:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
+.c3:focus:not(:focus-visible):not(:hover) > circle,
+.c3:focus:not(:focus-visible):not(:hover) > ellipse,
+.c3:focus:not(:focus-visible):not(:hover) > line,
+.c3:focus:not(:focus-visible):not(:hover) > path,
+.c3:focus:not(:focus-visible):not(:hover) > polygon,
+.c3:focus:not(:focus-visible):not(:hover) > polyline,
+.c3:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
+.c3:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -1148,7 +1148,7 @@ exports[`Tabs change to second tab 2`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 eiEooU"
+        class="StyledButton-sc-323bzc-0 gsQNSg"
         role="tab"
         type="button"
       >
@@ -1165,7 +1165,7 @@ exports[`Tabs change to second tab 2`] = `
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 eiEooU"
+        class="StyledButton-sc-323bzc-0 gsQNSg"
         role="tab"
         type="button"
       >
@@ -1288,43 +1288,43 @@ exports[`Tabs complex title 1`] = `
   text-align: inherit;
 }
 
-.c3:focus {
+.c3:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
+.c3:focus:not(:hover) > circle,
+.c3:focus:not(:hover) > ellipse,
+.c3:focus:not(:hover) > line,
+.c3:focus:not(:hover) > path,
+.c3:focus:not(:hover) > polygon,
+.c3:focus:not(:hover) > polyline,
+.c3:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus::-moz-focus-inner {
+.c3:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c3:focus:not(:focus-visible) {
+.c3:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
+.c3:focus:not(:focus-visible):not(:hover) > circle,
+.c3:focus:not(:focus-visible):not(:hover) > ellipse,
+.c3:focus:not(:focus-visible):not(:hover) > line,
+.c3:focus:not(:focus-visible):not(:hover) > path,
+.c3:focus:not(:focus-visible):not(:hover) > polygon,
+.c3:focus:not(:focus-visible):not(:hover) > polyline,
+.c3:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
+.c3:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -1534,43 +1534,43 @@ exports[`Tabs no Tab 1`] = `
   text-align: inherit;
 }
 
-.c3:focus {
+.c3:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
+.c3:focus:not(:hover) > circle,
+.c3:focus:not(:hover) > ellipse,
+.c3:focus:not(:hover) > line,
+.c3:focus:not(:hover) > path,
+.c3:focus:not(:hover) > polygon,
+.c3:focus:not(:hover) > polyline,
+.c3:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus::-moz-focus-inner {
+.c3:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c3:focus:not(:focus-visible) {
+.c3:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
+.c3:focus:not(:focus-visible):not(:hover) > circle,
+.c3:focus:not(:focus-visible):not(:hover) > ellipse,
+.c3:focus:not(:focus-visible):not(:hover) > line,
+.c3:focus:not(:focus-visible):not(:hover) > path,
+.c3:focus:not(:focus-visible):not(:hover) > polygon,
+.c3:focus:not(:focus-visible):not(:hover) > polyline,
+.c3:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
+.c3:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -1765,43 +1765,43 @@ exports[`Tabs onClick 1`] = `
   text-align: inherit;
 }
 
-.c3:focus {
+.c3:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
+.c3:focus:not(:hover) > circle,
+.c3:focus:not(:hover) > ellipse,
+.c3:focus:not(:hover) > line,
+.c3:focus:not(:hover) > path,
+.c3:focus:not(:hover) > polygon,
+.c3:focus:not(:hover) > polyline,
+.c3:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus::-moz-focus-inner {
+.c3:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c3:focus:not(:focus-visible) {
+.c3:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
+.c3:focus:not(:focus-visible):not(:hover) > circle,
+.c3:focus:not(:focus-visible):not(:hover) > ellipse,
+.c3:focus:not(:focus-visible):not(:hover) > line,
+.c3:focus:not(:focus-visible):not(:hover) > path,
+.c3:focus:not(:focus-visible):not(:hover) > polygon,
+.c3:focus:not(:focus-visible):not(:hover) > polyline,
+.c3:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
+.c3:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -2047,43 +2047,43 @@ exports[`Tabs set on hover 1`] = `
   text-align: inherit;
 }
 
-.c3:focus {
+.c3:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
+.c3:focus:not(:hover) > circle,
+.c3:focus:not(:hover) > ellipse,
+.c3:focus:not(:hover) > line,
+.c3:focus:not(:hover) > path,
+.c3:focus:not(:hover) > polygon,
+.c3:focus:not(:hover) > polyline,
+.c3:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus::-moz-focus-inner {
+.c3:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c3:focus:not(:focus-visible) {
+.c3:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
+.c3:focus:not(:focus-visible):not(:hover) > circle,
+.c3:focus:not(:focus-visible):not(:hover) > ellipse,
+.c3:focus:not(:focus-visible):not(:hover) > line,
+.c3:focus:not(:focus-visible):not(:hover) > path,
+.c3:focus:not(:focus-visible):not(:hover) > polygon,
+.c3:focus:not(:focus-visible):not(:hover) > polyline,
+.c3:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
+.c3:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -2234,7 +2234,7 @@ exports[`Tabs set on hover 2`] = `
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 eiEooU"
+        class="StyledButton-sc-323bzc-0 gsQNSg"
         role="tab"
         type="button"
       >
@@ -2251,7 +2251,7 @@ exports[`Tabs set on hover 2`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 eiEooU"
+        class="StyledButton-sc-323bzc-0 gsQNSg"
         role="tab"
         type="button"
       >
@@ -2291,7 +2291,7 @@ exports[`Tabs set on hover 3`] = `
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 eiEooU"
+        class="StyledButton-sc-323bzc-0 gsQNSg"
         role="tab"
         type="button"
       >
@@ -2308,7 +2308,7 @@ exports[`Tabs set on hover 3`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 eiEooU"
+        class="StyledButton-sc-323bzc-0 gsQNSg"
         role="tab"
         type="button"
       >
@@ -2348,7 +2348,7 @@ exports[`Tabs set on hover 4`] = `
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 eiEooU"
+        class="StyledButton-sc-323bzc-0 gsQNSg"
         role="tab"
         type="button"
       >
@@ -2365,7 +2365,7 @@ exports[`Tabs set on hover 4`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 eiEooU"
+        class="StyledButton-sc-323bzc-0 gsQNSg"
         role="tab"
         type="button"
       >
@@ -2405,7 +2405,7 @@ exports[`Tabs set on hover 5`] = `
       <button
         aria-expanded="true"
         aria-selected="true"
-        class="StyledButton-sc-323bzc-0 eiEooU"
+        class="StyledButton-sc-323bzc-0 gsQNSg"
         role="tab"
         type="button"
       >
@@ -2422,7 +2422,7 @@ exports[`Tabs set on hover 5`] = `
       <button
         aria-expanded="false"
         aria-selected="false"
-        class="StyledButton-sc-323bzc-0 eiEooU"
+        class="StyledButton-sc-323bzc-0 gsQNSg"
         role="tab"
         type="button"
       >
@@ -2531,43 +2531,43 @@ exports[`Tabs should allow to extend tab styles 1`] = `
   text-align: inherit;
 }
 
-.c3:focus {
+.c3:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
+.c3:focus:not(:hover) > circle,
+.c3:focus:not(:hover) > ellipse,
+.c3:focus:not(:hover) > line,
+.c3:focus:not(:hover) > path,
+.c3:focus:not(:hover) > polygon,
+.c3:focus:not(:hover) > polyline,
+.c3:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus::-moz-focus-inner {
+.c3:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c3:focus:not(:focus-visible) {
+.c3:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
+.c3:focus:not(:focus-visible):not(:hover) > circle,
+.c3:focus:not(:focus-visible):not(:hover) > ellipse,
+.c3:focus:not(:focus-visible):not(:hover) > line,
+.c3:focus:not(:focus-visible):not(:hover) > path,
+.c3:focus:not(:focus-visible):not(:hover) > polygon,
+.c3:focus:not(:focus-visible):not(:hover) > polyline,
+.c3:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
+.c3:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -2794,43 +2794,43 @@ exports[`Tabs should apply custom theme disabled style 1`] = `
   text-align: inherit;
 }
 
-.c3:focus {
+.c3:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
+.c3:focus:not(:hover) > circle,
+.c3:focus:not(:hover) > ellipse,
+.c3:focus:not(:hover) > line,
+.c3:focus:not(:hover) > path,
+.c3:focus:not(:hover) > polygon,
+.c3:focus:not(:hover) > polyline,
+.c3:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus::-moz-focus-inner {
+.c3:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c3:focus:not(:focus-visible) {
+.c3:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
+.c3:focus:not(:focus-visible):not(:hover) > circle,
+.c3:focus:not(:focus-visible):not(:hover) > ellipse,
+.c3:focus:not(:focus-visible):not(:hover) > line,
+.c3:focus:not(:focus-visible):not(:hover) > path,
+.c3:focus:not(:focus-visible):not(:hover) > polygon,
+.c3:focus:not(:focus-visible):not(:hover) > polyline,
+.c3:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
+.c3:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -2854,43 +2854,43 @@ exports[`Tabs should apply custom theme disabled style 1`] = `
   cursor: default;
 }
 
-.c7:focus {
+.c7:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus > circle,
-.c7:focus > ellipse,
-.c7:focus > line,
-.c7:focus > path,
-.c7:focus > polygon,
-.c7:focus > polyline,
-.c7:focus > rect {
+.c7:focus:not(:hover) > circle,
+.c7:focus:not(:hover) > ellipse,
+.c7:focus:not(:hover) > line,
+.c7:focus:not(:hover) > path,
+.c7:focus:not(:hover) > polygon,
+.c7:focus:not(:hover) > polyline,
+.c7:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus::-moz-focus-inner {
+.c7:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c7:focus:not(:focus-visible) {
+.c7:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c7:focus:not(:focus-visible) > circle,
-.c7:focus:not(:focus-visible) > ellipse,
-.c7:focus:not(:focus-visible) > line,
-.c7:focus:not(:focus-visible) > path,
-.c7:focus:not(:focus-visible) > polygon,
-.c7:focus:not(:focus-visible) > polyline,
-.c7:focus:not(:focus-visible) > rect {
+.c7:focus:not(:focus-visible):not(:hover) > circle,
+.c7:focus:not(:focus-visible):not(:hover) > ellipse,
+.c7:focus:not(:focus-visible):not(:hover) > line,
+.c7:focus:not(:focus-visible):not(:hover) > path,
+.c7:focus:not(:focus-visible):not(:hover) > polygon,
+.c7:focus:not(:focus-visible):not(:hover) > polyline,
+.c7:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c7:focus:not(:focus-visible)::-moz-focus-inner {
+.c7:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -3467,43 +3467,43 @@ exports[`Tabs should have no accessibility violations 1`] = `
   text-align: inherit;
 }
 
-.c3:focus {
+.c3:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
+.c3:focus:not(:hover) > circle,
+.c3:focus:not(:hover) > ellipse,
+.c3:focus:not(:hover) > line,
+.c3:focus:not(:hover) > path,
+.c3:focus:not(:hover) > polygon,
+.c3:focus:not(:hover) > polyline,
+.c3:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus::-moz-focus-inner {
+.c3:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c3:focus:not(:focus-visible) {
+.c3:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
+.c3:focus:not(:focus-visible):not(:hover) > circle,
+.c3:focus:not(:focus-visible):not(:hover) > ellipse,
+.c3:focus:not(:focus-visible):not(:hover) > line,
+.c3:focus:not(:focus-visible):not(:hover) > path,
+.c3:focus:not(:focus-visible):not(:hover) > polygon,
+.c3:focus:not(:focus-visible):not(:hover) > polyline,
+.c3:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
+.c3:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -3649,43 +3649,43 @@ exports[`Tabs should have no default styles with plain prop 1`] = `
   text-align: inherit;
 }
 
-.c3:focus {
+.c3:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
+.c3:focus:not(:hover) > circle,
+.c3:focus:not(:hover) > ellipse,
+.c3:focus:not(:hover) > line,
+.c3:focus:not(:hover) > path,
+.c3:focus:not(:hover) > polygon,
+.c3:focus:not(:hover) > polyline,
+.c3:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus::-moz-focus-inner {
+.c3:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c3:focus:not(:focus-visible) {
+.c3:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
+.c3:focus:not(:focus-visible):not(:hover) > circle,
+.c3:focus:not(:focus-visible):not(:hover) > ellipse,
+.c3:focus:not(:focus-visible):not(:hover) > line,
+.c3:focus:not(:focus-visible):not(:hover) > path,
+.c3:focus:not(:focus-visible):not(:hover) > polygon,
+.c3:focus:not(:focus-visible):not(:hover) > polyline,
+.c3:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
+.c3:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -3845,43 +3845,43 @@ exports[`Tabs should style as disabled 1`] = `
   text-align: inherit;
 }
 
-.c3:focus {
+.c3:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
+.c3:focus:not(:hover) > circle,
+.c3:focus:not(:hover) > ellipse,
+.c3:focus:not(:hover) > line,
+.c3:focus:not(:hover) > path,
+.c3:focus:not(:hover) > polygon,
+.c3:focus:not(:hover) > polyline,
+.c3:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus::-moz-focus-inner {
+.c3:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c3:focus:not(:focus-visible) {
+.c3:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
+.c3:focus:not(:focus-visible):not(:hover) > circle,
+.c3:focus:not(:focus-visible):not(:hover) > ellipse,
+.c3:focus:not(:focus-visible):not(:hover) > line,
+.c3:focus:not(:focus-visible):not(:hover) > path,
+.c3:focus:not(:focus-visible):not(:hover) > polygon,
+.c3:focus:not(:focus-visible):not(:hover) > polyline,
+.c3:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
+.c3:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -3905,43 +3905,43 @@ exports[`Tabs should style as disabled 1`] = `
   cursor: default;
 }
 
-.c7:focus {
+.c7:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus > circle,
-.c7:focus > ellipse,
-.c7:focus > line,
-.c7:focus > path,
-.c7:focus > polygon,
-.c7:focus > polyline,
-.c7:focus > rect {
+.c7:focus:not(:hover) > circle,
+.c7:focus:not(:hover) > ellipse,
+.c7:focus:not(:hover) > line,
+.c7:focus:not(:hover) > path,
+.c7:focus:not(:hover) > polygon,
+.c7:focus:not(:hover) > polyline,
+.c7:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus::-moz-focus-inner {
+.c7:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c7:focus:not(:focus-visible) {
+.c7:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c7:focus:not(:focus-visible) > circle,
-.c7:focus:not(:focus-visible) > ellipse,
-.c7:focus:not(:focus-visible) > line,
-.c7:focus:not(:focus-visible) > path,
-.c7:focus:not(:focus-visible) > polygon,
-.c7:focus:not(:focus-visible) > polyline,
-.c7:focus:not(:focus-visible) > rect {
+.c7:focus:not(:focus-visible):not(:hover) > circle,
+.c7:focus:not(:focus-visible):not(:hover) > ellipse,
+.c7:focus:not(:focus-visible):not(:hover) > line,
+.c7:focus:not(:focus-visible):not(:hover) > path,
+.c7:focus:not(:focus-visible):not(:hover) > polygon,
+.c7:focus:not(:focus-visible):not(:hover) > polyline,
+.c7:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c7:focus:not(:focus-visible)::-moz-focus-inner {
+.c7:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -4196,43 +4196,43 @@ exports[`Tabs styled component should change tab color when active 1`] = `
   text-align: inherit;
 }
 
-.c3:focus {
+.c3:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
+.c3:focus:not(:hover) > circle,
+.c3:focus:not(:hover) > ellipse,
+.c3:focus:not(:hover) > line,
+.c3:focus:not(:hover) > path,
+.c3:focus:not(:hover) > polygon,
+.c3:focus:not(:hover) > polyline,
+.c3:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus::-moz-focus-inner {
+.c3:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c3:focus:not(:focus-visible) {
+.c3:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
+.c3:focus:not(:focus-visible):not(:hover) > circle,
+.c3:focus:not(:focus-visible):not(:hover) > ellipse,
+.c3:focus:not(:focus-visible):not(:hover) > line,
+.c3:focus:not(:focus-visible):not(:hover) > path,
+.c3:focus:not(:focus-visible):not(:hover) > polygon,
+.c3:focus:not(:focus-visible):not(:hover) > polyline,
+.c3:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
+.c3:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -4527,43 +4527,43 @@ exports[`Tabs with icon + reverse 1`] = `
   text-align: inherit;
 }
 
-.c3:focus {
+.c3:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
+.c3:focus:not(:hover) > circle,
+.c3:focus:not(:hover) > ellipse,
+.c3:focus:not(:hover) > line,
+.c3:focus:not(:hover) > path,
+.c3:focus:not(:hover) > polygon,
+.c3:focus:not(:hover) > polyline,
+.c3:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus::-moz-focus-inner {
+.c3:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c3:focus:not(:focus-visible) {
+.c3:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
+.c3:focus:not(:focus-visible):not(:hover) > circle,
+.c3:focus:not(:focus-visible):not(:hover) > ellipse,
+.c3:focus:not(:focus-visible):not(:hover) > line,
+.c3:focus:not(:focus-visible):not(:hover) > path,
+.c3:focus:not(:focus-visible):not(:hover) > polygon,
+.c3:focus:not(:focus-visible):not(:hover) > polyline,
+.c3:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
+.c3:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 

--- a/src/js/components/Tag/__tests__/__snapshots__/Tag-test.tsx.snap
+++ b/src/js/components/Tag/__tests__/__snapshots__/Tag-test.tsx.snap
@@ -180,43 +180,48 @@ exports[`Tag onClick 1`] = `
   text-align: inherit;
 }
 
-.c1:focus {
+.c1:hover {
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
+}
+
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -399,43 +404,48 @@ exports[`Tag onRemove 1`] = `
   line-height: 0;
 }
 
-.c5:focus {
+.c5:hover {
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
+}
+
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 

--- a/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.tsx.snap
+++ b/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.tsx.snap
@@ -376,43 +376,43 @@ exports[`TextInput calls onSuggestionsClose 2`] = `
   width: 100%;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -610,43 +610,43 @@ exports[`TextInput calls onSuggestionsOpen 1`] = `
   width: 100%;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -921,43 +921,43 @@ exports[`TextInput close suggestion drop 2`] = `
   width: 100%;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -1251,43 +1251,43 @@ exports[`TextInput complex suggestions 2`] = `
   width: 100%;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -2055,43 +2055,43 @@ exports[`TextInput large drop height 1`] = `
   width: 100%;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -2270,43 +2270,43 @@ exports[`TextInput medium drop height 1`] = `
   width: 100%;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -3756,43 +3756,43 @@ exports[`TextInput select suggestion 2`] = `
   width: 100%;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -4719,43 +4719,43 @@ exports[`TextInput small drop height 1`] = `
   width: 100%;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -5016,43 +5016,43 @@ exports[`TextInput suggestions 2`] = `
   width: 100%;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 

--- a/src/js/components/Tip/__tests__/__snapshots__/Tip-test.tsx.snap
+++ b/src/js/components/Tip/__tests__/__snapshots__/Tip-test.tsx.snap
@@ -154,43 +154,47 @@ exports[`Tip focus and blur events on the Tip's child 1`] = `
   transition-timing-function: ease-in-out;
 }
 
-.c1:focus {
+.c1:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -221,7 +225,7 @@ exports[`Tip focus and blur events on the Tip's child 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 bUiuPe"
 >
   <button
-    class="StyledButton-sc-323bzc-0 LnlOO"
+    class="StyledButton-sc-323bzc-0 dJfmuO"
     type="button"
   >
     Test Events

--- a/src/js/components/Video/__tests__/__snapshots__/Video-test.js.snap
+++ b/src/js/components/Video/__tests__/__snapshots__/Video-test.js.snap
@@ -189,43 +189,43 @@ exports[`Video Configure Menu Button 1`] = `
   color: #FFFFFF;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -247,43 +247,43 @@ exports[`Video Configure Menu Button 1`] = `
   text-align: inherit;
 }
 
-.c16:focus {
+.c16:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c16:focus > circle,
-.c16:focus > ellipse,
-.c16:focus > line,
-.c16:focus > path,
-.c16:focus > polygon,
-.c16:focus > polyline,
-.c16:focus > rect {
+.c16:focus:not(:hover) > circle,
+.c16:focus:not(:hover) > ellipse,
+.c16:focus:not(:hover) > line,
+.c16:focus:not(:hover) > path,
+.c16:focus:not(:hover) > polygon,
+.c16:focus:not(:hover) > polyline,
+.c16:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c16:focus::-moz-focus-inner {
+.c16:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c16:focus:not(:focus-visible) {
+.c16:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c16:focus:not(:focus-visible) > circle,
-.c16:focus:not(:focus-visible) > ellipse,
-.c16:focus:not(:focus-visible) > line,
-.c16:focus:not(:focus-visible) > path,
-.c16:focus:not(:focus-visible) > polygon,
-.c16:focus:not(:focus-visible) > polyline,
-.c16:focus:not(:focus-visible) > rect {
+.c16:focus:not(:focus-visible):not(:hover) > circle,
+.c16:focus:not(:focus-visible):not(:hover) > ellipse,
+.c16:focus:not(:focus-visible):not(:hover) > line,
+.c16:focus:not(:focus-visible):not(:hover) > path,
+.c16:focus:not(:focus-visible):not(:hover) > polygon,
+.c16:focus:not(:focus-visible):not(:hover) > polyline,
+.c16:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c16:focus:not(:focus-visible)::-moz-focus-inner {
+.c16:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -688,43 +688,43 @@ exports[`Video End event handler 1`] = `
   color: #FFFFFF;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -746,43 +746,43 @@ exports[`Video End event handler 1`] = `
   text-align: inherit;
 }
 
-.c16:focus {
+.c16:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c16:focus > circle,
-.c16:focus > ellipse,
-.c16:focus > line,
-.c16:focus > path,
-.c16:focus > polygon,
-.c16:focus > polyline,
-.c16:focus > rect {
+.c16:focus:not(:hover) > circle,
+.c16:focus:not(:hover) > ellipse,
+.c16:focus:not(:hover) > line,
+.c16:focus:not(:hover) > path,
+.c16:focus:not(:hover) > polygon,
+.c16:focus:not(:hover) > polyline,
+.c16:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c16:focus::-moz-focus-inner {
+.c16:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c16:focus:not(:focus-visible) {
+.c16:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c16:focus:not(:focus-visible) > circle,
-.c16:focus:not(:focus-visible) > ellipse,
-.c16:focus:not(:focus-visible) > line,
-.c16:focus:not(:focus-visible) > path,
-.c16:focus:not(:focus-visible) > polygon,
-.c16:focus:not(:focus-visible) > polyline,
-.c16:focus:not(:focus-visible) > rect {
+.c16:focus:not(:focus-visible):not(:hover) > circle,
+.c16:focus:not(:focus-visible):not(:hover) > ellipse,
+.c16:focus:not(:focus-visible):not(:hover) > line,
+.c16:focus:not(:focus-visible):not(:hover) > path,
+.c16:focus:not(:focus-visible):not(:hover) > polygon,
+.c16:focus:not(:focus-visible):not(:hover) > polyline,
+.c16:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c16:focus:not(:focus-visible)::-moz-focus-inner {
+.c16:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -1175,43 +1175,43 @@ exports[`Video Play and Pause event handlers 1`] = `
   color: #FFFFFF;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -1233,43 +1233,43 @@ exports[`Video Play and Pause event handlers 1`] = `
   text-align: inherit;
 }
 
-.c16:focus {
+.c16:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c16:focus > circle,
-.c16:focus > ellipse,
-.c16:focus > line,
-.c16:focus > path,
-.c16:focus > polygon,
-.c16:focus > polyline,
-.c16:focus > rect {
+.c16:focus:not(:hover) > circle,
+.c16:focus:not(:hover) > ellipse,
+.c16:focus:not(:hover) > line,
+.c16:focus:not(:hover) > path,
+.c16:focus:not(:hover) > polygon,
+.c16:focus:not(:hover) > polyline,
+.c16:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c16:focus::-moz-focus-inner {
+.c16:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c16:focus:not(:focus-visible) {
+.c16:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c16:focus:not(:focus-visible) > circle,
-.c16:focus:not(:focus-visible) > ellipse,
-.c16:focus:not(:focus-visible) > line,
-.c16:focus:not(:focus-visible) > path,
-.c16:focus:not(:focus-visible) > polygon,
-.c16:focus:not(:focus-visible) > polyline,
-.c16:focus:not(:focus-visible) > rect {
+.c16:focus:not(:focus-visible):not(:hover) > circle,
+.c16:focus:not(:focus-visible):not(:hover) > ellipse,
+.c16:focus:not(:focus-visible):not(:hover) > line,
+.c16:focus:not(:focus-visible):not(:hover) > path,
+.c16:focus:not(:focus-visible):not(:hover) > polygon,
+.c16:focus:not(:focus-visible):not(:hover) > polyline,
+.c16:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c16:focus:not(:focus-visible)::-moz-focus-inner {
+.c16:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -1496,7 +1496,7 @@ exports[`Video Play and Pause event handlers 2`] = `
         class="StyledBox-sc-13pk1d4-0 dbooEK"
       >
         <button
-          class="StyledButton-sc-323bzc-0 lbPHCq"
+          class="StyledButton-sc-323bzc-0 jaFvoO"
           type="button"
         >
           .c0 {
@@ -1609,7 +1609,7 @@ exports[`Video Play and Pause event handlers 2`] = `
           aria-expanded="false"
           aria-haspopup="menu"
           aria-label="open menu"
-          class="StyledButton-sc-323bzc-0 eiEooU"
+          class="StyledButton-sc-323bzc-0 gsQNSg"
           type="button"
         >
           <div
@@ -1827,43 +1827,43 @@ exports[`Video autoPlay renders 1`] = `
   color: #FFFFFF;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -1885,43 +1885,43 @@ exports[`Video autoPlay renders 1`] = `
   text-align: inherit;
 }
 
-.c16:focus {
+.c16:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c16:focus > circle,
-.c16:focus > ellipse,
-.c16:focus > line,
-.c16:focus > path,
-.c16:focus > polygon,
-.c16:focus > polyline,
-.c16:focus > rect {
+.c16:focus:not(:hover) > circle,
+.c16:focus:not(:hover) > ellipse,
+.c16:focus:not(:hover) > line,
+.c16:focus:not(:hover) > path,
+.c16:focus:not(:hover) > polygon,
+.c16:focus:not(:hover) > polyline,
+.c16:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c16:focus::-moz-focus-inner {
+.c16:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c16:focus:not(:focus-visible) {
+.c16:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c16:focus:not(:focus-visible) > circle,
-.c16:focus:not(:focus-visible) > ellipse,
-.c16:focus:not(:focus-visible) > line,
-.c16:focus:not(:focus-visible) > path,
-.c16:focus:not(:focus-visible) > polygon,
-.c16:focus:not(:focus-visible) > polyline,
-.c16:focus:not(:focus-visible) > rect {
+.c16:focus:not(:focus-visible):not(:hover) > circle,
+.c16:focus:not(:focus-visible):not(:hover) > ellipse,
+.c16:focus:not(:focus-visible):not(:hover) > line,
+.c16:focus:not(:focus-visible):not(:hover) > path,
+.c16:focus:not(:focus-visible):not(:hover) > polygon,
+.c16:focus:not(:focus-visible):not(:hover) > polyline,
+.c16:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c16:focus:not(:focus-visible)::-moz-focus-inner {
+.c16:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -2313,43 +2313,43 @@ exports[`Video controls below renders 1`] = `
   color: #000000;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -2371,43 +2371,43 @@ exports[`Video controls below renders 1`] = `
   text-align: inherit;
 }
 
-.c16:focus {
+.c16:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c16:focus > circle,
-.c16:focus > ellipse,
-.c16:focus > line,
-.c16:focus > path,
-.c16:focus > polygon,
-.c16:focus > polyline,
-.c16:focus > rect {
+.c16:focus:not(:hover) > circle,
+.c16:focus:not(:hover) > ellipse,
+.c16:focus:not(:hover) > line,
+.c16:focus:not(:hover) > path,
+.c16:focus:not(:hover) > polygon,
+.c16:focus:not(:hover) > polyline,
+.c16:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c16:focus::-moz-focus-inner {
+.c16:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c16:focus:not(:focus-visible) {
+.c16:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c16:focus:not(:focus-visible) > circle,
-.c16:focus:not(:focus-visible) > ellipse,
-.c16:focus:not(:focus-visible) > line,
-.c16:focus:not(:focus-visible) > path,
-.c16:focus:not(:focus-visible) > polygon,
-.c16:focus:not(:focus-visible) > polyline,
-.c16:focus:not(:focus-visible) > rect {
+.c16:focus:not(:focus-visible):not(:hover) > circle,
+.c16:focus:not(:focus-visible):not(:hover) > ellipse,
+.c16:focus:not(:focus-visible):not(:hover) > line,
+.c16:focus:not(:focus-visible):not(:hover) > path,
+.c16:focus:not(:focus-visible):not(:hover) > polygon,
+.c16:focus:not(:focus-visible):not(:hover) > polyline,
+.c16:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c16:focus:not(:focus-visible)::-moz-focus-inner {
+.c16:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -2796,43 +2796,43 @@ exports[`Video controls over renders 1`] = `
   color: #FFFFFF;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -2854,43 +2854,43 @@ exports[`Video controls over renders 1`] = `
   text-align: inherit;
 }
 
-.c16:focus {
+.c16:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c16:focus > circle,
-.c16:focus > ellipse,
-.c16:focus > line,
-.c16:focus > path,
-.c16:focus > polygon,
-.c16:focus > polyline,
-.c16:focus > rect {
+.c16:focus:not(:hover) > circle,
+.c16:focus:not(:hover) > ellipse,
+.c16:focus:not(:hover) > line,
+.c16:focus:not(:hover) > path,
+.c16:focus:not(:hover) > polygon,
+.c16:focus:not(:hover) > polyline,
+.c16:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c16:focus::-moz-focus-inner {
+.c16:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c16:focus:not(:focus-visible) {
+.c16:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c16:focus:not(:focus-visible) > circle,
-.c16:focus:not(:focus-visible) > ellipse,
-.c16:focus:not(:focus-visible) > line,
-.c16:focus:not(:focus-visible) > path,
-.c16:focus:not(:focus-visible) > polygon,
-.c16:focus:not(:focus-visible) > polyline,
-.c16:focus:not(:focus-visible) > rect {
+.c16:focus:not(:focus-visible):not(:hover) > circle,
+.c16:focus:not(:focus-visible):not(:hover) > ellipse,
+.c16:focus:not(:focus-visible):not(:hover) > line,
+.c16:focus:not(:focus-visible):not(:hover) > path,
+.c16:focus:not(:focus-visible):not(:hover) > polygon,
+.c16:focus:not(:focus-visible):not(:hover) > polyline,
+.c16:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c16:focus:not(:focus-visible)::-moz-focus-inner {
+.c16:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -3283,43 +3283,43 @@ exports[`Video duration event handler 1`] = `
   color: #FFFFFF;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -3341,43 +3341,43 @@ exports[`Video duration event handler 1`] = `
   text-align: inherit;
 }
 
-.c16:focus {
+.c16:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c16:focus > circle,
-.c16:focus > ellipse,
-.c16:focus > line,
-.c16:focus > path,
-.c16:focus > polygon,
-.c16:focus > polyline,
-.c16:focus > rect {
+.c16:focus:not(:hover) > circle,
+.c16:focus:not(:hover) > ellipse,
+.c16:focus:not(:hover) > line,
+.c16:focus:not(:hover) > path,
+.c16:focus:not(:hover) > polygon,
+.c16:focus:not(:hover) > polyline,
+.c16:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c16:focus::-moz-focus-inner {
+.c16:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c16:focus:not(:focus-visible) {
+.c16:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c16:focus:not(:focus-visible) > circle,
-.c16:focus:not(:focus-visible) > ellipse,
-.c16:focus:not(:focus-visible) > line,
-.c16:focus:not(:focus-visible) > path,
-.c16:focus:not(:focus-visible) > polygon,
-.c16:focus:not(:focus-visible) > polyline,
-.c16:focus:not(:focus-visible) > rect {
+.c16:focus:not(:focus-visible):not(:hover) > circle,
+.c16:focus:not(:focus-visible):not(:hover) > ellipse,
+.c16:focus:not(:focus-visible):not(:hover) > line,
+.c16:focus:not(:focus-visible):not(:hover) > path,
+.c16:focus:not(:focus-visible):not(:hover) > polygon,
+.c16:focus:not(:focus-visible):not(:hover) > polyline,
+.c16:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c16:focus:not(:focus-visible)::-moz-focus-inner {
+.c16:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -3770,43 +3770,43 @@ exports[`Video fit  cover renders 1`] = `
   color: #FFFFFF;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -3828,43 +3828,43 @@ exports[`Video fit  cover renders 1`] = `
   text-align: inherit;
 }
 
-.c16:focus {
+.c16:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c16:focus > circle,
-.c16:focus > ellipse,
-.c16:focus > line,
-.c16:focus > path,
-.c16:focus > polygon,
-.c16:focus > polyline,
-.c16:focus > rect {
+.c16:focus:not(:hover) > circle,
+.c16:focus:not(:hover) > ellipse,
+.c16:focus:not(:hover) > line,
+.c16:focus:not(:hover) > path,
+.c16:focus:not(:hover) > polygon,
+.c16:focus:not(:hover) > polyline,
+.c16:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c16:focus::-moz-focus-inner {
+.c16:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c16:focus:not(:focus-visible) {
+.c16:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c16:focus:not(:focus-visible) > circle,
-.c16:focus:not(:focus-visible) > ellipse,
-.c16:focus:not(:focus-visible) > line,
-.c16:focus:not(:focus-visible) > path,
-.c16:focus:not(:focus-visible) > polygon,
-.c16:focus:not(:focus-visible) > polyline,
-.c16:focus:not(:focus-visible) > rect {
+.c16:focus:not(:focus-visible):not(:hover) > circle,
+.c16:focus:not(:focus-visible):not(:hover) > ellipse,
+.c16:focus:not(:focus-visible):not(:hover) > line,
+.c16:focus:not(:focus-visible):not(:hover) > path,
+.c16:focus:not(:focus-visible):not(:hover) > polygon,
+.c16:focus:not(:focus-visible):not(:hover) > polyline,
+.c16:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c16:focus:not(:focus-visible)::-moz-focus-inner {
+.c16:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -4262,43 +4262,43 @@ exports[`Video fit contain renders 1`] = `
   color: #FFFFFF;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -4320,43 +4320,43 @@ exports[`Video fit contain renders 1`] = `
   text-align: inherit;
 }
 
-.c16:focus {
+.c16:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c16:focus > circle,
-.c16:focus > ellipse,
-.c16:focus > line,
-.c16:focus > path,
-.c16:focus > polygon,
-.c16:focus > polyline,
-.c16:focus > rect {
+.c16:focus:not(:hover) > circle,
+.c16:focus:not(:hover) > ellipse,
+.c16:focus:not(:hover) > line,
+.c16:focus:not(:hover) > path,
+.c16:focus:not(:hover) > polygon,
+.c16:focus:not(:hover) > polyline,
+.c16:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c16:focus::-moz-focus-inner {
+.c16:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c16:focus:not(:focus-visible) {
+.c16:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c16:focus:not(:focus-visible) > circle,
-.c16:focus:not(:focus-visible) > ellipse,
-.c16:focus:not(:focus-visible) > line,
-.c16:focus:not(:focus-visible) > path,
-.c16:focus:not(:focus-visible) > polygon,
-.c16:focus:not(:focus-visible) > polyline,
-.c16:focus:not(:focus-visible) > rect {
+.c16:focus:not(:focus-visible):not(:hover) > circle,
+.c16:focus:not(:focus-visible):not(:hover) > ellipse,
+.c16:focus:not(:focus-visible):not(:hover) > line,
+.c16:focus:not(:focus-visible):not(:hover) > path,
+.c16:focus:not(:focus-visible):not(:hover) > polygon,
+.c16:focus:not(:focus-visible):not(:hover) > polyline,
+.c16:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c16:focus:not(:focus-visible)::-moz-focus-inner {
+.c16:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -4754,43 +4754,43 @@ exports[`Video loop renders 1`] = `
   color: #FFFFFF;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -4812,43 +4812,43 @@ exports[`Video loop renders 1`] = `
   text-align: inherit;
 }
 
-.c16:focus {
+.c16:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c16:focus > circle,
-.c16:focus > ellipse,
-.c16:focus > line,
-.c16:focus > path,
-.c16:focus > polygon,
-.c16:focus > polyline,
-.c16:focus > rect {
+.c16:focus:not(:hover) > circle,
+.c16:focus:not(:hover) > ellipse,
+.c16:focus:not(:hover) > line,
+.c16:focus:not(:hover) > path,
+.c16:focus:not(:hover) > polygon,
+.c16:focus:not(:hover) > polyline,
+.c16:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c16:focus::-moz-focus-inner {
+.c16:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c16:focus:not(:focus-visible) {
+.c16:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c16:focus:not(:focus-visible) > circle,
-.c16:focus:not(:focus-visible) > ellipse,
-.c16:focus:not(:focus-visible) > line,
-.c16:focus:not(:focus-visible) > path,
-.c16:focus:not(:focus-visible) > polygon,
-.c16:focus:not(:focus-visible) > polyline,
-.c16:focus:not(:focus-visible) > rect {
+.c16:focus:not(:focus-visible):not(:hover) > circle,
+.c16:focus:not(:focus-visible):not(:hover) > ellipse,
+.c16:focus:not(:focus-visible):not(:hover) > line,
+.c16:focus:not(:focus-visible):not(:hover) > path,
+.c16:focus:not(:focus-visible):not(:hover) > polygon,
+.c16:focus:not(:focus-visible):not(:hover) > polyline,
+.c16:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c16:focus:not(:focus-visible)::-moz-focus-inner {
+.c16:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -5242,43 +5242,43 @@ exports[`Video mouse events handlers of controls 1`] = `
   color: #FFFFFF;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -5300,43 +5300,43 @@ exports[`Video mouse events handlers of controls 1`] = `
   text-align: inherit;
 }
 
-.c16:focus {
+.c16:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c16:focus > circle,
-.c16:focus > ellipse,
-.c16:focus > line,
-.c16:focus > path,
-.c16:focus > polygon,
-.c16:focus > polyline,
-.c16:focus > rect {
+.c16:focus:not(:hover) > circle,
+.c16:focus:not(:hover) > ellipse,
+.c16:focus:not(:hover) > line,
+.c16:focus:not(:hover) > path,
+.c16:focus:not(:hover) > polygon,
+.c16:focus:not(:hover) > polyline,
+.c16:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c16:focus::-moz-focus-inner {
+.c16:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c16:focus:not(:focus-visible) {
+.c16:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c16:focus:not(:focus-visible) > circle,
-.c16:focus:not(:focus-visible) > ellipse,
-.c16:focus:not(:focus-visible) > line,
-.c16:focus:not(:focus-visible) > path,
-.c16:focus:not(:focus-visible) > polygon,
-.c16:focus:not(:focus-visible) > polyline,
-.c16:focus:not(:focus-visible) > rect {
+.c16:focus:not(:focus-visible):not(:hover) > circle,
+.c16:focus:not(:focus-visible):not(:hover) > ellipse,
+.c16:focus:not(:focus-visible):not(:hover) > line,
+.c16:focus:not(:focus-visible):not(:hover) > path,
+.c16:focus:not(:focus-visible):not(:hover) > polygon,
+.c16:focus:not(:focus-visible):not(:hover) > polyline,
+.c16:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c16:focus:not(:focus-visible)::-moz-focus-inner {
+.c16:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -5563,7 +5563,7 @@ exports[`Video mouse events handlers of controls 2`] = `
         class="StyledBox-sc-13pk1d4-0 dbooEK"
       >
         <button
-          class="StyledButton-sc-323bzc-0 lbPHCq"
+          class="StyledButton-sc-323bzc-0 jaFvoO"
           type="button"
         >
           <svg
@@ -5634,7 +5634,7 @@ exports[`Video mouse events handlers of controls 2`] = `
           aria-expanded="false"
           aria-haspopup="menu"
           aria-label="open menu"
-          class="StyledButton-sc-323bzc-0 eiEooU"
+          class="StyledButton-sc-323bzc-0 gsQNSg"
           type="button"
         >
           <div
@@ -5686,7 +5686,7 @@ exports[`Video mouse events handlers of controls 3`] = `
         class="StyledBox-sc-13pk1d4-0 dbooEK"
       >
         <button
-          class="StyledButton-sc-323bzc-0 lbPHCq"
+          class="StyledButton-sc-323bzc-0 jaFvoO"
           type="button"
         >
           <svg
@@ -5757,7 +5757,7 @@ exports[`Video mouse events handlers of controls 3`] = `
           aria-expanded="false"
           aria-haspopup="menu"
           aria-label="open menu"
-          class="StyledButton-sc-323bzc-0 eiEooU"
+          class="StyledButton-sc-323bzc-0 gsQNSg"
           type="button"
         >
           <div
@@ -5975,43 +5975,43 @@ exports[`Video mute renders 1`] = `
   color: #FFFFFF;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -6033,43 +6033,43 @@ exports[`Video mute renders 1`] = `
   text-align: inherit;
 }
 
-.c16:focus {
+.c16:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c16:focus > circle,
-.c16:focus > ellipse,
-.c16:focus > line,
-.c16:focus > path,
-.c16:focus > polygon,
-.c16:focus > polyline,
-.c16:focus > rect {
+.c16:focus:not(:hover) > circle,
+.c16:focus:not(:hover) > ellipse,
+.c16:focus:not(:hover) > line,
+.c16:focus:not(:hover) > path,
+.c16:focus:not(:hover) > polygon,
+.c16:focus:not(:hover) > polyline,
+.c16:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c16:focus::-moz-focus-inner {
+.c16:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c16:focus:not(:focus-visible) {
+.c16:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c16:focus:not(:focus-visible) > circle,
-.c16:focus:not(:focus-visible) > ellipse,
-.c16:focus:not(:focus-visible) > line,
-.c16:focus:not(:focus-visible) > path,
-.c16:focus:not(:focus-visible) > polygon,
-.c16:focus:not(:focus-visible) > polyline,
-.c16:focus:not(:focus-visible) > rect {
+.c16:focus:not(:focus-visible):not(:hover) > circle,
+.c16:focus:not(:focus-visible):not(:hover) > ellipse,
+.c16:focus:not(:focus-visible):not(:hover) > line,
+.c16:focus:not(:focus-visible):not(:hover) > path,
+.c16:focus:not(:focus-visible):not(:hover) > polygon,
+.c16:focus:not(:focus-visible):not(:hover) > polyline,
+.c16:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c16:focus:not(:focus-visible)::-moz-focus-inner {
+.c16:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -6462,43 +6462,43 @@ exports[`Video renders 1`] = `
   color: #FFFFFF;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -6520,43 +6520,43 @@ exports[`Video renders 1`] = `
   text-align: inherit;
 }
 
-.c16:focus {
+.c16:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c16:focus > circle,
-.c16:focus > ellipse,
-.c16:focus > line,
-.c16:focus > path,
-.c16:focus > polygon,
-.c16:focus > polyline,
-.c16:focus > rect {
+.c16:focus:not(:hover) > circle,
+.c16:focus:not(:hover) > ellipse,
+.c16:focus:not(:hover) > line,
+.c16:focus:not(:hover) > path,
+.c16:focus:not(:hover) > polygon,
+.c16:focus:not(:hover) > polyline,
+.c16:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c16:focus::-moz-focus-inner {
+.c16:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c16:focus:not(:focus-visible) {
+.c16:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c16:focus:not(:focus-visible) > circle,
-.c16:focus:not(:focus-visible) > ellipse,
-.c16:focus:not(:focus-visible) > line,
-.c16:focus:not(:focus-visible) > path,
-.c16:focus:not(:focus-visible) > polygon,
-.c16:focus:not(:focus-visible) > polyline,
-.c16:focus:not(:focus-visible) > rect {
+.c16:focus:not(:focus-visible):not(:hover) > circle,
+.c16:focus:not(:focus-visible):not(:hover) > ellipse,
+.c16:focus:not(:focus-visible):not(:hover) > line,
+.c16:focus:not(:focus-visible):not(:hover) > path,
+.c16:focus:not(:focus-visible):not(:hover) > polygon,
+.c16:focus:not(:focus-visible):not(:hover) > polyline,
+.c16:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c16:focus:not(:focus-visible)::-moz-focus-inner {
+.c16:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -6949,43 +6949,43 @@ exports[`Video renders with theme 1`] = `
   color: #FFFFFF;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -7007,43 +7007,43 @@ exports[`Video renders with theme 1`] = `
   text-align: inherit;
 }
 
-.c16:focus {
+.c16:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c16:focus > circle,
-.c16:focus > ellipse,
-.c16:focus > line,
-.c16:focus > path,
-.c16:focus > polygon,
-.c16:focus > polyline,
-.c16:focus > rect {
+.c16:focus:not(:hover) > circle,
+.c16:focus:not(:hover) > ellipse,
+.c16:focus:not(:hover) > line,
+.c16:focus:not(:hover) > path,
+.c16:focus:not(:hover) > polygon,
+.c16:focus:not(:hover) > polyline,
+.c16:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c16:focus::-moz-focus-inner {
+.c16:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c16:focus:not(:focus-visible) {
+.c16:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c16:focus:not(:focus-visible) > circle,
-.c16:focus:not(:focus-visible) > ellipse,
-.c16:focus:not(:focus-visible) > line,
-.c16:focus:not(:focus-visible) > path,
-.c16:focus:not(:focus-visible) > polygon,
-.c16:focus:not(:focus-visible) > polyline,
-.c16:focus:not(:focus-visible) > rect {
+.c16:focus:not(:focus-visible):not(:hover) > circle,
+.c16:focus:not(:focus-visible):not(:hover) > ellipse,
+.c16:focus:not(:focus-visible):not(:hover) > line,
+.c16:focus:not(:focus-visible):not(:hover) > path,
+.c16:focus:not(:focus-visible):not(:hover) > polygon,
+.c16:focus:not(:focus-visible):not(:hover) > polyline,
+.c16:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c16:focus:not(:focus-visible)::-moz-focus-inner {
+.c16:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -7436,43 +7436,43 @@ exports[`Video scrubber 1`] = `
   color: #FFFFFF;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -7494,43 +7494,43 @@ exports[`Video scrubber 1`] = `
   text-align: inherit;
 }
 
-.c16:focus {
+.c16:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c16:focus > circle,
-.c16:focus > ellipse,
-.c16:focus > line,
-.c16:focus > path,
-.c16:focus > polygon,
-.c16:focus > polyline,
-.c16:focus > rect {
+.c16:focus:not(:hover) > circle,
+.c16:focus:not(:hover) > ellipse,
+.c16:focus:not(:hover) > line,
+.c16:focus:not(:hover) > path,
+.c16:focus:not(:hover) > polygon,
+.c16:focus:not(:hover) > polyline,
+.c16:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c16:focus::-moz-focus-inner {
+.c16:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c16:focus:not(:focus-visible) {
+.c16:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c16:focus:not(:focus-visible) > circle,
-.c16:focus:not(:focus-visible) > ellipse,
-.c16:focus:not(:focus-visible) > line,
-.c16:focus:not(:focus-visible) > path,
-.c16:focus:not(:focus-visible) > polygon,
-.c16:focus:not(:focus-visible) > polyline,
-.c16:focus:not(:focus-visible) > rect {
+.c16:focus:not(:focus-visible):not(:hover) > circle,
+.c16:focus:not(:focus-visible):not(:hover) > ellipse,
+.c16:focus:not(:focus-visible):not(:hover) > line,
+.c16:focus:not(:focus-visible):not(:hover) > path,
+.c16:focus:not(:focus-visible):not(:hover) > polygon,
+.c16:focus:not(:focus-visible):not(:hover) > polyline,
+.c16:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c16:focus:not(:focus-visible)::-moz-focus-inner {
+.c16:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -7757,7 +7757,7 @@ exports[`Video scrubber 2`] = `
         class="StyledBox-sc-13pk1d4-0 dbooEK"
       >
         <button
-          class="StyledButton-sc-323bzc-0 lbPHCq"
+          class="StyledButton-sc-323bzc-0 jaFvoO"
           type="button"
         >
           <svg
@@ -7828,7 +7828,7 @@ exports[`Video scrubber 2`] = `
           aria-expanded="false"
           aria-haspopup="menu"
           aria-label="open menu"
-          class="StyledButton-sc-323bzc-0 eiEooU"
+          class="StyledButton-sc-323bzc-0 gsQNSg"
           type="button"
         >
           <div
@@ -8046,43 +8046,43 @@ exports[`Video timeUpdate event handler 1`] = `
   color: #FFFFFF;
 }
 
-.c5:focus {
+.c5:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c5:focus:not(:hover) > circle,
+.c5:focus:not(:hover) > ellipse,
+.c5:focus:not(:hover) > line,
+.c5:focus:not(:hover) > path,
+.c5:focus:not(:hover) > polygon,
+.c5:focus:not(:hover) > polyline,
+.c5:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c5:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible):not(:hover) > circle,
+.c5:focus:not(:focus-visible):not(:hover) > ellipse,
+.c5:focus:not(:focus-visible):not(:hover) > line,
+.c5:focus:not(:focus-visible):not(:hover) > path,
+.c5:focus:not(:focus-visible):not(:hover) > polygon,
+.c5:focus:not(:focus-visible):not(:hover) > polyline,
+.c5:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -8104,43 +8104,43 @@ exports[`Video timeUpdate event handler 1`] = `
   text-align: inherit;
 }
 
-.c16:focus {
+.c16:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c16:focus > circle,
-.c16:focus > ellipse,
-.c16:focus > line,
-.c16:focus > path,
-.c16:focus > polygon,
-.c16:focus > polyline,
-.c16:focus > rect {
+.c16:focus:not(:hover) > circle,
+.c16:focus:not(:hover) > ellipse,
+.c16:focus:not(:hover) > line,
+.c16:focus:not(:hover) > path,
+.c16:focus:not(:hover) > polygon,
+.c16:focus:not(:hover) > polyline,
+.c16:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c16:focus::-moz-focus-inner {
+.c16:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c16:focus:not(:focus-visible) {
+.c16:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c16:focus:not(:focus-visible) > circle,
-.c16:focus:not(:focus-visible) > ellipse,
-.c16:focus:not(:focus-visible) > line,
-.c16:focus:not(:focus-visible) > path,
-.c16:focus:not(:focus-visible) > polygon,
-.c16:focus:not(:focus-visible) > polyline,
-.c16:focus:not(:focus-visible) > rect {
+.c16:focus:not(:focus-visible):not(:hover) > circle,
+.c16:focus:not(:focus-visible):not(:hover) > ellipse,
+.c16:focus:not(:focus-visible):not(:hover) > line,
+.c16:focus:not(:focus-visible):not(:hover) > path,
+.c16:focus:not(:focus-visible):not(:hover) > polygon,
+.c16:focus:not(:focus-visible):not(:hover) > polyline,
+.c16:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c16:focus:not(:focus-visible)::-moz-focus-inner {
+.c16:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 

--- a/src/js/themes/__tests__/__snapshots__/theme-test.js.snap
+++ b/src/js/themes/__tests__/__snapshots__/theme-test.js.snap
@@ -1604,43 +1604,43 @@ exports[`Grommet grommet theme 1`] = `
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c1:focus {
+.c1:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
+.c1:focus:not(:hover) > circle,
+.c1:focus:not(:hover) > ellipse,
+.c1:focus:not(:hover) > line,
+.c1:focus:not(:hover) > path,
+.c1:focus:not(:hover) > polygon,
+.c1:focus:not(:hover) > polyline,
+.c1:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c1:focus::-moz-focus-inner {
+.c1:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus:not(:focus-visible) {
+.c1:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c1:focus:not(:focus-visible):not(:hover) > circle,
+.c1:focus:not(:focus-visible):not(:hover) > ellipse,
+.c1:focus:not(:focus-visible):not(:hover) > line,
+.c1:focus:not(:focus-visible):not(:hover) > path,
+.c1:focus:not(:focus-visible):not(:hover) > polygon,
+.c1:focus:not(:focus-visible):not(:hover) > polyline,
+.c1:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c1:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
@@ -1662,43 +1662,43 @@ exports[`Grommet grommet theme 1`] = `
   text-align: inherit;
 }
 
-.c2:focus {
+.c2:focus:not(:hover) {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c2:focus > circle,
-.c2:focus > ellipse,
-.c2:focus > line,
-.c2:focus > path,
-.c2:focus > polygon,
-.c2:focus > polyline,
-.c2:focus > rect {
+.c2:focus:not(:hover) > circle,
+.c2:focus:not(:hover) > ellipse,
+.c2:focus:not(:hover) > line,
+.c2:focus:not(:hover) > path,
+.c2:focus:not(:hover) > polygon,
+.c2:focus:not(:hover) > polyline,
+.c2:focus:not(:hover) > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c2:focus::-moz-focus-inner {
+.c2:focus:not(:hover)::-moz-focus-inner {
   border: 0;
 }
 
-.c2:focus:not(:focus-visible) {
+.c2:focus:not(:focus-visible):not(:hover) {
   outline: none;
   box-shadow: none;
 }
 
-.c2:focus:not(:focus-visible) > circle,
-.c2:focus:not(:focus-visible) > ellipse,
-.c2:focus:not(:focus-visible) > line,
-.c2:focus:not(:focus-visible) > path,
-.c2:focus:not(:focus-visible) > polygon,
-.c2:focus:not(:focus-visible) > polyline,
-.c2:focus:not(:focus-visible) > rect {
+.c2:focus:not(:focus-visible):not(:hover) > circle,
+.c2:focus:not(:focus-visible):not(:hover) > ellipse,
+.c2:focus:not(:focus-visible):not(:hover) > line,
+.c2:focus:not(:focus-visible):not(:hover) > path,
+.c2:focus:not(:focus-visible):not(:hover) > polygon,
+.c2:focus:not(:focus-visible):not(:hover) > polyline,
+.c2:focus:not(:focus-visible):not(:hover) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c2:focus:not(:focus-visible)::-moz-focus-inner {
+.c2:focus:not(:focus-visible):not(:hover)::-moz-focus-inner {
   border: 0;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

This PR fixes this issue #6015 

#### Where should the reviewer start?

On the Button Component variations

#### What testing has been done on this PR?
- Update the `:focus` state in all snapshots
- Update the `:focus` test on the Button Component Test
 
#### How should this be manually tested?

Going to Storybook and test the Button Components on the hover state after click

#### Do Jest tests follow these best practices?
Yep

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
nope

#### Should this PR be mentioned in the release notes?
Yep

#### Is this change backwards compatible or is it a breaking change?
