### PR TITLE
Added onTab event listener to SelectContainer

### DIFF
--- a/src/js/components/Select/SelectContainer.js
+++ b/src/js/components/Select/SelectContainer.js
@@ -375,6 +375,10 @@ const SelectContainer = forwardRef(
         onUp={onPreviousOption}
         onDown={onNextOption}
         onKeyDown={onKeyDownOption}
+        onTab={(event) => {
+          // swallow tab event when the drop is opened
+          event.preventDefault();
+        }}
       >
         <StyledContainer
           ref={ref}


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Mimics the [core HTML select ](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select)behavior by swallowing the tab event of Select when the drop is open.
Currently, when the Select drop is opened and the user is tabbing, the tabbing throws the user unexpectedly out to the Select and the webpage.
#### Where should the reviewer start?
SelectContainer
#### What testing has been done on this PR?
Storybook examples of Select.
#### How should this be manually tested?
Go over Select on storybook, and make sure that the Tab is working as expected when the drop is closed (tabs regularly) and when the drop is opened (tab is ignored). This change should not impact other components other than Select that uses Drop.
#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
https://github.com/grommet/grommet/issues/5896
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No
#### Should this PR be mentioned in the release notes?
Yes
#### Is this change backwards compatible or is it a breaking change?
It's a bug fix and it's the. the right approach we should follow. I don't think it is not backward compatible.