### PR TITLE
Fixed clear button filling vertically on Firefox

### DIFF
--- a/src/js/components/Select/SelectContainer.js
+++ b/src/js/components/Select/SelectContainer.js
@@ -41,7 +41,12 @@ const ClearButton = forwardRef(({ clear, onClear, name, theme }, ref) => {
   const align = position !== 'bottom' ? 'start' : 'center';
   const buttonLabel = label || `Clear ${name || 'selection'}`;
   return (
-    <Button fill ref={ref} onClick={onClear} focusIndicator={false}>
+    <Button
+      fill="horizontal"
+      ref={ref}
+      onClick={onClear}
+      focusIndicator={false}
+    >
       <Box {...theme.select.clear.container} align={align}>
         <Text {...theme.select.clear.text}>{buttonLabel}</Text>
       </Box>

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -3641,11 +3641,6 @@ exports[`Select default value clear 1`] = `
   padding: 0;
   text-align: inherit;
   width: 100%;
-  height: 100%;
-  max-width: none;
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
 }
 
 .c5:focus:not(:focus-visible) {


### PR DESCRIPTION
#### What does this PR do?
Fixes the clear button on Select to only fill horizontally instead of both horizontally and vertically which caused an issue on Firefox:
Before (`fill={true}`)
<img width="352" alt="Screen Shot 2022-04-26 at 2 32 16 PM" src="https://user-images.githubusercontent.com/54560994/165388976-394e41d5-9192-4b6d-b35b-1944595a804f.png">


After (`fill='horizontal'`)
<img width="354" alt="Screen Shot 2022-04-26 at 2 32 59 PM" src="https://user-images.githubusercontent.com/54560994/165388799-416ed469-25a4-4ee7-ade4-ae0cc63beeee.png">


#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No
#### Should this PR be mentioned in the release notes?
Yes, a released version of grommet contains this bug (v2.22.0)
#### Is this change backwards compatible or is it a breaking change?
Backwards compatible