### PR TITLE
Fix tip behavior when child becomes disabled

### DIFF
--- a/src/js/components/Tip/Tip.js
+++ b/src/js/components/Tip/Tip.js
@@ -31,6 +31,10 @@ const Tip = forwardRef(({ children, content, dropProps, plain }, tipRef) => {
 
   const componentRef = useForwardedRef(tipRef);
 
+  useEffect(() => {
+    if (children?.props?.disabled === true) setOver(false);
+  }, [children]);
+
   // Three use case for children
   // 1. Tip has a single child + it is a React Element => Great!
   // 2. Tip has a single child +  not React Element =>

--- a/src/js/components/Tip/__tests__/Tip-test.tsx
+++ b/src/js/components/Tip/__tests__/Tip-test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { render, fireEvent, waitFor } from '@testing-library/react';
 import { screen } from '@testing-library/dom';
 import { axe } from 'jest-axe';
@@ -6,6 +6,7 @@ import 'jest-styled-components';
 import 'jest-axe/extend-expect';
 import 'regenerator-runtime/runtime';
 import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
 
 import { Box } from '../../Box';
 import { Button } from '../../Button';
@@ -196,5 +197,36 @@ describe('Tip', () => {
     expect(onFocus).toHaveBeenCalledTimes(1);
     await user.tab();
     expect(onBlur).toHaveBeenCalledTimes(1);
+  });
+
+  test.only(`child becomes disable while tip is showing`, async () => {
+    const Test = () => {
+      const [count, setCount] = useState(0);
+      return (
+        <Grommet>
+          <Tip content="tip content">
+            <Button
+              label="Decrease"
+              disabled={!count}
+              onClick={() => setCount(count - 1)}
+            />
+          </Tip>
+          <Button
+            label="Increase"
+            tip={{ content: 'Test', dropProps: { align: { bottom: 'top' } } }}
+            onClick={() => setCount(count + 1)}
+          />
+        </Grommet>
+      );
+    };
+
+    const user = userEvent.setup();
+
+    render(<Test />);
+    await user.click(screen.getByText('Increase'));
+    await user.hover(screen.getByText('Decrease'));
+    expect(screen.getByText('tip content')).toBeInTheDocument();
+    await user.click(screen.getByText('Decrease'));
+    expect(screen.queryByText('tip content')).not.toBeInTheDocument();
   });
 });

--- a/src/js/components/Tip/stories/typescript/Simple.tsx
+++ b/src/js/components/Tip/stories/typescript/Simple.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { grommet, Box, Button, Grommet, Tip } from 'grommet';
+import { Box, Button, Tip } from 'grommet';
 
 export const Simple = () => (
   // Uncomment <Grommet> lines when using outside of storybook


### PR DESCRIPTION
#### What does this PR do?
Fixes and issue where Tip continued to display when a button was hovered over and then became disabled.

I also removed extra imports from the Tip/Simple story

#### Where should the reviewer start?

#### What testing has been done on this PR?
Added a jest test
Tested with the following story
```
import React, { useState } from 'react';

import { Box, Button, Tip } from 'grommet';

export const Test = () => {
  const [count, setCount] = useState(0);
  return (
    <Box pad="large">
      {count}
      <Box
        width="small"
        margin={{ top: 'xlarge' }}
        gap="medium"
        direction="row"
      >
        <Tip content="test">
          <Button
            label="Decrease"
            // tip={{ content: 'Test', dropProps: { align: { bottom: 'top' } } }}
            disabled={!count}
            onClick={() => setCount(count - 1)}
          /> 
        </Tip>
        <Button
          label="Increase"
          tip={{ content: 'Test', dropProps: { align: { bottom: 'top' } } }}
          onClick={() => setCount(count + 1)}
        />
      </Box>
    </Box>
  );
};

Test.args = {
  full: true,
};

export default {
  title: 'Controls/Tip/Test',
};
```
#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [x] `screen` is used for querying.
- [x] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [x] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes https://github.com/grommet/grommet/issues/6135

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No
#### Should this PR be mentioned in the release notes?
Maybe
#### Is this change backwards compatible or is it a breaking change?
Backwards compatible