### PR TITLE
Fixed Select to continue showing search term after an option is selected

### DIFF
--- a/src/js/components/Select/Select.js
+++ b/src/js/components/Select/Select.js
@@ -245,7 +245,6 @@ const Select = forwardRef(
           }
           onChange(adjustedEvent);
         }
-        setSearch();
       },
       [closeOnChange, onChange, onRequestClose, setValue, triggerChangeEvent],
     );


### PR DESCRIPTION
#### What does this PR do?
If we have a Select with `closeOnChange={false}` and `search` and a user searches then selects an option, the search term will clear but the list of options will still be filtered based on the search term.

This PR changes the behavior so that the search term is not cleared when an option is selected.

#### Where should the reviewer start?

#### What testing has been done on this PR?
Tested with the Select/Search story

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes https://github.com/grommet/grommet/issues/6133

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No
#### Should this PR be mentioned in the release notes?
Yes
#### Is this change backwards compatible or is it a breaking change?
Backward compatible