### PR TITLE
Include Grid props in NameValueList props type

### DIFF
--- a/src/js/components/NameValueList/index.d.ts
+++ b/src/js/components/NameValueList/index.d.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { AlignType, WidthType } from '../../utils';
+import { GridProps } from '../Grid'
 export interface NameValueListProps {
   align?: AlignType;
   layout?: 'column' | 'grid';
@@ -16,9 +17,9 @@ export interface NameValueListProps {
   };
 }
 export interface NameValueListExtendedProps
-  extends NameValueListProps,
+  extends NameValueListProps, GridProps,
     Omit<JSX.IntrinsicElements['dl'], keyof NameValueListProps> {}
 
-declare const NameValueList: React.FC<NameValueListProps>;
+declare const NameValueList: React.FC<NameValueListExtendedProps>;
 
 export { NameValueList };


### PR DESCRIPTION
#### What does this PR do? 
It broadens the type for NameValueList's props to include Grid's props. This makes the types match what the code actually does.

#### What testing has been done on this PR?
I have verified that the the fix works by editing the source in `node_modules`

#### How should this be manually tested?
See above

#### Any background context you want to provide?
Here is where the rest of the props to `NameValueList` get passed to `Grid`
https://github.com/grommet/grommet/blob/d34c1e8826b7632aefa488bf5409472603875242/src/js/components/NameValueList/NameValueList.js#L62

#### What are the relevant issues?
None

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Yes: https://github.com/grommet/grommet-site/pull/370

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible