### PR TITLE
Update PageHeader defaults

### DIFF
--- a/src/js/components/PageHeader/__tests__/__snapshots__/PageHeader-test.tsx.snap
+++ b/src/js/components/PageHeader/__tests__/__snapshots__/PageHeader-test.tsx.snap
@@ -205,7 +205,7 @@ exports[`PageHeader basic 1`] = `
   display: grid;
   box-sizing: border-box;
   width: 100%;
-  grid-template-areas: "parent null" "title actions" "subtitle actions";
+  grid-template-areas: "parent parent" "title actions" "subtitle actions";
   grid-template-columns: minmax(192px,1fr) auto;
   grid-gap: 6px 48px;
   grid-template-rows: auto auto auto;
@@ -215,7 +215,7 @@ exports[`PageHeader basic 1`] = `
   margin: 0px;
   font-size: 18px;
   line-height: 24px;
-  max-width: none;
+  max-width: 432px;
 }
 
 @media only screen and (max-width:768px) {
@@ -496,7 +496,7 @@ exports[`PageHeader children 1`] = `
   display: grid;
   box-sizing: border-box;
   width: 100%;
-  grid-template-areas: "parent null" "title actions" "subtitle actions";
+  grid-template-areas: "parent parent" "title actions" "subtitle actions";
   grid-template-columns: minmax(192px,1fr) auto;
   grid-gap: 6px 48px;
   grid-template-rows: auto auto auto;
@@ -506,7 +506,7 @@ exports[`PageHeader children 1`] = `
   margin: 0px;
   font-size: 18px;
   line-height: 24px;
-  max-width: none;
+  max-width: 432px;
 }
 
 @media only screen and (max-width:768px) {
@@ -804,7 +804,7 @@ exports[`PageHeader custom theme 1`] = `
   display: grid;
   box-sizing: border-box;
   width: 100%;
-  grid-template-areas: "parent null" "title actions" "subtitle actions";
+  grid-template-areas: "parent parent" "title actions" "subtitle actions";
   grid-template-columns: minmax(192px,1fr) auto;
   grid-gap: 6px 48px;
   grid-template-rows: auto auto auto;
@@ -814,7 +814,7 @@ exports[`PageHeader custom theme 1`] = `
   margin: 0px;
   font-size: 18px;
   line-height: 24px;
-  max-width: none;
+  max-width: 432px;
 }
 
 @media only screen and (max-width:768px) {

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -1941,7 +1941,7 @@ Object {
             "areas": Array [
               Array [
                 "parent",
-                "null",
+                "parent",
               ],
               Array [
                 "title",
@@ -1955,7 +1955,7 @@ Object {
             "columns": Array [
               Array [
                 "medium",
-                "large",
+                "flex",
               ],
               "auto",
             ],
@@ -1973,7 +1973,7 @@ Object {
             "areas": Array [
               Array [
                 "parent",
-                "null",
+                "parent",
               ],
               Array [
                 "title",
@@ -1987,7 +1987,7 @@ Object {
             "columns": Array [
               Array [
                 "medium",
-                "large",
+                "flex",
               ],
               "auto",
             ],
@@ -2008,7 +2008,7 @@ Object {
             "areas": Array [
               Array [
                 "parent",
-                "null",
+                "parent",
               ],
               Array [
                 "title",
@@ -2037,7 +2037,6 @@ Object {
             ],
           },
           "subtitle": Object {
-            "fill": true,
             "margin": "none",
           },
           "title": Object {

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1277,7 +1277,6 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       subtitle: {
         // any paragraph props
         margin: 'none',
-        fill: true,
       },
       title: {
         // any heading props
@@ -1286,7 +1285,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       },
       small: {
         areas: [
-          ['parent', 'null'],
+          ['parent', 'parent'],
           ['title', 'actions'],
           ['subtitle', 'actions'],
         ],
@@ -1296,21 +1295,21 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       },
       medium: {
         areas: [
-          ['parent', 'null'],
+          ['parent', 'parent'],
           ['title', 'actions'],
           ['subtitle', 'actions'],
         ],
-        columns: [['medium', 'large'], 'auto'],
+        columns: [['medium', 'flex'], 'auto'],
         rows: ['auto', 'auto', 'auto'],
         gap: { row: 'xsmall', column: 'medium' },
       },
       large: {
         areas: [
-          ['parent', 'null'],
+          ['parent', 'parent'],
           ['title', 'actions'],
           ['subtitle', 'actions'],
         ],
-        columns: [['medium', 'large'], 'auto'],
+        columns: [['medium', 'flex'], 'auto'],
         rows: ['auto', 'auto', 'auto'],
         gap: { row: 'xsmall', column: 'large' },
       },


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Updates default behavior of subtitle, gridAreas, and column definitions to improve the readability and responsiveness of the component.

#### Where should the reviewer start?
base.js

#### What testing has been done on this PR?

Tested with: https://github.com/grommet/hpe-design-system/issues/2557

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

N/A

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

https://github.com/grommet/hpe-design-system/issues/2603

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Yes. https://github.com/grommet/grommet-site/pull/384

#### Should this PR be mentioned in the release notes?
No.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible, component hasn't been released yet.