### PR TITLE
Add global to notification propTypes and index.d.ts

### DIFF
--- a/src/js/components/Notification/index.d.ts
+++ b/src/js/components/Notification/index.d.ts
@@ -5,6 +5,7 @@ export type StatusType = 'critical' | 'warning' | 'normal' | 'unknown';
 
 export interface NotificationProps {
   actions?: AnchorType[];
+  global?: boolean;
   title?: string;
   message?: string;
   status?: StatusType;

--- a/src/js/components/Notification/propTypes.js
+++ b/src/js/components/Notification/propTypes.js
@@ -5,6 +5,7 @@ let PropType = {};
 if (process.env.NODE_ENV !== 'production') {
   PropType = {
     actions: PropTypes.arrayOf(PropTypes.shape(AnchorPropTypes)),
+    global: PropTypes.bool,
     title: PropTypes.string,
     message: PropTypes.string,
     status: PropTypes.oneOf(['critical', 'warning', 'normal', 'unknown']),


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Adds missing `propTypes` and `index.d.ts` definition for `global` prop of Notification.

#### Where should the reviewer start?
src/js/components/Notification/index.d.ts

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

N/A

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #6113 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Updates handled in: https://github.com/grommet/grommet-site/pull/383

#### Should this PR be mentioned in the release notes?
No.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.