### PR TITLE
Improve keyboard accessibility of Tabs

### DIFF
--- a/package.json
+++ b/package.json
@@ -191,7 +191,7 @@
   "bundlesize": [
     {
       "path": "./dist/grommet.min.js",
-      "maxSize": "130 kB"
+      "maxSize": "131 kB"
     }
   ],
   "keywords": [

--- a/src/js/components/Keyboard/Keyboard.js
+++ b/src/js/components/Keyboard/Keyboard.js
@@ -7,6 +7,8 @@ const KEYS = {
   13: 'onEnter',
   27: 'onEsc',
   32: 'onSpace',
+  35: 'onEnd',
+  36: 'onHome',
   37: 'onLeft',
   38: 'onUp',
   39: 'onRight',

--- a/src/js/components/Tab/Tab.js
+++ b/src/js/components/Tab/Tab.js
@@ -1,4 +1,4 @@
-import React, { forwardRef, useContext, useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { ThemeContext } from 'styled-components';
 
 import { defaultProps } from '../../default-props';
@@ -12,194 +12,184 @@ import { normalizeColor } from '../../utils';
 import { StyledTab } from './StyledTab';
 import { TabPropTypes } from './propTypes';
 
-const Tab = forwardRef(
-  (
-    {
-      active: activeProp, // don't pass with rest
-      disabled,
-      children,
-      icon,
-      plain,
-      title,
-      onMouseOver,
-      onMouseOut,
-      reverse,
-      onClick,
-      ...rest
-    },
+const Tab = ({
+  active: activeProp, // don't pass with rest
+  disabled,
+  children,
+  icon,
+  plain,
+  title,
+  onMouseOver,
+  onMouseOut,
+  reverse,
+  onClick,
+  ...rest
+}) => {
+  const {
+    active,
+    activeIndex,
     ref,
-  ) => {
-    const {
-      active,
-      activeIndex,
-      onActivate,
-      setActiveContent,
-      setActiveTitle,
-    } = useContext(TabsContext);
-    const theme = useContext(ThemeContext) || defaultProps.theme;
-    const [over, setOver] = useState(undefined);
-    const [focus, setFocus] = useState(undefined);
-    let normalizedTitle = title;
-    const tabStyles = {};
+    onActivate,
+    setActiveContent,
+    setActiveTitle,
+  } = useContext(TabsContext);
+  const theme = useContext(ThemeContext) || defaultProps.theme;
+  const [over, setOver] = useState(undefined);
+  const [focus, setFocus] = useState(undefined);
+  let normalizedTitle = title;
+  const tabStyles = {};
 
-    useEffect(() => {
-      if (active) {
-        setActiveContent(children);
-        const activeTitle = typeof title === 'string' ? title : activeIndex + 1;
-        setActiveTitle(activeTitle);
-      }
-    }, [
-      active,
-      activeIndex,
-      children,
-      setActiveContent,
-      setActiveTitle,
-      title,
-    ]);
+  useEffect(() => {
+    if (active) {
+      setActiveContent(children);
+      const activeTitle = typeof title === 'string' ? title : activeIndex + 1;
+      setActiveTitle(activeTitle);
+    }
+  }, [active, activeIndex, children, setActiveContent, setActiveTitle, title]);
 
-    const onMouseOverTab = (event) => {
-      setOver(true);
-      if (onMouseOver) {
-        onMouseOver(event);
-      }
-    };
+  const onMouseOverTab = (event) => {
+    setOver(true);
+    if (onMouseOver) {
+      onMouseOver(event);
+    }
+  };
 
-    const onMouseOutTab = (event) => {
-      setOver(undefined);
-      if (onMouseOut) {
-        onMouseOut(event);
-      }
-    };
+  const onMouseOutTab = (event) => {
+    setOver(undefined);
+    if (onMouseOut) {
+      onMouseOut(event);
+    }
+  };
 
-    const onClickTab = (event) => {
-      if (event) {
-        event.preventDefault();
-      }
-      onActivate();
-      if (onClick) {
-        onClick(event);
-      }
-    };
+  const onClickTab = (event) => {
+    if (event) {
+      event.preventDefault();
+    }
+    onActivate();
+    if (onClick) {
+      onClick(event);
+    }
+  };
 
-    if (active && disabled) {
-      console.warn(
-        // eslint-disable-next-line max-len
-        `Warning: Tab props 'active' and 'disabled' have both been set to TRUE on the same Tab resulting in an interesting Tab state. Is this your intent?`,
+  if (active && disabled) {
+    console.warn(
+      // eslint-disable-next-line max-len
+      `Warning: Tab props 'active' and 'disabled' have both been set to TRUE on the same Tab resulting in an interesting Tab state. Is this your intent?`,
+    );
+  }
+
+  if (!plain) {
+    if (typeof title !== 'string') {
+      normalizedTitle = title;
+    } else if (active) {
+      normalizedTitle = <Text {...theme.tab.active}>{title}</Text>;
+    } else if (disabled && theme.tab.disabled) {
+      normalizedTitle = <Text {...theme.tab.disabled}>{title}</Text>;
+    } else {
+      normalizedTitle = (
+        <Text color={over ? theme.tab.hover.color : theme.tab.color}>
+          {title}
+        </Text>
       );
     }
 
-    if (!plain) {
-      if (typeof title !== 'string') {
-        normalizedTitle = title;
-      } else if (active) {
-        normalizedTitle = <Text {...theme.tab.active}>{title}</Text>;
-      } else if (disabled && theme.tab.disabled) {
-        normalizedTitle = <Text {...theme.tab.disabled}>{title}</Text>;
-      } else {
-        normalizedTitle = (
-          <Text color={over ? theme.tab.hover.color : theme.tab.color}>
-            {title}
-          </Text>
-        );
-      }
-
-      if (theme.tab.border) {
-        let borderColor =
-          theme.tab.border.color || theme.global.control.border.color;
-        if (active) {
-          borderColor = theme.tab.border.active.color || borderColor;
-        } else if (disabled && theme.tab.border.disabled) {
-          borderColor = theme.tab.border.disabled.color || borderColor;
-        } else if (over) {
-          borderColor = theme.tab.border.hover.color || borderColor;
-        }
-        borderColor = normalizeColor(borderColor, theme);
-
-        tabStyles.border = {
-          side: theme.tab.border.side,
-          size: theme.tab.border.size,
-          color: borderColor,
-        };
-      }
-
-      tabStyles.background = active
-        ? theme.tab.active.background || theme.tab.background
-        : theme.tab.background;
-      tabStyles.pad = theme.tab.pad;
-      tabStyles.margin = theme.tab.margin;
-    }
-
-    // needed to apply hover/active styles to the icon
-    const renderIcon = (iconProp) => {
+    if (theme.tab.border) {
+      let borderColor =
+        theme.tab.border.color || theme.global.control.border.color;
       if (active) {
-        return React.cloneElement(iconProp, {
-          ...theme.tab.active,
-        });
+        borderColor = theme.tab.border.active.color || borderColor;
+      } else if (disabled && theme.tab.border.disabled) {
+        borderColor = theme.tab.border.disabled.color || borderColor;
+      } else if (over) {
+        borderColor = theme.tab.border.hover.color || borderColor;
       }
-      if (disabled) {
-        return React.cloneElement(iconProp, { ...theme.tab.disabled });
-      }
-      return React.cloneElement(iconProp, {
-        color: over ? theme.tab.hover.color : theme.tab.color,
-      });
-    };
+      borderColor = normalizeColor(borderColor, theme);
 
-    let normalizedIcon;
-    if (icon) {
-      normalizedIcon = renderIcon(icon);
-    }
-
-    const first = reverse ? normalizedTitle : normalizedIcon;
-    const second = reverse ? normalizedIcon : normalizedTitle;
-
-    let withIconStyles;
-    if (first && second) {
-      withIconStyles = {
-        direction: 'row',
-        align: 'center',
-        justify: 'center',
-        gap: 'small',
+      tabStyles.border = {
+        side: theme.tab.border.side,
+        size: theme.tab.border.size,
+        color: borderColor,
       };
     }
 
-    return (
-      <Button
-        ref={ref}
-        plain
-        role="tab"
-        aria-selected={active}
-        aria-expanded={active}
+    tabStyles.background = active
+      ? theme.tab.active.background || theme.tab.background
+      : theme.tab.background;
+    tabStyles.pad = theme.tab.pad;
+    tabStyles.margin = theme.tab.margin;
+  }
+
+  // needed to apply hover/active styles to the icon
+  const renderIcon = (iconProp) => {
+    if (active) {
+      return React.cloneElement(iconProp, {
+        ...theme.tab.active,
+      });
+    }
+    if (disabled) {
+      return React.cloneElement(iconProp, { ...theme.tab.disabled });
+    }
+    return React.cloneElement(iconProp, {
+      color: over ? theme.tab.hover.color : theme.tab.color,
+    });
+  };
+
+  let normalizedIcon;
+  if (icon) {
+    normalizedIcon = renderIcon(icon);
+  }
+
+  const first = reverse ? normalizedTitle : normalizedIcon;
+  const second = reverse ? normalizedIcon : normalizedTitle;
+
+  let withIconStyles;
+  if (first && second) {
+    withIconStyles = {
+      direction: 'row',
+      align: 'center',
+      justify: 'center',
+      gap: 'small',
+    };
+  }
+
+  return (
+    <Button
+      ref={ref}
+      plain
+      role="tab"
+      aria-selected={active}
+      aria-expanded={active}
+      disabled={disabled}
+      {...rest}
+      onClick={onClickTab}
+      onMouseOver={onMouseOverTab}
+      onMouseOut={onMouseOutTab}
+      onFocus={() => {
+        setFocus(true);
+        if (onMouseOver) onMouseOver();
+      }}
+      onBlur={() => {
+        setFocus(undefined);
+        if (onMouseOut) onMouseOut();
+      }}
+      // ensure focus outline is not covered by hover styling
+      // of adjacent tabs
+      style={focus && { zIndex: 1 }}
+      tabIndex={active ? 0 : -1}
+    >
+      <StyledTab
+        as={Box}
         disabled={disabled}
-        {...rest}
-        onClick={onClickTab}
-        onMouseOver={onMouseOverTab}
-        onMouseOut={onMouseOutTab}
-        onFocus={() => {
-          setFocus(true);
-          if (onMouseOver) onMouseOver();
-        }}
-        onBlur={() => {
-          setFocus(undefined);
-          if (onMouseOut) onMouseOut();
-        }}
-        // ensure focus outline is not covered by hover styling
-        // of adjacent tabs
-        style={focus && { zIndex: 1 }}
+        plain={plain}
+        {...withIconStyles}
+        {...tabStyles}
       >
-        <StyledTab
-          as={Box}
-          disabled={disabled}
-          plain={plain}
-          {...withIconStyles}
-          {...tabStyles}
-        >
-          {first}
-          {second}
-        </StyledTab>
-      </Button>
-    );
-  },
-);
+        {first}
+        {second}
+      </StyledTab>
+    </Button>
+  );
+};
 
 Tab.displayName = 'Tab';
 Tab.defaultProps = {};

--- a/src/js/components/Tab/Tab.js
+++ b/src/js/components/Tab/Tab.js
@@ -175,7 +175,7 @@ const Tab = ({
       // ensure focus outline is not covered by hover styling
       // of adjacent tabs
       style={focus && { zIndex: 1 }}
-      tabIndex={active ? 0 : -1}
+      tabIndex={focus || active ? 0 : -1}
     >
       <StyledTab
         as={Box}

--- a/src/js/components/Tabs/Tabs.js
+++ b/src/js/components/Tabs/Tabs.js
@@ -141,6 +141,7 @@ const Tabs = forwardRef(
             wrap
             background={theme.tabs.header.background}
             gap={theme.tabs.gap}
+            onBlur={() => setFocusIndex(activeIndex)}
             {...tabsHeaderStyles}
           >
             {tabs}

--- a/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.tsx.snap
+++ b/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.tsx.snap
@@ -241,6 +241,7 @@ exports[`Tabs Custom Tab component 1`] = `
         aria-selected="true"
         class="c3"
         role="tab"
+        tabindex="0"
         type="button"
       >
         <div
@@ -258,6 +259,7 @@ exports[`Tabs Custom Tab component 1`] = `
         aria-selected="false"
         class="c3"
         role="tab"
+        tabindex="-1"
         type="button"
       >
         <div
@@ -523,6 +525,7 @@ exports[`Tabs Tab 1`] = `
         aria-selected="true"
         class="c3"
         role="tab"
+        tabindex="0"
         type="button"
       >
         <div
@@ -540,6 +543,7 @@ exports[`Tabs Tab 1`] = `
         aria-selected="false"
         class="c3"
         role="tab"
+        tabindex="-1"
         type="button"
       >
         <div
@@ -811,6 +815,7 @@ exports[`Tabs alignControls 1`] = `
         aria-selected="true"
         class="c3"
         role="tab"
+        tabindex="0"
         type="button"
       >
         <div
@@ -828,6 +833,7 @@ exports[`Tabs alignControls 1`] = `
         aria-selected="false"
         class="c3"
         role="tab"
+        tabindex="-1"
         type="button"
       >
         <div
@@ -1093,6 +1099,7 @@ exports[`Tabs change to second tab 1`] = `
         aria-selected="true"
         class="c3"
         role="tab"
+        tabindex="0"
         type="button"
       >
         <div
@@ -1110,6 +1117,7 @@ exports[`Tabs change to second tab 1`] = `
         aria-selected="false"
         class="c3"
         role="tab"
+        tabindex="-1"
         type="button"
       >
         <div
@@ -1150,6 +1158,7 @@ exports[`Tabs change to second tab 2`] = `
         aria-selected="false"
         class="StyledButton-sc-323bzc-0 iqZbKa"
         role="tab"
+        tabindex="-1"
         type="button"
       >
         <div
@@ -1167,6 +1176,7 @@ exports[`Tabs change to second tab 2`] = `
         aria-selected="true"
         class="StyledButton-sc-323bzc-0 iqZbKa"
         role="tab"
+        tabindex="0"
         type="button"
       >
         <div
@@ -1420,6 +1430,7 @@ exports[`Tabs complex title 1`] = `
         aria-selected="true"
         class="c3"
         role="tab"
+        tabindex="0"
         type="button"
       >
         <div
@@ -1435,6 +1446,7 @@ exports[`Tabs complex title 1`] = `
         aria-selected="false"
         class="c3"
         role="tab"
+        tabindex="-1"
         type="button"
       >
         <div
@@ -1640,6 +1652,7 @@ exports[`Tabs no Tab 1`] = `
         aria-selected="true"
         class="c3"
         role="tab"
+        tabindex="0"
         type="button"
       >
         <div
@@ -1897,6 +1910,7 @@ exports[`Tabs onClick 1`] = `
         aria-selected="true"
         class="c3"
         role="tab"
+        tabindex="0"
         type="button"
       >
         <div
@@ -1914,6 +1928,7 @@ exports[`Tabs onClick 1`] = `
         aria-selected="false"
         class="c3"
         role="tab"
+        tabindex="-1"
         type="button"
       >
         <div
@@ -2179,6 +2194,7 @@ exports[`Tabs set on hover 1`] = `
         aria-selected="true"
         class="c3"
         role="tab"
+        tabindex="0"
         type="button"
       >
         <div
@@ -2196,6 +2212,7 @@ exports[`Tabs set on hover 1`] = `
         aria-selected="false"
         class="c3"
         role="tab"
+        tabindex="-1"
         type="button"
       >
         <div
@@ -2236,6 +2253,7 @@ exports[`Tabs set on hover 2`] = `
         aria-selected="true"
         class="StyledButton-sc-323bzc-0 iqZbKa"
         role="tab"
+        tabindex="0"
         type="button"
       >
         <div
@@ -2253,6 +2271,7 @@ exports[`Tabs set on hover 2`] = `
         aria-selected="false"
         class="StyledButton-sc-323bzc-0 iqZbKa"
         role="tab"
+        tabindex="-1"
         type="button"
       >
         <div
@@ -2293,6 +2312,7 @@ exports[`Tabs set on hover 3`] = `
         aria-selected="true"
         class="StyledButton-sc-323bzc-0 iqZbKa"
         role="tab"
+        tabindex="0"
         type="button"
       >
         <div
@@ -2310,6 +2330,7 @@ exports[`Tabs set on hover 3`] = `
         aria-selected="false"
         class="StyledButton-sc-323bzc-0 iqZbKa"
         role="tab"
+        tabindex="-1"
         type="button"
       >
         <div
@@ -2350,6 +2371,7 @@ exports[`Tabs set on hover 4`] = `
         aria-selected="true"
         class="StyledButton-sc-323bzc-0 iqZbKa"
         role="tab"
+        tabindex="0"
         type="button"
       >
         <div
@@ -2367,6 +2389,7 @@ exports[`Tabs set on hover 4`] = `
         aria-selected="false"
         class="StyledButton-sc-323bzc-0 iqZbKa"
         role="tab"
+        tabindex="-1"
         type="button"
       >
         <div
@@ -2407,6 +2430,7 @@ exports[`Tabs set on hover 5`] = `
         aria-selected="true"
         class="StyledButton-sc-323bzc-0 iqZbKa"
         role="tab"
+        tabindex="0"
         type="button"
       >
         <div
@@ -2424,6 +2448,7 @@ exports[`Tabs set on hover 5`] = `
         aria-selected="false"
         class="StyledButton-sc-323bzc-0 iqZbKa"
         role="tab"
+        tabindex="-1"
         type="button"
       >
         <div
@@ -2648,6 +2673,7 @@ exports[`Tabs should allow to extend tab styles 1`] = `
         aria-selected="true"
         class="c3"
         role="tab"
+        tabindex="0"
         type="button"
       >
         <div
@@ -2661,6 +2687,7 @@ exports[`Tabs should allow to extend tab styles 1`] = `
         aria-selected="false"
         class="c3"
         role="tab"
+        tabindex="-1"
         type="button"
       >
         <div
@@ -2994,6 +3021,7 @@ exports[`Tabs should apply custom theme disabled style 1`] = `
         aria-selected="true"
         class="c3"
         role="tab"
+        tabindex="0"
         type="button"
       >
         <div
@@ -3012,6 +3040,7 @@ exports[`Tabs should apply custom theme disabled style 1`] = `
         class="c7"
         disabled=""
         role="tab"
+        tabindex="-1"
         type="button"
       >
         <div
@@ -3347,6 +3376,7 @@ exports[`Tabs should apply custom theme disabled style when theme.button.default
         aria-selected="true"
         class="c3"
         role="tab"
+        tabindex="0"
         type="button"
       >
         <div
@@ -3365,6 +3395,7 @@ exports[`Tabs should apply custom theme disabled style when theme.button.default
         class="c7"
         disabled=""
         role="tab"
+        tabindex="-1"
         type="button"
       >
         <div
@@ -3575,6 +3606,7 @@ exports[`Tabs should have no accessibility violations 1`] = `
           aria-selected="true"
           class="c3"
           role="tab"
+          tabindex="0"
           type="button"
         >
           <div
@@ -3718,6 +3750,7 @@ exports[`Tabs should have no default styles with plain prop 1`] = `
         aria-selected="true"
         class="c3"
         role="tab"
+        tabindex="0"
         type="button"
       >
         <div
@@ -4044,6 +4077,7 @@ exports[`Tabs should style as disabled 1`] = `
         aria-selected="true"
         class="c3"
         role="tab"
+        tabindex="0"
         type="button"
       >
         <div
@@ -4062,6 +4096,7 @@ exports[`Tabs should style as disabled 1`] = `
         class="c7"
         disabled=""
         role="tab"
+        tabindex="-1"
         type="button"
       >
         <div
@@ -4336,6 +4371,7 @@ exports[`Tabs styled component should change tab color when active 1`] = `
         aria-selected="false"
         class="c3 c4"
         role="tab"
+        tabindex="-1"
         type="button"
       >
         <div
@@ -4353,6 +4389,7 @@ exports[`Tabs styled component should change tab color when active 1`] = `
         aria-selected="true"
         class="c3 c8"
         role="tab"
+        tabindex="0"
         type="button"
       >
         <div
@@ -4370,6 +4407,7 @@ exports[`Tabs styled component should change tab color when active 1`] = `
         aria-selected="false"
         class="c3 c4"
         role="tab"
+        tabindex="-1"
         type="button"
       >
         <div
@@ -4665,6 +4703,7 @@ exports[`Tabs with icon + reverse 1`] = `
         aria-selected="true"
         class="c3"
         role="tab"
+        tabindex="0"
         type="button"
       >
         <div
@@ -4688,6 +4727,7 @@ exports[`Tabs with icon + reverse 1`] = `
         aria-selected="false"
         class="c3"
         role="tab"
+        tabindex="-1"
         type="button"
       >
         <div

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -2599,18 +2599,7 @@ Object {
     },
     "render": [Function],
   },
-  "Tab": Object {
-    "$$typeof": Symbol(react.forward_ref),
-    "defaultProps": Object {},
-    "propTypes": Object {
-      "disabled": [Function],
-      "icon": [Function],
-      "plain": [Function],
-      "reverse": [Function],
-      "title": [Function],
-    },
-    "render": [Function],
-  },
+  "Tab": [Function],
   "Table": [Function],
   "TableBody": Object {
     "$$typeof": Symbol(react.forward_ref),


### PR DESCRIPTION
#### What does this PR do?
- When keyboard tab reaches Tabs, focus is placed on active Tab. (Other tabs are not in the tabIndex)
- The other tabs are reached with the left and right arrow keys on the keyboard.
- Pressing "Enter" should select and change the active Tab.
- The 'home' key ('fn' + 'left arrow' on mac)  should move focus to the first Tab.
- The 'end' key ('fn' + 'right arrow' on mac) should move focus to the last Tab.

Additional notes:
This PR adds 'onEnd' and 'onHome' to Keyboard. In addition to being used in this PR I believe there are other components that can utilize these to align with the recommended accessible keyboard support.

I changed Tab to use the ref approach [outlined here](https://gist.github.com/gaearon/1a018a023347fe1c2476073330cc5509) instead of using forward ref. It seemed like this was the better approach when a parent has multiple children each with their own ref.

#### Where should the reviewer start?

#### What testing has been done on this PR?
Tested with existing Tab stories

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
https://github.com/grommet/grommet/issues/6117

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Yes, this PR adds 'onEnd' and 'onHome' to Keyboard

#### Should this PR be mentioned in the release notes?
Yes

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible