### PR TITLE
Change Tip to respect mouse and focus functions from child

### DIFF
--- a/package.json
+++ b/package.json
@@ -191,7 +191,7 @@
   "bundlesize": [
     {
       "path": "./dist/grommet.min.js",
-      "maxSize": "129 kB"
+      "maxSize": "130 kB"
     }
   ],
   "keywords": [

--- a/src/js/components/Tip/Tip.js
+++ b/src/js/components/Tip/Tip.js
@@ -52,14 +52,14 @@ const Tip = forwardRef(({ children, content, dropProps, plain }, tipRef) => {
       setOver(false);
     },
     onFocus: () => {
+      if (child.props?.onFocus) child.props.onFocus();
       if (usingKeyboard) {
-        if (child.props?.onFocus) child.props.onFocus();
         setOver(true);
       }
     },
     onBlur: () => {
+      if (child.props?.onBlur) child.props.onBlur();
       if (usingKeyboard) {
-        if (child.props?.onBlur) child.props.onBlur();
         setOver(false);
       }
     },

--- a/src/js/components/Tip/Tip.js
+++ b/src/js/components/Tip/Tip.js
@@ -43,21 +43,21 @@ const Tip = forwardRef(({ children, content, dropProps, plain }, tipRef) => {
     Children.only(children);
 
   const clonedChild = cloneElement(child, {
-    onMouseEnter: () => {
-      if (child.props?.onMouseEnter) child.props.onMouseEnter();
+    onMouseEnter: (event) => {
       setOver(true);
+      if (child.props?.onMouseEnter) child.props.onMouseEnter(event);
     },
-    onMouseLeave: () => {
-      if (child.props?.onMouseLeave) child.props.onMouseLeave();
+    onMouseLeave: (event) => {
       setOver(false);
+      if (child.props?.onMouseLeave) child.props.onMouseLeave(event);
     },
-    onFocus: () => {
-      if (child.props?.onFocus) child.props.onFocus();
+    onFocus: (event) => {
       if (usingKeyboard) setOver(true);
+      if (child.props?.onFocus) child.props.onFocus(event);
     },
-    onBlur: () => {
-      if (child.props?.onBlur) child.props.onBlur();
+    onBlur: (event) => {
       if (usingKeyboard) setOver(false);
+      if (child.props?.onBlur) child.props.onBlur(event);
     },
     key: 'tip-child',
     ref: (node) => {

--- a/src/js/components/Tip/Tip.js
+++ b/src/js/components/Tip/Tip.js
@@ -53,15 +53,11 @@ const Tip = forwardRef(({ children, content, dropProps, plain }, tipRef) => {
     },
     onFocus: () => {
       if (child.props?.onFocus) child.props.onFocus();
-      if (usingKeyboard) {
-        setOver(true);
-      }
+      if (usingKeyboard) setOver(true);
     },
     onBlur: () => {
       if (child.props?.onBlur) child.props.onBlur();
-      if (usingKeyboard) {
-        setOver(false);
-      }
+      if (usingKeyboard) setOver(false);
     },
     key: 'tip-child',
     ref: (node) => {

--- a/src/js/components/Tip/Tip.js
+++ b/src/js/components/Tip/Tip.js
@@ -43,13 +43,25 @@ const Tip = forwardRef(({ children, content, dropProps, plain }, tipRef) => {
     Children.only(children);
 
   const clonedChild = cloneElement(child, {
-    onMouseEnter: () => setOver(true),
-    onMouseLeave: () => setOver(false),
+    onMouseEnter: () => {
+      if (child.props?.onMouseEnter) child.props.onMouseEnter();
+      setOver(true);
+    },
+    onMouseLeave: () => {
+      if (child.props?.onMouseLeave) child.props.onMouseLeave();
+      setOver(false);
+    },
     onFocus: () => {
-      if (usingKeyboard) setOver(true);
+      if (usingKeyboard) {
+        if (child.props?.onFocus) child.props.onFocus();
+        setOver(true);
+      }
     },
     onBlur: () => {
-      if (usingKeyboard) setOver(false);
+      if (usingKeyboard) {
+        if (child.props?.onBlur) child.props.onBlur();
+        setOver(false);
+      }
     },
     key: 'tip-child',
     ref: (node) => {

--- a/src/js/components/Tip/__tests__/Tip-test.tsx
+++ b/src/js/components/Tip/__tests__/Tip-test.tsx
@@ -5,6 +5,7 @@ import { axe } from 'jest-axe';
 import 'jest-styled-components';
 import 'jest-axe/extend-expect';
 import 'regenerator-runtime/runtime';
+import userEvent from '@testing-library/user-event';
 
 import { Box } from '../../Box';
 import { Button } from '../../Button';
@@ -166,5 +167,34 @@ describe('Tip', () => {
     }).toThrow(
       `React.Children.only expected to receive a single React element child.`,
     );
+  });
+
+  test(`call child mouse and focus functions`, async () => {
+    const user = userEvent.setup();
+    const onMouseEnter = jest.fn();
+    const onMouseLeave = jest.fn();
+    const onFocus = jest.fn();
+    const onBlur = jest.fn();
+    render(
+      <Grommet>
+        <Tip content="tip info">
+          <Button
+            label="Button label"
+            onMouseEnter={onMouseEnter}
+            onMouseLeave={onMouseLeave}
+            onFocus={onFocus}
+            onBlur={onBlur}
+          />
+        </Tip>
+      </Grommet>,
+    );
+    await user.hover(screen.getByText('Button label'));
+    expect(onMouseEnter).toHaveBeenCalledTimes(1);
+    await user.unhover(screen.getByText('Button label'));
+    expect(onMouseLeave).toHaveBeenCalledTimes(1);
+    await user.tab();
+    expect(onFocus).toHaveBeenCalledTimes(1);
+    await user.tab();
+    expect(onBlur).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
#### What does this PR do?
Fix Tip to respect onMouseEnter, onMouseLeave, onFocus, and onBlur functions from child
#### Where should the reviewer start?

#### What testing has been done on this PR?
Tested with the following story
``` javascript
import React from 'react';
import { grommet, Box, Button, Grommet, Tip } from 'grommet';

export const Test = () => (
  <Box align="center" justify="center" pad="large" gap="xlarge">
    <Tip content="action info">
      <Button
        label="Edit onMouseEnter Hijacked"
        onClick={() => {}}
        fill
        onMouseEnter={() => console.log('Mouse enter A')}
        onMouseLeave={() => console.log('Mouse leave A')}
        onFocus={() => console.log('Focus A')}
        onBlur={() => console.log('Blur A')}
      />
    </Tip>
    <Button
      label="Edit onMouseEnter Hijacked"
      onClick={() => {}}
      fill
      onMouseEnter={() => console.log('Mouse enter B')}
      onMouseLeave={() => console.log('Mouse leave B')}
      onFocus={() => console.log('Focus B')}
      onBlur={() => console.log('Blur B')}
      tip="Hijacker"
    />
  </Box>
);

export default {
  title: 'Controls/Tip/Test',
};
```
#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [x] `screen` is used for querying.
- [x] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [x] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes https://github.com/grommet/grommet/issues/6093
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No
#### Should this PR be mentioned in the release notes?
Yes
#### Is this change backwards compatible or is it a breaking change?
Backwards compatible