### PR TITLE
Updated All Components Select to use inline drop POC

### DIFF
--- a/src/js/all/stories/AllComponents.js
+++ b/src/js/all/stories/AllComponents.js
@@ -123,6 +123,7 @@ const Components = () => {
     </Box>,
     <Box key="input" gap="small">
       <Select
+        dropProps={{ inline: true }}
         placeholder="Select"
         options={['One', 'Two']}
         onChange={() => {}}


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR is a POC for https://github.com/grommet/grommet/pull/6034

Looking deeper into the functionality of allowing Drop to be rendered inline to its parent component on the DOM, I've applied `<Select dropProps: {{ inline: true}} ... />` to the Select on "All Components" story, and although the drop is placed 'inline' to the owning element on the DOM, the keyboard navigation issue is still not resolved, and the tabbing takes the user to the end of the page rather than to the next interactive element.

I think this PR is valid and the All Components Select story should use an inline drop, however, the inline prop should solve the keyboard navigation issue which currently is still an issue.

IMO, I don't see a good functional reason to allow inline rendering of the Drop if it's not solving the keyboard tabbing that is skipping to the end of the page.

#### Where should the reviewer start?
The story
#### What testing has been done on this PR?
storybook
#### How should this be manually tested?
It's a POC
#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
POC for the Drop inline functionality

#### What are the relevant issues?
#6032 
#5896 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Nope
#### Should this PR be mentioned in the release notes?
Nope
#### Is this change backwards compatible or is it a breaking change?
backwards compatible