### PR TITLE
Upgrade babel-plugin-styled-components

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^27.5.1",
     "babel-loader": "^8.2.5",
-    "babel-plugin-styled-components": "2.0.6",
+    "babel-plugin-styled-components": "^2.0.7",
     "babel-plugin-transform-imports": "^2.0.0",
     "bundlesize": "^0.18.1",
     "chromatic": "^6.5.4",

--- a/src/js/components/CheckBox/__tests__/__snapshots__/CheckBox-test.tsx.snap
+++ b/src/js/components/CheckBox/__tests__/__snapshots__/CheckBox-test.tsx.snap
@@ -326,7 +326,7 @@ exports[`CheckBox controlled 2`] = `
     >
       <input
         checked=""
-        class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
+        class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
         type="checkbox"
       />
       <div

--- a/src/js/components/CheckBoxGroup/__tests__/__snapshots__/CheckBoxGroup-test.tsx.snap
+++ b/src/js/components/CheckBoxGroup/__tests__/__snapshots__/CheckBoxGroup-test.tsx.snap
@@ -16,7 +16,7 @@ exports[`CheckBoxGroup custom theme 1`] = `
         class="StyledBox-sc-13pk1d4-0 gibDHu StyledCheckBox-sc-1dbk5ju-6 eJWclz"
       >
         <input
-          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
           type="checkbox"
         />
         <div
@@ -38,7 +38,7 @@ exports[`CheckBoxGroup custom theme 1`] = `
         class="StyledBox-sc-13pk1d4-0 gibDHu StyledCheckBox-sc-1dbk5ju-6 eJWclz"
       >
         <input
-          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
           type="checkbox"
         />
         <div
@@ -71,7 +71,7 @@ exports[`CheckBoxGroup disabled renders 1`] = `
         disabled=""
       >
         <input
-          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 izuNoZ"
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cgrsMd"
           disabled=""
           type="checkbox"
         />
@@ -97,7 +97,7 @@ exports[`CheckBoxGroup disabled renders 1`] = `
         disabled=""
       >
         <input
-          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 izuNoZ"
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cgrsMd"
           disabled=""
           type="checkbox"
         />
@@ -125,7 +125,7 @@ exports[`CheckBoxGroup disabled renders 1`] = `
         disabled=""
       >
         <input
-          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 izuNoZ"
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cgrsMd"
           disabled=""
           type="checkbox"
         />
@@ -153,7 +153,7 @@ exports[`CheckBoxGroup disabled renders 1`] = `
         disabled=""
       >
         <input
-          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 izuNoZ"
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cgrsMd"
           disabled=""
           type="checkbox"
         />
@@ -186,7 +186,7 @@ exports[`CheckBoxGroup initial value renders 1`] = `
         class="StyledBox-sc-13pk1d4-0 gibDHu StyledCheckBox-sc-1dbk5ju-6 eJWclz"
       >
         <input
-          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
           type="checkbox"
         />
         <div
@@ -209,7 +209,7 @@ exports[`CheckBoxGroup initial value renders 1`] = `
       >
         <input
           checked=""
-          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
           type="checkbox"
         />
         <div
@@ -243,7 +243,7 @@ exports[`CheckBoxGroup initial value renders 1`] = `
       >
         <input
           checked=""
-          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
           type="checkbox"
         />
         <div
@@ -285,7 +285,7 @@ exports[`CheckBoxGroup labelKey 1`] = `
         class="StyledBox-sc-13pk1d4-0 gibDHu StyledCheckBox-sc-1dbk5ju-6 eJWclz"
       >
         <input
-          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
           type="checkbox"
         />
         <div
@@ -307,7 +307,7 @@ exports[`CheckBoxGroup labelKey 1`] = `
         class="StyledBox-sc-13pk1d4-0 gibDHu StyledCheckBox-sc-1dbk5ju-6 eJWclz"
       >
         <input
-          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
           type="checkbox"
         />
         <div
@@ -338,7 +338,7 @@ exports[`CheckBoxGroup onChange 1`] = `
         class="StyledBox-sc-13pk1d4-0 gibDHu StyledCheckBox-sc-1dbk5ju-6 eJWclz"
       >
         <input
-          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
           type="checkbox"
         />
         <div
@@ -371,7 +371,7 @@ exports[`CheckBoxGroup onChange 1`] = `
         class="StyledBox-sc-13pk1d4-0 gibDHu StyledCheckBox-sc-1dbk5ju-6 eJWclz"
       >
         <input
-          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
           type="checkbox"
         />
         <div
@@ -403,7 +403,7 @@ exports[`CheckBoxGroup onClick for check and uncheck a CheckBox 1`] = `
         class="StyledBox-sc-13pk1d4-0 gibDHu StyledCheckBox-sc-1dbk5ju-6 eJWclz"
       >
         <input
-          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
           type="checkbox"
         />
         <div
@@ -436,7 +436,7 @@ exports[`CheckBoxGroup onClick for check and uncheck a CheckBox 1`] = `
         class="StyledBox-sc-13pk1d4-0 gibDHu StyledCheckBox-sc-1dbk5ju-6 eJWclz"
       >
         <input
-          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
           type="checkbox"
         />
         <div
@@ -468,7 +468,7 @@ exports[`CheckBoxGroup onClick for check and uncheck a CheckBox 2`] = `
         class="StyledBox-sc-13pk1d4-0 gibDHu StyledCheckBox-sc-1dbk5ju-6 eJWclz"
       >
         <input
-          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
           type="checkbox"
         />
         <div
@@ -490,7 +490,7 @@ exports[`CheckBoxGroup onClick for check and uncheck a CheckBox 2`] = `
         class="StyledBox-sc-13pk1d4-0 gibDHu StyledCheckBox-sc-1dbk5ju-6 eJWclz"
       >
         <input
-          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
           type="checkbox"
         />
         <div
@@ -521,7 +521,7 @@ exports[`CheckBoxGroup options renders 1`] = `
         class="StyledBox-sc-13pk1d4-0 gibDHu StyledCheckBox-sc-1dbk5ju-6 eJWclz"
       >
         <input
-          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
           type="checkbox"
         />
         <div
@@ -543,7 +543,7 @@ exports[`CheckBoxGroup options renders 1`] = `
         class="StyledBox-sc-13pk1d4-0 gibDHu StyledCheckBox-sc-1dbk5ju-6 eJWclz"
       >
         <input
-          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
           type="checkbox"
         />
         <div
@@ -575,7 +575,7 @@ exports[`CheckBoxGroup value renders 1`] = `
       >
         <input
           checked=""
-          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
           type="checkbox"
         />
         <div
@@ -608,7 +608,7 @@ exports[`CheckBoxGroup value renders 1`] = `
         class="StyledBox-sc-13pk1d4-0 gibDHu StyledCheckBox-sc-1dbk5ju-6 eJWclz"
       >
         <input
-          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
           type="checkbox"
         />
         <div
@@ -639,7 +639,7 @@ exports[`CheckBoxGroup valueKey 1`] = `
         class="StyledBox-sc-13pk1d4-0 gibDHu StyledCheckBox-sc-1dbk5ju-6 eJWclz"
       >
         <input
-          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
           type="checkbox"
         />
         <div
@@ -661,7 +661,7 @@ exports[`CheckBoxGroup valueKey 1`] = `
         class="StyledBox-sc-13pk1d4-0 gibDHu StyledCheckBox-sc-1dbk5ju-6 eJWclz"
       >
         <input
-          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
           type="checkbox"
         />
         <div

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -3517,7 +3517,7 @@ exports[`DataTable custom theme 2`] = `
               >
                 <input
                   checked=""
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 izuNoZ"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cgrsMd"
                   disabled=""
                   type="checkbox"
                 />
@@ -3581,7 +3581,7 @@ exports[`DataTable custom theme 2`] = `
                 disabled=""
               >
                 <input
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 izuNoZ"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cgrsMd"
                   disabled=""
                   type="checkbox"
                 />
@@ -11532,7 +11532,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
                 class="StyledBox-sc-13pk1d4-0 hKKecH StyledCheckBox-sc-1dbk5ju-6 eJWclz"
               >
                 <input
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
                   type="checkbox"
                 />
                 <div
@@ -11663,7 +11663,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
                 class="StyledBox-sc-13pk1d4-0 hKKecH StyledCheckBox-sc-1dbk5ju-6 eJWclz"
               >
                 <input
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
                   type="checkbox"
                 />
                 <div
@@ -11783,7 +11783,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
                 class="StyledBox-sc-13pk1d4-0 hKKecH StyledCheckBox-sc-1dbk5ju-6 eJWclz"
               >
                 <input
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
                   type="checkbox"
                 />
                 <div
@@ -11919,7 +11919,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
                 class="StyledBox-sc-13pk1d4-0 hKKecH StyledCheckBox-sc-1dbk5ju-6 eJWclz"
               >
                 <input
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
                   type="checkbox"
                 />
                 <div
@@ -12011,7 +12011,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
                 class="StyledBox-sc-13pk1d4-0 hKKecH StyledCheckBox-sc-1dbk5ju-6 eJWclz"
               >
                 <input
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
                   type="checkbox"
                 />
                 <div
@@ -12092,7 +12092,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
                 class="StyledBox-sc-13pk1d4-0 hKKecH StyledCheckBox-sc-1dbk5ju-6 eJWclz"
               >
                 <input
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
                   type="checkbox"
                 />
                 <div
@@ -12703,7 +12703,7 @@ exports[`DataTable onSelect select/unselect all 2`] = `
                 class="StyledBox-sc-13pk1d4-0 hKKecH StyledCheckBox-sc-1dbk5ju-6 eJWclz"
               >
                 <input
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
                   type="checkbox"
                 />
                 <div
@@ -12795,7 +12795,7 @@ exports[`DataTable onSelect select/unselect all 2`] = `
                 class="StyledBox-sc-13pk1d4-0 hKKecH StyledCheckBox-sc-1dbk5ju-6 eJWclz"
               >
                 <input
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
                   type="checkbox"
                 />
                 <div
@@ -12882,7 +12882,7 @@ exports[`DataTable onSelect select/unselect all 2`] = `
                 class="StyledBox-sc-13pk1d4-0 hKKecH StyledCheckBox-sc-1dbk5ju-6 eJWclz"
               >
                 <input
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
                   type="checkbox"
                 />
                 <div
@@ -12969,7 +12969,7 @@ exports[`DataTable onSelect select/unselect all 2`] = `
                 class="StyledBox-sc-13pk1d4-0 hKKecH StyledCheckBox-sc-1dbk5ju-6 eJWclz"
               >
                 <input
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
                   type="checkbox"
                 />
                 <div
@@ -13056,7 +13056,7 @@ exports[`DataTable onSelect select/unselect all 2`] = `
                 class="StyledBox-sc-13pk1d4-0 hKKecH StyledCheckBox-sc-1dbk5ju-6 eJWclz"
               >
                 <input
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
                   type="checkbox"
                 />
                 <div
@@ -13159,7 +13159,7 @@ exports[`DataTable onSelect select/unselect all 3`] = `
                 class="StyledBox-sc-13pk1d4-0 hKKecH StyledCheckBox-sc-1dbk5ju-6 eJWclz"
               >
                 <input
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
                   type="checkbox"
                 />
                 <div
@@ -13220,7 +13220,7 @@ exports[`DataTable onSelect select/unselect all 3`] = `
                 class="StyledBox-sc-13pk1d4-0 hKKecH StyledCheckBox-sc-1dbk5ju-6 eJWclz"
               >
                 <input
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
                   type="checkbox"
                 />
                 <div
@@ -13276,7 +13276,7 @@ exports[`DataTable onSelect select/unselect all 3`] = `
                 class="StyledBox-sc-13pk1d4-0 hKKecH StyledCheckBox-sc-1dbk5ju-6 eJWclz"
               >
                 <input
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
                   type="checkbox"
                 />
                 <div
@@ -13332,7 +13332,7 @@ exports[`DataTable onSelect select/unselect all 3`] = `
                 class="StyledBox-sc-13pk1d4-0 hKKecH StyledCheckBox-sc-1dbk5ju-6 eJWclz"
               >
                 <input
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
                   type="checkbox"
                 />
                 <div
@@ -13388,7 +13388,7 @@ exports[`DataTable onSelect select/unselect all 3`] = `
                 class="StyledBox-sc-13pk1d4-0 hKKecH StyledCheckBox-sc-1dbk5ju-6 eJWclz"
               >
                 <input
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
                   type="checkbox"
                 />
                 <div
@@ -21375,7 +21375,7 @@ exports[`DataTable select 2`] = `
                 class="StyledBox-sc-13pk1d4-0 hKKecH StyledCheckBox-sc-1dbk5ju-6 eJWclz"
               >
                 <input
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
                   type="checkbox"
                 />
                 <div
@@ -21454,7 +21454,7 @@ exports[`DataTable select 2`] = `
               >
                 <input
                   checked=""
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
                   type="checkbox"
                 />
                 <div
@@ -21508,7 +21508,7 @@ exports[`DataTable select 2`] = `
                 class="StyledBox-sc-13pk1d4-0 hKKecH StyledCheckBox-sc-1dbk5ju-6 eJWclz"
               >
                 <input
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
                   type="checkbox"
                 />
                 <div

--- a/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.tsx.snap
+++ b/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.tsx.snap
@@ -1729,7 +1729,7 @@ exports[`DateInput controlled format inline 2`] = `
       >
         <input
           autocomplete="off"
-          class="StyledMaskedInput-sc-99vkfa-0 OaCNq"
+          class="StyledMaskedInput-sc-99vkfa-0 bLvERa"
           id="item"
           name="item"
           placeholder="mm/dd/yyyy"
@@ -13408,7 +13408,7 @@ exports[`DateInput select format 2`] = `
     >
       <input
         autocomplete="off"
-        class="StyledMaskedInput-sc-99vkfa-0 OaCNq"
+        class="StyledMaskedInput-sc-99vkfa-0 bLvERa"
         id="item"
         name="item"
         placeholder="mm/dd/yyyy"
@@ -16170,7 +16170,7 @@ exports[`DateInput select format inline 2`] = `
       >
         <input
           autocomplete="off"
-          class="StyledMaskedInput-sc-99vkfa-0 OaCNq"
+          class="StyledMaskedInput-sc-99vkfa-0 bLvERa"
           id="item"
           name="item"
           placeholder="mm/dd/yyyy"
@@ -21261,7 +21261,7 @@ exports[`DateInput select format inline range 2`] = `
       >
         <input
           autocomplete="off"
-          class="StyledMaskedInput-sc-99vkfa-0 OaCNq"
+          class="StyledMaskedInput-sc-99vkfa-0 bLvERa"
           id="item"
           name="item"
           placeholder="mm/dd/yyyy-mm/dd/yyyy"
@@ -30549,7 +30549,7 @@ exports[`DateInput type format inline 2`] = `
       >
         <input
           autocomplete="off"
-          class="StyledMaskedInput-sc-99vkfa-0 OaCNq"
+          class="StyledMaskedInput-sc-99vkfa-0 bLvERa"
           id="item"
           name="item"
           placeholder="mm/dd/yyyy"
@@ -35561,7 +35561,7 @@ exports[`DateInput type format inline range 2`] = `
       >
         <input
           autocomplete="off"
-          class="StyledMaskedInput-sc-99vkfa-0 OaCNq"
+          class="StyledMaskedInput-sc-99vkfa-0 bLvERa"
           id="item"
           name="item"
           placeholder="mm/dd/yyyy-mm/dd/yyyy"
@@ -37820,7 +37820,7 @@ exports[`DateInput type format inline range partial 2`] = `
       >
         <input
           autocomplete="off"
-          class="StyledMaskedInput-sc-99vkfa-0 OaCNq"
+          class="StyledMaskedInput-sc-99vkfa-0 bLvERa"
           id="item"
           name="item"
           placeholder="mm/dd/yyyy-mm/dd/yyyy"
@@ -38684,7 +38684,7 @@ exports[`DateInput type format inline range partial 3`] = `
       >
         <input
           autocomplete="off"
-          class="StyledMaskedInput-sc-99vkfa-0 OaCNq"
+          class="StyledMaskedInput-sc-99vkfa-0 bLvERa"
           id="item"
           name="item"
           placeholder="mm/dd/yyyy-mm/dd/yyyy"
@@ -47873,7 +47873,7 @@ exports[`DateInput type format inline short 2`] = `
       >
         <input
           autocomplete="off"
-          class="StyledMaskedInput-sc-99vkfa-0 OaCNq"
+          class="StyledMaskedInput-sc-99vkfa-0 bLvERa"
           id="item"
           name="item"
           placeholder="m/d/yy"

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-controlled.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-controlled.js.snap
@@ -223,7 +223,7 @@ exports[`Form controlled controlled 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
+            class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
             name="test"
             placeholder="test input"
             value="v"
@@ -257,7 +257,7 @@ exports[`Form controlled controlled 3`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
+            class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
             name="test"
             placeholder="test input"
             value="v"
@@ -630,7 +630,7 @@ exports[`Form controlled controlled Array of Form Fields 2`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
+              class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
               name="phones[0].number"
               placeholder="number test input 1"
               value=""
@@ -649,7 +649,7 @@ exports[`Form controlled controlled Array of Form Fields 2`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
+              class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
               name="phones[0].ext"
               placeholder="ext test input 1"
               value=""
@@ -672,7 +672,7 @@ exports[`Form controlled controlled Array of Form Fields 2`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
+              class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
               name="phones[1].number"
               placeholder="number test input 2"
               value="123456789"
@@ -691,7 +691,7 @@ exports[`Form controlled controlled Array of Form Fields 2`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
+              class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
               name="phones[1].ext"
               placeholder="ext test input 2"
               value=""
@@ -714,7 +714,7 @@ exports[`Form controlled controlled Array of Form Fields 2`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
+              class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
               name="phones[2].number"
               placeholder="number test input 3"
               value=""
@@ -733,7 +733,7 @@ exports[`Form controlled controlled Array of Form Fields 2`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
+              class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
               name="phones[2].ext"
               placeholder="ext test input 3"
               value="999"
@@ -771,7 +771,7 @@ exports[`Form controlled controlled Array of Form Fields 3`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
+              class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
               name="phones[0].number"
               placeholder="number test input 1"
               value=""
@@ -790,7 +790,7 @@ exports[`Form controlled controlled Array of Form Fields 3`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
+              class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
               name="phones[0].ext"
               placeholder="ext test input 1"
               value=""
@@ -813,7 +813,7 @@ exports[`Form controlled controlled Array of Form Fields 3`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
+              class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
               name="phones[1].number"
               placeholder="number test input 2"
               value="123456789"
@@ -832,7 +832,7 @@ exports[`Form controlled controlled Array of Form Fields 3`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
+              class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
               name="phones[1].ext"
               placeholder="ext test input 2"
               value=""
@@ -855,7 +855,7 @@ exports[`Form controlled controlled Array of Form Fields 3`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
+              class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
               name="phones[2].number"
               placeholder="number test input 3"
               value=""
@@ -874,7 +874,7 @@ exports[`Form controlled controlled Array of Form Fields 3`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
+              class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
               name="phones[2].ext"
               placeholder="ext test input 3"
               value="999"
@@ -1206,7 +1206,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate 2`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
+              class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
               name="phones[0].number"
               placeholder="number test input 1"
               value=""
@@ -1252,7 +1252,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate 2`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
+              class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
               name="phones[0].ext"
               placeholder="ext test input 1"
               value=""
@@ -1275,7 +1275,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate 2`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
+              class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
               name="phones[1].number"
               placeholder="number test input 2"
               value=""
@@ -1321,7 +1321,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate 2`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
+              class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
               name="phones[1].ext"
               placeholder="ext test input 2"
               value=""
@@ -1653,7 +1653,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate custom error
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
+              class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
               name="phones[0].number"
               placeholder="number test input 1"
               value=""
@@ -1672,7 +1672,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate custom error
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
+              class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
               name="phones[0].ext"
               placeholder="ext test input 1"
               value=""
@@ -1695,7 +1695,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate custom error
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
+              class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
               name="phones[1].number"
               placeholder="number test input 2"
               value="sadasd"
@@ -1741,7 +1741,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate custom error
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
+              class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
               name="phones[1].ext"
               placeholder="ext test input 2"
               value=""
@@ -2004,7 +2004,7 @@ exports[`Form controlled controlled FormField deprecated 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
+            class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
             id="test"
             name="test"
             value="v"
@@ -2044,7 +2044,7 @@ exports[`Form controlled controlled FormField deprecated 3`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
+            class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
             id="test"
             name="test"
             value="v"
@@ -2285,7 +2285,7 @@ exports[`Form controlled controlled input 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
+            class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
             name="test"
             placeholder="test input"
             value="v"
@@ -2319,7 +2319,7 @@ exports[`Form controlled controlled input 3`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
+            class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
             name="test"
             placeholder="test input"
             value="v"
@@ -2560,7 +2560,7 @@ exports[`Form controlled controlled input lazy 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
+            class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
             name="test"
             placeholder="test input"
             value="v"
@@ -2594,7 +2594,7 @@ exports[`Form controlled controlled input lazy 3`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
+            class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
             name="test"
             placeholder="test input"
             value="v"
@@ -2835,7 +2835,7 @@ exports[`Form controlled controlled lazy 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
+            class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
             name="test"
             placeholder="test input"
             value="v"
@@ -2869,7 +2869,7 @@ exports[`Form controlled controlled lazy 3`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
+            class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
             name="test"
             placeholder="test input"
             value="v"
@@ -3317,7 +3317,7 @@ exports[`Form controlled controlled onValidate 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
+            class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
             name="test"
             placeholder="test input"
             value=""
@@ -3585,7 +3585,7 @@ exports[`Form controlled controlled onValidate custom error 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
+            class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
             name="test"
             placeholder="test input"
             value=""
@@ -3853,7 +3853,7 @@ exports[`Form controlled controlled onValidate custom info 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
+            class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
             name="test"
             placeholder="test input"
             value=""
@@ -4283,7 +4283,7 @@ exports[`Form controlled dynamicly removed fields using blur validation
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
+            class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
             name="name"
             placeholder="test name"
             value=""
@@ -4305,7 +4305,7 @@ exports[`Form controlled dynamicly removed fields using blur validation
             class="StyledBox-sc-13pk1d4-0 gibDHu StyledCheckBox-sc-1dbk5ju-6 eJWclz"
           >
             <input
-              class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
+              class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
               name="toggle"
               type="checkbox"
             />
@@ -4523,7 +4523,7 @@ exports[`Form controlled dynamicly removed fields using blur validation
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
+            class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
             name="name"
             placeholder="test name"
             value=""
@@ -4545,7 +4545,7 @@ exports[`Form controlled dynamicly removed fields using blur validation
             class="StyledBox-sc-13pk1d4-0 gibDHu StyledCheckBox-sc-1dbk5ju-6 eJWclz"
           >
             <input
-              class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
+              class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
               name="toggle"
               type="checkbox"
             />

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
@@ -1320,7 +1320,7 @@ exports[`Form uncontrolled dynamicly removed fields should be removed from form 
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
+            class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
             name="name"
             placeholder="test name"
             value=""
@@ -1342,7 +1342,7 @@ exports[`Form uncontrolled dynamicly removed fields should be removed from form 
             class="StyledBox-sc-13pk1d4-0 gibDHu StyledCheckBox-sc-1dbk5ju-6 eJWclz"
           >
             <input
-              class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
+              class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
               name="toggle"
               type="checkbox"
             />
@@ -1755,7 +1755,7 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
+            class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
             name="name"
             placeholder="test name"
             value=""
@@ -1777,7 +1777,7 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation
             class="StyledBox-sc-13pk1d4-0 gibDHu StyledCheckBox-sc-1dbk5ju-6 eJWclz"
           >
             <input
-              class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
+              class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
               name="toggle"
               type="checkbox"
             />
@@ -1995,7 +1995,7 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
+            class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
             name="name"
             placeholder="test name"
             value=""
@@ -2017,7 +2017,7 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation
             class="StyledBox-sc-13pk1d4-0 gibDHu StyledCheckBox-sc-1dbk5ju-6 eJWclz"
           >
             <input
-              class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
+              class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
               name="toggle"
               type="checkbox"
             />
@@ -3377,7 +3377,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
               >
                 <input
                   autocomplete="off"
-                  class="StyledTextInput-sc-1x30a0s-0 fKwwIt Select__SelectTextInput-sc-17idtfo-0 bQAqdj"
+                  class="StyledTextInput-sc-1x30a0s-0 kkBhYd Select__SelectTextInput-sc-17idtfo-0 bQAqdj"
                   id="test-select__input"
                   name="test-select"
                   placeholder="test select"
@@ -3430,7 +3430,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
             class="StyledBox-sc-13pk1d4-0 gibDHu StyledCheckBox-sc-1dbk5ju-6 eJWclz"
           >
             <input
-              class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
+              class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
               id="test-checkbox"
               name="test-checkbox"
               type="checkbox"
@@ -3463,7 +3463,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
           role="radiogroup"
         >
           <label
-            class="StyledRadioButton__StyledRadioButtonContainer-sc-g1f6ld-0 kwYmqp"
+            class="StyledRadioButton__StyledRadioButtonContainer-sc-g1f6ld-0 isBpzl"
             for="test-radiobuttongroup-one"
           >
             <div
@@ -3491,7 +3491,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
             class="StyledBox__StyledBoxGap-sc-13pk1d4-1 qdAYv"
           />
           <label
-            class="StyledRadioButton__StyledRadioButtonContainer-sc-g1f6ld-0 kwYmqp"
+            class="StyledRadioButton__StyledRadioButtonContainer-sc-g1f6ld-0 isBpzl"
             for="test-radiobuttongroup-two"
           >
             <div
@@ -3519,7 +3519,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
             class="StyledBox__StyledBoxGap-sc-13pk1d4-1 qdAYv"
           />
           <label
-            class="StyledRadioButton__StyledRadioButtonContainer-sc-g1f6ld-0 kwYmqp"
+            class="StyledRadioButton__StyledRadioButtonContainer-sc-g1f6ld-0 isBpzl"
             for="test-radiobuttongroup-three"
           >
             <div
@@ -3779,7 +3779,7 @@ exports[`Form uncontrolled uncontrolled 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
+            class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
             name="test"
             placeholder="test input"
             value=""
@@ -3813,7 +3813,7 @@ exports[`Form uncontrolled uncontrolled 3`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
+            class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
             name="test"
             placeholder="test input"
             value=""
@@ -4054,7 +4054,7 @@ exports[`Form uncontrolled uncontrolled onValidate 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
+            class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
             name="test"
             placeholder="test input"
             value=""
@@ -4322,7 +4322,7 @@ exports[`Form uncontrolled uncontrolled onValidate custom error 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
+            class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
             name="test"
             placeholder="test input"
             value=""
@@ -4590,7 +4590,7 @@ exports[`Form uncontrolled uncontrolled onValidate custom info 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
+            class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
             name="test"
             placeholder="test input"
             value=""

--- a/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.js.snap
+++ b/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.js.snap
@@ -1067,7 +1067,7 @@ exports[`MaskedInput event target props are available option via mouse 4`] = `
 >
   <input
     autocomplete="off"
-    class="StyledMaskedInput-sc-99vkfa-0 fRHXoP"
+    class="StyledMaskedInput-sc-99vkfa-0 gAjxFv"
     data-testid="test-input"
     id="item"
     name="item"
@@ -1869,7 +1869,7 @@ exports[`MaskedInput next and previous without options 2`] = `
 >
   <input
     autocomplete="off"
-    class="StyledMaskedInput-sc-99vkfa-0 hetwLm"
+    class="StyledMaskedInput-sc-99vkfa-0 jPKjwi"
     data-testid="test-input"
     id="item"
     name="item"
@@ -2292,7 +2292,7 @@ exports[`MaskedInput option via mouse 4`] = `
 >
   <input
     autocomplete="off"
-    class="StyledMaskedInput-sc-99vkfa-0 fRHXoP"
+    class="StyledMaskedInput-sc-99vkfa-0 gAjxFv"
     data-testid="test-input"
     id="item"
     name="item"

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -2660,7 +2660,7 @@ exports[`Select complex options and children 2`] = `
       >
         <input
           autocomplete="off"
-          class="StyledTextInput-sc-1x30a0s-0 fKwwIt Select__SelectTextInput-sc-17idtfo-0 bQAqdj"
+          class="StyledTextInput-sc-1x30a0s-0 kkBhYd Select__SelectTextInput-sc-17idtfo-0 bQAqdj"
           id="test-select__input"
           placeholder="test select"
           readonly=""
@@ -4464,7 +4464,7 @@ exports[`Select disabled 2`] = `
       >
         <input
           autocomplete="off"
-          class="StyledTextInput-sc-1x30a0s-0 fKwwIt Select__SelectTextInput-sc-17idtfo-0 fDnYDX"
+          class="StyledTextInput-sc-1x30a0s-0 kkBhYd Select__SelectTextInput-sc-17idtfo-0 fDnYDX"
           id="test-select__input"
           placeholder="test select"
           readonly=""
@@ -8984,7 +8984,7 @@ exports[`Select prop: onOpen 2`] = `
       >
         <input
           autocomplete="off"
-          class="StyledTextInput-sc-1x30a0s-0 fKwwIt Select__SelectTextInput-sc-17idtfo-0 bQAqdj"
+          class="StyledTextInput-sc-1x30a0s-0 kkBhYd Select__SelectTextInput-sc-17idtfo-0 bQAqdj"
           id="test-select__input"
           placeholder="test select"
           readonly=""
@@ -9894,7 +9894,7 @@ exports[`Select renders custom up and down icons 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fKwwIt Select__SelectTextInput-sc-17idtfo-0 bQAqdj"
+            class="StyledTextInput-sc-1x30a0s-0 kkBhYd Select__SelectTextInput-sc-17idtfo-0 bQAqdj"
             placeholder="Select..."
             readonly=""
             tabindex="-1"
@@ -11967,7 +11967,7 @@ exports[`Select search 3`] = `
 exports[`Select search 4`] = `
 <input
   autocomplete="off"
-  class="StyledTextInput-sc-1x30a0s-0 bUIvzg"
+  class="StyledTextInput-sc-1x30a0s-0 cxcKvg"
   type="search"
   value=""
 />
@@ -11976,7 +11976,7 @@ exports[`Select search 4`] = `
 exports[`Select search 5`] = `
 <input
   autocomplete="off"
-  class="StyledTextInput-sc-1x30a0s-0 bUIvzg"
+  class="StyledTextInput-sc-1x30a0s-0 cxcKvg"
   type="search"
   value="o"
 />
@@ -12620,7 +12620,7 @@ exports[`Select search and select 3`] = `
 exports[`Select search and select 4`] = `
 <input
   autocomplete="off"
-  class="StyledTextInput-sc-1x30a0s-0 bUIvzg"
+  class="StyledTextInput-sc-1x30a0s-0 cxcKvg"
   type="search"
   value=""
 />
@@ -12629,7 +12629,7 @@ exports[`Select search and select 4`] = `
 exports[`Select search and select 5`] = `
 <input
   autocomplete="off"
-  class="StyledTextInput-sc-1x30a0s-0 bUIvzg"
+  class="StyledTextInput-sc-1x30a0s-0 cxcKvg"
   type="search"
   value="t"
 />
@@ -14490,7 +14490,7 @@ exports[`Select select option by typing should not break if caller passes JSX 2`
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 fKwwIt Select__SelectTextInput-sc-17idtfo-0 bQAqdj"
+            class="StyledTextInput-sc-1x30a0s-0 kkBhYd Select__SelectTextInput-sc-17idtfo-0 bQAqdj"
             id="test-select__input"
             placeholder="test select"
             readonly=""

--- a/src/js/components/Select/__tests__/__snapshots__/SelectMultiple-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/SelectMultiple-test.js.snap
@@ -3111,7 +3111,7 @@ exports[`Select Controlled multiple values 2`] = `
       >
         <input
           autocomplete="off"
-          class="StyledTextInput-sc-1x30a0s-0 fKwwIt Select__SelectTextInput-sc-17idtfo-0 bQAqdj"
+          class="StyledTextInput-sc-1x30a0s-0 kkBhYd Select__SelectTextInput-sc-17idtfo-0 bQAqdj"
           id="test-select__input"
           placeholder="test select"
           readonly=""

--- a/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.tsx.snap
+++ b/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.tsx.snap
@@ -506,7 +506,7 @@ exports[`TextInput calls onSuggestionsClose 4`] = `
   >
     <input
       autocomplete="off"
-      class="StyledTextInput-sc-1x30a0s-0 jxFxho"
+      class="StyledTextInput-sc-1x30a0s-0 doZMBU"
       data-testid="test-input"
       id="item"
       name="item"
@@ -1051,7 +1051,7 @@ exports[`TextInput close suggestion drop 4`] = `
   >
     <input
       autocomplete="off"
-      class="StyledTextInput-sc-1x30a0s-0 jxFxho"
+      class="StyledTextInput-sc-1x30a0s-0 doZMBU"
       data-testid="test-input"
       id="item"
       name="item"
@@ -1653,7 +1653,7 @@ exports[`TextInput handles next and previous without suggestion 2`] = `
   >
     <input
       autocomplete="off"
-      class="StyledTextInput-sc-1x30a0s-0 jxFxho"
+      class="StyledTextInput-sc-1x30a0s-0 doZMBU"
       data-testid="test-input"
       id="item"
       name="item"
@@ -3886,7 +3886,7 @@ exports[`TextInput select suggestion 4`] = `
   >
     <input
       autocomplete="off"
-      class="StyledTextInput-sc-1x30a0s-0 bEniJV"
+      class="StyledTextInput-sc-1x30a0s-0 gexBpp"
       data-testid="test-input"
       id="item"
       name="item"
@@ -4486,7 +4486,7 @@ exports[`TextInput should only show default placeholder when placeholder is a
   >
     <input
       autocomplete="off"
-      class="StyledTextInput-sc-1x30a0s-0 jxFxho"
+      class="StyledTextInput-sc-1x30a0s-0 doZMBU"
       data-testid="placeholder"
       id="placeholder"
       name="placeholder"

--- a/src/js/components/Video/__tests__/__snapshots__/Video-test.js.snap
+++ b/src/js/components/Video/__tests__/__snapshots__/Video-test.js.snap
@@ -1545,7 +1545,7 @@ exports[`Video Play and Pause event handlers 2`] = `
     tabindex="-1"
   >
     <video
-      class="StyledVideo-sc-w4v8h9-0 fLrMDE"
+      class="StyledVideo-sc-w4v8h9-0 jMymic"
     >
       <source
         src="small.mp4"
@@ -5781,7 +5781,7 @@ exports[`Video mouse events handlers of controls 2`] = `
     tabindex="-1"
   >
     <video
-      class="StyledVideo-sc-w4v8h9-0 fLrMDE"
+      class="StyledVideo-sc-w4v8h9-0 jMymic"
     >
       <source
         src="small.mp4"
@@ -5905,7 +5905,7 @@ exports[`Video mouse events handlers of controls 3`] = `
     tabindex="-1"
   >
     <video
-      class="StyledVideo-sc-w4v8h9-0 fLrMDE"
+      class="StyledVideo-sc-w4v8h9-0 jMymic"
     >
       <source
         src="small.mp4"
@@ -8061,7 +8061,7 @@ exports[`Video scrubber 2`] = `
     tabindex="-1"
   >
     <video
-      class="StyledVideo-sc-w4v8h9-0 fLrMDE"
+      class="StyledVideo-sc-w4v8h9-0 jMymic"
     >
       <source
         src="small.mp4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11,18 +11,17 @@
     "@jridgewell/trace-mapping" "^0.3.9"
 
 "@babel/cli@^7.17.6":
-  version "7.17.6"
-  resolved "https://registry.yarnpkg.com/@babel/cli/-/cli-7.17.6.tgz#169e5935f1795f0b62ded5a2accafeedfe5c5363"
-  integrity sha512-l4w608nsDNlxZhiJ5tE3DbNmr61fIKMZ6fTBo171VEFuFMIYuJ3mHRhTLEkKKyvx2Mizkkv/0a8OJOnZqkKYNA==
+  version "7.17.10"
+  resolved "https://registry.yarnpkg.com/@babel/cli/-/cli-7.17.10.tgz#5ea0bf6298bb78f3b59c7c06954f9bd1c79d5943"
+  integrity sha512-OygVO1M2J4yPMNOW9pb+I6kFGpQK77HmG44Oz3hg8xQIl5L/2zq+ZohwAdSaqYgVwM0SfmPHZHphH4wR8qzVYw==
   dependencies:
-    "@jridgewell/trace-mapping" "^0.3.4"
+    "@jridgewell/trace-mapping" "^0.3.8"
     commander "^4.0.1"
     convert-source-map "^1.1.0"
     fs-readdir-recursive "^1.1.0"
     glob "^7.0.0"
     make-dir "^2.1.0"
     slash "^2.0.0"
-    source-map "^0.5.0"
   optionalDependencies:
     "@nicolo-ribaudo/chokidar-2" "2.1.8-no-fsevents.3"
     chokidar "^3.4.0"
@@ -34,10 +33,10 @@
   dependencies:
     "@babel/highlight" "^7.16.7"
 
-"@babel/compat-data@^7.13.11", "@babel/compat-data@^7.16.8", "@babel/compat-data@^7.17.0", "@babel/compat-data@^7.17.7":
-  version "7.17.7"
-  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.17.7.tgz#078d8b833fbbcc95286613be8c716cef2b519fa2"
-  integrity sha512-p8pdE6j0a29TNGebNm7NzYZWB3xVZJBZ7XGs42uAKzQo8VQ3F0By/cQCtUEABwIqw5zo6WA4NbmxsfzADzMKnQ==
+"@babel/compat-data@^7.13.11", "@babel/compat-data@^7.17.0", "@babel/compat-data@^7.17.10":
+  version "7.17.10"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.17.10.tgz#711dc726a492dfc8be8220028b1b92482362baab"
+  integrity sha512-GZt/TCsG70Ms19gfZO1tM4CVnXsPgEPBCpJu+Qz3L0LUDsY5nZqFZglIoPC1kIYOtNBZlrnFT+klg12vFGZXrw==
 
 "@babel/core@7.12.9":
   version "7.12.9"
@@ -62,20 +61,20 @@
     source-map "^0.5.0"
 
 "@babel/core@^7.1.0", "@babel/core@^7.12.10", "@babel/core@^7.12.3", "@babel/core@^7.17.9", "@babel/core@^7.7.2", "@babel/core@^7.7.5", "@babel/core@^7.8.0":
-  version "7.17.9"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.17.9.tgz#6bae81a06d95f4d0dec5bb9d74bbc1f58babdcfe"
-  integrity sha512-5ug+SfZCpDAkVp9SFIZAzlW18rlzsOcJGaetCjkySnrXXDUw9AR8cDUm1iByTmdWM6yxX6/zycaV76w3YTF2gw==
+  version "7.17.10"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.17.10.tgz#74ef0fbf56b7dfc3f198fc2d927f4f03e12f4b05"
+  integrity sha512-liKoppandF3ZcBnIYFjfSDHZLKdLHGJRkoWtG8zQyGJBQfIYobpnVGI5+pLBNtS6psFLDzyq8+h5HiVljW9PNA==
   dependencies:
     "@ampproject/remapping" "^2.1.0"
     "@babel/code-frame" "^7.16.7"
-    "@babel/generator" "^7.17.9"
-    "@babel/helper-compilation-targets" "^7.17.7"
+    "@babel/generator" "^7.17.10"
+    "@babel/helper-compilation-targets" "^7.17.10"
     "@babel/helper-module-transforms" "^7.17.7"
     "@babel/helpers" "^7.17.9"
-    "@babel/parser" "^7.17.9"
+    "@babel/parser" "^7.17.10"
     "@babel/template" "^7.16.7"
-    "@babel/traverse" "^7.17.9"
-    "@babel/types" "^7.17.0"
+    "@babel/traverse" "^7.17.10"
+    "@babel/types" "^7.17.10"
     convert-source-map "^1.7.0"
     debug "^4.1.0"
     gensync "^1.0.0-beta.2"
@@ -91,14 +90,14 @@
     eslint-visitor-keys "^2.1.0"
     semver "^6.3.0"
 
-"@babel/generator@^7.12.11", "@babel/generator@^7.12.5", "@babel/generator@^7.17.9", "@babel/generator@^7.7.2":
-  version "7.17.9"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.17.9.tgz#f4af9fd38fa8de143c29fce3f71852406fc1e2fc"
-  integrity sha512-rAdDousTwxbIxbz5I7GEQ3lUip+xVCXooZNbsydCWs3xA7ZsYOv+CFRdzGxRX78BmQHu9B1Eso59AOZQOJDEdQ==
+"@babel/generator@^7.12.11", "@babel/generator@^7.12.5", "@babel/generator@^7.17.10", "@babel/generator@^7.7.2":
+  version "7.17.10"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.17.10.tgz#c281fa35b0c349bbe9d02916f4ae08fc85ed7189"
+  integrity sha512-46MJZZo9y3o4kmhBVc7zW7i8dtR1oIK/sdO5NcfcZRhTGYi+KKJRtHNgsU6c4VUcJmUNV/LQdebD/9Dlv4K+Tg==
   dependencies:
-    "@babel/types" "^7.17.0"
+    "@babel/types" "^7.17.10"
+    "@jridgewell/gen-mapping" "^0.1.0"
     jsesc "^2.5.1"
-    source-map "^0.5.0"
 
 "@babel/helper-annotate-as-pure@^7.16.0", "@babel/helper-annotate-as-pure@^7.16.7":
   version "7.16.7"
@@ -115,14 +114,14 @@
     "@babel/helper-explode-assignable-expression" "^7.16.7"
     "@babel/types" "^7.16.7"
 
-"@babel/helper-compilation-targets@^7.13.0", "@babel/helper-compilation-targets@^7.16.7", "@babel/helper-compilation-targets@^7.17.7":
-  version "7.17.7"
-  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.17.7.tgz#a3c2924f5e5f0379b356d4cfb313d1414dc30e46"
-  integrity sha512-UFzlz2jjd8kroj0hmCFV5zr+tQPi1dpC2cRsDV/3IEW8bJfCPrPpmcSN6ZS8RqIq4LXcmpipCQFPddyFA5Yc7w==
+"@babel/helper-compilation-targets@^7.13.0", "@babel/helper-compilation-targets@^7.16.7", "@babel/helper-compilation-targets@^7.17.10":
+  version "7.17.10"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.17.10.tgz#09c63106d47af93cf31803db6bc49fef354e2ebe"
+  integrity sha512-gh3RxjWbauw/dFiU/7whjd0qN9K6nPJMqe6+Er7rOavFh0CQUSwhAE3IcTho2rywPJFxej6TUUHDkWcYI6gGqQ==
   dependencies:
-    "@babel/compat-data" "^7.17.7"
+    "@babel/compat-data" "^7.17.10"
     "@babel/helper-validator-option" "^7.16.7"
-    browserslist "^4.17.5"
+    browserslist "^4.20.2"
     semver "^6.3.0"
 
 "@babel/helper-create-class-features-plugin@^7.16.10", "@babel/helper-create-class-features-plugin@^7.16.7", "@babel/helper-create-class-features-plugin@^7.17.6", "@babel/helper-create-class-features-plugin@^7.17.9":
@@ -138,7 +137,7 @@
     "@babel/helper-replace-supers" "^7.16.7"
     "@babel/helper-split-export-declaration" "^7.16.7"
 
-"@babel/helper-create-regexp-features-plugin@^7.16.7":
+"@babel/helper-create-regexp-features-plugin@^7.16.7", "@babel/helper-create-regexp-features-plugin@^7.17.0":
   version "7.17.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.17.0.tgz#1dcc7d40ba0c6b6b25618997c5dbfd310f186fe1"
   integrity sha512-awO2So99wG6KnlE+TPs6rn83gCz5WlEePJDTnLEqbchMVrBeAujURVphRdigsk094VhvZehFoNOihSlcBjwsXA==
@@ -328,21 +327,21 @@
     js-tokens "^4.0.0"
 
 "@babel/node@^7.16.8":
-  version "7.16.8"
-  resolved "https://registry.yarnpkg.com/@babel/node/-/node-7.16.8.tgz#57ba1dfa63dbcc72d477f05597ce07f1c4f8b558"
-  integrity sha512-V2dopEtPUL4LD+e8UtMIZB6BbsmMsS/7E1ZAvWNINzBfi7Cf3X9MLCpzHVZT4HeeF1lQl72IRtqqVt2RUImwyA==
+  version "7.17.10"
+  resolved "https://registry.yarnpkg.com/@babel/node/-/node-7.17.10.tgz#7fae7b2abe0c43387dd31292dc6007261817e504"
+  integrity sha512-sFFMyvw23U8QOcTnLJnw2/Myr01e4+iLVy7rHAHrNSnXAfnwS3j2NqihpmZm7TotyNKKf/y8cJ96T5asY46eyw==
   dependencies:
-    "@babel/register" "^7.16.8"
+    "@babel/register" "^7.17.7"
     commander "^4.0.1"
-    core-js "^3.20.2"
+    core-js "^3.22.1"
     node-environment-flags "^1.0.5"
     regenerator-runtime "^0.13.4"
     v8flags "^3.1.1"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.12.11", "@babel/parser@^7.12.7", "@babel/parser@^7.14.7", "@babel/parser@^7.16.7", "@babel/parser@^7.17.9":
-  version "7.17.9"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.17.9.tgz#9c94189a6062f0291418ca021077983058e171ef"
-  integrity sha512-vqUSBLP8dQHFPdPi9bc5GK9vRkYHJ49fsZdtoJ8EQ8ibpwk5rPKfvNIwChB0KVXcIjcepEBBd2VHC5r9Gy8ueg==
+"@babel/parser@^7.1.0", "@babel/parser@^7.12.11", "@babel/parser@^7.12.7", "@babel/parser@^7.14.7", "@babel/parser@^7.16.7", "@babel/parser@^7.17.10":
+  version "7.17.10"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.17.10.tgz#873b16db82a8909e0fbd7f115772f4b739f6ce78"
+  integrity sha512-n2Q6i+fnJqzOaq2VkdXxy2TCPCWQZHiCo0XqmrCvDWcZQKRyZzYi4Z0yxlBuN0w+r2ZHmre+Q087DSrw3pbJDQ==
 
 "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@^7.16.7":
   version "7.16.7"
@@ -377,7 +376,7 @@
     "@babel/helper-create-class-features-plugin" "^7.16.7"
     "@babel/helper-plugin-utils" "^7.16.7"
 
-"@babel/plugin-proposal-class-static-block@^7.16.7":
+"@babel/plugin-proposal-class-static-block@^7.17.6":
   version "7.17.6"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-static-block/-/plugin-proposal-class-static-block-7.17.6.tgz#164e8fd25f0d80fa48c5a4d1438a6629325ad83c"
   integrity sha512-X/tididvL2zbs7jZCeeRJ8167U/+Ac135AM6jCAx6gYXDUviZV5Ku9UDvWS2NCuWlFjIRXklYhwo6HhAC7ETnA==
@@ -471,7 +470,7 @@
     "@babel/plugin-syntax-object-rest-spread" "^7.8.0"
     "@babel/plugin-transform-parameters" "^7.12.1"
 
-"@babel/plugin-proposal-object-rest-spread@^7.12.1", "@babel/plugin-proposal-object-rest-spread@^7.16.7":
+"@babel/plugin-proposal-object-rest-spread@^7.12.1", "@babel/plugin-proposal-object-rest-spread@^7.17.3":
   version "7.17.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.17.3.tgz#d9eb649a54628a51701aef7e0ea3d17e2b9dd390"
   integrity sha512-yuL5iQA/TbZn+RGAfxQXfi7CNLmKi1f8zInn4IgobuCWcAb7i+zj4TYzQ9l8cEzVyJ89PDGuqxK1xZpUDISesw==
@@ -695,9 +694,9 @@
     "@babel/helper-plugin-utils" "^7.14.5"
 
 "@babel/plugin-syntax-typescript@^7.16.7", "@babel/plugin-syntax-typescript@^7.7.2":
-  version "7.16.7"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.16.7.tgz#39c9b55ee153151990fb038651d58d3fd03f98f8"
-  integrity sha512-YhUIJHHGkqPgEcMYkPCKTyGUdoGKWtopIycQyjJH8OjvRgOYsXsaKehLVPScKJWAULPxMa4N1vCe6szREFlZ7A==
+  version "7.17.10"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.17.10.tgz#80031e6042cad6a95ed753f672ebd23c30933195"
+  integrity sha512-xJefea1DWXW09pW4Tm9bjwVlPDyYA2it3fWlmEjpYz6alPvTUjL0EOzNzI/FEOyI3r4/J7uVH5UqKgl1TQ5hqQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.16.7"
 
@@ -752,7 +751,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.16.7"
 
-"@babel/plugin-transform-destructuring@^7.12.1", "@babel/plugin-transform-destructuring@^7.16.7":
+"@babel/plugin-transform-destructuring@^7.12.1", "@babel/plugin-transform-destructuring@^7.17.7":
   version "7.17.7"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.17.7.tgz#49dc2675a7afa9a5e4c6bdee636061136c3408d1"
   integrity sha512-XVh0r5yq9sLR4vZ6eVZe8FKfIcSgaTBxVBRSYokRj2qksf6QerYnTxz9/GTuKTH/n/HwLP7t6gtlybHetJ/6hQ==
@@ -829,7 +828,7 @@
     "@babel/helper-plugin-utils" "^7.16.7"
     babel-plugin-dynamic-import-node "^2.3.3"
 
-"@babel/plugin-transform-modules-commonjs@^7.16.8":
+"@babel/plugin-transform-modules-commonjs@^7.17.9":
   version "7.17.9"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.17.9.tgz#274be1a2087beec0254d4abd4d86e52442e1e5b6"
   integrity sha512-2TBFd/r2I6VlYn0YRTz2JdazS+FoUuQ2rIFHoAxtyP/0G3D82SBLaRq9rnUkpqlLg03Byfl/+M32mpxjO6KaPw==
@@ -839,7 +838,7 @@
     "@babel/helper-simple-access" "^7.17.7"
     babel-plugin-dynamic-import-node "^2.3.3"
 
-"@babel/plugin-transform-modules-systemjs@^7.16.7":
+"@babel/plugin-transform-modules-systemjs@^7.17.8":
   version "7.17.8"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.17.8.tgz#81fd834024fae14ea78fbe34168b042f38703859"
   integrity sha512-39reIkMTUVagzgA5x88zDYXPCMT6lcaRKs1+S9K6NKBPErbgO/w/kP8GlNQTC87b412ZTlmNgr3k2JrWgHH+Bw==
@@ -858,12 +857,12 @@
     "@babel/helper-module-transforms" "^7.16.7"
     "@babel/helper-plugin-utils" "^7.16.7"
 
-"@babel/plugin-transform-named-capturing-groups-regex@^7.16.8":
-  version "7.16.8"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.16.8.tgz#7f860e0e40d844a02c9dcf9d84965e7dfd666252"
-  integrity sha512-j3Jw+n5PvpmhRR+mrgIh04puSANCk/T/UA3m3P1MjJkhlK906+ApHhDIqBQDdOgL/r1UYpz4GNclTXxyZrYGSw==
+"@babel/plugin-transform-named-capturing-groups-regex@^7.17.10":
+  version "7.17.10"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.17.10.tgz#715dbcfafdb54ce8bccd3d12e8917296a4ba66a4"
+  integrity sha512-v54O6yLaJySCs6mGzaVOUw9T967GnH38T6CQSAtnzdNPwu84l2qAjssKzo/WSO8Yi7NF+7ekm5cVbF/5qiIgNA==
   dependencies:
-    "@babel/helper-create-regexp-features-plugin" "^7.16.7"
+    "@babel/helper-create-regexp-features-plugin" "^7.17.0"
 
 "@babel/plugin-transform-new-target@^7.16.7":
   version "7.16.7"
@@ -927,7 +926,7 @@
     "@babel/helper-annotate-as-pure" "^7.16.7"
     "@babel/helper-plugin-utils" "^7.16.7"
 
-"@babel/plugin-transform-regenerator@^7.16.7":
+"@babel/plugin-transform-regenerator@^7.17.9":
   version "7.17.9"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.17.9.tgz#0a33c3a61cf47f45ed3232903683a0afd2d3460c"
   integrity sha512-Lc2TfbxR1HOyn/c6b4Y/b6NHoTb67n/IoWLxTu4kC7h4KQnWlhCq2S8Tx0t2SVvv5Uu87Hs+6JEJ5kt2tYGylQ==
@@ -1002,26 +1001,26 @@
     "@babel/helper-plugin-utils" "^7.16.7"
 
 "@babel/preset-env@^7.12.11", "@babel/preset-env@^7.16.11":
-  version "7.16.11"
-  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.16.11.tgz#5dd88fd885fae36f88fd7c8342475c9f0abe2982"
-  integrity sha512-qcmWG8R7ZW6WBRPZK//y+E3Cli151B20W1Rv7ln27vuPaXU/8TKms6jFdiJtF7UDTxcrb7mZd88tAeK9LjdT8g==
+  version "7.17.10"
+  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.17.10.tgz#a81b093669e3eb6541bb81a23173c5963c5de69c"
+  integrity sha512-YNgyBHZQpeoBSRBg0xixsZzfT58Ze1iZrajvv0lJc70qDDGuGfonEnMGfWeSY0mQ3JTuCWFbMkzFRVafOyJx4g==
   dependencies:
-    "@babel/compat-data" "^7.16.8"
-    "@babel/helper-compilation-targets" "^7.16.7"
+    "@babel/compat-data" "^7.17.10"
+    "@babel/helper-compilation-targets" "^7.17.10"
     "@babel/helper-plugin-utils" "^7.16.7"
     "@babel/helper-validator-option" "^7.16.7"
     "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression" "^7.16.7"
     "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining" "^7.16.7"
     "@babel/plugin-proposal-async-generator-functions" "^7.16.8"
     "@babel/plugin-proposal-class-properties" "^7.16.7"
-    "@babel/plugin-proposal-class-static-block" "^7.16.7"
+    "@babel/plugin-proposal-class-static-block" "^7.17.6"
     "@babel/plugin-proposal-dynamic-import" "^7.16.7"
     "@babel/plugin-proposal-export-namespace-from" "^7.16.7"
     "@babel/plugin-proposal-json-strings" "^7.16.7"
     "@babel/plugin-proposal-logical-assignment-operators" "^7.16.7"
     "@babel/plugin-proposal-nullish-coalescing-operator" "^7.16.7"
     "@babel/plugin-proposal-numeric-separator" "^7.16.7"
-    "@babel/plugin-proposal-object-rest-spread" "^7.16.7"
+    "@babel/plugin-proposal-object-rest-spread" "^7.17.3"
     "@babel/plugin-proposal-optional-catch-binding" "^7.16.7"
     "@babel/plugin-proposal-optional-chaining" "^7.16.7"
     "@babel/plugin-proposal-private-methods" "^7.16.11"
@@ -1047,7 +1046,7 @@
     "@babel/plugin-transform-block-scoping" "^7.16.7"
     "@babel/plugin-transform-classes" "^7.16.7"
     "@babel/plugin-transform-computed-properties" "^7.16.7"
-    "@babel/plugin-transform-destructuring" "^7.16.7"
+    "@babel/plugin-transform-destructuring" "^7.17.7"
     "@babel/plugin-transform-dotall-regex" "^7.16.7"
     "@babel/plugin-transform-duplicate-keys" "^7.16.7"
     "@babel/plugin-transform-exponentiation-operator" "^7.16.7"
@@ -1056,15 +1055,15 @@
     "@babel/plugin-transform-literals" "^7.16.7"
     "@babel/plugin-transform-member-expression-literals" "^7.16.7"
     "@babel/plugin-transform-modules-amd" "^7.16.7"
-    "@babel/plugin-transform-modules-commonjs" "^7.16.8"
-    "@babel/plugin-transform-modules-systemjs" "^7.16.7"
+    "@babel/plugin-transform-modules-commonjs" "^7.17.9"
+    "@babel/plugin-transform-modules-systemjs" "^7.17.8"
     "@babel/plugin-transform-modules-umd" "^7.16.7"
-    "@babel/plugin-transform-named-capturing-groups-regex" "^7.16.8"
+    "@babel/plugin-transform-named-capturing-groups-regex" "^7.17.10"
     "@babel/plugin-transform-new-target" "^7.16.7"
     "@babel/plugin-transform-object-super" "^7.16.7"
     "@babel/plugin-transform-parameters" "^7.16.7"
     "@babel/plugin-transform-property-literals" "^7.16.7"
-    "@babel/plugin-transform-regenerator" "^7.16.7"
+    "@babel/plugin-transform-regenerator" "^7.17.9"
     "@babel/plugin-transform-reserved-words" "^7.16.7"
     "@babel/plugin-transform-shorthand-properties" "^7.16.7"
     "@babel/plugin-transform-spread" "^7.16.7"
@@ -1074,11 +1073,11 @@
     "@babel/plugin-transform-unicode-escapes" "^7.16.7"
     "@babel/plugin-transform-unicode-regex" "^7.16.7"
     "@babel/preset-modules" "^0.1.5"
-    "@babel/types" "^7.16.8"
+    "@babel/types" "^7.17.10"
     babel-plugin-polyfill-corejs2 "^0.3.0"
     babel-plugin-polyfill-corejs3 "^0.5.0"
     babel-plugin-polyfill-regenerator "^0.3.0"
-    core-js-compat "^3.20.2"
+    core-js-compat "^3.22.1"
     semver "^6.3.0"
 
 "@babel/preset-flow@^7.12.1":
@@ -1122,7 +1121,7 @@
     "@babel/helper-validator-option" "^7.16.7"
     "@babel/plugin-transform-typescript" "^7.16.7"
 
-"@babel/register@^7.12.1", "@babel/register@^7.16.8":
+"@babel/register@^7.12.1", "@babel/register@^7.17.7":
   version "7.17.7"
   resolved "https://registry.yarnpkg.com/@babel/register/-/register-7.17.7.tgz#5eef3e0f4afc07e25e847720e7b987ae33f08d0b"
   integrity sha512-fg56SwvXRifootQEDQAu1mKdjh5uthPzdO0N6t358FktfL4XjAVXuH58ULoiW8mesxiOgNIrxiImqEwv0+hRRA==
@@ -1157,26 +1156,26 @@
     "@babel/parser" "^7.16.7"
     "@babel/types" "^7.16.7"
 
-"@babel/traverse@^7.1.6", "@babel/traverse@^7.12.11", "@babel/traverse@^7.12.9", "@babel/traverse@^7.13.0", "@babel/traverse@^7.16.7", "@babel/traverse@^7.16.8", "@babel/traverse@^7.17.3", "@babel/traverse@^7.17.9", "@babel/traverse@^7.4.5", "@babel/traverse@^7.7.2":
-  version "7.17.9"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.17.9.tgz#1f9b207435d9ae4a8ed6998b2b82300d83c37a0d"
-  integrity sha512-PQO8sDIJ8SIwipTPiR71kJQCKQYB5NGImbOviK8K+kg5xkNSYXLBupuX9QhatFowrsvo9Hj8WgArg3W7ijNAQw==
+"@babel/traverse@^7.1.6", "@babel/traverse@^7.12.11", "@babel/traverse@^7.12.9", "@babel/traverse@^7.13.0", "@babel/traverse@^7.16.7", "@babel/traverse@^7.16.8", "@babel/traverse@^7.17.10", "@babel/traverse@^7.17.3", "@babel/traverse@^7.17.9", "@babel/traverse@^7.4.5", "@babel/traverse@^7.7.2":
+  version "7.17.10"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.17.10.tgz#1ee1a5ac39f4eac844e6cf855b35520e5eb6f8b5"
+  integrity sha512-VmbrTHQteIdUUQNTb+zE12SHS/xQVIShmBPhlNP12hD5poF2pbITW1Z4172d03HegaQWhLffdkRJYtAzp0AGcw==
   dependencies:
     "@babel/code-frame" "^7.16.7"
-    "@babel/generator" "^7.17.9"
+    "@babel/generator" "^7.17.10"
     "@babel/helper-environment-visitor" "^7.16.7"
     "@babel/helper-function-name" "^7.17.9"
     "@babel/helper-hoist-variables" "^7.16.7"
     "@babel/helper-split-export-declaration" "^7.16.7"
-    "@babel/parser" "^7.17.9"
-    "@babel/types" "^7.17.0"
+    "@babel/parser" "^7.17.10"
+    "@babel/types" "^7.17.10"
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/types@^7.0.0", "@babel/types@^7.12.11", "@babel/types@^7.12.7", "@babel/types@^7.16.0", "@babel/types@^7.16.7", "@babel/types@^7.16.8", "@babel/types@^7.17.0", "@babel/types@^7.2.0", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4", "@babel/types@^7.4.4":
-  version "7.17.0"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.17.0.tgz#a826e368bccb6b3d84acd76acad5c0d87342390b"
-  integrity sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==
+"@babel/types@^7.0.0", "@babel/types@^7.12.11", "@babel/types@^7.12.7", "@babel/types@^7.16.0", "@babel/types@^7.16.7", "@babel/types@^7.16.8", "@babel/types@^7.17.0", "@babel/types@^7.17.10", "@babel/types@^7.2.0", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4", "@babel/types@^7.4.4":
+  version "7.17.10"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.17.10.tgz#d35d7b4467e439fcf06d195f8100e0fea7fc82c4"
+  integrity sha512-9O26jG0mBYfGkUYCYZRnBwbVLd1UZOICEr2Em6InB6jVfsAv1GKgwXHmrSg+WFWDmeKTA6vyTZiN8tCSM5Oo3A==
   dependencies:
     "@babel/helper-validator-identifier" "^7.16.7"
     to-fast-properties "^2.0.0"
@@ -1552,7 +1551,7 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.11.tgz#771a1d8d744eeb71b6adb35808e1a6c7b9b8c8ec"
   integrity sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg==
 
-"@jridgewell/trace-mapping@^0.3.4", "@jridgewell/trace-mapping@^0.3.7", "@jridgewell/trace-mapping@^0.3.9":
+"@jridgewell/trace-mapping@^0.3.7", "@jridgewell/trace-mapping@^0.3.8", "@jridgewell/trace-mapping@^0.3.9":
   version "0.3.9"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz#6534fd5933a53ba7cbf3a17615e273a0d1273ff9"
   integrity sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
@@ -2572,9 +2571,9 @@
     form-data "^3.0.0"
 
 "@types/node@*", "@types/node@^17.0.29":
-  version "17.0.29"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.29.tgz#7f2e1159231d4a077bb660edab0fde373e375a3d"
-  integrity sha512-tx5jMmMFwx7wBwq/V7OohKDVb/JwJU5qCVkeLMh1//xycAJ/ESuw9aJ9SEtlCZDYi2pBfe4JkisSoAtbOsBNAA==
+  version "17.0.30"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.30.tgz#2c6e8512acac70815e8176aa30c38025067880ef"
+  integrity sha512-oNBIZjIqyHYP8VCNAV9uEytXVeXG2oR0w9lgAXro20eugRQfY002qr3CUl6BAe+Yf/z3CRjPdz27Pu6WWtuSRw==
 
 "@types/node@^14.0.10":
   version "14.18.16"
@@ -2627,9 +2626,9 @@
   integrity sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==
 
 "@types/react-dom@^18.0.0":
-  version "18.0.0"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.0.0.tgz#b13f8d098e4b0c45df4f1ed123833143b0c71141"
-  integrity sha512-49897Y0UiCGmxZqpC8Blrf6meL8QUla6eb+BBhn69dTXlmuOlzkfr7HHY/O8J25e1lTUMs+YYxSlVDAaGHCOLg==
+  version "18.0.3"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.0.3.tgz#a022ea08c75a476fe5e96b675c3e673363853831"
+  integrity sha512-1RRW9kst+67gveJRYPxGmVy8eVJ05O43hg77G2j5m76/RFJtMbcfAs2viQ2UNsvvDg8F7OfQZx8qQcl6ymygaQ==
   dependencies:
     "@types/react" "*"
 
@@ -3000,9 +2999,9 @@ acorn@^8.2.4, acorn@^8.5.0, acorn@^8.7.0:
   integrity sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==
 
 address@^1.0.1, address@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/address/-/address-1.1.2.tgz#bf1116c9c758c51b7a933d296b72c221ed9428b6"
-  integrity sha512-aT6camzM4xEA54YVJYSqxz1kv4IHnQZRtThJJHhUMRExaU5spC7jX5ugSwTaTgJliIgs4VhZOk7htClvQ/LmRA==
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/address/-/address-1.2.0.tgz#d352a62c92fee90f89a693eccd2a8b2139ab02d9"
+  integrity sha512-tNEZYz5G/zYunxFm7sfhAxkXEuLj3K6BKwv6ZURlsF6yiUQ65z0Q2wZW9L5cPUl9ocofGvXOdFYbFHp0+6MOig==
 
 agent-base@6:
   version "6.0.2"
@@ -3542,18 +3541,7 @@ babel-plugin-react-docgen@^4.2.1:
     lodash "^4.17.15"
     react-docgen "^5.0.0"
 
-babel-plugin-styled-components@2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.6.tgz#6f76c7f7224b7af7edc24a4910351948c691fc90"
-  integrity sha512-Sk+7o/oa2HfHv3Eh8sxoz75/fFvEdHsXV4grdeHufX0nauCmymlnN0rGhIvfpMQSJMvGutJ85gvCGea4iqmDpg==
-  dependencies:
-    "@babel/helper-annotate-as-pure" "^7.16.0"
-    "@babel/helper-module-imports" "^7.16.0"
-    babel-plugin-syntax-jsx "^6.18.0"
-    lodash "^4.17.11"
-    picomatch "^2.3.0"
-
-"babel-plugin-styled-components@>= 1.12.0":
+"babel-plugin-styled-components@>= 1.12.0", babel-plugin-styled-components@^2.0.7:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.7.tgz#c81ef34b713f9da2b7d3f5550df0d1e19e798086"
   integrity sha512-i7YhvPgVqRKfoQ66toiZ06jPNA3p6ierpfUuEWxNF+fV27Uv5gxBkf8KZLHUCc1nFA9j6+80pYoIpqCeyW3/bA==
@@ -3843,7 +3831,7 @@ browserify-zlib@^0.2.0:
   dependencies:
     pako "~1.0.5"
 
-browserslist@^4.12.0, browserslist@^4.17.5, browserslist@^4.18.1, browserslist@^4.20.3:
+browserslist@^4.12.0, browserslist@^4.18.1, browserslist@^4.20.2, browserslist@^4.20.3:
   version "4.20.3"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.20.3.tgz#eb7572f49ec430e054f56d52ff0ebe9be915f8bf"
   integrity sha512-NBhymBQl1zM0Y5dQT/O+xiLP9/rzOIQdKM/eMJBAq7yBgaB6krIYLGejrwVYnSHZdqjscB1SPuAjHwxjvN6Wdg==
@@ -4547,7 +4535,7 @@ copyfiles@^2.4.1:
     untildify "^4.0.0"
     yargs "^16.1.0"
 
-core-js-compat@^3.20.2, core-js-compat@^3.21.0, core-js-compat@^3.8.1:
+core-js-compat@^3.21.0, core-js-compat@^3.22.1, core-js-compat@^3.8.1:
   version "3.22.3"
   resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.22.3.tgz#9b10d786052d042bc97ee8df9c0d1fb6a49c2005"
   integrity sha512-wliMbvPI2idgFWpFe7UEyHMvu6HWgW8WA+HnDRtgzoSDYvXFMpoGX1H3tPDDXrcfUSyXafCLDd7hOeMQHEZxGw==
@@ -4560,7 +4548,7 @@ core-js-pure@^3.20.2, core-js-pure@^3.8.1, core-js-pure@^3.8.2:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.22.3.tgz#181d1b6321fb29fe99c16a1f28beb840ab84ad36"
   integrity sha512-oN88zz7nmKROMy8GOjs+LN+0LedIvbMdnB5XsTlhcOg1WGARt9l0LFg0zohdoFmCsEZ1h2ZbSQ6azj3M+vhzwQ==
 
-core-js@^3.0.4, core-js@^3.20.2, core-js@^3.22.3, core-js@^3.6.5, core-js@^3.8.2:
+core-js@^3.0.4, core-js@^3.22.1, core-js@^3.22.3, core-js@^3.6.5, core-js@^3.8.2:
   version "3.22.3"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.22.3.tgz#498c41d997654cb00e81c7a54b44f0ab21ab01d5"
   integrity sha512-1t+2a/d2lppW1gkLXx3pKPVGbBdxXAkqztvWb1EJ8oF8O2gIGiytzflNiFEehYwVK/t2ryUsGBoOFFvNx95mbg==
@@ -5172,9 +5160,9 @@ ee-first@1.1.1:
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
 electron-to-chromium@^1.4.118:
-  version "1.4.124"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.124.tgz#e9015e234d8632920dcdf5480351da9e845ed220"
-  integrity sha512-VhaE9VUYU6d2eIb+4xf83CATD+T+3bTzvxvlADkQE+c2hisiw3sZmvEDtsW704+Zky9WZGhBuQXijDVqSriQLA==
+  version "1.4.127"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.127.tgz#4ef19d5d920abe2676d938f4170729b44f7f423a"
+  integrity sha512-nhD6S8nKI0O2MueC6blNOEZio+/PWppE/pevnf3LOlQA/fKPCrDp2Ao4wx4LFwmIkJpVdFdn2763YWLy9ENIZg==
 
 element-resize-detector@^1.2.2:
   version "1.2.4"
@@ -6509,9 +6497,9 @@ grommet-theme-hp@^0.1.2:
   integrity sha512-pRJxgzJ6oWKNg4hq8csi7hEgH0qeMyP3m/cjQVTk473lH1OdgzqNfjyjQXJf80Fnp6Azm+ovwuNNGCKWCZxcvg==
 
 grommet-theme-hpe@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/grommet-theme-hpe/-/grommet-theme-hpe-3.0.0.tgz#fcdd206549891dbd89122592d45df2e8d86bef68"
-  integrity sha512-FeQMlgSOxf4/AhT8iU+vldPPOzWZxOVSwGLt62r02K2ojgjmbbZ38rmIBu8huilJcyU4LpC355c9dzVS59HV9Q==
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/grommet-theme-hpe/-/grommet-theme-hpe-3.0.1.tgz#e390daf4726d50cdafe07cd6bc127d9e57fb19e3"
+  integrity sha512-4I5N29FmOyYaK/eHGcwMo8LF6bVe9Hf6llPwS4OJIPfWgbnLa38eRGIopguIw5ysLOeaXYFHjc4OacgRdTR4Wg==
 
 gzip-size@^4.0.0:
   version "4.1.0"
@@ -11311,9 +11299,9 @@ terser@^4.1.2, terser@^4.6.3:
     source-map-support "~0.5.12"
 
 terser@^5.3.4:
-  version "5.13.0"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.13.0.tgz#d43fd71861df1b4df743980caa257c6fa03acc44"
-  integrity sha512-sgQ99P+fRBM1jAYzN9RTnD/xEWx/7LZgYTCRgmYriSq1wxxqiQPJgXkkLBBuwySDWJ2PP0PnVQyuf4xLUuH4Ng==
+  version "5.13.1"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.13.1.tgz#66332cdc5a01b04a224c9fad449fc1a18eaa1799"
+  integrity sha512-hn4WKOfwnwbYfe48NgrQjqNOH9jzLqRcIfbYytOXCOv46LBfWr9bDS17MQqOi+BWGD0sJK3Sj5NC/gJjiojaoA==
   dependencies:
     acorn "^8.5.0"
     commander "^2.20.0"
@@ -11605,9 +11593,9 @@ typedarray@^0.0.6:
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
 typescript@^4.6.3:
-  version "4.6.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.3.tgz#eefeafa6afdd31d725584c67a0eaba80f6fc6c6c"
-  integrity sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==
+  version "4.6.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.4.tgz#caa78bbc3a59e6a5c510d35703f6a09877ce45e9"
+  integrity sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==
 
 uglify-js@^3.1.4:
   version "3.15.4"


### PR DESCRIPTION
#### What does this PR do?
Upgrades grommet to use the latest version of babel-plugin-styled-components

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
https://github.com/grommet/hpe-design-system/issues/2552

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No
#### Should this PR be mentioned in the release notes?
No
#### Is this change backwards compatible or is it a breaking change?
Backwards compatible