### PR TITLE
PageHeader - Add pad to theme

### DIFF
--- a/src/js/components/PageHeader/PageHeader.js
+++ b/src/js/components/PageHeader/PageHeader.js
@@ -17,7 +17,13 @@ const PageHeader = forwardRef(
       theme.pageHeader[breakpoint] || theme.pageHeader.medium;
 
     return (
-      <Header ref={ref} direction="column" gap="none" {...rest}>
+      <Header
+        ref={ref}
+        direction="column"
+        gap="none"
+        pad={theme.pageHeader.pad}
+        {...rest}
+      >
         <Grid
           columns={columns}
           rows={rows}

--- a/src/js/components/PageHeader/__tests__/__snapshots__/PageHeader-test.tsx.snap
+++ b/src/js/components/PageHeader/__tests__/__snapshots__/PageHeader-test.tsx.snap
@@ -35,6 +35,8 @@ exports[`PageHeader basic 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+  padding-top: 48px;
+  padding-bottom: 24px;
 }
 
 .c3 {
@@ -219,6 +221,18 @@ exports[`PageHeader basic 1`] = `
 }
 
 @media only screen and (max-width:768px) {
+  .c1 {
+    padding-top: 24px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    padding-bottom: 12px;
+  }
+}
+
+@media only screen and (max-width:768px) {
   .c6 {
     margin: 0px;
   }
@@ -321,6 +335,8 @@ exports[`PageHeader children 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+  padding-top: 48px;
+  padding-bottom: 24px;
 }
 
 .c3 {
@@ -510,6 +526,18 @@ exports[`PageHeader children 1`] = `
 }
 
 @media only screen and (max-width:768px) {
+  .c1 {
+    padding-top: 24px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    padding-bottom: 12px;
+  }
+}
+
+@media only screen and (max-width:768px) {
   .c6 {
     margin: 0px;
   }
@@ -617,6 +645,8 @@ exports[`PageHeader custom theme 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+  padding-top: 48px;
+  padding-bottom: 24px;
 }
 
 .c3 {
@@ -815,6 +845,18 @@ exports[`PageHeader custom theme 1`] = `
   font-size: 18px;
   line-height: 24px;
   max-width: 432px;
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    padding-top: 24px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    padding-bottom: 12px;
+  }
 }
 
 @media only screen and (max-width:768px) {

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -2001,6 +2001,10 @@ Object {
               "auto",
             ],
           },
+          "pad": Object {
+            "bottom": "medium",
+            "top": "large",
+          },
           "parent": Object {
             "align": "start",
           },

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -1156,6 +1156,7 @@ export interface ThemeType {
   };
   pageHeader?: {
     actions?: BoxProps;
+    pad?: PadType;
     parent?: BoxProps;
     subtitle?: ParagraphProps;
     title?: HeadingProps;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1270,6 +1270,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         // any box props
         align: 'end',
       },
+      // pad: undefined,
       parent: {
         // any box props
         align: 'start',

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1270,7 +1270,10 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         // any box props
         align: 'end',
       },
-      // pad: undefined,
+      pad: {
+        top: 'large',
+        bottom: 'medium',
+      },
       parent: {
         // any box props
         align: 'start',


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

- Allows a caller to set default PageHeader pad in their theme.
- Related to: https://github.com/grommet/hpe-design-system/issues/2603

#### Where should the reviewer start?

PageHeader.js + base.js

#### What testing has been done on this PR?

- Jest suite
- Manual storybook

#### How should this be manually tested?

- Storybook 
  - Verify that a top and bottom pad is now added as default
  - PageHeader custom themed --> add specify `pageHeader.pad` in custom theme --> confirm pad is rendered as expected.

#### Do Jest tests follow these best practices?

N/A no adjustments or additions to Jest tests.

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

https://github.com/grommet/hpe-design-system/issues/2603

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

Yes, pad should be added to the PageHeader theme documentation.

#### Should this PR be mentioned in the release notes?

No. Only the announcement of NEW PageHeader.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.
