### PR TITLE
Fix for #5677 : Improved accessibility of Calendar 

### DIFF
--- a/src/js/components/Calendar/Calendar.js
+++ b/src/js/components/Calendar/Calendar.js
@@ -173,12 +173,18 @@ const CalendarDay = ({
   children,
   fill,
   size,
+  focus,
   isInRange,
   isSelected,
   otherMonth,
   buttonProps = {},
 }) => (
-  <StyledDayContainer role="gridcell" sizeProp={size} fillContainer={fill}>
+  <StyledDayContainer
+    role="gridcell"
+    sizeProp={size}
+    fillContainer={fill}
+    focus={focus}
+  >
     <CalendarDayButton fill={fill} {...buttonProps}>
       <StyledDay
         disabledProp={buttonProps.disabled}
@@ -832,6 +838,7 @@ const Calendar = forwardRef(
               }}
               isInRange={inRange}
               isSelected={selected}
+              focus={!focus && active?.getTime() === day.getTime()}
               otherMonth={day.getMonth() !== reference.getMonth()}
               size={size}
               fill={fill}
@@ -944,6 +951,7 @@ const Calendar = forwardRef(
             onUp={(event) => {
               event.preventDefault();
               event.stopPropagation(); // so the page doesn't scroll
+              setFocus(false);
               setActive(addDays(active, -7));
               if (!betweenDates(addDays(active, -7), displayBounds)) {
                 changeReference(addDays(active, -7));
@@ -952,18 +960,21 @@ const Calendar = forwardRef(
             onDown={(event) => {
               event.preventDefault();
               event.stopPropagation(); // so the page doesn't scroll
+              setFocus(false);
               setActive(addDays(active, 7));
               if (!betweenDates(addDays(active, 7), displayBounds)) {
                 changeReference(active);
               }
             }}
             onLeft={() => {
+              setFocus(false);
               setActive(addDays(active, -1));
               if (!betweenDates(addDays(active, -1), displayBounds)) {
                 changeReference(active);
               }
             }}
             onRight={() => {
+              setFocus(false);
               setActive(addDays(active, 1));
               if (!betweenDates(addDays(active, 2), displayBounds)) {
                 changeReference(active);
@@ -986,9 +997,11 @@ const Calendar = forwardRef(
               focus={focus}
               onFocus={() => {
                 setFocus(true);
+
                 // caller focused onto Calendar via keyboard
-                if (!mouseDown) {
+                if (!mouseDown && !focus) {
                   setActive(new Date(firstDayInMonth));
+                  setFocus(false);
                 }
               }}
               onBlur={() => {

--- a/src/js/components/Calendar/StyledCalendar.js
+++ b/src/js/components/Calendar/StyledCalendar.js
@@ -43,6 +43,7 @@ const weeksContainerSizeStyle = (props) => {
 };
 const StyledWeeksContainer = styled.div`
   overflow: hidden;
+  outline: none;
   ${(props) => weeksContainerSizeStyle(props)}
   ${(props) => props.focus && !props.plain && focusStyle()};
 `;
@@ -101,6 +102,7 @@ Object.setPrototypeOf(StyledWeek.defaultProps, defaultProps);
 // widths of 7 days to equally fill 100% of the row.
 const StyledDayContainer = styled.div`
   flex: 0 1 auto;
+  ${(props) => props.focus && !props.plain && focusStyle()}
   ${(props) => props.fillContainer && 'width: 14.3%;'}
 `;
 


### PR DESCRIPTION
Added functionality for the focus to be on the day, when a user navigates using a keyboard.


#### What does this PR do?

**In code**
- This PR introduces `focus` prop to the `StyledDayContainer`.

 **For the User**
- If the user navigates to the `Calendar` component using `tab` key, the first day of the month will be in focus rather than the entire `Calendar`
- If the user decides navigates the calendar using the arrow key, the focus will shift to the active day.
- If the user decides to return to mouse pointer, the entire `Calendar` would come in focus on Mouse Down ( & selection)



#### Where should the reviewer start?

- The reviewer could start from file `src/js/components/Calendar/StyledCalendar.js` , where I have added the required props.
- Further, the reviewer can refer file `src/js/components/Calendar/Calendar.js` at line 1002, 1004 and thereon.


#### What testing has been done on this PR?

- I have tested it using the storybook. Screenshots of the functionality below : 



#### How should this be manually tested?

- The tester could use tab keys to reach the `Calendar` Component, once in focus, the arrow keys could be used to navigate.

#### Do Jest tests follow these best practices?

#### Any background context you want to provide?

#### What are the relevant issues?
#5677 

#### Screenshots (if appropriate)
![PR (2)](https://user-images.githubusercontent.com/80472243/162431412-400766d8-9f43-4ead-805a-fa4001a10f09.gif)
![PR (3)](https://user-images.githubusercontent.com/80472243/162431424-68f26ab2-8e55-410d-b49d-b3242debe0c4.gif)


#### Do the grommet docs need to be updated?
- Don't think so.

#### Should this PR be mentioned in the release notes?
- Not sure

#### Is this change backwards compatible or is it a breaking change?
- It should be.
