### PR TITLE
fix: show clear button on select only when select has value

### DIFF
--- a/src/js/components/Select/SelectContainer.js
+++ b/src/js/components/Select/SelectContainer.js
@@ -349,6 +349,16 @@ const SelectContainer = forwardRef(
       [activeIndex, selectOption, options],
     );
 
+    const shouldShowClearButton = (position) => {
+      const hasValue = Boolean(multiple ? value.length : value);
+      const showAtPosition =
+        position === 'bottom'
+          ? clear?.position === 'bottom'
+          : clear?.position !== 'bottom';
+
+      return clear && hasValue && showAtPosition;
+    };
+
     const customSearchInput = theme.select.searchInput;
     const SelectTextInput = customSearchInput || TextInput;
     const selectOptionsStyle = theme.select.options
@@ -396,7 +406,7 @@ const SelectContainer = forwardRef(
             ref={optionsRef}
             aria-multiselectable={multiple}
           >
-            {clear && clear.position !== 'bottom' && value && (
+            {shouldShowClearButton('top') && (
               <ClearButton
                 ref={clearRef}
                 clear={clear}
@@ -495,7 +505,7 @@ const SelectContainer = forwardRef(
                 </Box>
               </SelectOption>
             )}
-            {clear && clear.position === 'bottom' && value && (
+            {shouldShowClearButton('bottom') && (
               <ClearButton
                 ref={clearRef}
                 clear={clear}

--- a/src/js/components/Select/__tests__/SelectMultiple-test.js
+++ b/src/js/components/Select/__tests__/SelectMultiple-test.js
@@ -1,9 +1,11 @@
 import React from 'react';
-import { act, render, fireEvent } from '@testing-library/react';
+import { act, render, fireEvent, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 import 'jest-axe/extend-expect';
 import 'regenerator-runtime/runtime';
 import 'jest-styled-components';
+import '@testing-library/jest-dom';
 
 import { createPortal, expectPortal } from '../../../utils/portal';
 
@@ -22,13 +24,13 @@ describe('Select Controlled', () => {
     );
     const results = await axe(container, {
       rules: {
-        /* This rule is flagged because Select is built using a 
-        TextInput within a DropButton. According to Dequeue and 
-        WCAG 4.1.2 "interactive controls must not have focusable 
+        /* This rule is flagged because Select is built using a
+        TextInput within a DropButton. According to Dequeue and
+        WCAG 4.1.2 "interactive controls must not have focusable
         descendants". Jest-axe is assuming that the input is focusable
-        and since the input is a descendant of the button the rule is 
-        flagged. However, the TextInput is built so that it is read 
-        only and cannot receive focus. Select is accessible 
+        and since the input is a descendant of the button the rule is
+        flagged. However, the TextInput is built so that it is read
+        only and cannot receive focus. Select is accessible
         according to the WCAG specification, but jest-axe is flagging
         it so we are disabling this rule. */
         'nested-interactive': { enabled: false },
@@ -117,6 +119,29 @@ describe('Select Controlled', () => {
       document.getElementById('test-select__drop').querySelector('button'),
     );
     expect(onChange).toBeCalledWith(expect.objectContaining({ value: [] }));
+  });
+
+  test('deselect all options should remove clear selection', () => {
+    render(
+      <Select
+        id="test-select"
+        placeholder="test select"
+        multiple
+        options={['one', 'two']}
+        clear
+      />,
+    );
+
+    userEvent.click(screen.getByPlaceholderText('test select'));
+    userEvent.click(screen.getByRole('option', { name: 'one' }));
+    userEvent.click(screen.getByPlaceholderText('test select'));
+
+    expect(screen.getByText('Clear selection')).toBeInTheDocument();
+
+    userEvent.click(screen.getByRole('option', { name: 'one' }));
+    userEvent.click(screen.getByPlaceholderText('test select'));
+
+    expect(screen.queryByText('Clear selection')).not.toBeInTheDocument();
   });
 
   test('multiple onChange without valueKey', () => {

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -514,7 +514,6 @@ exports[`Select Clear option renders - bottom 1`] = `
       <div
         class="c9"
       />
-      
     </div>
   </div>
 </div>
@@ -742,7 +741,6 @@ exports[`Select Clear option renders correct label when wrapped in FormField 1`]
       role="listbox"
       tabindex="-1"
     >
-      
       <button
         aria-posinset="1"
         aria-selected="false"
@@ -1003,7 +1001,6 @@ exports[`Select Clear option renders custom label 1`] = `
       role="listbox"
       tabindex="-1"
     >
-      
       <button
         aria-posinset="1"
         aria-selected="false"
@@ -1264,7 +1261,6 @@ exports[`Select Clear option renders- top 1`] = `
       role="listbox"
       tabindex="-1"
     >
-      
       <button
         aria-posinset="1"
         aria-selected="false"

--- a/src/js/components/Select/stories/Clear.js
+++ b/src/js/components/Select/stories/Clear.js
@@ -10,8 +10,8 @@ const ClearTop = () => {
     <Box fill align="center" justify="start" pad="large">
       <Select
         placeholder="Clear Options"
-        multiple
         value={value}
+        multiple
         options={options}
         onChange={({ value: nextValue }) => setValue(nextValue)}
         clear
@@ -20,10 +20,29 @@ const ClearTop = () => {
   );
 };
 
+const ClearBottom = () => {
+  const [value, setValue] = useState();
+  return (
+    <Box fill align="center" justify="start" pad="large">
+      <Select
+        placeholder="Clear Options"
+        value={value}
+        multiple
+        options={options}
+        onChange={({ value: nextValue }) => setValue(nextValue)}
+        clear={{ position: 'bottom' }}
+      />
+    </Box>
+  );
+};
+
 export const Clear = () => (
   // Uncomment <Grommet> lines when using outside of storybook
   // <Grommet theme={...}>
-  <ClearTop />
+  <>
+    <ClearTop />
+    <ClearBottom />
+  </>
   // </Grommet>
 );
 


### PR DESCRIPTION
#### What does this PR do?
It fixes the issue https://github.com/grommet/grommet/issues/6039

#### Where should the reviewer start?
It can start reproducing the bug in local storybook

#### What testing has been done on this PR?
Created unit test

#### How should this be manually tested?
Yes, it should

#### Do Jest tests follow these best practices?

- [x] `screen` is used for querying.
- [x] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [x] `userEvent` is used in place of `fireEvent`.

**NOTE** Need to use getByPlaceholderText since I didn't find a role for dropdown button. 

#### What are the relevant issues?
https://github.com/grommet/grommet/issues/6039

#### Do the grommet docs need to be updated?
No

#### Is this change backwards compatible or is it a breaking change?
Yes, it is
