### PR TITLE
Fix arrow key issue with clear on top in Select

### DIFF
--- a/src/js/components/Select/SelectContainer.js
+++ b/src/js/components/Select/SelectContainer.js
@@ -87,27 +87,16 @@ const SelectContainer = forwardRef(
     const optionsRef = useRef();
     const clearRef = useRef();
 
-    const focusOption = (index) => {
+    useEffect(() => {
       const optionsNode = optionsRef.current;
-      if (optionsNode) {
+      if (optionsNode.children) {
+        const clearButton = clearRef.current;
+        let index = activeIndex;
+        if (clear && clear.position !== 'bottom' && clearButton) index += 1;
         const optionNode = optionsNode.children[index];
-        if (optionNode) {
-          optionNode.focus();
-        }
+        if (optionNode) optionNode.focus();
       }
-    };
-
-    useEffect(() => {
-      const optionsNode = optionsRef.current;
-      if (optionsNode.children) focusOption(activeIndex);
-    }, [activeIndex]);
-
-    // adjust activeIndex when options change
-    useEffect(() => {
-      if (activeIndex === -1 && optionIndexesInValue.length) {
-        focusOption(optionIndexesInValue[0]);
-      }
-    }, [activeIndex, optionIndexesInValue]);
+    }, [activeIndex, clear]);
 
     // set initial focus
     useEffect(() => {

--- a/src/js/components/Select/__tests__/__snapshots__/SelectMultiple-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/SelectMultiple-test.js.snap
@@ -2773,7 +2773,7 @@ exports[`Select Controlled multiple onChange without valueKey 4`] = `
       <button
         aria-posinset="1"
         aria-setsize="2"
-        class="StyledButton-sc-323bzc-0 igrvhE SelectContainer__SelectOption-sc-1wi0ul8-1 hgxEgi"
+        class="StyledButton-sc-323bzc-0 gYfHFH SelectContainer__SelectOption-sc-1wi0ul8-1 hgxEgi"
         role="option"
         tabindex="-1"
         type="button"


### PR DESCRIPTION
#### What does this PR do?
This PR fixes and issue with Select when the Clear button's position is at the top of the drop and you are navigating with the keyboard, the wrong option is selected.

https://user-images.githubusercontent.com/54560994/165365587-6bc07856-4215-40d7-874e-defcc5252834.mp4
Steps to reproduce:
1. Go to the Select/Clear story https://storybook.grommet.io/?path=/story/input-select-clear--clear
2. Open the first select
3. navigate with the keyboard to "option 2" and select it
4. Re-open the select and navigate down to "option 1" and then back up to "Clear selection"
5. Attempting to select "Clear selection" results in "option 1" being selected.

This problem stems from the fact that having a clear button at the top of the select changes the index of all the other options. Which is why the following code was added `if (clear && clear.position !== 'bottom' && clearButton) index += 1;`

This issue was introduced in this PR: https://github.com/grommet/grommet/pull/6030

#### Where should the reviewer start?

#### What testing has been done on this PR?
Tested with Select/Clear and Select/Search stories to make sure keyboard navigation is working correctly with clear, the search typing bug that #6030 solved is still fixed, and made sure that when selecting multiple options the keyboard navigation is working as expected.

#### How should this be manually tested?
See above ^

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No
#### Should this PR be mentioned in the release notes?
No, this problem currently only exists on the stable branch
#### Is this change backwards compatible or is it a breaking change?
backwards compatible