### PR TITLE
Fixed hover indicator to fill cell on DataTable header

### DIFF
--- a/src/js/components/DataTable/Header.js
+++ b/src/js/components/DataTable/Header.js
@@ -372,6 +372,7 @@ const Header = forwardRef(
                 );
               }
 
+              // content should fill any available space in cell
               content = (
                 <Box flex="grow" fill={onResize ? 'vertical' : false}>
                   {content}
@@ -418,9 +419,6 @@ const Header = forwardRef(
                   </Box>
                 );
               }
-
-              // content should fill any available space in cell
-              // content = <Box flex="grow">{content}</Box>;
 
               const cellPin = [...pin];
               if (columnPin) cellPin.push('left');

--- a/src/js/components/DataTable/Header.js
+++ b/src/js/components/DataTable/Header.js
@@ -419,7 +419,6 @@ const Header = forwardRef(
                   </Box>
                 );
               }
-
               const cellPin = [...pin];
               if (columnPin) cellPin.push('left');
 

--- a/src/js/components/DataTable/Header.js
+++ b/src/js/components/DataTable/Header.js
@@ -345,7 +345,11 @@ const Header = forwardRef(
               }
 
               // content should fill any available space in cell
-              content = <Box flex="grow">{content}</Box>;
+              content = (
+                <Box flex="grow" fill={onSort ? 'vertical' : false}>
+                  {content}
+                </Box>
+              );
 
               if (search || onResize) {
                 const resizer = onResize ? (

--- a/src/js/components/DataTable/Header.js
+++ b/src/js/components/DataTable/Header.js
@@ -13,7 +13,7 @@ import { defaultProps } from '../../default-props';
 import { Box } from '../Box';
 import { Button } from '../Button';
 import { CheckBox } from '../CheckBox';
-import { TableCell } from '../TableCell';
+import { TableCell, verticalAlignToJustify } from '../TableCell/TableCell';
 import { Text } from '../Text';
 
 import { Resizer } from './Resizer';
@@ -325,11 +325,8 @@ const Header = forwardRef(
 
               if (verticalAlign || columnVerticalAlign) {
                 const vertical = verticalAlign || columnVerticalAlign;
-                let justify = 'center';
-                if (vertical === 'bottom') justify = 'end';
-                if (vertical === 'top') justify = 'start';
                 content = (
-                  <Box height="100%" justify={justify}>
+                  <Box height="100%" justify={verticalAlignToJustify[vertical]}>
                     {content}
                   </Box>
                 );
@@ -373,8 +370,12 @@ const Header = forwardRef(
               }
 
               // content should fill any available space in cell
+              // If `onResize` or `search` is true we need to explicitly set
+              // fill because later if either of these props is true content
+              // will be wrapped with an additional Box, preventing this Box
+              // from automatically filling the vertical space.
               content = (
-                <Box flex="grow" fill={onResize ? 'vertical' : false}>
+                <Box flex="grow" fill={onResize || search ? 'vertical' : false}>
                   {content}
                 </Box>
               );

--- a/src/js/components/DataTable/Header.js
+++ b/src/js/components/DataTable/Header.js
@@ -346,7 +346,10 @@ const Header = forwardRef(
 
               // content should fill any available space in cell
               content = (
-                <Box flex="grow" fill={onSort ? 'vertical' : false}>
+                <Box
+                  flex="grow"
+                  fill={onSort && sortable !== false ? 'vertical' : false}
+                >
                   {content}
                 </Box>
               );

--- a/src/js/components/DataTable/Header.js
+++ b/src/js/components/DataTable/Header.js
@@ -372,6 +372,12 @@ const Header = forwardRef(
                 );
               }
 
+              content = (
+                <Box flex="grow" fill={onResize ? 'vertical' : false}>
+                  {content}
+                </Box>
+              );
+
               if (search || onResize) {
                 const resizer = onResize ? (
                   <Resizer property={property} onResize={onResize} />
@@ -414,7 +420,7 @@ const Header = forwardRef(
               }
 
               // content should fill any available space in cell
-              content = <Box flex="grow">{content}</Box>;
+              // content = <Box flex="grow">{content}</Box>;
 
               const cellPin = [...pin];
               if (columnPin) cellPin.push('left');

--- a/src/js/components/DataTable/Header.js
+++ b/src/js/components/DataTable/Header.js
@@ -51,7 +51,7 @@ const separateThemeProps = (theme) => {
 
 // build up CSS from basic to specific based on the supplied sub-object paths.
 // adapted from StyledButtonKind to only include parts relevant for DataTable
-const buttonStyle = ({ pad, theme }) => {
+const buttonStyle = ({ pad, theme, verticalAlign }) => {
   const styles = [];
   const [layoutProps, , iconProps] = separateThemeProps(theme);
 
@@ -85,6 +85,19 @@ const buttonStyle = ({ pad, theme }) => {
           stroke: ${normalizeColor(iconProps.color, theme)};
           fill: ${normalizeColor(iconProps.color, theme)};
         }
+      `,
+    );
+  }
+
+  let align = 'center';
+  if (verticalAlign === 'bottom') align = 'end';
+  if (verticalAlign === 'top') align = 'start';
+
+  if (verticalAlign) {
+    styles.push(
+      css`
+        display: inline-flex;
+        align-items: ${align};
       `,
     );
   }
@@ -310,6 +323,18 @@ const Header = forwardRef(
                 );
               }
 
+              if (verticalAlign || columnVerticalAlign) {
+                const vertical = verticalAlign || columnVerticalAlign;
+                let justify = 'center';
+                if (vertical === 'bottom') justify = 'end';
+                if (vertical === 'top') justify = 'start';
+                content = (
+                  <Box height="100%" justify={justify}>
+                    {content}
+                  </Box>
+                );
+              }
+
               if (onSort && sortable !== false) {
                 let Icon;
                 if (onSort && sortable !== false) {
@@ -332,6 +357,7 @@ const Header = forwardRef(
                     sort={sort}
                     pad={cellProps.pad}
                     sortable
+                    verticalAlign={verticalAlign || columnVerticalAlign}
                   >
                     <Box
                       direction="row"
@@ -345,16 +371,6 @@ const Header = forwardRef(
                   </StyledHeaderCellButton>
                 );
               }
-
-              // content should fill any available space in cell
-              content = (
-                <Box
-                  flex="grow"
-                  fill={onSort && sortable !== false ? 'vertical' : false}
-                >
-                  {content}
-                </Box>
-              );
 
               if (search || onResize) {
                 const resizer = onResize ? (
@@ -396,6 +412,10 @@ const Header = forwardRef(
                   </Box>
                 );
               }
+
+              // content should fill any available space in cell
+              content = <Box flex="grow">{content}</Box>;
+
               const cellPin = [...pin];
               if (columnPin) cellPin.push('left');
 

--- a/src/js/components/DataTable/StyledDataTable.js
+++ b/src/js/components/DataTable/StyledDataTable.js
@@ -22,7 +22,7 @@ const StyledDataTable = styled(Table)`
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto; /* helps Firefox to get table contents to not overflow */
+  height: 100%;
   ${genericStyles}
   ${(props) => props.fillProp && fillStyle(props.fillProp)}
   ${(props) =>

--- a/src/js/components/DataTable/StyledDataTable.js
+++ b/src/js/components/DataTable/StyledDataTable.js
@@ -115,6 +115,7 @@ const StyledDataTableHeader = styled(TableHeader)`
   ${(props) =>
     props.size &&
     `
+    height: fit-content;
     display: table;
     width: calc(100% - ${props.scrollOffset}px);
     table-layout: fixed;

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -2765,23 +2765,6 @@ exports[`DataTable custom theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
-}
-
-.c6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2796,6 +2779,24 @@ exports[`DataTable custom theme 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+  height: 100%;
 }
 
 .c9 {
@@ -3255,10 +3256,10 @@ exports[`DataTable custom theme 1`] = `
         >
           <div
             class="c5"
+            style="position: relative;"
           >
             <div
               class="c6"
-              style="position: relative;"
             >
               <button
                 class="c7 c8"
@@ -3274,26 +3275,26 @@ exports[`DataTable custom theme 1`] = `
                   </span>
                 </div>
               </button>
+            </div>
+            <div
+              class="c11"
+            >
               <div
-                class="c11"
+                class="c12"
               >
                 <div
-                  class="c12"
-                >
-                  <div
-                    class="c13"
-                  />
-                </div>
+                  class="c13"
+                />
+              </div>
+              <div
+                class="c14"
+              >
                 <div
-                  class="c14"
+                  class="c15 c16"
                 >
                   <div
-                    class="c15 c16"
-                  >
-                    <div
-                      class="c17"
-                    />
-                  </div>
+                    class="c17"
+                  />
                 </div>
               </div>
             </div>
@@ -3444,11 +3445,11 @@ exports[`DataTable custom theme 2`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 fqUnkf"
+            class="StyledBox-sc-13pk1d4-0 fMHUIp"
+            style="position: relative;"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 fMHUIp"
-              style="position: relative;"
+              class="StyledBox-sc-13pk1d4-0 eUIwDt"
             >
               <button
                 class="StyledButton-sc-323bzc-0 iIPNKk Header__StyledHeaderCellButton-sc-1baku5q-0 brJnFl"
@@ -3464,26 +3465,26 @@ exports[`DataTable custom theme 2`] = `
                   </span>
                 </div>
               </button>
+            </div>
+            <div
+              class="StyledStack-sc-ajspsk-0 DIRUt"
+            >
               <div
-                class="StyledStack-sc-ajspsk-0 DIRUt"
+                class="StyledStack__StyledStackLayer-sc-ajspsk-1 bBReQo"
               >
                 <div
-                  class="StyledStack__StyledStackLayer-sc-ajspsk-1 bBReQo"
-                >
-                  <div
-                    class="StyledBox-sc-13pk1d4-0 cxMCmj"
-                  />
-                </div>
+                  class="StyledBox-sc-13pk1d4-0 cxMCmj"
+                />
+              </div>
+              <div
+                class="StyledStack__StyledStackLayer-sc-ajspsk-1 sanMr"
+              >
                 <div
-                  class="StyledStack__StyledStackLayer-sc-ajspsk-1 sanMr"
+                  class="StyledBox-sc-13pk1d4-0 dbtwtd Resizer__InteractionBox-sc-8l808w-0 hCPcHP"
                 >
                   <div
-                    class="StyledBox-sc-13pk1d4-0 dbtwtd Resizer__InteractionBox-sc-8l808w-0 hCPcHP"
-                  >
-                    <div
-                      class="StyledBox-sc-13pk1d4-0 claeHG"
-                    />
-                  </div>
+                    class="StyledBox-sc-13pk1d4-0 claeHG"
+                  />
                 </div>
               </div>
             </div>
@@ -18480,23 +18481,6 @@ exports[`DataTable resizeable 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
-}
-
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -18511,6 +18495,24 @@ exports[`DataTable resizeable 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+  height: 100%;
 }
 
 .c10 {
@@ -18715,39 +18717,39 @@ exports[`DataTable resizeable 1`] = `
         >
           <div
             class="c4"
+            style="position: relative;"
           >
             <div
               class="c5"
-              style="position: relative;"
             >
               <span
                 class="c6"
               >
                 A
               </span>
+            </div>
+            <div
+              class="c7"
+            />
+            <div
+              class="c8"
+            >
               <div
-                class="c7"
-              />
-              <div
-                class="c8"
+                class="c9"
               >
                 <div
-                  class="c9"
-                >
-                  <div
-                    class="c10"
-                  />
-                </div>
+                  class="c10"
+                />
+              </div>
+              <div
+                class="c11"
+              >
                 <div
-                  class="c11"
+                  class="c12 c13"
                 >
                   <div
-                    class="c12 c13"
-                  >
-                    <div
-                      class="c14"
-                    />
-                  </div>
+                    class="c14"
+                  />
                 </div>
               </div>
             </div>
@@ -18759,39 +18761,39 @@ exports[`DataTable resizeable 1`] = `
         >
           <div
             class="c4"
+            style="position: relative;"
           >
             <div
               class="c5"
-              style="position: relative;"
             >
               <span
                 class="c6"
               >
                 B
               </span>
+            </div>
+            <div
+              class="c7"
+            />
+            <div
+              class="c8"
+            >
               <div
-                class="c7"
-              />
-              <div
-                class="c8"
+                class="c9"
               >
                 <div
-                  class="c9"
-                >
-                  <div
-                    class="c10"
-                  />
-                </div>
+                  class="c10"
+                />
+              </div>
+              <div
+                class="c11"
+              >
                 <div
-                  class="c11"
+                  class="c12 c13"
                 >
                   <div
-                    class="c12 c13"
-                  >
-                    <div
-                      class="c14"
-                    />
-                  </div>
+                    class="c14"
+                  />
                 </div>
               </div>
             </div>
@@ -20402,23 +20404,6 @@ exports[`DataTable search 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
-}
-
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -20433,6 +20418,23 @@ exports[`DataTable search 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
 }
 
 .c12 {
@@ -20620,28 +20622,28 @@ exports[`DataTable search 1`] = `
               >
                 A
               </span>
-              <div
-                class="c7"
-              />
-              <button
-                aria-label="Open search by a"
-                class="c8"
-                type="button"
-              >
-                <svg
-                  aria-label="FormSearch"
-                  class="c9"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="M13.8 13.8 18 18l-4.2-4.2zM10.5 15a4.5 4.5 0 1 0 0-9 4.5 4.5 0 0 0 0 9z"
-                    fill="none"
-                    stroke="#000"
-                    stroke-width="2"
-                  />
-                </svg>
-              </button>
             </div>
+            <div
+              class="c7"
+            />
+            <button
+              aria-label="Open search by a"
+              class="c8"
+              type="button"
+            >
+              <svg
+                aria-label="FormSearch"
+                class="c9"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M13.8 13.8 18 18l-4.2-4.2zM10.5 15a4.5 4.5 0 1 0 0-9 4.5 4.5 0 0 0 0 9z"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </button>
           </div>
         </th>
       </tr>
@@ -20726,20 +20728,21 @@ exports[`DataTable search 2`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 fqUnkf"
+            class="StyledBox-sc-13pk1d4-0 fMHUIp"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 fMHUIp"
+              class="StyledBox-sc-13pk1d4-0 fqUnkf"
             >
               <span
                 class="StyledText-sc-1sadyjn-0 hpCRgD"
               >
                 A
               </span>
-              <div
-                class="StyledBox__StyledBoxGap-sc-13pk1d4-1 lbllaT"
-              />
-              .c0 {
+            </div>
+            <div
+              class="StyledBox__StyledBoxGap-sc-13pk1d4-1 lbllaT"
+            />
+            .c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -20842,19 +20845,18 @@ exports[`DataTable search 2`] = `
 }
 
 <div
-                class="c0"
+              class="c0"
+            >
+              <div
+                class="c1"
               >
-                <div
-                  class="c1"
-                >
-                  <input
-                    aria-label="Search by a"
-                    autocomplete="off"
-                    class="c2"
-                    name="search-a"
-                    value="["
-                  />
-                </div>
+                <input
+                  aria-label="Search by a"
+                  autocomplete="off"
+                  class="c2"
+                  name="search-a"
+                  value="["
+                />
               </div>
             </div>
           </div>

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -2765,6 +2765,23 @@ exports[`DataTable custom theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2779,24 +2796,6 @@ exports[`DataTable custom theme 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-}
-
-.c6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
-  height: 100%;
 }
 
 .c9 {
@@ -3256,10 +3255,10 @@ exports[`DataTable custom theme 1`] = `
         >
           <div
             class="c5"
-            style="position: relative;"
           >
             <div
               class="c6"
+              style="position: relative;"
             >
               <button
                 class="c7 c8"
@@ -3275,26 +3274,26 @@ exports[`DataTable custom theme 1`] = `
                   </span>
                 </div>
               </button>
-            </div>
-            <div
-              class="c11"
-            >
               <div
-                class="c12"
+                class="c11"
               >
                 <div
-                  class="c13"
-                />
-              </div>
-              <div
-                class="c14"
-              >
-                <div
-                  class="c15 c16"
+                  class="c12"
                 >
                   <div
-                    class="c17"
+                    class="c13"
                   />
+                </div>
+                <div
+                  class="c14"
+                >
+                  <div
+                    class="c15 c16"
+                  >
+                    <div
+                      class="c17"
+                    />
+                  </div>
                 </div>
               </div>
             </div>
@@ -3445,11 +3444,11 @@ exports[`DataTable custom theme 2`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 fMHUIp"
-            style="position: relative;"
+            class="StyledBox-sc-13pk1d4-0 fqUnkf"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 eUIwDt"
+              class="StyledBox-sc-13pk1d4-0 fMHUIp"
+              style="position: relative;"
             >
               <button
                 class="StyledButton-sc-323bzc-0 iIPNKk Header__StyledHeaderCellButton-sc-1baku5q-0 brJnFl"
@@ -3465,26 +3464,26 @@ exports[`DataTable custom theme 2`] = `
                   </span>
                 </div>
               </button>
-            </div>
-            <div
-              class="StyledStack-sc-ajspsk-0 DIRUt"
-            >
               <div
-                class="StyledStack__StyledStackLayer-sc-ajspsk-1 bBReQo"
+                class="StyledStack-sc-ajspsk-0 DIRUt"
               >
                 <div
-                  class="StyledBox-sc-13pk1d4-0 cxMCmj"
-                />
-              </div>
-              <div
-                class="StyledStack__StyledStackLayer-sc-ajspsk-1 sanMr"
-              >
-                <div
-                  class="StyledBox-sc-13pk1d4-0 dbtwtd Resizer__InteractionBox-sc-8l808w-0 hCPcHP"
+                  class="StyledStack__StyledStackLayer-sc-ajspsk-1 bBReQo"
                 >
                   <div
-                    class="StyledBox-sc-13pk1d4-0 claeHG"
+                    class="StyledBox-sc-13pk1d4-0 cxMCmj"
                   />
+                </div>
+                <div
+                  class="StyledStack__StyledStackLayer-sc-ajspsk-1 sanMr"
+                >
+                  <div
+                    class="StyledBox-sc-13pk1d4-0 dbtwtd Resizer__InteractionBox-sc-8l808w-0 hCPcHP"
+                  >
+                    <div
+                      class="StyledBox-sc-13pk1d4-0 claeHG"
+                    />
+                  </div>
                 </div>
               </div>
             </div>
@@ -13457,7 +13456,6 @@ exports[`DataTable onSort 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
-  height: 100%;
 }
 
 .c7 {
@@ -13794,7 +13792,7 @@ exports[`DataTable onSort 2`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eUIwDt"
+            class="StyledBox-sc-13pk1d4-0 fqUnkf"
           >
             <button
               class="StyledButton-sc-323bzc-0 iIPNKk Header__StyledHeaderCellButton-sc-1baku5q-0 jdyvfX"
@@ -13894,7 +13892,7 @@ exports[`DataTable onSort 2`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eUIwDt"
+            class="StyledBox-sc-13pk1d4-0 fqUnkf"
           >
             <button
               class="StyledButton-sc-323bzc-0 iIPNKk Header__StyledHeaderCellButton-sc-1baku5q-0 jdyvfX"
@@ -14075,7 +14073,6 @@ exports[`DataTable onSort external 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
-  height: 100%;
 }
 
 .c7 {
@@ -14443,7 +14440,7 @@ exports[`DataTable onSort external 2`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eUIwDt"
+            class="StyledBox-sc-13pk1d4-0 fqUnkf"
           >
             <button
               class="StyledButton-sc-323bzc-0 iIPNKk Header__StyledHeaderCellButton-sc-1baku5q-0 jdyvfX"
@@ -14523,7 +14520,7 @@ exports[`DataTable onSort external 2`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eUIwDt"
+            class="StyledBox-sc-13pk1d4-0 fqUnkf"
           >
             <button
               class="StyledButton-sc-323bzc-0 iIPNKk Header__StyledHeaderCellButton-sc-1baku5q-0 jdyvfX"
@@ -18483,6 +18480,23 @@ exports[`DataTable resizeable 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -18497,23 +18511,6 @@ exports[`DataTable resizeable 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-}
-
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
 }
 
 .c10 {
@@ -18718,39 +18715,39 @@ exports[`DataTable resizeable 1`] = `
         >
           <div
             class="c4"
-            style="position: relative;"
           >
             <div
               class="c5"
+              style="position: relative;"
             >
               <span
                 class="c6"
               >
                 A
               </span>
-            </div>
-            <div
-              class="c7"
-            />
-            <div
-              class="c8"
-            >
               <div
-                class="c9"
+                class="c7"
+              />
+              <div
+                class="c8"
               >
                 <div
-                  class="c10"
-                />
-              </div>
-              <div
-                class="c11"
-              >
-                <div
-                  class="c12 c13"
+                  class="c9"
                 >
                   <div
-                    class="c14"
+                    class="c10"
                   />
+                </div>
+                <div
+                  class="c11"
+                >
+                  <div
+                    class="c12 c13"
+                  >
+                    <div
+                      class="c14"
+                    />
+                  </div>
                 </div>
               </div>
             </div>
@@ -18762,39 +18759,39 @@ exports[`DataTable resizeable 1`] = `
         >
           <div
             class="c4"
-            style="position: relative;"
           >
             <div
               class="c5"
+              style="position: relative;"
             >
               <span
                 class="c6"
               >
                 B
               </span>
-            </div>
-            <div
-              class="c7"
-            />
-            <div
-              class="c8"
-            >
               <div
-                class="c9"
+                class="c7"
+              />
+              <div
+                class="c8"
               >
                 <div
-                  class="c10"
-                />
-              </div>
-              <div
-                class="c11"
-              >
-                <div
-                  class="c12 c13"
+                  class="c9"
                 >
                   <div
-                    class="c14"
+                    class="c10"
                   />
+                </div>
+                <div
+                  class="c11"
+                >
+                  <div
+                    class="c12 c13"
+                  >
+                    <div
+                      class="c14"
+                    />
+                  </div>
                 </div>
               </div>
             </div>
@@ -20405,6 +20402,23 @@ exports[`DataTable search 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -20419,23 +20433,6 @@ exports[`DataTable search 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-}
-
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
 }
 
 .c12 {
@@ -20623,28 +20620,28 @@ exports[`DataTable search 1`] = `
               >
                 A
               </span>
-            </div>
-            <div
-              class="c7"
-            />
-            <button
-              aria-label="Open search by a"
-              class="c8"
-              type="button"
-            >
-              <svg
-                aria-label="FormSearch"
-                class="c9"
-                viewBox="0 0 24 24"
+              <div
+                class="c7"
+              />
+              <button
+                aria-label="Open search by a"
+                class="c8"
+                type="button"
               >
-                <path
-                  d="M13.8 13.8 18 18l-4.2-4.2zM10.5 15a4.5 4.5 0 1 0 0-9 4.5 4.5 0 0 0 0 9z"
-                  fill="none"
-                  stroke="#000"
-                  stroke-width="2"
-                />
-              </svg>
-            </button>
+                <svg
+                  aria-label="FormSearch"
+                  class="c9"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M13.8 13.8 18 18l-4.2-4.2zM10.5 15a4.5 4.5 0 1 0 0-9 4.5 4.5 0 0 0 0 9z"
+                    fill="none"
+                    stroke="#000"
+                    stroke-width="2"
+                  />
+                </svg>
+              </button>
+            </div>
           </div>
         </th>
       </tr>
@@ -20729,21 +20726,20 @@ exports[`DataTable search 2`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 fMHUIp"
+            class="StyledBox-sc-13pk1d4-0 fqUnkf"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 fqUnkf"
+              class="StyledBox-sc-13pk1d4-0 fMHUIp"
             >
               <span
                 class="StyledText-sc-1sadyjn-0 hpCRgD"
               >
                 A
               </span>
-            </div>
-            <div
-              class="StyledBox__StyledBoxGap-sc-13pk1d4-1 lbllaT"
-            />
-            .c0 {
+              <div
+                class="StyledBox__StyledBoxGap-sc-13pk1d4-1 lbllaT"
+              />
+              .c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -20846,18 +20842,19 @@ exports[`DataTable search 2`] = `
 }
 
 <div
-              class="c0"
-            >
-              <div
-                class="c1"
+                class="c0"
               >
-                <input
-                  aria-label="Search by a"
-                  autocomplete="off"
-                  class="c2"
-                  name="search-a"
-                  value="["
-                />
+                <div
+                  class="c1"
+                >
+                  <input
+                    aria-label="Search by a"
+                    autocomplete="off"
+                    class="c2"
+                    name="search-a"
+                    value="["
+                  />
+                </div>
               </div>
             </div>
           </div>
@@ -36484,7 +36481,6 @@ exports[`DataTable sort 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
-  height: 100%;
 }
 
 .c7 {
@@ -36894,7 +36890,6 @@ exports[`DataTable sort external 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
-  height: 100%;
 }
 
 .c7 {
@@ -37304,7 +37299,6 @@ exports[`DataTable sort nested object 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
-  height: 100%;
 }
 
 .c7 {
@@ -37714,7 +37708,6 @@ exports[`DataTable sort nested object with onSort 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
-  height: 100%;
 }
 
 .c7 {
@@ -38090,7 +38083,6 @@ exports[`DataTable sortable 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
-  height: 100%;
 }
 
 .c7 {
@@ -38427,7 +38419,7 @@ exports[`DataTable sortable 2`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eUIwDt"
+            class="StyledBox-sc-13pk1d4-0 fqUnkf"
           >
             <button
               class="StyledButton-sc-323bzc-0 iIPNKk Header__StyledHeaderCellButton-sc-1baku5q-0 jdyvfX"
@@ -38527,7 +38519,7 @@ exports[`DataTable sortable 2`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eUIwDt"
+            class="StyledBox-sc-13pk1d4-0 fqUnkf"
           >
             <button
               class="StyledButton-sc-323bzc-0 iIPNKk Header__StyledHeaderCellButton-sc-1baku5q-0 jdyvfX"
@@ -39222,7 +39214,26 @@ exports[`DataTable verticalAlign 1`] = `
   flex: 1 0 auto;
 }
 
-.c8 {
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 100%;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -39240,12 +39251,31 @@ exports[`DataTable verticalAlign 1`] = `
   justify-content: flex-start;
 }
 
-.c5 {
+.c12 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 100%;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.c6 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c9 {
+.c10 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
@@ -39265,30 +39295,13 @@ exports[`DataTable verticalAlign 1`] = `
   padding-bottom: 6px;
 }
 
-.c7 {
+.c8 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
   text-align: inherit;
   vertical-align: top;
   text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-.c10 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  width: 96px;
-  max-width: 96px;
-  overflow: hidden;
-  vertical-align: bottom;
-  text-align: start;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
   padding-left: 12px;
   padding-right: 12px;
   padding-top: 6px;
@@ -39300,6 +39313,9 @@ exports[`DataTable verticalAlign 1`] = `
   padding: 0;
   font-weight: inherit;
   text-align: inherit;
+  width: 96px;
+  max-width: 96px;
+  overflow: hidden;
   vertical-align: bottom;
   text-align: start;
   border-bottom: solid 1px rgba(0,0,0,0.33);
@@ -39309,7 +39325,21 @@ exports[`DataTable verticalAlign 1`] = `
   padding-bottom: 6px;
 }
 
-.c12 {
+.c13 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  vertical-align: bottom;
+  text-align: start;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c14 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -39325,7 +39355,7 @@ exports[`DataTable verticalAlign 1`] = `
   padding-bottom: 6px;
 }
 
-.c13 {
+.c15 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -39342,7 +39372,7 @@ exports[`DataTable verticalAlign 1`] = `
   padding-bottom: 6px;
 }
 
-.c14 {
+.c16 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -39369,11 +39399,11 @@ exports[`DataTable verticalAlign 1`] = `
   height: 100%;
 }
 
-.c6:focus {
+.c7:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c6:focus:not(:focus-visible) {
+.c7:focus:not(:focus-visible) {
   outline: none;
 }
 
@@ -39402,11 +39432,15 @@ exports[`DataTable verticalAlign 1`] = `
             <div
               class="c4"
             >
-              <span
+              <div
                 class="c5"
               >
-                A
-              </span>
+                <span
+                  class="c6"
+                >
+                  A
+                </span>
+              </div>
             </div>
           </th>
           <th
@@ -39416,43 +39450,47 @@ exports[`DataTable verticalAlign 1`] = `
             <div
               class="c4"
             >
-              <span
+              <div
                 class="c5"
               >
-                B
-              </span>
+                <span
+                  class="c6"
+                >
+                  B
+                </span>
+              </div>
             </div>
           </th>
         </tr>
       </thead>
       <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c6"
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c7"
       >
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c7 "
+            class="c8 "
             scope="row"
           >
             <div
-              class="c8"
+              class="c9"
             >
               <span
-                class="c9"
+                class="c10"
               >
                 one
               </span>
             </div>
           </th>
           <td
-            class="c7 "
+            class="c8 "
           >
             <div
-              class="c8"
+              class="c9"
             >
               <span
-                class="c5"
+                class="c6"
               >
                 1
               </span>
@@ -39463,27 +39501,27 @@ exports[`DataTable verticalAlign 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c7 "
+            class="c8 "
             scope="row"
           >
             <div
-              class="c8"
+              class="c9"
             >
               <span
-                class="c9"
+                class="c10"
               >
                 two
               </span>
             </div>
           </th>
           <td
-            class="c7 "
+            class="c8 "
           >
             <div
-              class="c8"
+              class="c9"
             >
               <span
-                class="c5"
+                class="c6"
               >
                 2
               </span>
@@ -39502,57 +39540,65 @@ exports[`DataTable verticalAlign 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c10 "
-            scope="col"
-          >
-            <div
-              class="c4"
-            >
-              <span
-                class="c5"
-              >
-                A
-              </span>
-            </div>
-          </th>
-          <th
             class="c11 "
             scope="col"
           >
             <div
               class="c4"
             >
-              <span
-                class="c5"
+              <div
+                class="c12"
               >
-                B
-              </span>
+                <span
+                  class="c6"
+                >
+                  A
+                </span>
+              </div>
+            </div>
+          </th>
+          <th
+            class="c13 "
+            scope="col"
+          >
+            <div
+              class="c4"
+            >
+              <div
+                class="c12"
+              >
+                <span
+                  class="c6"
+                >
+                  B
+                </span>
+              </div>
             </div>
           </th>
         </tr>
       </thead>
       <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c6"
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c7"
       >
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c12 "
+            class="c14 "
             scope="row"
           >
             <div
-              class="c8"
+              class="c9"
             />
           </th>
           <td
-            class="c7 "
+            class="c8 "
           >
             <div
-              class="c8"
+              class="c9"
             >
               <span
-                class="c5"
+                class="c6"
               >
                 1
               </span>
@@ -39563,21 +39609,21 @@ exports[`DataTable verticalAlign 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c12 "
+            class="c14 "
             scope="row"
           >
             <div
-              class="c8"
+              class="c9"
             />
           </th>
           <td
-            class="c7 "
+            class="c8 "
           >
             <div
-              class="c8"
+              class="c9"
             >
               <span
-                class="c5"
+                class="c6"
               >
                 2
               </span>
@@ -39592,23 +39638,23 @@ exports[`DataTable verticalAlign 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2"
         >
           <td
-            class="c13 "
+            class="c15 "
           >
             <div
-              class="c8"
+              class="c9"
             >
               <span
-                class="c9"
+                class="c10"
               >
                 This is a long footer that wraps
               </span>
             </div>
           </td>
           <td
-            class="c14 "
+            class="c16 "
           >
             <div
-              class="c8"
+              class="c9"
             />
           </td>
         </tr>

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -20435,6 +20435,7 @@ exports[`DataTable search 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  height: 100%;
 }
 
 .c12 {
@@ -20731,7 +20732,7 @@ exports[`DataTable search 2`] = `
             class="StyledBox-sc-13pk1d4-0 fMHUIp"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 fqUnkf"
+              class="StyledBox-sc-13pk1d4-0 eUIwDt"
             >
               <span
                 class="StyledText-sc-1sadyjn-0 hpCRgD"

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -82,7 +82,7 @@ exports[`DataTable !primaryKey 1`] = `
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
 }
 
 .c6:focus {
@@ -334,7 +334,7 @@ exports[`DataTable absoluteColumnSizes 1`] = `
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
 }
 
 .c7:focus {
@@ -564,7 +564,7 @@ exports[`DataTable aggregate 1`] = `
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
 }
 
 .c6:focus {
@@ -822,7 +822,7 @@ exports[`DataTable aggregate with nested object 1`] = `
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
 }
 
 .c6:focus {
@@ -1188,7 +1188,7 @@ exports[`DataTable background 1`] = `
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
 }
 
 .c6:focus {
@@ -1701,7 +1701,7 @@ exports[`DataTable basic 1`] = `
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
 }
 
 .c6:focus {
@@ -1932,7 +1932,7 @@ exports[`DataTable border 1`] = `
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
 }
 
 .c6:focus {
@@ -2579,7 +2579,7 @@ exports[`DataTable click 1`] = `
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
 }
 
 .c7 {
@@ -2678,7 +2678,7 @@ exports[`DataTable click 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 ciKqQZ StyledDataTable-sc-xrlyjm-0 eXMpft"
+    class="StyledTable-sc-1m3u5g-6 ciKqQZ StyledDataTable-sc-xrlyjm-0 hmFzTO"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -2796,6 +2796,7 @@ exports[`DataTable custom theme 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  height: 100%;
 }
 
 .c9 {
@@ -3182,7 +3183,7 @@ exports[`DataTable custom theme 1`] = `
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
 }
 
 .c18:focus {
@@ -3427,7 +3428,7 @@ exports[`DataTable custom theme 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 ciKqQZ StyledDataTable-sc-xrlyjm-0 eXMpft"
+    class="StyledTable-sc-1m3u5g-6 ciKqQZ StyledDataTable-sc-xrlyjm-0 hmFzTO"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -3448,7 +3449,7 @@ exports[`DataTable custom theme 2`] = `
             style="position: relative;"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 fqUnkf"
+              class="StyledBox-sc-13pk1d4-0 eUIwDt"
             >
               <button
                 class="StyledButton-sc-323bzc-0 iIPNKk Header__StyledHeaderCellButton-sc-1baku5q-0 brJnFl"
@@ -3700,7 +3701,7 @@ exports[`DataTable disabled click 1`] = `
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
 }
 
 .c10 {
@@ -3800,7 +3801,7 @@ exports[`DataTable disabled click 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 ciKqQZ StyledDataTable-sc-xrlyjm-0 eXMpft"
+    class="StyledTable-sc-1m3u5g-6 ciKqQZ StyledDataTable-sc-xrlyjm-0 hmFzTO"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -4167,7 +4168,7 @@ exports[`DataTable disabled select 1`] = `
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
 }
 
 .c14:focus {
@@ -4393,7 +4394,7 @@ exports[`DataTable empty 1`] = `
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
 }
 
 .c3:focus {
@@ -4531,7 +4532,7 @@ exports[`DataTable fill 1`] = `
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
   width: 100%;
   height: 100%;
 }
@@ -4540,7 +4541,7 @@ exports[`DataTable fill 1`] = `
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
   width: 100%;
 }
 
@@ -4548,7 +4549,7 @@ exports[`DataTable fill 1`] = `
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
   height: 100%;
 }
 
@@ -5075,7 +5076,7 @@ exports[`DataTable footer 1`] = `
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
 }
 
 .c6:focus {
@@ -5484,7 +5485,7 @@ exports[`DataTable groupBy 1`] = `
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
 }
 
 .c11:focus {
@@ -5713,7 +5714,7 @@ exports[`DataTable groupBy 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 ciKqQZ StyledDataTable-sc-xrlyjm-0 eXMpft"
+    class="StyledTable-sc-1m3u5g-6 ciKqQZ StyledDataTable-sc-xrlyjm-0 hmFzTO"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -6200,7 +6201,7 @@ exports[`DataTable groupBy expand 1`] = `
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
 }
 
 .c11:focus {
@@ -6778,7 +6779,7 @@ exports[`DataTable groupBy property 1`] = `
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
 }
 
 .c11:focus {
@@ -7007,7 +7008,7 @@ exports[`DataTable groupBy property 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 ciKqQZ StyledDataTable-sc-xrlyjm-0 eXMpft"
+    class="StyledTable-sc-1m3u5g-6 ciKqQZ StyledDataTable-sc-xrlyjm-0 hmFzTO"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -7284,7 +7285,7 @@ exports[`DataTable groupBy toggle 1`] = `
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
 }
 
 .c6:focus {
@@ -7490,7 +7491,7 @@ exports[`DataTable groupBy toggle 2`] = `
     toggle
   </button>
   <table
-    class="StyledTable-sc-1m3u5g-6 ciKqQZ StyledDataTable-sc-xrlyjm-0 eXMpft"
+    class="StyledTable-sc-1m3u5g-6 ciKqQZ StyledDataTable-sc-xrlyjm-0 hmFzTO"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -8079,7 +8080,7 @@ exports[`DataTable groupBy toggle 3`] = `
     toggle
   </button>
   <table
-    class="StyledTable-sc-1m3u5g-6 ciKqQZ StyledDataTable-sc-xrlyjm-0 eXMpft"
+    class="StyledTable-sc-1m3u5g-6 ciKqQZ StyledDataTable-sc-xrlyjm-0 hmFzTO"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -8755,7 +8756,7 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
 }
 
 .c18:focus {
@@ -9625,7 +9626,7 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
 }
 
 .c18:focus {
@@ -10355,7 +10356,7 @@ exports[`DataTable onSelect + groupBy should select all items within a group 1`]
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
 }
 
 .c18:focus {
@@ -11057,7 +11058,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 1`
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
 }
 
 .c17:focus {
@@ -11368,7 +11369,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
   class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 ciKqQZ StyledDataTable-sc-xrlyjm-0 eXMpft"
+    class="StyledTable-sc-1m3u5g-6 ciKqQZ StyledDataTable-sc-xrlyjm-0 hmFzTO"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -11755,7 +11756,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
   class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 ciKqQZ StyledDataTable-sc-xrlyjm-0 eXMpft"
+    class="StyledTable-sc-1m3u5g-6 ciKqQZ StyledDataTable-sc-xrlyjm-0 hmFzTO"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -12242,7 +12243,7 @@ exports[`DataTable onSelect select/unselect all 1`] = `
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
 }
 
 .c13:focus {
@@ -12570,7 +12571,7 @@ exports[`DataTable onSelect select/unselect all 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 ciKqQZ StyledDataTable-sc-xrlyjm-0 eXMpft"
+    class="StyledTable-sc-1m3u5g-6 ciKqQZ StyledDataTable-sc-xrlyjm-0 hmFzTO"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -13026,7 +13027,7 @@ exports[`DataTable onSelect select/unselect all 3`] = `
   class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 ciKqQZ StyledDataTable-sc-xrlyjm-0 eXMpft"
+    class="StyledTable-sc-1m3u5g-6 ciKqQZ StyledDataTable-sc-xrlyjm-0 hmFzTO"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -13348,6 +13349,7 @@ exports[`DataTable onSort 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  height: 100%;
 }
 
 .c7 {
@@ -13484,7 +13486,7 @@ exports[`DataTable onSort 1`] = `
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
 }
 
 .c9:focus {
@@ -13671,7 +13673,7 @@ exports[`DataTable onSort 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 ciKqQZ StyledDataTable-sc-xrlyjm-0 eXMpft"
+    class="StyledTable-sc-1m3u5g-6 ciKqQZ StyledDataTable-sc-xrlyjm-0 hmFzTO"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -13684,7 +13686,7 @@ exports[`DataTable onSort 2`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 fqUnkf"
+            class="StyledBox-sc-13pk1d4-0 eUIwDt"
           >
             <button
               class="StyledButton-sc-323bzc-0 iIPNKk Header__StyledHeaderCellButton-sc-1baku5q-0 jdyvfX"
@@ -13784,7 +13786,7 @@ exports[`DataTable onSort 2`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 fqUnkf"
+            class="StyledBox-sc-13pk1d4-0 eUIwDt"
           >
             <button
               class="StyledButton-sc-323bzc-0 iIPNKk Header__StyledHeaderCellButton-sc-1baku5q-0 jdyvfX"
@@ -13965,6 +13967,7 @@ exports[`DataTable onSort external 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  height: 100%;
 }
 
 .c7 {
@@ -14111,7 +14114,7 @@ exports[`DataTable onSort external 1`] = `
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
 }
 
 .c11:focus {
@@ -14319,7 +14322,7 @@ exports[`DataTable onSort external 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 ciKqQZ StyledDataTable-sc-xrlyjm-0 eXMpft"
+    class="StyledTable-sc-1m3u5g-6 ciKqQZ StyledDataTable-sc-xrlyjm-0 hmFzTO"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -14332,7 +14335,7 @@ exports[`DataTable onSort external 2`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 fqUnkf"
+            class="StyledBox-sc-13pk1d4-0 eUIwDt"
           >
             <button
               class="StyledButton-sc-323bzc-0 iIPNKk Header__StyledHeaderCellButton-sc-1baku5q-0 jdyvfX"
@@ -14412,7 +14415,7 @@ exports[`DataTable onSort external 2`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 fqUnkf"
+            class="StyledBox-sc-13pk1d4-0 eUIwDt"
           >
             <button
               class="StyledButton-sc-323bzc-0 iIPNKk Header__StyledHeaderCellButton-sc-1baku5q-0 jdyvfX"
@@ -14676,7 +14679,7 @@ exports[`DataTable pad 1`] = `
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
 }
 
 .c6:focus {
@@ -15189,7 +15192,7 @@ exports[`DataTable paths 1`] = `
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
 }
 
 .c6:focus {
@@ -15462,7 +15465,7 @@ exports[`DataTable pin + background 1`] = `
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
 }
 
 .c8:focus {
@@ -16114,7 +16117,7 @@ exports[`DataTable pin + background context 1`] = `
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
 }
 
 .c9:focus {
@@ -16696,7 +16699,7 @@ exports[`DataTable pin 1`] = `
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
 }
 
 .c8:focus {
@@ -17291,7 +17294,7 @@ exports[`DataTable placeholder 1`] = `
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
 }
 
 .c6:focus {
@@ -17725,7 +17728,7 @@ exports[`DataTable primaryKey 1`] = `
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
 }
 
 .c6:focus {
@@ -17979,7 +17982,7 @@ exports[`DataTable relativeColumnSizes 1`] = `
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
 }
 
 .c7:focus {
@@ -18214,7 +18217,7 @@ exports[`DataTable replace 1`] = `
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
 }
 
 .c6:focus {
@@ -18559,7 +18562,7 @@ exports[`DataTable resizeable 1`] = `
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
 }
 
 .c15:focus {
@@ -19019,7 +19022,7 @@ exports[`DataTable rowDetails 1`] = `
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
 }
 
 .c7:focus {
@@ -19623,7 +19626,7 @@ exports[`DataTable rowDetails condtional 1`] = `
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
 }
 
 .c7:focus {
@@ -20085,7 +20088,7 @@ exports[`DataTable rowProps 1`] = `
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
 }
 
 .c6:focus {
@@ -20462,7 +20465,7 @@ exports[`DataTable search 1`] = `
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
 }
 
 .c10:focus {
@@ -20605,7 +20608,7 @@ exports[`DataTable search 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 ciKqQZ StyledDataTable-sc-xrlyjm-0 eXMpft"
+    class="StyledTable-sc-1m3u5g-6 ciKqQZ StyledDataTable-sc-xrlyjm-0 hmFzTO"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -21035,7 +21038,7 @@ exports[`DataTable select 1`] = `
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
 }
 
 .c14:focus {
@@ -21240,7 +21243,7 @@ exports[`DataTable select 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 ciKqQZ StyledDataTable-sc-xrlyjm-0 eXMpft"
+    class="StyledTable-sc-1m3u5g-6 ciKqQZ StyledDataTable-sc-xrlyjm-0 hmFzTO"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -22034,7 +22037,7 @@ exports[`DataTable should apply pagination styling 1`] = `
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
 }
 
 .c8:focus {
@@ -23898,7 +23901,7 @@ exports[`DataTable should not show paginate controls when data is empty array 1`
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
 }
 
 .c8:focus {
@@ -24078,7 +24081,7 @@ exports[`DataTable should not show paginate controls when length of data < step 
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
 }
 
 .c8:focus {
@@ -24820,7 +24823,7 @@ exports[`DataTable should paginate 1`] = `
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
 }
 
 .c8:focus {
@@ -27164,7 +27167,7 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
 }
 
 .c8:focus {
@@ -28462,7 +28465,7 @@ exports[`DataTable should render new data when page changes 1`] = `
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
 }
 
 .c8:focus {
@@ -30243,7 +30246,7 @@ exports[`DataTable should render new data when page changes 2`] = `
       class="StyledBox-sc-13pk1d4-0 iZicmW"
     >
       <table
-        class="StyledTable-sc-1m3u5g-6 ciKqQZ StyledDataTable-sc-xrlyjm-0 eXMpft"
+        class="StyledTable-sc-1m3u5g-6 ciKqQZ StyledDataTable-sc-xrlyjm-0 hmFzTO"
       >
         <thead
           class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -32354,7 +32357,7 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
 }
 
 .c8:focus {
@@ -34698,7 +34701,7 @@ exports[`DataTable should show correct page when "show" is { page: # } 1`] = `
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
 }
 
 .c8:focus {
@@ -36373,6 +36376,7 @@ exports[`DataTable sort 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  height: 100%;
 }
 
 .c7 {
@@ -36519,7 +36523,7 @@ exports[`DataTable sort 1`] = `
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
 }
 
 .c11:focus {
@@ -36782,6 +36786,7 @@ exports[`DataTable sort external 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  height: 100%;
 }
 
 .c7 {
@@ -36928,7 +36933,7 @@ exports[`DataTable sort external 1`] = `
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
 }
 
 .c11:focus {
@@ -37191,6 +37196,7 @@ exports[`DataTable sort nested object 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  height: 100%;
 }
 
 .c7 {
@@ -37337,7 +37343,7 @@ exports[`DataTable sort nested object 1`] = `
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
 }
 
 .c11:focus {
@@ -37600,6 +37606,7 @@ exports[`DataTable sort nested object with onSort 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  height: 100%;
 }
 
 .c7 {
@@ -37746,7 +37753,7 @@ exports[`DataTable sort nested object with onSort 1`] = `
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
 }
 
 .c11:focus {
@@ -37975,6 +37982,7 @@ exports[`DataTable sortable 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  height: 100%;
 }
 
 .c7 {
@@ -38111,7 +38119,7 @@ exports[`DataTable sortable 1`] = `
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
 }
 
 .c9:focus {
@@ -38298,7 +38306,7 @@ exports[`DataTable sortable 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 ciKqQZ StyledDataTable-sc-xrlyjm-0 eXMpft"
+    class="StyledTable-sc-1m3u5g-6 ciKqQZ StyledDataTable-sc-xrlyjm-0 hmFzTO"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -38311,7 +38319,7 @@ exports[`DataTable sortable 2`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 fqUnkf"
+            class="StyledBox-sc-13pk1d4-0 eUIwDt"
           >
             <button
               class="StyledButton-sc-323bzc-0 iIPNKk Header__StyledHeaderCellButton-sc-1baku5q-0 jdyvfX"
@@ -38411,7 +38419,7 @@ exports[`DataTable sortable 2`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 fqUnkf"
+            class="StyledBox-sc-13pk1d4-0 eUIwDt"
           >
             <button
               class="StyledButton-sc-323bzc-0 iIPNKk Header__StyledHeaderCellButton-sc-1baku5q-0 jdyvfX"
@@ -38657,7 +38665,7 @@ exports[`DataTable themeColumnSizes 1`] = `
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
 }
 
 .c7:focus {
@@ -38911,7 +38919,7 @@ exports[`DataTable units 1`] = `
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
-  height: auto;
+  height: 100%;
 }
 
 .c8:focus {

--- a/src/js/components/TableCell/TableCell.js
+++ b/src/js/components/TableCell/TableCell.js
@@ -17,7 +17,7 @@ import { TableContext } from '../Table/TableContext';
 import { StyledTableCell } from '../Table/StyledTable';
 import { TableCellPropTypes } from './propTypes';
 
-const verticalAlignToJustify = {
+export const verticalAlignToJustify = {
   middle: 'center',
   top: 'start',
   bottom: 'end',


### PR DESCRIPTION
#### What does this PR do?
Fixes an issue with DataTable where if the columns in the table are `sortable` and there are columns that have names that span multiple lines and columns names that are only on one line, the one line column header button will not fill the vertical space in the header. See screenshots below for a visual.

Notes:
1. This PR changes `height: auto` to `height: 100%` in `StyledDataTable.js`. We previously had height set to 100% but it was changed to auto in https://github.com/grommet/grommet/pull/3533 to fix an issue in FireFox where having a DataTable with the `groupBy` prop set, wrapped with `<Box fill>` resulted in this:
<img width="699" alt="Screen Shot 2022-04-22 at 1 56 37 PM" src="https://user-images.githubusercontent.com/54560994/164785062-b950a57c-a8b9-430b-9498-3c5ce0dc3cdb.png">

See [this related slack thread](https://grommet.slack.com/archives/C04LMHN59/p1573141859413900) for more info.
The change from `height: auto` to `height: 100%` was made over 2 years ago and it looks like something either changed on our end with Grommet or with FireFox because I am no longer seeing this issue in FireFox when I set height back to 100%.

2. This fix does not work for FireFox, the sortable button in the header will not fill the cell if other cells wrap multiple lines. The fix is working in both chrome and safari.

#### Where should the reviewer start?
[StyledDataTable.js](https://github.com/grommet/grommet/compare/master...jcfilben:fix/dataTable-hover?expand=1#diff-3c607ce17d65f5520f60a0b3ad2154f7d906796eb228bd0a0ebb076090a9286b)

#### What testing has been done on this PR?
Tested with the existing DataTable stories as well as the code provided in this slack thread https://grommet.slack.com/archives/C04LMHN59/p1573141859413900.

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes https://github.com/grommet/grommet/issues/5968

#### Screenshots (if appropriate)
Before:
<img width="697" alt="Screen Shot 2022-04-22 at 1 48 16 PM" src="https://user-images.githubusercontent.com/54560994/164784047-b2d76d9a-4694-4211-b51e-1a2c1de09a33.png">
After:
<img width="691" alt="Screen Shot 2022-04-22 at 1 48 50 PM" src="https://user-images.githubusercontent.com/54560994/164784113-5b8d32dd-db53-4ea7-9489-4811f41e16c3.png">

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Yes

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible