### PR TITLE
Changed Drop to add onFocusOutside

### DIFF
--- a/src/js/all/stories/AllComponents.js
+++ b/src/js/all/stories/AllComponents.js
@@ -126,31 +126,32 @@ const Components = () => {
         placeholder="Select"
         options={['One', 'Two']}
         onChange={() => {}}
+        dropProps={{ inline: true, trapFocus: false }}
       />
       <CheckBox
         name="check"
         checked={checkBox}
         label="CheckBox"
-        onChange={event => setCheckBox(event.target.checked)}
+        onChange={(event) => setCheckBox(event.target.checked)}
       />
       <CheckBox
         name="toggle"
         toggle
         checked={checkBox}
         label="CheckBox toggle"
-        onChange={event => setCheckBox(event.target.checked)}
+        onChange={(event) => setCheckBox(event.target.checked)}
       />
       <RadioButtonGroup
         name="radio"
         options={['RadioButton 1', 'RadioButton 2']}
         value={radioButton}
-        onChange={event => setRadioButton(event.target.value)}
+        onChange={(event) => setRadioButton(event.target.value)}
       />
       <TextInput
         placeholder="TextInput"
         suggestions={['a', 'b', 'c']}
         value={textInput}
-        onChange={event => setTextInput(event.target.value)}
+        onChange={(event) => setTextInput(event.target.value)}
         onSelect={({ suggestion }) => setTextInput(suggestion)}
       />
       <MaskedInput
@@ -170,13 +171,13 @@ const Components = () => {
           },
         ]}
         value={maskedInput}
-        onChange={event => setMaskedInput(event.target.value)}
+        onChange={(event) => setMaskedInput(event.target.value)}
       />
       <TextArea placeholder="TextArea" />
       <RangeInput value={24} onChange={() => {}} />
       <Stack>
         <Box direction="row" justify="between">
-          {[0, 1, 2, 3].map(value => (
+          {[0, 1, 2, 3].map((value) => (
             <Box key={value} pad="small">
               <Text style={{ fontFamily: 'monospace' }}>{value}</Text>
             </Box>
@@ -190,7 +191,7 @@ const Components = () => {
           size="full"
           round="small"
           values={rangeSelector}
-          onChange={values => setRangeSelector(values)}
+          onChange={(values) => setRangeSelector(values)}
         />
       </Stack>
       <FormField label="FormField">
@@ -228,7 +229,7 @@ const Components = () => {
           { value: 5, color: 'light-4' },
         ]}
       >
-        {value => (
+        {(value) => (
           <Box pad="xsmall" background={value.color} fill>
             <Text size="large">{value.value}</Text>
           </Box>
@@ -237,12 +238,12 @@ const Components = () => {
       <Stack>
         <Box>
           <Box direction="row">
-            {[1, 2].map(id => (
+            {[1, 2].map((id) => (
               <Node key={id} id={id} />
             ))}
           </Box>
           <Box direction="row">
-            {[3, 4].map(id => (
+            {[3, 4].map((id) => (
               <Node key={id} id={id} />
             ))}
           </Box>
@@ -279,7 +280,7 @@ const Components = () => {
       </Accordion>
     </Box>,
     <Box key="tabs">
-      <Tabs activeIndex={tabIndex} onActive={index => setTabIndex(index)}>
+      <Tabs activeIndex={tabIndex} onActive={(index) => setTabIndex(index)}>
         <Tab title="Tab 1">
           <Box pad="small">
             <Text>Tab 1 content</Text>
@@ -327,7 +328,7 @@ const Components = () => {
               size="small"
               options={Object.keys(themes)}
               value={themeName}
-              onChange={event => setThemeName(event.option)}
+              onChange={(event) => setThemeName(event.option)}
             />
           </Box>
           {themeCanMode && (
@@ -347,7 +348,7 @@ const Components = () => {
                 size="small"
                 options={['default', 'dark-1', 'light-1']}
                 value={background}
-                onChange={event => setBackground(event.option)}
+                onChange={(event) => setBackground(event.option)}
               />
             </Box>
           )}
@@ -357,7 +358,9 @@ const Components = () => {
               max={36}
               step={2}
               value={baseSize}
-              onChange={event => setBaseSize(parseInt(event.target.value, 10))}
+              onChange={(event) =>
+                setBaseSize(parseInt(event.target.value, 10))
+              }
             />
           </Box>
           <Text size="small">{`${baseSize}px base spacing`}</Text>

--- a/src/js/components/Drop/index.d.ts
+++ b/src/js/components/Drop/index.d.ts
@@ -21,6 +21,7 @@ export interface DropProps {
   inline?: boolean;
   onClickOutside?: React.MouseEventHandler<HTMLDocument>;
   onEsc?: KeyboardType;
+  onFocusOutside?: React.FocusEventHandler<HTMLDocument>;
   overflow?:
     | 'auto'
     | 'hidden'

--- a/src/js/components/Drop/propTypes.js
+++ b/src/js/components/Drop/propTypes.js
@@ -34,6 +34,7 @@ if (process.env.NODE_ENV !== 'production') {
     margin: marginProp,
     onClickOutside: PropTypes.func,
     onEsc: PropTypes.func,
+    onFocusOutside: PropTypes.func,
     overflow: dropOverflowPropTypes,
     plain: PropTypes.bool,
     responsive: PropTypes.bool,

--- a/src/js/components/DropButton/DropButton.js
+++ b/src/js/components/DropButton/DropButton.js
@@ -83,6 +83,7 @@ const DropButton = forwardRef(
             target={dropTarget || buttonRef.current}
             onClickOutside={onDropClose}
             onEsc={onDropClose}
+            onFocusOutside={dropProps?.inline ? onDropClose : undefined}
             {...dropProps}
           >
             {dropContent}

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -301,6 +301,7 @@ Object {
       "margin": [Function],
       "onClickOutside": [Function],
       "onEsc": [Function],
+      "onFocusOutside": [Function],
       "overflow": [Function],
       "plain": [Function],
       "responsive": [Function],


### PR DESCRIPTION
#### What does this PR do?

Changed Drop to add onFocusOutside.
This allows callers to combine `dropProps: { inline: true, trapFocus: false, onFocusOutside: () => {} }` to get Firefox-like behavior for a Drop. Namely, when the Drop is open and the user changes the focus to an element outside the Drop, the Drop can be closed.

For this pull request, the Select in the AllComponents story has been changed to specify `dropProps={{ inline: true, trapFocus: false }}` and DropButton detects the `inline` and automatically wires up the `onFocusOutside` to close the Drop.

This is meant to explore correctness of the behavior. I expect that the exact API signature and any theme configuration will need additional contemplation.

#### Where should the reviewer start?

Interact with the Select component in the All Components story to test the behavior.
Then, take a look at DropButton, then inside DropContainer for the real meat.

#### What testing has been done on this PR?

All Components story

#### How should this be manually tested?

All Components story

#### Do Jest tests follow these best practices?

no unit tests yet, tricky where focus is concerned

#### What are the relevant issues?

#### Do the grommet docs need to be updated?

yes

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
