### PR TITLE
Fix onChange type for FileInput

### DIFF
--- a/src/js/components/FileInput/index.d.ts
+++ b/src/js/components/FileInput/index.d.ts
@@ -22,10 +22,11 @@ export interface FileInputProps {
   };
   multiple?: boolean | { aggregateThreshold?: number; max?: number };
   name?: string;
+  onChange?: (event?: any, { files }?: { files: any }) => void;
   renderFile?: (...args: any[]) => void;
 }
 
-type inputProps = Omit<JSX.IntrinsicElements['input'], 'multiple'>;
+type inputProps = Omit<JSX.IntrinsicElements['input'], 'multiple' | 'onChange'>;
 
 export interface FileInputExtendedProps extends FileInputProps, inputProps {}
 

--- a/src/js/components/FileInput/index.d.ts
+++ b/src/js/components/FileInput/index.d.ts
@@ -22,7 +22,11 @@ export interface FileInputProps {
   };
   multiple?: boolean | { aggregateThreshold?: number; max?: number };
   name?: string;
-  onChange?: (event?: any, { files }?: { files: any }) => void;
+  onChange?: (
+    event?: React.ChangeEvent<HTMLInputElement>,
+    { files }?: { files: object },
+    { target }?: { target: { files: object } },
+  ) => void;
   renderFile?: (...args: any[]) => void;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fixes the typescript definition for onChange in FileInput

#### Where should the reviewer start?

#### What testing has been done on this PR?
Tested with the following code in a typescript story:
```typescript
const onChange = (event, { files }) => {
  console.log(files);
);
```
and
```typescript
const onChange = ({ target: { files } }) => {
  console.log(files);
};
```

with `<FileInput onChange={onChange} />`

#### How should this be manually tested?
Test an `onChange` function with FileInput in a typescript file

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes https://github.com/grommet/grommet/issues/6143

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No
#### Should this PR be mentioned in the release notes?
Maybe
#### Is this change backwards compatible or is it a breaking change?
Backwards compatible