### PR TITLE
Upgraded testing-library/user-event

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@testing-library/dom": "^8.12.0",
     "@testing-library/jest-dom": "^5.16.3",
     "@testing-library/react": "^12.1.2",
-    "@testing-library/user-event": "^13.5.0",
+    "@testing-library/user-event": "^14.0.4",
     "@types/jest": "^27.4.0",
     "@types/jest-axe": "^3.5.3",
     "@types/node": "^17.0.23",

--- a/src/js/components/Accordion/__tests__/Accordion-test.tsx
+++ b/src/js/components/Accordion/__tests__/Accordion-test.tsx
@@ -90,8 +90,8 @@ describe('Accordion', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
-  test('change to second Panel', () => {
-    jest.useFakeTimers('modern');
+  test('change to second Panel', async () => {
+    const user = userEvent.setup();
     const onActive = jest.fn();
     const { asFragment } = render(
       <Grommet>
@@ -103,13 +103,14 @@ describe('Accordion', () => {
     );
     expect(asFragment()).toMatchSnapshot();
 
-    userEvent.click(screen.getByRole('tab', { name: /Panel 2/i }));
+    await user.click(screen.getByRole('tab', { name: /Panel 2/i }));
 
     expect(onActive).toBeCalled();
     expect(asFragment()).toMatchSnapshot();
   });
 
-  test('change to second Panel without onActive', () => {
+  test('change to second Panel without onActive', async () => {
+    const user = userEvent.setup();
     const { asFragment } = render(
       <Grommet>
         <Accordion animate={false}>
@@ -120,12 +121,13 @@ describe('Accordion', () => {
     );
     expect(asFragment()).toMatchSnapshot();
 
-    userEvent.click(screen.getByRole('tab', { name: /Panel 2/i }));
+    await user.click(screen.getByRole('tab', { name: /Panel 2/i }));
 
     expect(asFragment()).toMatchSnapshot();
   });
 
-  test('multiple panels', () => {
+  test('multiple panels', async () => {
+    const user = userEvent.setup();
     const onActive = jest.fn();
     const { asFragment } = render(
       <Grommet>
@@ -137,22 +139,22 @@ describe('Accordion', () => {
     );
     expect(asFragment()).toMatchSnapshot();
 
-    userEvent.click(screen.getByRole('tab', { name: /Panel 2/i }));
+    await user.click(screen.getByRole('tab', { name: /Panel 2/i }));
     expect(onActive).toBeCalledWith([1]);
 
     expect(asFragment()).toMatchSnapshot();
 
-    userEvent.click(screen.getByRole('tab', { name: /Panel 1/i }));
+    await user.click(screen.getByRole('tab', { name: /Panel 1/i }));
     expect(onActive).toBeCalledWith([1, 0]);
 
     expect(asFragment()).toMatchSnapshot();
 
-    userEvent.click(screen.getByRole('tab', { name: /Panel 2/i }));
+    await user.click(screen.getByRole('tab', { name: /Panel 2/i }));
     expect(onActive).toBeCalledWith([0]);
 
     expect(asFragment()).toMatchSnapshot();
 
-    userEvent.click(screen.getByRole('tab', { name: /Panel 1/i }));
+    await user.click(screen.getByRole('tab', { name: /Panel 1/i }));
     expect(onActive).toBeCalledWith([]);
 
     expect(asFragment()).toMatchSnapshot();
@@ -191,7 +193,8 @@ describe('Accordion', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
-  test('change active index', () => {
+  test('change active index', async () => {
+    const user = userEvent.setup();
     const onActive = jest.fn();
     const { asFragment } = render(
       <Grommet>
@@ -203,12 +206,13 @@ describe('Accordion', () => {
     );
     expect(asFragment()).toMatchSnapshot();
 
-    userEvent.click(screen.getByRole('tab', { name: /Panel 1/i }));
+    await user.click(screen.getByRole('tab', { name: /Panel 1/i }));
     expect(onActive).toBeCalledWith([0]);
     expect(asFragment()).toMatchSnapshot();
   });
 
-  test('focus and hover styles', () => {
+  test('focus and hover styles', async () => {
+    const user = userEvent.setup();
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
     const { asFragment } = render(
       <Grommet theme={{ accordion: { hover: { color: 'red' } } }}>
@@ -226,13 +230,14 @@ describe('Accordion', () => {
       </Grommet>,
     );
 
-    userEvent.click(screen.getByRole('tab', { name: /Panel 1/i }));
+    await user.click(screen.getByRole('tab', { name: /Panel 1/i }));
     expect(asFragment()).toMatchSnapshot();
     expect(warnSpy).toHaveBeenCalled();
     warnSpy.mockRestore();
   });
 
-  test('backward compatibility of hover.color = undefined', () => {
+  test('backward compatibility of hover.color = undefined', async () => {
+    const user = userEvent.setup();
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
     const { asFragment } = render(
       <Grommet
@@ -256,14 +261,15 @@ describe('Accordion', () => {
       </Grommet>,
     );
 
-    userEvent.tab();
+    await user.tab();
     // hover color should be undefined
     expect(asFragment()).toMatchSnapshot();
     expect(warnSpy).toHaveBeenCalled();
     warnSpy.mockRestore();
   });
 
-  test('theme hover of hover.heading.color', () => {
+  test('theme hover of hover.heading.color', async () => {
+    const user = userEvent.setup();
     const { asFragment } = render(
       <Grommet
         theme={{
@@ -286,12 +292,13 @@ describe('Accordion', () => {
       </Grommet>,
     );
 
-    userEvent.tab();
+    await user.tab();
     // hover color should be undefined
     expect(asFragment()).toMatchSnapshot();
   });
 
-  test('set on hover', () => {
+  test('set on hover', async () => {
+    const user = userEvent.setup();
     const onMouseOver1 = jest.fn();
     const onMouseOut1 = jest.fn();
     const onMouseOver2 = jest.fn();
@@ -317,18 +324,19 @@ describe('Accordion', () => {
       </Grommet>,
     );
 
-    userEvent.hover(screen.getByRole('tab', { name: /Panel 1/i }));
+    await user.hover(screen.getByRole('tab', { name: /Panel 1/i }));
     expect(onMouseOver1).toHaveBeenCalled();
-    userEvent.unhover(screen.getByRole('tab', { name: /Panel 1/i }));
+    await user.unhover(screen.getByRole('tab', { name: /Panel 1/i }));
     expect(onMouseOut1).toHaveBeenCalled();
 
-    userEvent.hover(screen.getByRole('tab', { name: /Panel 2/i }));
+    await user.hover(screen.getByRole('tab', { name: /Panel 2/i }));
     expect(onMouseOver2).toHaveBeenCalled();
-    userEvent.unhover(screen.getByRole('tab', { name: /Panel 2/i }));
+    await user.unhover(screen.getByRole('tab', { name: /Panel 2/i }));
     expect(onMouseOver2).toHaveBeenCalled();
   });
 
-  test('wrapped panel', () => {
+  test('wrapped panel', async () => {
+    const user = userEvent.setup();
     const onActive = jest.fn();
     const { asFragment } = render(
       <Grommet>
@@ -340,13 +348,14 @@ describe('Accordion', () => {
     );
     expect(asFragment()).toMatchSnapshot();
 
-    userEvent.click(screen.getByRole('tab', { name: /Panel 1/i }));
+    await user.click(screen.getByRole('tab', { name: /Panel 1/i }));
     expect(onActive).toBeCalledWith([0]);
     expect(screen.getByText('Panel body 1')).not.toBeNull();
     expect(asFragment()).toMatchSnapshot();
   });
 
-  test('blur styles', () => {
+  test('blur styles', async () => {
+    const user = userEvent.setup();
     const onBlur = jest.fn();
     const { asFragment } = render(
       <Grommet theme={{ accordion: { hover: { heading: { color: 'red' } } } }}>
@@ -365,10 +374,10 @@ describe('Accordion', () => {
     );
 
     // tab to the first accordion panel
-    userEvent.tab();
+    await user.tab();
     expect(asFragment()).toMatchSnapshot();
     // tab away from the first accordion panel
-    userEvent.tab();
+    await user.tab();
     expect(onBlur).toHaveBeenCalled();
   });
 });

--- a/src/js/components/Button/__tests__/Button-test.tsx
+++ b/src/js/components/Button/__tests__/Button-test.tsx
@@ -219,7 +219,9 @@ describe('Button', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test('focus', () => {
+  test('focus', async () => {
+    const user = userEvent.setup();
+
     const { container } = render(
       <Grommet>
         <Button label="Test focus" onClick={() => {}} />
@@ -231,7 +233,7 @@ describe('Button', () => {
     expect(button).not.toHaveFocus();
     expect(document.body).toHaveFocus();
 
-    userEvent.tab();
+    await user.tab();
 
     expect(button).toHaveFocus();
     expect(document.body).not.toHaveFocus();

--- a/src/js/components/Carousel/__tests__/Carousel-test.tsx
+++ b/src/js/components/Carousel/__tests__/Carousel-test.tsx
@@ -47,6 +47,8 @@ describe('Carousel', () => {
   });
 
   test('arrow navigation: next', async () => {
+    const user = userEvent.setup();
+
     render(
       <Grommet>
         <Carousel controls="arrows">
@@ -62,7 +64,7 @@ describe('Carousel', () => {
      * - Expecting "Slide Two" to be visible
      */
     const nextButton = screen.getByLabelText('Next');
-    userEvent.click(nextButton);
+    await user.click(nextButton);
     await waitFor(() => {
       expect(getSlideOne()).not.toBeVisible();
       expect(getSlideTwo()).toBeVisible();
@@ -70,6 +72,8 @@ describe('Carousel', () => {
   });
 
   test('arrow navigation: previous', async () => {
+    const user = userEvent.setup();
+
     render(
       <Grommet>
         <Carousel initialChild={1} controls="arrows">
@@ -86,7 +90,7 @@ describe('Carousel', () => {
      * - Expecting "Slide One" to be visible
      */
     const previousButton = screen.getByLabelText('Previous');
-    userEvent.click(previousButton);
+    await user.click(previousButton);
     await waitFor(() => {
       expect(getSlideTwo()).not.toBeVisible();
       expect(getSlideOne()).toBeVisible();
@@ -94,6 +98,8 @@ describe('Carousel', () => {
   });
 
   test('selector navigation: forward', async () => {
+    const user = userEvent.setup();
+
     render(
       <Grommet>
         <Carousel controls="selectors">
@@ -110,7 +116,7 @@ describe('Carousel', () => {
      * - Expecting "Slide Three" to be visible
      */
     const thirdSelector = screen.getByLabelText('Jump to slide 3');
-    userEvent.click(thirdSelector);
+    await user.click(thirdSelector);
     await waitFor(() => {
       expect(getSlideOne()).not.toBeVisible();
       expect(getSlideThree()).toBeVisible();
@@ -118,6 +124,8 @@ describe('Carousel', () => {
   });
 
   test('selector navigation: backward', async () => {
+    const user = userEvent.setup();
+
     render(
       <Grommet>
         <Carousel initialChild={2} controls="selectors">
@@ -134,7 +142,7 @@ describe('Carousel', () => {
      * - Expecting "Slide One" to be visible
      */
     const firstSelector = screen.getByLabelText('Jump to slide 1');
-    userEvent.click(firstSelector);
+    await user.click(firstSelector);
     await waitFor(() => {
       expect(getSlideThree()).not.toBeVisible();
       expect(getSlideOne()).toBeVisible();
@@ -226,6 +234,8 @@ describe('Carousel', () => {
   });
 
   test('interactive slide', async () => {
+    const user = userEvent.setup({ delay: null });
+
     const someFunction = jest.fn();
     render(
       <Grommet>
@@ -242,8 +252,7 @@ describe('Carousel', () => {
       </Grommet>,
     );
 
-    const testButton = screen.getByLabelText('Test Button');
-    userEvent.click(testButton);
+    await user.click(screen.getByLabelText('Test Button'));
     expect(someFunction).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/js/components/DateInput/__tests__/DateInput-test.tsx
+++ b/src/js/components/DateInput/__tests__/DateInput-test.tsx
@@ -192,7 +192,9 @@ describe('DateInput', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test('dates initialized with empty array', () => {
+  test('dates initialized with empty array', async () => {
+    const user = userEvent.setup();
+
     const onChange = jest.fn((event) => event.value);
 
     const { getByText } = render(
@@ -209,7 +211,7 @@ describe('DateInput', () => {
         />
       </Grommet>,
     );
-    userEvent.click(getByText('20'));
+    await user.click(getByText('20'));
     expect(onChange).toHaveBeenCalled();
     expect(onChange).toHaveReturnedWith([
       `2020-07-20T08:00:00.000Z`,
@@ -243,7 +245,9 @@ describe('DateInput', () => {
     expect(document.getElementById('item__drop')).not.toBeNull();
   });
 
-  test('click', () => {
+  test('click', async () => {
+    const user = userEvent.setup();
+
     const { getByPlaceholderText } = render(
       <Grommet>
         <DateInput
@@ -256,7 +260,7 @@ describe('DateInput', () => {
       </Grommet>,
     );
 
-    userEvent.click(getByPlaceholderText('mm/dd/yyyy'));
+    await user.click(getByPlaceholderText('mm/dd/yyyy'));
     expect(document.getElementById('item__drop')).toBeNull();
   });
 
@@ -893,7 +897,9 @@ describe('DateInput', () => {
     expect(container.children).toMatchSnapshot();
   });
 
-  test('clicking calendar icon should open drop', () => {
+  test('clicking calendar icon should open drop', async () => {
+    const user = userEvent.setup();
+
     render(
       <Grommet>
         <DateInput format="m/d/yy" defaultValue="2021-01-01" />
@@ -902,13 +908,15 @@ describe('DateInput', () => {
     expect(
       screen.queryByRole('heading', { name: /January 2021/i }),
     ).not.toBeInTheDocument();
-    userEvent.click(screen.getByRole('button', { name: /Calendar/i }));
+    await user.click(screen.getByRole('button', { name: /Calendar/i }));
     expect(
       screen.getByRole('heading', { name: /January 2021/i }),
     ).toBeInTheDocument();
   });
 
-  test('handle focus in FormField', () => {
+  test('handle focus in FormField', async () => {
+    const user = userEvent.setup();
+
     const onFocus = jest.fn();
     const { asFragment } = render(
       <Grommet>
@@ -919,9 +927,9 @@ describe('DateInput', () => {
         </Form>
       </Grommet>,
     );
-    userEvent.tab();
+    await user.tab();
     expect(asFragment()).toMatchSnapshot();
-    userEvent.tab();
+    await user.tab();
     expect(asFragment()).toMatchSnapshot();
     expect(onFocus).toHaveBeenCalledTimes(1);
   });

--- a/src/js/components/Image/__tests__/Image-test.tsx
+++ b/src/js/components/Image/__tests__/Image-test.tsx
@@ -98,6 +98,8 @@ test('Image onError', () => {
 });
 
 test('Image fallback', async () => {
+  const user = userEvent.setup();
+
   const onError = jest.fn();
   const fallbackImage = 'https://v2.grommet.io/assets/IMG_4245.jpg';
   const regularImage = 'https://v2.grommet.io/img/stak-hurrah.svg';
@@ -129,7 +131,7 @@ test('Image fallback', async () => {
   let imgSrc = screen.getByRole<HTMLImageElement>('img').src;
   expect(imgSrc).toEqual(fallbackImage);
 
-  userEvent.click(screen.getByRole('button', { name: /Update Image/i }));
+  await user.click(screen.getByRole('button', { name: /Update Image/i }));
   imgSrc = screen.getByRole<HTMLImageElement>('img').src;
   expect(imgSrc).toEqual(regularImage);
 });

--- a/src/js/components/MaskedInput/__tests__/MaskedInput-test.js
+++ b/src/js/components/MaskedInput/__tests__/MaskedInput-test.js
@@ -193,6 +193,8 @@ describe('MaskedInput', () => {
   });
 
   test('should not enable to type beyond options via keyboard', async () => {
+    const user = userEvent.setup();
+
     const onChange = jest.fn((event) => event.target.value);
     render(
       <MaskedInput
@@ -209,13 +211,15 @@ describe('MaskedInput', () => {
       />,
     );
 
-    userEvent.type(screen.getByRole('textbox'), 'abbb');
+    await user.type(screen.getByRole('textbox'), 'abbb');
 
     expect(onChange).toHaveBeenCalled();
     expect(onChange).toHaveReturnedWith('abb');
   });
 
   test('restrictToOptions=false allows typing beyond options', async () => {
+    const user = userEvent.setup();
+
     const onChange = jest.fn((event) => event.target.value);
     render(
       <MaskedInput
@@ -233,7 +237,7 @@ describe('MaskedInput', () => {
       />,
     );
 
-    userEvent.type(screen.getByRole('textbox'), 'abbb');
+    await user.type(screen.getByRole('textbox'), 'abbb');
 
     expect(onChange).toHaveBeenCalled();
     expect(onChange).toHaveReturnedWith('abbb');

--- a/src/js/components/Notification/__tests__/Notification-test.js
+++ b/src/js/components/Notification/__tests__/Notification-test.js
@@ -41,7 +41,9 @@ describe('Notification', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
-  test('onClose', () => {
+  test('onClose', async () => {
+    const user = userEvent.setup();
+
     const onClose = jest.fn();
     render(
       <Grommet>
@@ -49,7 +51,7 @@ describe('Notification', () => {
       </Grommet>,
     );
 
-    userEvent.click(screen.getByRole('button'));
+    await user.click(screen.getByRole('button'));
     expect(onClose).toBeCalled();
   });
 
@@ -83,7 +85,9 @@ describe('Notification', () => {
     }),
   );
 
-  test('autoClose true', () => {
+  test('autoClose true', async () => {
+    const user = userEvent.setup({ delay: null });
+
     jest.useFakeTimers('modern');
     const onOpen = jest.fn();
     const onClose = jest.fn();
@@ -113,7 +117,7 @@ describe('Notification', () => {
       );
     };
     render(<Test />);
-    userEvent.click(screen.getByRole('button', { name: 'Show Notification' }));
+    await user.click(screen.getByRole('button', { name: 'Show Notification' }));
     expect(screen.getByText('Status Title')).toBeInTheDocument();
     expect(onOpen).toHaveBeenCalled();
     act(() => {
@@ -122,7 +126,9 @@ describe('Notification', () => {
     expect(onClose).toHaveBeenCalled();
   });
 
-  test('autoClose false', () => {
+  test('autoClose false', async () => {
+    const user = userEvent.setup({ delay: null });
+
     jest.useFakeTimers('modern');
     const onOpen = jest.fn();
     const onClose = jest.fn();
@@ -152,7 +158,7 @@ describe('Notification', () => {
       );
     };
     render(<Test />);
-    userEvent.click(screen.getByRole('button', { name: 'Show Notification' }));
+    await user.click(screen.getByRole('button', { name: 'Show Notification' }));
     expect(onOpen).toHaveBeenCalled();
     act(() => {
       jest.advanceTimersByTime(9000);

--- a/src/js/components/RoutedAnchor/__tests__/RoutedAnchor-test.js
+++ b/src/js/components/RoutedAnchor/__tests__/RoutedAnchor-test.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { render, screen, fireEvent, createEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import 'jest-styled-components';
+import 'regenerator-runtime/runtime';
 
 import { Grommet } from '../../Grommet';
 import { RoutedAnchor } from '..';
@@ -85,7 +86,9 @@ describe('RoutedAnchor', () => {
     expect(warnSpy).toHaveBeenCalled();
   });
 
-  test('skips onClick if right clicked', () => {
+  test('skips onClick if right clicked', async () => {
+    const user = userEvent.setup();
+
     const onClick = jest.fn();
     render(
       <Grommet>
@@ -97,8 +100,10 @@ describe('RoutedAnchor', () => {
 
     const anchor = screen.getByRole('link');
 
-    userEvent.click(anchor, { ctrlKey: true });
-    userEvent.click(anchor, { metaKey: true });
+    await user.pointer([
+      { target: anchor },
+      { keys: '[MouseRight]', target: anchor },
+    ]);
 
     expect(onClick).not.toHaveBeenCalled();
     expect(warnSpy).toHaveBeenCalled();

--- a/src/js/components/RoutedButton/__tests__/RoutedButton-test.js
+++ b/src/js/components/RoutedButton/__tests__/RoutedButton-test.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { createEvent, fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import 'jest-styled-components';
+import 'regenerator-runtime/runtime';
 
 import { Grommet, RoutedButton } from '../..';
 
@@ -94,7 +95,9 @@ describe('RoutedButton', () => {
     expect(warnSpy).toHaveBeenCalledWith(warning);
   });
 
-  test('RoutedButton skips onClick if right clicked', () => {
+  test('RoutedButton skips onClick if right clicked', async () => {
+    const user = userEvent.setup();
+
     const onClick = jest.fn();
     render(
       <Grommet>
@@ -106,8 +109,10 @@ describe('RoutedButton', () => {
 
     const anchor = screen.getByRole('link');
 
-    userEvent.click(anchor, { ctrlKey: true });
-    userEvent.click(anchor, { metaKey: true });
+    await user.pointer([
+      { target: anchor },
+      { keys: '[MouseRight]', target: anchor },
+    ]);
 
     expect(onClick).not.toHaveBeenCalled();
     expect(warnSpy).toHaveBeenCalledWith(warning);

--- a/src/js/components/Select/__tests__/SelectMultiple-test.js
+++ b/src/js/components/Select/__tests__/SelectMultiple-test.js
@@ -121,7 +121,9 @@ describe('Select Controlled', () => {
     expect(onChange).toBeCalledWith(expect.objectContaining({ value: [] }));
   });
 
-  test('deselect all options should remove clear selection', () => {
+  test('deselect all options should remove clear selection', async () => {
+    const user = userEvent.setup();
+
     render(
       <Select
         id="test-select"
@@ -132,14 +134,14 @@ describe('Select Controlled', () => {
       />,
     );
 
-    userEvent.click(screen.getByPlaceholderText('test select'));
-    userEvent.click(screen.getByRole('option', { name: 'one' }));
-    userEvent.click(screen.getByPlaceholderText('test select'));
+    await user.click(screen.getByPlaceholderText('test select'));
+    await user.click(screen.getByRole('option', { name: 'one' }));
+    await user.click(screen.getByPlaceholderText('test select'));
 
     expect(screen.getByText('Clear selection')).toBeInTheDocument();
 
-    userEvent.click(screen.getByRole('option', { name: 'one' }));
-    userEvent.click(screen.getByPlaceholderText('test select'));
+    await user.click(screen.getByRole('option', { name: 'one' }));
+    await user.click(screen.getByPlaceholderText('test select'));
 
     expect(screen.queryByText('Clear selection')).not.toBeInTheDocument();
   });

--- a/src/js/components/Tag/__tests__/Tag-test.tsx
+++ b/src/js/components/Tag/__tests__/Tag-test.tsx
@@ -45,7 +45,9 @@ describe('Tag', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test('onClick', () => {
+  test('onClick', async () => {
+    const user = userEvent.setup();
+
     const onClick = jest.fn();
     const { container } = render(
       <Grommet>
@@ -53,13 +55,15 @@ describe('Tag', () => {
       </Grommet>,
     );
 
-    userEvent.click(screen.getByRole('button'));
+    await user.click(screen.getByRole('button'));
     expect(onClick).toBeCalled();
 
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test('onRemove', () => {
+  test('onRemove', async () => {
+    const user = userEvent.setup();
+
     const onRemove = jest.fn();
     const { container } = render(
       <Grommet>
@@ -67,7 +71,7 @@ describe('Tag', () => {
       </Grommet>,
     );
 
-    userEvent.click(screen.getByRole('button'));
+    await user.click(screen.getByRole('button'));
     expect(onRemove).toBeCalled();
 
     expect(container.firstChild).toMatchSnapshot();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2355,12 +2355,10 @@
     "@testing-library/dom" "^8.0.0"
     "@types/react-dom" "*"
 
-"@testing-library/user-event@^13.5.0":
-  version "13.5.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-13.5.0.tgz#69d77007f1e124d55314a2b73fd204b333b13295"
-  integrity sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
+"@testing-library/user-event@^14.0.4":
+  version "14.0.4"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.0.4.tgz#5b430a9c27f25078bff4471661b755115d0db9d4"
+  integrity sha512-VBZe5lcUsmrQyOwIFvqOxLBoaTw1/Qy4Ek+VgmFYs719bs2SxUp42vbsb7ATlQDkHdj4OIQlucfpwxe5WoG1jA==
 
 "@tootallnate/once@1":
   version "1.1.2"


### PR DESCRIPTION
#### What does this PR do?
Upgrades testing-library/user-event to the latest version

More info about the changes from v13 to v14 of user-event can be found here: https://testing-library.com/docs/user-event/intro
Notable changes are that all the user event apis return promises and [userEvent.setup()](https://testing-library.com/docs/user-event/setup) should now be used at the beginning of tests that use userEvents.

#### Where should the reviewer start?

#### What testing has been done on this PR?
yarn test
#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
https://github.com/grommet/hpe-design-system/issues/2498

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
backwards compatible