### PR TITLE
Allow theme to specify Anchor gap

### DIFF
--- a/src/js/components/Anchor/Anchor.js
+++ b/src/js/components/Anchor/Anchor.js
@@ -24,7 +24,7 @@ const Anchor = forwardRef(
       children,
       color,
       disabled,
-      gap = 'small',
+      gap,
       href,
       icon,
       label,
@@ -84,7 +84,7 @@ const Anchor = forwardRef(
             as="span"
             direction="row"
             align="center"
-            gap={gap}
+            gap={gap || theme.anchor.gap}
             responsive={false}
             style={{ display: 'inline-flex' }}
           >

--- a/src/js/components/Anchor/__tests__/Anchor-test.tsx
+++ b/src/js/components/Anchor/__tests__/Anchor-test.tsx
@@ -198,7 +198,8 @@ describe('Anchor', () => {
 
   test('gap renders', () => {
     const { container } = render(
-      <Grommet>
+      <Grommet theme={{ anchor: { gap: 'xsmall' } }}>
+        <Anchor icon={<svg />} label="Theme Gap" href="#" />
         <Anchor icon={<svg />} label="Small Gap" href="#" gap="small" />
         <Anchor icon={<svg />} label="Medium Gap" href="#" gap="medium" />
         <Anchor icon={<svg />} label="Large Gap" href="#" gap="large" />

--- a/src/js/components/Anchor/__tests__/__snapshots__/Anchor-test.tsx.snap
+++ b/src/js/components/Anchor/__tests__/__snapshots__/Anchor-test.tsx.snap
@@ -169,7 +169,7 @@ exports[`Anchor gap renders 1`] = `
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
   align-self: stretch;
-  width: 12px;
+  width: 6px;
 }
 
 .c4 {
@@ -179,7 +179,7 @@ exports[`Anchor gap renders 1`] = `
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
   align-self: stretch;
-  width: 24px;
+  width: 12px;
 }
 
 .c5 {
@@ -189,10 +189,20 @@ exports[`Anchor gap renders 1`] = `
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
   align-self: stretch;
-  width: 48px;
+  width: 24px;
 }
 
 .c6 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  width: 48px;
+}
+
+.c7 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -236,7 +246,7 @@ exports[`Anchor gap renders 1`] = `
         <span
           class="c3"
         />
-        Small Gap
+        Theme Gap
       </span>
     </a>
     <a
@@ -253,7 +263,7 @@ exports[`Anchor gap renders 1`] = `
         <span
           class="c4"
         />
-        Medium Gap
+        Small Gap
       </span>
     </a>
     <a
@@ -270,7 +280,7 @@ exports[`Anchor gap renders 1`] = `
         <span
           class="c5"
         />
-        Large Gap
+        Medium Gap
       </span>
     </a>
     <a
@@ -286,6 +296,23 @@ exports[`Anchor gap renders 1`] = `
         />
         <span
           class="c6"
+        />
+        Large Gap
+      </span>
+    </a>
+    <a
+      class="c1"
+      href="#"
+    >
+      <span
+        class="c2"
+        style="display: inline-flex;"
+      >
+        <svg
+          color="#7D4CDB"
+        />
+        <span
+          class="c7"
         />
         5px Gap
       </span>

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -780,6 +780,7 @@ Object {
             "light": "brand",
           },
           "fontWeight": 600,
+          "gap": "small",
           "hover": Object {
             "textDecoration": "underline",
           },

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -445,6 +445,7 @@ export interface ThemeType {
     color?: ColorType;
     extend?: ExtendType<PropsOf<typeof Anchor>>;
     fontWeight?: number;
+    gap?: GapType;
     hover?: {
       extend?: ExtendType<PropsOf<typeof Anchor>>;
       textDecoration?: string;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -363,6 +363,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         dark: 'accent-1',
         light: 'brand',
       },
+      gap: 'small',
       hover: {
         textDecoration: 'underline',
         // fontWeight: undefined,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Adds `theme.anchor.gap` to allow the gap to be specified by the theme. Necessary for HPE theme.

#### Where should the reviewer start?
base.js

#### What testing has been done on this PR?
Tested in story and added jest test.

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Yes.

#### Should this PR be mentioned in the release notes?
Yes.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.