### PR TITLE
Fix onClickOutside and animation for Layer and Drop in a shadow dom

### DIFF
--- a/package.json
+++ b/package.json
@@ -191,7 +191,7 @@
   "bundlesize": [
     {
       "path": "./dist/grommet.min.js",
-      "maxSize": "130 kB"
+      "maxSize": "131 kB"
     }
   ],
   "keywords": [

--- a/src/js/components/Drop/DropContainer.js
+++ b/src/js/components/Drop/DropContainer.js
@@ -6,7 +6,7 @@ import React, {
   useRef,
 } from 'react';
 import { ThemeContext } from 'styled-components';
-
+import { ContainerTargetContext } from '../../contexts/ContainerTargetContext';
 import { FocusedContainer } from '../FocusedContainer';
 import {
   backgroundIsDark,
@@ -57,6 +57,7 @@ const DropContainer = forwardRef(
     },
     ref,
   ) => {
+    const containerTarget = useContext(ContainerTargetContext);
     const theme = useContext(ThemeContext) || defaultProps.theme;
     const portalContext = useContext(PortalContext) || defaultPortalContext;
     const portalId = useMemo(() => portalContext.length, [portalContext]);
@@ -258,7 +259,8 @@ const DropContainer = forwardRef(
       const onClickDocument = (event) => {
         // determine which portal id the target is in, if any
         let clickedPortalId = null;
-        let node = event.target;
+        let node =
+          containerTarget === document.body ? event.target : event?.path[0];
         while (clickedPortalId === null && node !== document) {
           const attr = node.getAttribute('data-g-portal-id');
           if (attr !== null) clickedPortalId = parseInt(attr, 10);
@@ -295,6 +297,7 @@ const DropContainer = forwardRef(
       };
     }, [
       align,
+      containerTarget,
       onAlign,
       dropTarget,
       onClickOutside,

--- a/src/js/components/Layer/Layer.js
+++ b/src/js/components/Layer/Layer.js
@@ -54,7 +54,10 @@ const Layer = forwardRef((props, ref) => {
           }
           setTimeout(() => {
             // we add the id and query here so the unit tests work
-            const clone = document.getElementById('layerClone');
+            const clone =
+              containerTarget === document.body
+                ? document.getElementById('layerClone')
+                : containerTarget.getElementById('layerClone');
             if (clone) {
               containerTarget.removeChild(clone);
               layerContainer.remove();

--- a/src/js/components/Layer/LayerContainer.js
+++ b/src/js/components/Layer/LayerContainer.js
@@ -12,6 +12,7 @@ import { FocusedContainer } from '../FocusedContainer';
 import { Keyboard } from '../Keyboard';
 import { ResponsiveContext } from '../../contexts/ResponsiveContext';
 import { OptionsContext } from '../../contexts/OptionsContext';
+import { ContainerTargetContext } from '../../contexts/ContainerTargetContext';
 import {
   backgroundIsDark,
   findVisibleParent,
@@ -48,6 +49,7 @@ const LayerContainer = forwardRef(
     },
     ref,
   ) => {
+    const containerTarget = useContext(ContainerTargetContext);
     const theme = useContext(ThemeContext) || defaultProps.theme;
     const size = useContext(ResponsiveContext);
     // layerOptions was created to preserve backwards compatibility but
@@ -96,7 +98,8 @@ const LayerContainer = forwardRef(
       const onClickDocument = (event) => {
         // determine which portal id the target is in, if any
         let clickedPortalId = null;
-        let node = event.target;
+        let node =
+          containerTarget === document.body ? event.target : event?.path[0];
         while (clickedPortalId === null && node !== document && node !== null) {
           // check if user click occurred within the layer
           const attr = node.getAttribute('data-g-portal-id');
@@ -169,7 +172,7 @@ const LayerContainer = forwardRef(
           document.removeEventListener('mousedown', onClickDocument);
         }
       };
-    }, [layerTarget, onClickOutside, portalContext, portalId]);
+    }, [containerTarget, layerTarget, onClickOutside, portalContext, portalId]);
 
     let content = (
       <StyledContainer


### PR DESCRIPTION
#### What does this PR do?
Fixes an issue where when a Layer or Drop is rendered in a shadow dom any click is identified as a click outside the Layer or Drop, this causes the Layer or Drop to close whenever a click occurs. This PR also fixes an issue with Layer when animate is true it is in a shadow dom the Layer will not be removed when it is closed.

#### Where should the reviewer start?
Start by looking at this codesandbox to see what the issue is https://codesandbox.io/s/wizardly-poincare-uufkpw?file=/src/index.js

#### What testing has been done on this PR?
Tested with the following code: (note getting storybook to play nicely with shadow dom is tricky so I ended up testing in a separate project)
CSS file: (while in a shadow dom we should not see this css applied)
```
p {
  color: red;
}
```
index.js file:
``` javascript
import React, { useState } from "react";
import ReactDOM from "react-dom";
import "./index.css";
import { StyleSheetManager } from "styled-components";
import { Box, Grommet, Button, Layer, DropButton } from "grommet";

const apphost = document.getElementById("root");
const appNode = apphost.attachShadow({ mode: "open" });
const appStyleSlot = document.createElement("section");
appNode.appendChild(appStyleSlot);
const renderAppIn = document.createElement("div");
appStyleSlot.appendChild(renderAppIn);

// Prepare shadow node for portal
const portalhost = document.createElement("div");
const portalNode = portalhost.attachShadow({ mode: "open" });
const portalStyleSlot = document.createElement("section");
portalNode.appendChild(portalStyleSlot);
const renderPortalIn = document.createElement("div");
portalStyleSlot.appendChild(renderPortalIn);

const MyGrommetApp = () => {
  const initialShowModal = false;
  const [showModal, setShowModal] = useState(initialShowModal);

  return (
    <StyleSheetManager target={appStyleSlot}>
      <Grommet containerTarget={appNode}>
        <Box gap="medium" pad="large" id="layer">
          <DropButton
            label="Drop Test"
            dropContent={
              <Box pad="large" background="light-2">
                <p>This text should be black</p>
                <Button
                  label="test"
                  onClick={() => console.log("Drop test button clicked")}
                />
              </Box>
            }
          />
          <Button
            primary
            label="Open Modal"
            onClick={() => setShowModal(true)}
          />
          <>
            {showModal && ( // Render Grommet Layer under Shadow DOM inside a portal
              <>
                <Layer
                  onClickOutside={() => setShowModal(false)}
                  onEsc={() => setShowModal(false)}
                >
                  <p>This text should be black</p>
                  <Button label="close" onClick={() => setShowModal(false)} />
                  <Button
                    label="test"
                    onClick={() => console.log("Layer test button clicked")}
                  />
                </Layer>
              </>
            )}
          </>
        </Box>
      </Grommet>
    </StyleSheetManager>
  );
};

const root = ReactDOM.createRoot(renderAppIn);
root.render(<MyGrommetApp />);
```
#### How should this be manually tested?
In a separate project using this method: https://github.com/grommet/grommet/wiki/How-to-Apply-Your-Grommet-Development-Branch-to-a-Local-Project

#### Do Jest tests follow these best practices?
Still looking into testing shadow doms, not sure if jest support is 100% there for this
- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes https://github.com/grommet/grommet/issues/6105

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No
#### Should this PR be mentioned in the release notes?
Yes
#### Is this change backwards compatible or is it a breaking change?
Backwards compatible