### PR TITLE
revert babel back

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^27.5.1",
     "babel-loader": "^8.2.5",
-    "babel-plugin-styled-components": "^2.0.7",
+    "babel-plugin-styled-components": "2.0.6",
     "babel-plugin-transform-imports": "^2.0.0",
     "bundlesize": "^0.18.1",
     "chromatic": "^6.5.4",

--- a/src/js/components/CheckBox/__tests__/__snapshots__/CheckBox-test.tsx.snap
+++ b/src/js/components/CheckBox/__tests__/__snapshots__/CheckBox-test.tsx.snap
@@ -326,7 +326,7 @@ exports[`CheckBox controlled 2`] = `
     >
       <input
         checked=""
-        class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
+        class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
         type="checkbox"
       />
       <div

--- a/src/js/components/CheckBoxGroup/__tests__/__snapshots__/CheckBoxGroup-test.tsx.snap
+++ b/src/js/components/CheckBoxGroup/__tests__/__snapshots__/CheckBoxGroup-test.tsx.snap
@@ -16,7 +16,7 @@ exports[`CheckBoxGroup custom theme 1`] = `
         class="StyledBox-sc-13pk1d4-0 gibDHu StyledCheckBox-sc-1dbk5ju-6 eJWclz"
       >
         <input
-          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
           type="checkbox"
         />
         <div
@@ -38,7 +38,7 @@ exports[`CheckBoxGroup custom theme 1`] = `
         class="StyledBox-sc-13pk1d4-0 gibDHu StyledCheckBox-sc-1dbk5ju-6 eJWclz"
       >
         <input
-          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
           type="checkbox"
         />
         <div
@@ -71,7 +71,7 @@ exports[`CheckBoxGroup disabled renders 1`] = `
         disabled=""
       >
         <input
-          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cgrsMd"
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 izuNoZ"
           disabled=""
           type="checkbox"
         />
@@ -97,7 +97,7 @@ exports[`CheckBoxGroup disabled renders 1`] = `
         disabled=""
       >
         <input
-          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cgrsMd"
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 izuNoZ"
           disabled=""
           type="checkbox"
         />
@@ -125,7 +125,7 @@ exports[`CheckBoxGroup disabled renders 1`] = `
         disabled=""
       >
         <input
-          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cgrsMd"
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 izuNoZ"
           disabled=""
           type="checkbox"
         />
@@ -153,7 +153,7 @@ exports[`CheckBoxGroup disabled renders 1`] = `
         disabled=""
       >
         <input
-          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cgrsMd"
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 izuNoZ"
           disabled=""
           type="checkbox"
         />
@@ -186,7 +186,7 @@ exports[`CheckBoxGroup initial value renders 1`] = `
         class="StyledBox-sc-13pk1d4-0 gibDHu StyledCheckBox-sc-1dbk5ju-6 eJWclz"
       >
         <input
-          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
           type="checkbox"
         />
         <div
@@ -209,7 +209,7 @@ exports[`CheckBoxGroup initial value renders 1`] = `
       >
         <input
           checked=""
-          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
           type="checkbox"
         />
         <div
@@ -243,7 +243,7 @@ exports[`CheckBoxGroup initial value renders 1`] = `
       >
         <input
           checked=""
-          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
           type="checkbox"
         />
         <div
@@ -285,7 +285,7 @@ exports[`CheckBoxGroup labelKey 1`] = `
         class="StyledBox-sc-13pk1d4-0 gibDHu StyledCheckBox-sc-1dbk5ju-6 eJWclz"
       >
         <input
-          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
           type="checkbox"
         />
         <div
@@ -307,7 +307,7 @@ exports[`CheckBoxGroup labelKey 1`] = `
         class="StyledBox-sc-13pk1d4-0 gibDHu StyledCheckBox-sc-1dbk5ju-6 eJWclz"
       >
         <input
-          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
           type="checkbox"
         />
         <div
@@ -338,7 +338,7 @@ exports[`CheckBoxGroup onChange 1`] = `
         class="StyledBox-sc-13pk1d4-0 gibDHu StyledCheckBox-sc-1dbk5ju-6 eJWclz"
       >
         <input
-          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
           type="checkbox"
         />
         <div
@@ -371,7 +371,7 @@ exports[`CheckBoxGroup onChange 1`] = `
         class="StyledBox-sc-13pk1d4-0 gibDHu StyledCheckBox-sc-1dbk5ju-6 eJWclz"
       >
         <input
-          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
           type="checkbox"
         />
         <div
@@ -403,7 +403,7 @@ exports[`CheckBoxGroup onClick for check and uncheck a CheckBox 1`] = `
         class="StyledBox-sc-13pk1d4-0 gibDHu StyledCheckBox-sc-1dbk5ju-6 eJWclz"
       >
         <input
-          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
           type="checkbox"
         />
         <div
@@ -436,7 +436,7 @@ exports[`CheckBoxGroup onClick for check and uncheck a CheckBox 1`] = `
         class="StyledBox-sc-13pk1d4-0 gibDHu StyledCheckBox-sc-1dbk5ju-6 eJWclz"
       >
         <input
-          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
           type="checkbox"
         />
         <div
@@ -468,7 +468,7 @@ exports[`CheckBoxGroup onClick for check and uncheck a CheckBox 2`] = `
         class="StyledBox-sc-13pk1d4-0 gibDHu StyledCheckBox-sc-1dbk5ju-6 eJWclz"
       >
         <input
-          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
           type="checkbox"
         />
         <div
@@ -490,7 +490,7 @@ exports[`CheckBoxGroup onClick for check and uncheck a CheckBox 2`] = `
         class="StyledBox-sc-13pk1d4-0 gibDHu StyledCheckBox-sc-1dbk5ju-6 eJWclz"
       >
         <input
-          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
           type="checkbox"
         />
         <div
@@ -521,7 +521,7 @@ exports[`CheckBoxGroup options renders 1`] = `
         class="StyledBox-sc-13pk1d4-0 gibDHu StyledCheckBox-sc-1dbk5ju-6 eJWclz"
       >
         <input
-          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
           type="checkbox"
         />
         <div
@@ -543,7 +543,7 @@ exports[`CheckBoxGroup options renders 1`] = `
         class="StyledBox-sc-13pk1d4-0 gibDHu StyledCheckBox-sc-1dbk5ju-6 eJWclz"
       >
         <input
-          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
           type="checkbox"
         />
         <div
@@ -575,7 +575,7 @@ exports[`CheckBoxGroup value renders 1`] = `
       >
         <input
           checked=""
-          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
           type="checkbox"
         />
         <div
@@ -608,7 +608,7 @@ exports[`CheckBoxGroup value renders 1`] = `
         class="StyledBox-sc-13pk1d4-0 gibDHu StyledCheckBox-sc-1dbk5ju-6 eJWclz"
       >
         <input
-          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
           type="checkbox"
         />
         <div
@@ -639,7 +639,7 @@ exports[`CheckBoxGroup valueKey 1`] = `
         class="StyledBox-sc-13pk1d4-0 gibDHu StyledCheckBox-sc-1dbk5ju-6 eJWclz"
       >
         <input
-          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
           type="checkbox"
         />
         <div
@@ -661,7 +661,7 @@ exports[`CheckBoxGroup valueKey 1`] = `
         class="StyledBox-sc-13pk1d4-0 gibDHu StyledCheckBox-sc-1dbk5ju-6 eJWclz"
       >
         <input
-          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
+          class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
           type="checkbox"
         />
         <div

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -3517,7 +3517,7 @@ exports[`DataTable custom theme 2`] = `
               >
                 <input
                   checked=""
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cgrsMd"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 izuNoZ"
                   disabled=""
                   type="checkbox"
                 />
@@ -3581,7 +3581,7 @@ exports[`DataTable custom theme 2`] = `
                 disabled=""
               >
                 <input
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cgrsMd"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 izuNoZ"
                   disabled=""
                   type="checkbox"
                 />
@@ -11532,7 +11532,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
                 class="StyledBox-sc-13pk1d4-0 hKKecH StyledCheckBox-sc-1dbk5ju-6 eJWclz"
               >
                 <input
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
                   type="checkbox"
                 />
                 <div
@@ -11663,7 +11663,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
                 class="StyledBox-sc-13pk1d4-0 hKKecH StyledCheckBox-sc-1dbk5ju-6 eJWclz"
               >
                 <input
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
                   type="checkbox"
                 />
                 <div
@@ -11783,7 +11783,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
                 class="StyledBox-sc-13pk1d4-0 hKKecH StyledCheckBox-sc-1dbk5ju-6 eJWclz"
               >
                 <input
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
                   type="checkbox"
                 />
                 <div
@@ -11919,7 +11919,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
                 class="StyledBox-sc-13pk1d4-0 hKKecH StyledCheckBox-sc-1dbk5ju-6 eJWclz"
               >
                 <input
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
                   type="checkbox"
                 />
                 <div
@@ -12011,7 +12011,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
                 class="StyledBox-sc-13pk1d4-0 hKKecH StyledCheckBox-sc-1dbk5ju-6 eJWclz"
               >
                 <input
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
                   type="checkbox"
                 />
                 <div
@@ -12092,7 +12092,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
                 class="StyledBox-sc-13pk1d4-0 hKKecH StyledCheckBox-sc-1dbk5ju-6 eJWclz"
               >
                 <input
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
                   type="checkbox"
                 />
                 <div
@@ -12703,7 +12703,7 @@ exports[`DataTable onSelect select/unselect all 2`] = `
                 class="StyledBox-sc-13pk1d4-0 hKKecH StyledCheckBox-sc-1dbk5ju-6 eJWclz"
               >
                 <input
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
                   type="checkbox"
                 />
                 <div
@@ -12795,7 +12795,7 @@ exports[`DataTable onSelect select/unselect all 2`] = `
                 class="StyledBox-sc-13pk1d4-0 hKKecH StyledCheckBox-sc-1dbk5ju-6 eJWclz"
               >
                 <input
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
                   type="checkbox"
                 />
                 <div
@@ -12882,7 +12882,7 @@ exports[`DataTable onSelect select/unselect all 2`] = `
                 class="StyledBox-sc-13pk1d4-0 hKKecH StyledCheckBox-sc-1dbk5ju-6 eJWclz"
               >
                 <input
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
                   type="checkbox"
                 />
                 <div
@@ -12969,7 +12969,7 @@ exports[`DataTable onSelect select/unselect all 2`] = `
                 class="StyledBox-sc-13pk1d4-0 hKKecH StyledCheckBox-sc-1dbk5ju-6 eJWclz"
               >
                 <input
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
                   type="checkbox"
                 />
                 <div
@@ -13056,7 +13056,7 @@ exports[`DataTable onSelect select/unselect all 2`] = `
                 class="StyledBox-sc-13pk1d4-0 hKKecH StyledCheckBox-sc-1dbk5ju-6 eJWclz"
               >
                 <input
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
                   type="checkbox"
                 />
                 <div
@@ -13159,7 +13159,7 @@ exports[`DataTable onSelect select/unselect all 3`] = `
                 class="StyledBox-sc-13pk1d4-0 hKKecH StyledCheckBox-sc-1dbk5ju-6 eJWclz"
               >
                 <input
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
                   type="checkbox"
                 />
                 <div
@@ -13220,7 +13220,7 @@ exports[`DataTable onSelect select/unselect all 3`] = `
                 class="StyledBox-sc-13pk1d4-0 hKKecH StyledCheckBox-sc-1dbk5ju-6 eJWclz"
               >
                 <input
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
                   type="checkbox"
                 />
                 <div
@@ -13276,7 +13276,7 @@ exports[`DataTable onSelect select/unselect all 3`] = `
                 class="StyledBox-sc-13pk1d4-0 hKKecH StyledCheckBox-sc-1dbk5ju-6 eJWclz"
               >
                 <input
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
                   type="checkbox"
                 />
                 <div
@@ -13332,7 +13332,7 @@ exports[`DataTable onSelect select/unselect all 3`] = `
                 class="StyledBox-sc-13pk1d4-0 hKKecH StyledCheckBox-sc-1dbk5ju-6 eJWclz"
               >
                 <input
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
                   type="checkbox"
                 />
                 <div
@@ -13388,7 +13388,7 @@ exports[`DataTable onSelect select/unselect all 3`] = `
                 class="StyledBox-sc-13pk1d4-0 hKKecH StyledCheckBox-sc-1dbk5ju-6 eJWclz"
               >
                 <input
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
                   type="checkbox"
                 />
                 <div
@@ -21375,7 +21375,7 @@ exports[`DataTable select 2`] = `
                 class="StyledBox-sc-13pk1d4-0 hKKecH StyledCheckBox-sc-1dbk5ju-6 eJWclz"
               >
                 <input
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
                   type="checkbox"
                 />
                 <div
@@ -21454,7 +21454,7 @@ exports[`DataTable select 2`] = `
               >
                 <input
                   checked=""
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
                   type="checkbox"
                 />
                 <div
@@ -21508,7 +21508,7 @@ exports[`DataTable select 2`] = `
                 class="StyledBox-sc-13pk1d4-0 hKKecH StyledCheckBox-sc-1dbk5ju-6 eJWclz"
               >
                 <input
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
                   type="checkbox"
                 />
                 <div

--- a/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.tsx.snap
+++ b/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.tsx.snap
@@ -1729,7 +1729,7 @@ exports[`DateInput controlled format inline 2`] = `
       >
         <input
           autocomplete="off"
-          class="StyledMaskedInput-sc-99vkfa-0 bLvERa"
+          class="StyledMaskedInput-sc-99vkfa-0 OaCNq"
           id="item"
           name="item"
           placeholder="mm/dd/yyyy"
@@ -13408,7 +13408,7 @@ exports[`DateInput select format 2`] = `
     >
       <input
         autocomplete="off"
-        class="StyledMaskedInput-sc-99vkfa-0 bLvERa"
+        class="StyledMaskedInput-sc-99vkfa-0 OaCNq"
         id="item"
         name="item"
         placeholder="mm/dd/yyyy"
@@ -16170,7 +16170,7 @@ exports[`DateInput select format inline 2`] = `
       >
         <input
           autocomplete="off"
-          class="StyledMaskedInput-sc-99vkfa-0 bLvERa"
+          class="StyledMaskedInput-sc-99vkfa-0 OaCNq"
           id="item"
           name="item"
           placeholder="mm/dd/yyyy"
@@ -21261,7 +21261,7 @@ exports[`DateInput select format inline range 2`] = `
       >
         <input
           autocomplete="off"
-          class="StyledMaskedInput-sc-99vkfa-0 bLvERa"
+          class="StyledMaskedInput-sc-99vkfa-0 OaCNq"
           id="item"
           name="item"
           placeholder="mm/dd/yyyy-mm/dd/yyyy"
@@ -30549,7 +30549,7 @@ exports[`DateInput type format inline 2`] = `
       >
         <input
           autocomplete="off"
-          class="StyledMaskedInput-sc-99vkfa-0 bLvERa"
+          class="StyledMaskedInput-sc-99vkfa-0 OaCNq"
           id="item"
           name="item"
           placeholder="mm/dd/yyyy"
@@ -35561,7 +35561,7 @@ exports[`DateInput type format inline range 2`] = `
       >
         <input
           autocomplete="off"
-          class="StyledMaskedInput-sc-99vkfa-0 bLvERa"
+          class="StyledMaskedInput-sc-99vkfa-0 OaCNq"
           id="item"
           name="item"
           placeholder="mm/dd/yyyy-mm/dd/yyyy"
@@ -37820,7 +37820,7 @@ exports[`DateInput type format inline range partial 2`] = `
       >
         <input
           autocomplete="off"
-          class="StyledMaskedInput-sc-99vkfa-0 bLvERa"
+          class="StyledMaskedInput-sc-99vkfa-0 OaCNq"
           id="item"
           name="item"
           placeholder="mm/dd/yyyy-mm/dd/yyyy"
@@ -38684,7 +38684,7 @@ exports[`DateInput type format inline range partial 3`] = `
       >
         <input
           autocomplete="off"
-          class="StyledMaskedInput-sc-99vkfa-0 bLvERa"
+          class="StyledMaskedInput-sc-99vkfa-0 OaCNq"
           id="item"
           name="item"
           placeholder="mm/dd/yyyy-mm/dd/yyyy"
@@ -47873,7 +47873,7 @@ exports[`DateInput type format inline short 2`] = `
       >
         <input
           autocomplete="off"
-          class="StyledMaskedInput-sc-99vkfa-0 bLvERa"
+          class="StyledMaskedInput-sc-99vkfa-0 OaCNq"
           id="item"
           name="item"
           placeholder="m/d/yy"

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-controlled.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-controlled.js.snap
@@ -223,7 +223,7 @@ exports[`Form controlled controlled 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
+            class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
             name="test"
             placeholder="test input"
             value="v"
@@ -257,7 +257,7 @@ exports[`Form controlled controlled 3`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
+            class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
             name="test"
             placeholder="test input"
             value="v"
@@ -630,7 +630,7 @@ exports[`Form controlled controlled Array of Form Fields 2`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
+              class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
               name="phones[0].number"
               placeholder="number test input 1"
               value=""
@@ -649,7 +649,7 @@ exports[`Form controlled controlled Array of Form Fields 2`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
+              class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
               name="phones[0].ext"
               placeholder="ext test input 1"
               value=""
@@ -672,7 +672,7 @@ exports[`Form controlled controlled Array of Form Fields 2`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
+              class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
               name="phones[1].number"
               placeholder="number test input 2"
               value="123456789"
@@ -691,7 +691,7 @@ exports[`Form controlled controlled Array of Form Fields 2`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
+              class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
               name="phones[1].ext"
               placeholder="ext test input 2"
               value=""
@@ -714,7 +714,7 @@ exports[`Form controlled controlled Array of Form Fields 2`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
+              class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
               name="phones[2].number"
               placeholder="number test input 3"
               value=""
@@ -733,7 +733,7 @@ exports[`Form controlled controlled Array of Form Fields 2`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
+              class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
               name="phones[2].ext"
               placeholder="ext test input 3"
               value="999"
@@ -771,7 +771,7 @@ exports[`Form controlled controlled Array of Form Fields 3`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
+              class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
               name="phones[0].number"
               placeholder="number test input 1"
               value=""
@@ -790,7 +790,7 @@ exports[`Form controlled controlled Array of Form Fields 3`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
+              class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
               name="phones[0].ext"
               placeholder="ext test input 1"
               value=""
@@ -813,7 +813,7 @@ exports[`Form controlled controlled Array of Form Fields 3`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
+              class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
               name="phones[1].number"
               placeholder="number test input 2"
               value="123456789"
@@ -832,7 +832,7 @@ exports[`Form controlled controlled Array of Form Fields 3`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
+              class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
               name="phones[1].ext"
               placeholder="ext test input 2"
               value=""
@@ -855,7 +855,7 @@ exports[`Form controlled controlled Array of Form Fields 3`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
+              class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
               name="phones[2].number"
               placeholder="number test input 3"
               value=""
@@ -874,7 +874,7 @@ exports[`Form controlled controlled Array of Form Fields 3`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
+              class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
               name="phones[2].ext"
               placeholder="ext test input 3"
               value="999"
@@ -1206,7 +1206,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate 2`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
+              class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
               name="phones[0].number"
               placeholder="number test input 1"
               value=""
@@ -1252,7 +1252,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate 2`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
+              class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
               name="phones[0].ext"
               placeholder="ext test input 1"
               value=""
@@ -1275,7 +1275,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate 2`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
+              class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
               name="phones[1].number"
               placeholder="number test input 2"
               value=""
@@ -1321,7 +1321,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate 2`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
+              class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
               name="phones[1].ext"
               placeholder="ext test input 2"
               value=""
@@ -1653,7 +1653,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate custom error
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
+              class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
               name="phones[0].number"
               placeholder="number test input 1"
               value=""
@@ -1672,7 +1672,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate custom error
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
+              class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
               name="phones[0].ext"
               placeholder="ext test input 1"
               value=""
@@ -1695,7 +1695,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate custom error
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
+              class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
               name="phones[1].number"
               placeholder="number test input 2"
               value="sadasd"
@@ -1741,7 +1741,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate custom error
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
+              class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
               name="phones[1].ext"
               placeholder="ext test input 2"
               value=""
@@ -2004,7 +2004,7 @@ exports[`Form controlled controlled FormField deprecated 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
+            class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
             id="test"
             name="test"
             value="v"
@@ -2044,7 +2044,7 @@ exports[`Form controlled controlled FormField deprecated 3`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
+            class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
             id="test"
             name="test"
             value="v"
@@ -2285,7 +2285,7 @@ exports[`Form controlled controlled input 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
+            class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
             name="test"
             placeholder="test input"
             value="v"
@@ -2319,7 +2319,7 @@ exports[`Form controlled controlled input 3`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
+            class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
             name="test"
             placeholder="test input"
             value="v"
@@ -2560,7 +2560,7 @@ exports[`Form controlled controlled input lazy 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
+            class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
             name="test"
             placeholder="test input"
             value="v"
@@ -2594,7 +2594,7 @@ exports[`Form controlled controlled input lazy 3`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
+            class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
             name="test"
             placeholder="test input"
             value="v"
@@ -2835,7 +2835,7 @@ exports[`Form controlled controlled lazy 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
+            class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
             name="test"
             placeholder="test input"
             value="v"
@@ -2869,7 +2869,7 @@ exports[`Form controlled controlled lazy 3`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
+            class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
             name="test"
             placeholder="test input"
             value="v"
@@ -3317,7 +3317,7 @@ exports[`Form controlled controlled onValidate 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
+            class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
             name="test"
             placeholder="test input"
             value=""
@@ -3585,7 +3585,7 @@ exports[`Form controlled controlled onValidate custom error 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
+            class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
             name="test"
             placeholder="test input"
             value=""
@@ -3853,7 +3853,7 @@ exports[`Form controlled controlled onValidate custom info 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
+            class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
             name="test"
             placeholder="test input"
             value=""
@@ -4283,7 +4283,7 @@ exports[`Form controlled dynamicly removed fields using blur validation
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
+            class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
             name="name"
             placeholder="test name"
             value=""
@@ -4305,7 +4305,7 @@ exports[`Form controlled dynamicly removed fields using blur validation
             class="StyledBox-sc-13pk1d4-0 gibDHu StyledCheckBox-sc-1dbk5ju-6 eJWclz"
           >
             <input
-              class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
+              class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
               name="toggle"
               type="checkbox"
             />
@@ -4523,7 +4523,7 @@ exports[`Form controlled dynamicly removed fields using blur validation
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
+            class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
             name="name"
             placeholder="test name"
             value=""
@@ -4545,7 +4545,7 @@ exports[`Form controlled dynamicly removed fields using blur validation
             class="StyledBox-sc-13pk1d4-0 gibDHu StyledCheckBox-sc-1dbk5ju-6 eJWclz"
           >
             <input
-              class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
+              class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
               name="toggle"
               type="checkbox"
             />

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
@@ -1320,7 +1320,7 @@ exports[`Form uncontrolled dynamicly removed fields should be removed from form 
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
+            class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
             name="name"
             placeholder="test name"
             value=""
@@ -1342,7 +1342,7 @@ exports[`Form uncontrolled dynamicly removed fields should be removed from form 
             class="StyledBox-sc-13pk1d4-0 gibDHu StyledCheckBox-sc-1dbk5ju-6 eJWclz"
           >
             <input
-              class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
+              class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
               name="toggle"
               type="checkbox"
             />
@@ -1755,7 +1755,7 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
+            class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
             name="name"
             placeholder="test name"
             value=""
@@ -1777,7 +1777,7 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation
             class="StyledBox-sc-13pk1d4-0 gibDHu StyledCheckBox-sc-1dbk5ju-6 eJWclz"
           >
             <input
-              class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
+              class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
               name="toggle"
               type="checkbox"
             />
@@ -1995,7 +1995,7 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
+            class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
             name="name"
             placeholder="test name"
             value=""
@@ -2017,7 +2017,7 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation
             class="StyledBox-sc-13pk1d4-0 gibDHu StyledCheckBox-sc-1dbk5ju-6 eJWclz"
           >
             <input
-              class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
+              class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
               name="toggle"
               type="checkbox"
             />
@@ -3377,7 +3377,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
               >
                 <input
                   autocomplete="off"
-                  class="StyledTextInput-sc-1x30a0s-0 kkBhYd Select__SelectTextInput-sc-17idtfo-0 bQAqdj"
+                  class="StyledTextInput-sc-1x30a0s-0 fKwwIt Select__SelectTextInput-sc-17idtfo-0 bQAqdj"
                   id="test-select__input"
                   name="test-select"
                   placeholder="test select"
@@ -3430,7 +3430,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
             class="StyledBox-sc-13pk1d4-0 gibDHu StyledCheckBox-sc-1dbk5ju-6 eJWclz"
           >
             <input
-              class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNxRHh"
+              class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
               id="test-checkbox"
               name="test-checkbox"
               type="checkbox"
@@ -3463,7 +3463,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
           role="radiogroup"
         >
           <label
-            class="StyledRadioButton__StyledRadioButtonContainer-sc-g1f6ld-0 isBpzl"
+            class="StyledRadioButton__StyledRadioButtonContainer-sc-g1f6ld-0 kwYmqp"
             for="test-radiobuttongroup-one"
           >
             <div
@@ -3491,7 +3491,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
             class="StyledBox__StyledBoxGap-sc-13pk1d4-1 qdAYv"
           />
           <label
-            class="StyledRadioButton__StyledRadioButtonContainer-sc-g1f6ld-0 isBpzl"
+            class="StyledRadioButton__StyledRadioButtonContainer-sc-g1f6ld-0 kwYmqp"
             for="test-radiobuttongroup-two"
           >
             <div
@@ -3519,7 +3519,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
             class="StyledBox__StyledBoxGap-sc-13pk1d4-1 qdAYv"
           />
           <label
-            class="StyledRadioButton__StyledRadioButtonContainer-sc-g1f6ld-0 isBpzl"
+            class="StyledRadioButton__StyledRadioButtonContainer-sc-g1f6ld-0 kwYmqp"
             for="test-radiobuttongroup-three"
           >
             <div
@@ -3779,7 +3779,7 @@ exports[`Form uncontrolled uncontrolled 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
+            class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
             name="test"
             placeholder="test input"
             value=""
@@ -3813,7 +3813,7 @@ exports[`Form uncontrolled uncontrolled 3`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
+            class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
             name="test"
             placeholder="test input"
             value=""
@@ -4054,7 +4054,7 @@ exports[`Form uncontrolled uncontrolled onValidate 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
+            class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
             name="test"
             placeholder="test input"
             value=""
@@ -4322,7 +4322,7 @@ exports[`Form uncontrolled uncontrolled onValidate custom error 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
+            class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
             name="test"
             placeholder="test input"
             value=""
@@ -4590,7 +4590,7 @@ exports[`Form uncontrolled uncontrolled onValidate custom info 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 kkBhYd"
+            class="StyledTextInput-sc-1x30a0s-0 fKwwIt"
             name="test"
             placeholder="test input"
             value=""

--- a/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.js.snap
+++ b/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.js.snap
@@ -1067,7 +1067,7 @@ exports[`MaskedInput event target props are available option via mouse 4`] = `
 >
   <input
     autocomplete="off"
-    class="StyledMaskedInput-sc-99vkfa-0 gAjxFv"
+    class="StyledMaskedInput-sc-99vkfa-0 fRHXoP"
     data-testid="test-input"
     id="item"
     name="item"
@@ -1869,7 +1869,7 @@ exports[`MaskedInput next and previous without options 2`] = `
 >
   <input
     autocomplete="off"
-    class="StyledMaskedInput-sc-99vkfa-0 jPKjwi"
+    class="StyledMaskedInput-sc-99vkfa-0 hetwLm"
     data-testid="test-input"
     id="item"
     name="item"
@@ -2292,7 +2292,7 @@ exports[`MaskedInput option via mouse 4`] = `
 >
   <input
     autocomplete="off"
-    class="StyledMaskedInput-sc-99vkfa-0 gAjxFv"
+    class="StyledMaskedInput-sc-99vkfa-0 fRHXoP"
     data-testid="test-input"
     id="item"
     name="item"

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -2660,7 +2660,7 @@ exports[`Select complex options and children 2`] = `
       >
         <input
           autocomplete="off"
-          class="StyledTextInput-sc-1x30a0s-0 kkBhYd Select__SelectTextInput-sc-17idtfo-0 bQAqdj"
+          class="StyledTextInput-sc-1x30a0s-0 fKwwIt Select__SelectTextInput-sc-17idtfo-0 bQAqdj"
           id="test-select__input"
           placeholder="test select"
           readonly=""
@@ -4464,7 +4464,7 @@ exports[`Select disabled 2`] = `
       >
         <input
           autocomplete="off"
-          class="StyledTextInput-sc-1x30a0s-0 kkBhYd Select__SelectTextInput-sc-17idtfo-0 fDnYDX"
+          class="StyledTextInput-sc-1x30a0s-0 fKwwIt Select__SelectTextInput-sc-17idtfo-0 fDnYDX"
           id="test-select__input"
           placeholder="test select"
           readonly=""
@@ -8984,7 +8984,7 @@ exports[`Select prop: onOpen 2`] = `
       >
         <input
           autocomplete="off"
-          class="StyledTextInput-sc-1x30a0s-0 kkBhYd Select__SelectTextInput-sc-17idtfo-0 bQAqdj"
+          class="StyledTextInput-sc-1x30a0s-0 fKwwIt Select__SelectTextInput-sc-17idtfo-0 bQAqdj"
           id="test-select__input"
           placeholder="test select"
           readonly=""
@@ -9894,7 +9894,7 @@ exports[`Select renders custom up and down icons 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 kkBhYd Select__SelectTextInput-sc-17idtfo-0 bQAqdj"
+            class="StyledTextInput-sc-1x30a0s-0 fKwwIt Select__SelectTextInput-sc-17idtfo-0 bQAqdj"
             placeholder="Select..."
             readonly=""
             tabindex="-1"
@@ -11967,7 +11967,7 @@ exports[`Select search 3`] = `
 exports[`Select search 4`] = `
 <input
   autocomplete="off"
-  class="StyledTextInput-sc-1x30a0s-0 cxcKvg"
+  class="StyledTextInput-sc-1x30a0s-0 bUIvzg"
   type="search"
   value=""
 />
@@ -11976,7 +11976,7 @@ exports[`Select search 4`] = `
 exports[`Select search 5`] = `
 <input
   autocomplete="off"
-  class="StyledTextInput-sc-1x30a0s-0 cxcKvg"
+  class="StyledTextInput-sc-1x30a0s-0 bUIvzg"
   type="search"
   value="o"
 />
@@ -12620,7 +12620,7 @@ exports[`Select search and select 3`] = `
 exports[`Select search and select 4`] = `
 <input
   autocomplete="off"
-  class="StyledTextInput-sc-1x30a0s-0 cxcKvg"
+  class="StyledTextInput-sc-1x30a0s-0 bUIvzg"
   type="search"
   value=""
 />
@@ -12629,7 +12629,7 @@ exports[`Select search and select 4`] = `
 exports[`Select search and select 5`] = `
 <input
   autocomplete="off"
-  class="StyledTextInput-sc-1x30a0s-0 cxcKvg"
+  class="StyledTextInput-sc-1x30a0s-0 bUIvzg"
   type="search"
   value="t"
 />
@@ -14490,7 +14490,7 @@ exports[`Select select option by typing should not break if caller passes JSX 2`
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 kkBhYd Select__SelectTextInput-sc-17idtfo-0 bQAqdj"
+            class="StyledTextInput-sc-1x30a0s-0 fKwwIt Select__SelectTextInput-sc-17idtfo-0 bQAqdj"
             id="test-select__input"
             placeholder="test select"
             readonly=""

--- a/src/js/components/Select/__tests__/__snapshots__/SelectMultiple-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/SelectMultiple-test.js.snap
@@ -3111,7 +3111,7 @@ exports[`Select Controlled multiple values 2`] = `
       >
         <input
           autocomplete="off"
-          class="StyledTextInput-sc-1x30a0s-0 kkBhYd Select__SelectTextInput-sc-17idtfo-0 bQAqdj"
+          class="StyledTextInput-sc-1x30a0s-0 fKwwIt Select__SelectTextInput-sc-17idtfo-0 bQAqdj"
           id="test-select__input"
           placeholder="test select"
           readonly=""

--- a/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.tsx.snap
+++ b/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.tsx.snap
@@ -519,7 +519,7 @@ exports[`TextInput calls onSuggestionsClose 4`] = `
       aria-autocomplete="list"
       aria-expanded="false"
       autocomplete="off"
-      class="StyledTextInput-sc-1x30a0s-0 doZMBU"
+      class="StyledTextInput-sc-1x30a0s-0 jxFxho"
       data-testid="test-input"
       id="item"
       name="item"
@@ -1086,7 +1086,7 @@ exports[`TextInput close suggestion drop 4`] = `
       aria-autocomplete="list"
       aria-expanded="false"
       autocomplete="off"
-      class="StyledTextInput-sc-1x30a0s-0 doZMBU"
+      class="StyledTextInput-sc-1x30a0s-0 jxFxho"
       data-testid="test-input"
       id="item"
       name="item"
@@ -1700,7 +1700,7 @@ exports[`TextInput handles next and previous without suggestion 2`] = `
   >
     <input
       autocomplete="off"
-      class="StyledTextInput-sc-1x30a0s-0 doZMBU"
+      class="StyledTextInput-sc-1x30a0s-0 jxFxho"
       data-testid="test-input"
       id="item"
       name="item"
@@ -3968,7 +3968,7 @@ exports[`TextInput select suggestion 4`] = `
       aria-autocomplete="list"
       aria-expanded="false"
       autocomplete="off"
-      class="StyledTextInput-sc-1x30a0s-0 gexBpp"
+      class="StyledTextInput-sc-1x30a0s-0 bEniJV"
       data-testid="test-input"
       id="item"
       name="item"
@@ -4572,7 +4572,7 @@ exports[`TextInput should only show default placeholder when placeholder is a
   >
     <input
       autocomplete="off"
-      class="StyledTextInput-sc-1x30a0s-0 doZMBU"
+      class="StyledTextInput-sc-1x30a0s-0 jxFxho"
       data-testid="placeholder"
       id="placeholder"
       name="placeholder"

--- a/src/js/components/Video/__tests__/__snapshots__/Video-test.js.snap
+++ b/src/js/components/Video/__tests__/__snapshots__/Video-test.js.snap
@@ -1545,7 +1545,7 @@ exports[`Video Play and Pause event handlers 2`] = `
     tabindex="-1"
   >
     <video
-      class="StyledVideo-sc-w4v8h9-0 jMymic"
+      class="StyledVideo-sc-w4v8h9-0 fLrMDE"
     >
       <source
         src="small.mp4"
@@ -5781,7 +5781,7 @@ exports[`Video mouse events handlers of controls 2`] = `
     tabindex="-1"
   >
     <video
-      class="StyledVideo-sc-w4v8h9-0 jMymic"
+      class="StyledVideo-sc-w4v8h9-0 fLrMDE"
     >
       <source
         src="small.mp4"
@@ -5905,7 +5905,7 @@ exports[`Video mouse events handlers of controls 3`] = `
     tabindex="-1"
   >
     <video
-      class="StyledVideo-sc-w4v8h9-0 jMymic"
+      class="StyledVideo-sc-w4v8h9-0 fLrMDE"
     >
       <source
         src="small.mp4"
@@ -8061,7 +8061,7 @@ exports[`Video scrubber 2`] = `
     tabindex="-1"
   >
     <video
-      class="StyledVideo-sc-w4v8h9-0 jMymic"
+      class="StyledVideo-sc-w4v8h9-0 fLrMDE"
     >
       <source
         src="small.mp4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3541,7 +3541,18 @@ babel-plugin-react-docgen@^4.2.1:
     lodash "^4.17.15"
     react-docgen "^5.0.0"
 
-"babel-plugin-styled-components@>= 1.12.0", babel-plugin-styled-components@^2.0.7:
+babel-plugin-styled-components@2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.6.tgz#6f76c7f7224b7af7edc24a4910351948c691fc90"
+  integrity sha512-Sk+7o/oa2HfHv3Eh8sxoz75/fFvEdHsXV4grdeHufX0nauCmymlnN0rGhIvfpMQSJMvGutJ85gvCGea4iqmDpg==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.16.0"
+    "@babel/helper-module-imports" "^7.16.0"
+    babel-plugin-syntax-jsx "^6.18.0"
+    lodash "^4.17.11"
+    picomatch "^2.3.0"
+
+"babel-plugin-styled-components@>= 1.12.0":
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.7.tgz#c81ef34b713f9da2b7d3f5550df0d1e19e798086"
   integrity sha512-i7YhvPgVqRKfoQ66toiZ06jPNA3p6ierpfUuEWxNF+fV27Uv5gxBkf8KZLHUCc1nFA9j6+80pYoIpqCeyW3/bA==


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR reverts 
  `"babel-plugin-styled-components": "2.0.6",`
#### Where should the reviewer start?
package.json
#### What testing has been done on this PR?
yarn test update
#### How should this be manually tested?
n/a
#### Do Jest tests follow these best practices?
n/a
- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
With this update, there were snapshot changes that were being made 
which is affecting any new PRs that are being made. Need to look further into why upgrading this package would include snapshot changes 
#### What are the relevant issues?
none
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
backward compatible