### PR TITLE
PageHeader - Added responsive prop

### DIFF
--- a/src/js/components/PageHeader/PageHeader.js
+++ b/src/js/components/PageHeader/PageHeader.js
@@ -9,12 +9,37 @@ import { Paragraph } from '../Paragraph';
 import { ResponsiveContext } from '../../contexts/ResponsiveContext';
 
 const PageHeader = forwardRef(
-  ({ actions, children, gridProps, parent, subtitle, title, ...rest }, ref) => {
+  (
+    {
+      actions,
+      children,
+      gridProps: gridPropsProp,
+      parent,
+      responsive,
+      subtitle,
+      title,
+      ...rest
+    },
+    ref,
+  ) => {
     const theme = useContext(ThemeContext);
     const breakpoint = useContext(ResponsiveContext);
 
-    const { areas, columns, gap, rows } =
-      theme.pageHeader[breakpoint] || theme.pageHeader.medium;
+    let actionsProps = { ...theme.pageHeader.actions };
+    let gridProps = theme.pageHeader[breakpoint] || theme.pageHeader.medium;
+
+    if (
+      responsive &&
+      theme.pageHeader.responsive.breakpoints.includes(breakpoint)
+    ) {
+      gridProps = { ...gridProps, ...theme.pageHeader.responsive };
+      actionsProps = {
+        ...actionsProps,
+        ...theme.pageHeader.responsive.actions,
+      };
+    }
+
+    const { areas, columns, gap, rows } = gridProps;
 
     return (
       <Header
@@ -30,7 +55,7 @@ const PageHeader = forwardRef(
           areas={areas}
           gap={gap}
           fill="horizontal"
-          {...gridProps}
+          {...gridPropsProp}
         >
           <Box gridArea="parent" {...theme.pageHeader.parent}>
             {parent}
@@ -49,7 +74,7 @@ const PageHeader = forwardRef(
               subtitle
             )}
           </Box>
-          <Box gridArea="actions" {...theme.pageHeader.actions}>
+          <Box gridArea="actions" {...actionsProps}>
             {actions}
           </Box>
         </Grid>

--- a/src/js/components/PageHeader/index.d.ts
+++ b/src/js/components/PageHeader/index.d.ts
@@ -16,6 +16,7 @@ export interface PageHeaderProps {
   actions?: JSX.Element;
   gridProps?: GridProps;
   parent?: JSX.Element;
+  responsive?: boolean;
   subtitle?: string | JSX.Element;
   title?: string | JSX.Element;
 }

--- a/src/js/components/PageHeader/propTypes.js
+++ b/src/js/components/PageHeader/propTypes.js
@@ -9,6 +9,7 @@ if (process.env.NODE_ENV !== 'production') {
     actions: PropTypes.element,
     gridProps: GridPropTypes,
     parent: PropTypes.element,
+    responsive: PropTypes.bool,
     subtitle: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
     title: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   };

--- a/src/js/components/PageHeader/stories/Responsive.js
+++ b/src/js/components/PageHeader/stories/Responsive.js
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import { Anchor, Button, PageHeader, Page, PageContent } from 'grommet';
+
+export const Responsive = () => (
+  // Uncomment <Grommet> lines when using outside of storybook
+  // <Grommet theme={...}>
+  <Page>
+    <PageContent>
+      <PageHeader
+        title="Grommet"
+        subtitle={`Responsive allows PageHeader layout to switch to a 
+        single column at responsive breakpoints specified in the theme.`}
+        actions={<Button label="Get Started" primary />}
+        parent={<Anchor label="Parent Page" />}
+        responsive
+      />
+    </PageContent>
+  </Page>
+  // </Grommet>
+);
+
+export default {
+  title: 'Layout/PageHeader/Responsive',
+};

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -2008,6 +2008,37 @@ Object {
           "parent": Object {
             "align": "start",
           },
+          "responsive": Object {
+            "actions": Object {
+              "align": "start",
+              "pad": Object {
+                "top": "small",
+              },
+            },
+            "areas": Array [
+              Array [
+                "parent",
+              ],
+              Array [
+                "title",
+              ],
+              Array [
+                "subtitle",
+              ],
+              Array [
+                "actions",
+              ],
+            ],
+            "breakpoints": Array [
+              "small",
+            ],
+            "columns": Array [
+              "auto",
+            ],
+            "rows": Array [
+              "auto",
+            ],
+          },
           "small": Object {
             "areas": Array [
               Array [

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -1161,6 +1161,7 @@ export interface ThemeType {
     responsive?: {
       actions?: BoxProps;
       areas?: AreasType;
+      breakpoints?: string[];
       columns?: GridColumnsType;
       rows?: GridSizeType;
       gap?: GridGapType;

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -1158,6 +1158,13 @@ export interface ThemeType {
     actions?: BoxProps;
     pad?: PadType;
     parent?: BoxProps;
+    responsive?: {
+      actions?: BoxProps;
+      areas?: AreasType;
+      columns?: GridColumnsType;
+      rows?: GridSizeType;
+      gap?: GridGapType;
+    };
     subtitle?: ParagraphProps;
     title?: HeadingProps;
     small?: {

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1278,6 +1278,20 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         // any box props
         align: 'start',
       },
+      responsive: {
+        actions: {
+          // any box props
+          align: 'start',
+          pad: {
+            top: 'small',
+          },
+        },
+        areas: [['parent'], ['title'], ['subtitle'], ['actions']],
+        breakpoints: ['small'],
+        columns: ['auto'],
+        rows: ['auto'],
+        // gap: undefined,
+      },
       subtitle: {
         // any paragraph props
         margin: 'none',


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Closes https://github.com/grommet/grommet/issues/6148

Proposes a `responsive` prop which allows the PageHeader to switch from a row-oriented, two-column layout to a single column presenting all page header regions at specified responsive breakpoints. This is useful in cases where the page header contains a primary action, which as a primary page action should always be visible instead of collapsing into an overflow menu.

`responsive` is used across a variety of Grommet components as a boolean indicating that the component should take on special presentation for smaller view ports. Typically the presentation is adjusted by scaling ([Box](https://v2.grommet.io/box#responsive), [Grid](https://v2.grommet.io/grid#responsive), [Heading](https://v2.grommet.io/heading#responsive), [Paragraph](https://v2.grommet.io/paragraph#responsive)) or by change in layout ([Drop](https://v2.grommet.io/drop#responsive), [Layer](https://v2.grommet.io/layer#responsive)).

If needed in the future, I could see `responsive` props being extended to accept an object which allows more precise control by the caller to affect specific responsive attributes to apply/not apply (e.g. layout direction, margin, pad, gap, font-size, etc.).

#### Where should the reviewer start?

PageHeader.js
[Storybook/PageHeader/Responsive]

#### What testing has been done on this PR?

Storybook

#### How should this be manually tested?

Storybook

#### Do Jest tests follow these best practices?

No Jest tests added

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

https://github.com/grommet/grommet/issues/6148

#### Screenshots (if appropriate)

**Responsive = false**
![Screen Shot 2022-05-27 at 9 58 31 AM](https://user-images.githubusercontent.com/1756948/170735956-f424fd73-f4a1-46cd-a82e-ae281fefa62a.png)

**Responsive = true**
![Screen Shot 2022-05-27 at 9 58 37 AM](https://user-images.githubusercontent.com/1756948/170736023-d71bf13f-19f4-4503-8118-1481a85d9b31.png)


#### Do the grommet docs need to be updated?

Yes.

#### Should this PR be mentioned in the release notes?

No. Should only announce NEW PageHeader

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible