### PR TITLE
Enhance Menu to allow grouped items

### DIFF
--- a/src/js/components/Menu/Menu.js
+++ b/src/js/components/Menu/Menu.js
@@ -288,6 +288,103 @@ const Menu = forwardRef((props, ref) => {
     </Box>
   );
 
+  const menuItem = (item, index) => {
+    // Determine whether the label is done as a child or
+    // as an option Button kind property.
+    const child = !theme.button.option ? (
+      <Box
+        align="start"
+        pad="small"
+        direction="row"
+        gap={item.gap}
+        justify={item.justify}
+      >
+        {item.reverse && item.label}
+        {item.icon}
+        {!item.reverse && item.label}
+      </Box>
+    ) : undefined;
+
+    // if we have a child, turn on plain, and hoverIndicator
+    return (
+      // eslint-disable-next-line react/no-array-index-key
+      <Box key={index} flex={false} role="none">
+        <Button
+          ref={(r) => {
+            buttonRefs.current[index] = r;
+          }}
+          role="menuitem"
+          onFocus={() => {
+            setActiveItemIndex(index);
+          }}
+          active={activeItemIndex === index}
+          focusIndicator={false}
+          plain={!child ? undefined : true}
+          align="start"
+          justify={item.justify}
+          kind={!child ? 'option' : undefined}
+          hoverIndicator={!child ? undefined : 'background'}
+          {...(!child
+            ? item
+            : {
+                ...item,
+                gap: undefined,
+                icon: undefined,
+                label: undefined,
+                reverse: undefined,
+              })}
+          onClick={(...args) => {
+            if (item.onClick) {
+              item.onClick(...args);
+            }
+            if (item.close !== false) {
+              onDropClose();
+            }
+          }}
+        >
+          {child}
+        </Button>
+      </Box>
+    );
+  };
+
+  let menuContent;
+  if (items.length && Array.isArray(items[0])) {
+    menuContent = items.map((group, i) => {
+      const groupHeading = group.find((item) => item.heading);
+
+      return (
+        <Box
+          {...theme.menu.group?.container}
+          border={
+            i > 0
+              ? { side: 'top', ...theme.menu.group?.container?.border }
+              : undefined
+          }
+        >
+          {groupHeading && (
+            <Box {...theme.menu.group?.heading?.container}>
+              <Text
+                id={groupHeading?.id}
+                // don't have screenreader announce this text element directly
+                // because it will be announced by with aria-labelledby below
+                aria-hidden="true"
+                {...theme.menu.group?.heading?.text}
+              >
+                {groupHeading?.heading}
+              </Text>
+            </Box>
+          )}
+          <Box role="group" aria-labelledby={groupHeading?.id}>
+            {group.map((item, j) =>
+              !item.heading ? menuItem(item, j) : undefined,
+            )}
+          </Box>
+        </Box>
+      );
+    });
+  } else menuContent = items.map((item, index) => menuItem(item, index));
+
   return (
     <Keyboard
       onDown={onDropOpen}
@@ -330,65 +427,7 @@ const Menu = forwardRef((props, ref) => {
                 ? controlMirror
                 : undefined}
               <Box overflow="auto" role="menu" a11yTitle={a11y}>
-                {items.map((item, index) => {
-                  // Determine whether the label is done as a child or
-                  // as an option Button kind property.
-                  const child = !theme.button.option ? (
-                    <Box
-                      align="start"
-                      pad="small"
-                      direction="row"
-                      gap={item.gap}
-                      justify={item.justify}
-                    >
-                      {item.reverse && item.label}
-                      {item.icon}
-                      {!item.reverse && item.label}
-                    </Box>
-                  ) : undefined;
-                  // if we have a child, turn on plain, and hoverIndicator
-
-                  return (
-                    // eslint-disable-next-line react/no-array-index-key
-                    <Box key={index} flex={false} role="none">
-                      <Button
-                        ref={(r) => {
-                          buttonRefs.current[index] = r;
-                        }}
-                        role="menuitem"
-                        onFocus={() => {
-                          setActiveItemIndex(index);
-                        }}
-                        active={activeItemIndex === index}
-                        focusIndicator={false}
-                        plain={!child ? undefined : true}
-                        align="start"
-                        justify={item.justify}
-                        kind={!child ? 'option' : undefined}
-                        hoverIndicator={!child ? undefined : 'background'}
-                        {...(!child
-                          ? item
-                          : {
-                              ...item,
-                              gap: undefined,
-                              icon: undefined,
-                              label: undefined,
-                              reverse: undefined,
-                            })}
-                        onClick={(...args) => {
-                          if (item.onClick) {
-                            item.onClick(...args);
-                          }
-                          if (item.close !== false) {
-                            onDropClose();
-                          }
-                        }}
-                      >
-                        {child}
-                      </Button>
-                    </Box>
-                  );
-                })}
+                {menuContent}
               </Box>
               {/*
                 If align.top was defined,

--- a/src/js/components/Menu/Menu.js
+++ b/src/js/components/Menu/Menu.js
@@ -362,6 +362,7 @@ const Menu = forwardRef((props, ref) => {
 
   let menuContent;
   if (itemCount && Array.isArray(items[0])) {
+    let index = 0;
     menuContent = items.map((group, groupIndex) => (
       <Box
         // eslint-disable-next-line react/no-array-index-key
@@ -369,18 +370,21 @@ const Menu = forwardRef((props, ref) => {
         {...theme.menu.group?.container}
         border={
           groupIndex > 0
-            ? { side: 'top', ...theme.menu.group?.container?.border }
+            ? {
+                side: 'top',
+                color: theme.menu.group?.separator?.color,
+                size: theme.menu.group?.separator?.size,
+              }
             : undefined
         }
       >
-        {/* index needs to be its index in the entire menu as if 
-        it were a flat array */}
-        {group.map((item, j) => {
-          let itemIndex = j;
-          for (let k = 0; k < groupIndex; k += 1) {
-            itemIndex += items[k].length;
-          }
-          return menuItem(item, itemIndex);
+        {group.map((item) => {
+          // item index needs to be its index in the entire menu as if
+          // it were a flat array
+          const currentIndex = index;
+          index += 1;
+
+          return menuItem(item, currentIndex);
         })}
       </Box>
     ));

--- a/src/js/components/Menu/__tests__/Menu-test.js
+++ b/src/js/components/Menu/__tests__/Menu-test.js
@@ -1,6 +1,7 @@
 import React from 'react';
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { getByText as getByTextDOM } from '@testing-library/dom';
+import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 
 import 'jest-axe/extend-expect';
@@ -589,5 +590,29 @@ describe('Menu', () => {
     );
 
     expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test('should group items', async () => {
+    const user = userEvent.setup();
+
+    window.scrollTo = jest.fn();
+    const onClick = jest.fn();
+    const { asFragment } = render(
+      <Grommet>
+        <Menu
+          label="Test Menu"
+          items={[
+            [{ label: 'Item 1' }, { label: 'Item 2', onClick }],
+            [{ label: 'Item 3' }],
+          ]}
+          open
+        />
+      </Grommet>,
+    );
+
+    await user.click(screen.getByRole('menuitem', { name: 'Item 2' }));
+    expect(onClick).toBeCalledTimes(1);
+
+    expect(asFragment()).toMatchSnapshot();
   });
 });

--- a/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
+++ b/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
@@ -5015,6 +5015,223 @@ exports[`Menu should apply themed drop props 1`] = `
 </div>
 `;
 
+exports[`Menu should group items 1`] = `
+<DocumentFragment>
+  .c5 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #7D4CDB;
+  stroke: #7D4CDB;
+}
+
+.c5 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c5 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c5 *[stroke*="#"],
+.c5 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c5 *[fill-rule],
+.c5 *[FILL-RULE],
+.c5 *[fill*="#"],
+.c5 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  padding: 12px;
+}
+
+.c4 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  width: 12px;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c1 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c1:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c1:focus > circle,
+.c1:focus > ellipse,
+.c1:focus > line,
+.c1:focus > path,
+.c1:focus > polygon,
+.c1:focus > polyline,
+.c1:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c1:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c1:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c1:focus:not(:focus-visible) > circle,
+.c1:focus:not(:focus-visible) > ellipse,
+.c1:focus:not(:focus-visible) > line,
+.c1:focus:not(:focus-visible) > path,
+.c1:focus:not(:focus-visible) > polygon,
+.c1:focus:not(:focus-visible) > polyline,
+.c1:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c1:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    padding: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+  .c4 {
+    width: 6px;
+  }
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+
+}
+
+<div
+    class="c0"
+  >
+    <button
+      aria-expanded="false"
+      aria-haspopup="menu"
+      aria-label="Open Menu"
+      class="c1"
+      type="button"
+    >
+      <div
+        class="c2"
+      >
+        <span
+          class="c3"
+        >
+          Test Menu
+        </span>
+        <div
+          class="c4"
+        />
+        <svg
+          aria-label="FormDown"
+          class="c5"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="m18 9-6 6-6-6"
+            fill="none"
+            stroke="#000"
+            stroke-width="2"
+          />
+        </svg>
+      </div>
+    </button>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`Menu should have no accessibility violations 1`] = `
 .c4 {
   display: inline-block;

--- a/src/js/components/Menu/index.d.ts
+++ b/src/js/components/Menu/index.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { DropProps } from '../Drop';
-import { ButtonType } from '../Button';
+import { ButtonProps, ButtonType } from '../Button';
 import {
   A11yTitleType,
   AlignSelfType,
@@ -31,7 +31,7 @@ export interface MenuProps {
   dropProps?: DropProps;
   gridArea?: GridAreaType;
   icon?: boolean | React.ReactNode;
-  items: object[] | object[][];
+  items: object[] | ({ heading?: string, id?: string} | ButtonProps)[][];
   justifyContent?: JustifyContentType;
   label?: string | React.ReactNode;
   margin?: MarginType;

--- a/src/js/components/Menu/index.d.ts
+++ b/src/js/components/Menu/index.d.ts
@@ -31,7 +31,7 @@ export interface MenuProps {
   dropProps?: DropProps;
   gridArea?: GridAreaType;
   icon?: boolean | React.ReactNode;
-  items: ButtonProps[] | ({ heading?: string, id?: string} | ButtonProps)[][];
+  items: ButtonProps[] | ButtonProps[][];
   justifyContent?: JustifyContentType;
   label?: string | React.ReactNode;
   margin?: MarginType;

--- a/src/js/components/Menu/index.d.ts
+++ b/src/js/components/Menu/index.d.ts
@@ -31,7 +31,7 @@ export interface MenuProps {
   dropProps?: DropProps;
   gridArea?: GridAreaType;
   icon?: boolean | React.ReactNode;
-  items: object[];
+  items: object[] | object[][];
   justifyContent?: JustifyContentType;
   label?: string | React.ReactNode;
   margin?: MarginType;

--- a/src/js/components/Menu/index.d.ts
+++ b/src/js/components/Menu/index.d.ts
@@ -31,7 +31,7 @@ export interface MenuProps {
   dropProps?: DropProps;
   gridArea?: GridAreaType;
   icon?: boolean | React.ReactNode;
-  items: object[] | ({ heading?: string, id?: string} | ButtonProps)[][];
+  items: ButtonProps[] | ({ heading?: string, id?: string} | ButtonProps)[][];
   justifyContent?: JustifyContentType;
   label?: string | React.ReactNode;
   margin?: MarginType;

--- a/src/js/components/Menu/propTypes.js
+++ b/src/js/components/Menu/propTypes.js
@@ -38,7 +38,10 @@ if (process.env.NODE_ENV !== 'production') {
       'stretch',
     ]),
     icon: PropTypes.oneOfType([PropTypes.bool, PropTypes.node]),
-    items: PropTypes.arrayOf(PropTypes.object).isRequired,
+    items: PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.object),
+      PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.object)),
+    ]).isRequired,
     label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
     messages: PropTypes.shape({
       closeMenu: PropTypes.string,

--- a/src/js/components/Menu/stories/Grouped.js
+++ b/src/js/components/Menu/stories/Grouped.js
@@ -1,86 +1,31 @@
 import React from 'react';
 
-import { Box, Menu, Text } from 'grommet';
-import { Figma, Github, Slack } from 'grommet-icons';
-
-const data = [
-  {
-    icon: <Github />,
-    title: 'Github',
-  },
-  {
-    icon: <Figma color="plain" />,
-    title: 'Figma',
-  },
-  {
-    icon: <Slack color="plain" />,
-    title: 'Slack',
-  },
-];
+import { Box, Menu } from 'grommet';
 
 export const Grouped = () => (
-  <Box direction="row" gap="xlarge" align="center" pad="large">
+  // Uncomment <Grommet> lines when using outside of storybook
+  // <Grommet theme={...}>
+  <Box align="center" pad="large">
     <Menu
       open
       dropProps={{
         align: { top: 'bottom', left: 'left' },
         elevation: 'xlarge',
       }}
-      label="Simple Groups"
-      items={[
-        [{ label: 'New file' }, { label: 'Copy link' }, { label: 'Edit file' }],
-        [{ label: 'Delete file' }],
-      ]}
-    />
-    <Menu
-      open
-      dropProps={{
-        align: { top: 'bottom', left: 'left' },
-        elevation: 'xlarge',
-      }}
-      label="Grouped with headings"
+      label="Grouped Menu"
       items={[
         [
-          { heading: 'Cloud Consoles', id: 'cloud-consoles' },
-          { label: 'HPE GreenLake Cloud Services' },
-          { label: 'HPE Data Services' },
-          { label: 'HPE Compute Ops Manager' },
-        ],
-        [
+          { label: 'View Details' },
           {
-            heading: 'HPE GreenLake Administration',
-            id: 'hpe-greenlake-admin',
+            label: 'Edit Permissions',
           },
-          { label: 'Manage Account' },
-          { label: 'Manage Devices' },
+          { label: 'Update Password' },
         ],
-      ]}
-    />
-    <Menu
-      open
-      dropProps={{
-        align: { top: 'bottom', left: 'left' },
-        elevation: 'xlarge',
-      }}
-      label="Complex labels"
-      items={[
-        [
-          { heading: 'Apps', id: 'apps' },
-          { label: <CustomLabel icon={data[0].icon} title={data[0].title} /> },
-          { label: <CustomLabel icon={data[1].icon} title={data[1].title} /> },
-          { label: <CustomLabel icon={data[2].icon} title={data[2].title} /> },
-        ],
-        [{ label: 'Find new apps' }, { label: 'Manage your apps' }],
+        [{ label: 'Delete' }],
       ]}
     />
   </Box>
-);
-
-const CustomLabel = ({ icon, title }) => (
-  <Box direction="row" gap="small">
-    {icon}
-    <Text>{title}</Text>
-  </Box>
+  // </Grommet>
 );
 
 Grouped.parameters = {

--- a/src/js/components/Menu/stories/Grouped.js
+++ b/src/js/components/Menu/stories/Grouped.js
@@ -1,0 +1,92 @@
+import React from 'react';
+
+import { Box, Menu, Text } from 'grommet';
+import { Figma, Github, Slack } from 'grommet-icons';
+
+const data = [
+  {
+    icon: <Github />,
+    title: 'Github',
+  },
+  {
+    icon: <Figma color="plain" />,
+    title: 'Figma',
+  },
+  {
+    icon: <Slack color="plain" />,
+    title: 'Slack',
+  },
+];
+
+export const Grouped = () => (
+  <Box direction="row" gap="xlarge" align="center" pad="large">
+    <Menu
+      open
+      dropProps={{
+        align: { top: 'bottom', left: 'left' },
+        elevation: 'xlarge',
+      }}
+      label="Simple Groups"
+      items={[
+        [{ label: 'New file' }, { label: 'Copy link' }, { label: 'Edit file' }],
+        [{ label: 'Delete file' }],
+      ]}
+    />
+    <Menu
+      open
+      dropProps={{
+        align: { top: 'bottom', left: 'left' },
+        elevation: 'xlarge',
+      }}
+      label="Grouped with titles"
+      items={[
+        [
+          { heading: 'Cloud Consoles', id: 'cloud-consoles' },
+          { label: 'HPE GreenLake Cloud Services' },
+          { label: 'HPE Data Services' },
+          { label: 'HPE Compute Ops Manager' },
+        ],
+        [
+          {
+            heading: 'HPE GreenLake Administration',
+            id: 'hpe-greenlake-admin',
+          },
+          { label: 'Manage Account' },
+          { label: 'Manage Devices' },
+        ],
+      ]}
+    />
+    <Menu
+      open
+      dropProps={{
+        align: { top: 'bottom', left: 'left' },
+        elevation: 'xlarge',
+      }}
+      label="Complex labels"
+      items={[
+        [
+          { heading: 'Apps', id: 'apps' },
+          { label: <CustomLabel icon={data[0].icon} title={data[0].title} /> },
+          { label: <CustomLabel icon={data[1].icon} title={data[1].title} /> },
+          { label: <CustomLabel icon={data[2].icon} title={data[2].title} /> },
+        ],
+        [{ label: 'Find new apps' }, { label: 'Manage your apps' }],
+      ]}
+    />
+  </Box>
+);
+
+const CustomLabel = ({ icon, title }) => (
+  <Box direction="row" gap="small">
+    {icon}
+    <Text>{title}</Text>
+  </Box>
+);
+
+Grouped.parameters = {
+  chromatic: { disable: true },
+};
+
+export default {
+  title: 'Controls/Menu/Grouped',
+};

--- a/src/js/components/Menu/stories/Grouped.js
+++ b/src/js/components/Menu/stories/Grouped.js
@@ -38,7 +38,7 @@ export const Grouped = () => (
         align: { top: 'bottom', left: 'left' },
         elevation: 'xlarge',
       }}
-      label="Grouped with titles"
+      label="Grouped with headings"
       items={[
         [
           { heading: 'Cloud Consoles', id: 'cloud-consoles' },

--- a/src/js/components/Menu/stories/Grouped.js
+++ b/src/js/components/Menu/stories/Grouped.js
@@ -7,7 +7,6 @@ export const Grouped = () => (
   // <Grommet theme={...}>
   <Box align="center" pad="large">
     <Menu
-      open
       dropProps={{
         align: { top: 'bottom', left: 'left' },
         elevation: 'xlarge',

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -1708,6 +1708,10 @@ Object {
                 "vertical": "xsmall",
               },
             },
+            "separator": Object {
+              "color": "border",
+              "size": "xsmall",
+            },
           },
           "icons": Object {
             "down": Object {

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -1708,17 +1708,6 @@ Object {
                 "vertical": "xsmall",
               },
             },
-            "heading": Object {
-              "container": Object {
-                "pad": Object {
-                  "bottom": "xsmall",
-                  "horizontal": "small",
-                },
-              },
-              "text": Object {
-                "size": "xsmall",
-              },
-            },
           },
           "icons": Object {
             "down": Object {

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -1702,6 +1702,24 @@ Object {
               "top": "top",
             },
           },
+          "group": Object {
+            "container": Object {
+              "pad": Object {
+                "vertical": "xsmall",
+              },
+            },
+            "heading": Object {
+              "container": Object {
+                "pad": Object {
+                  "bottom": "xsmall",
+                  "horizontal": "small",
+                },
+              },
+              "text": Object {
+                "size": "xsmall",
+              },
+            },
+          },
           "icons": Object {
             "down": Object {
               "$$typeof": Symbol(react.forward_ref),

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -1040,6 +1040,13 @@ export interface ThemeType {
     background?: BackgroundType;
     drop?: DropProps;
     extend?: ExtendType;
+    group?: {
+      container?: BoxProps;
+      separator?: {
+        color?: ColorType;
+        size?: string;
+      };
+    };
     icons?: {
       down?: any;
       up?: any;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1055,15 +1055,6 @@ export const generate = (baseSpacing = 24, scale = 6) => {
             vertical: 'xsmall',
           },
         },
-        heading: {
-          container: {
-            pad: {
-              horizontal: 'small',
-              bottom: 'xsmall',
-            },
-          },
-          text: { size: 'xsmall' },
-        },
       },
       icons: {
         down: FormDown,

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1055,6 +1055,10 @@ export const generate = (baseSpacing = 24, scale = 6) => {
             vertical: 'xsmall',
           },
         },
+        separator: {
+          color: 'border',
+          size: 'xsmall',
+        },
       },
       icons: {
         down: FormDown,

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1049,6 +1049,22 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         },
         // any drop props
       },
+      group: {
+        container: {
+          pad: {
+            vertical: 'xsmall',
+          },
+        },
+        heading: {
+          container: {
+            pad: {
+              horizontal: 'small',
+              bottom: 'xsmall',
+            },
+          },
+          text: { size: 'xsmall' },
+        },
+      },
       icons: {
         down: FormDown,
         // up: undefined,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

[Deploy Preview](https://deploy-preview-6162--sad-tereshkova-173d07.netlify.app/?path=/story/controls-menu-grouped--grouped)

This PR enhances `items` prop on Menu to allow for grouped items by passing an array of menu item arrays.

Looking for feedback on:
- [x] API surface
- [x] Theme structure
- [x] How separator is implemented as 'top' when index of group is not the first one

```
API

<Menu
   items={[
      [
         { label: 'View Details' },
         { label: 'Edit Permissions' },
      ],
      [
         { label: 'Delete' },
      ],
    ]}
/>
```

**Theme**
- Adds `theme.menu.group.container` --> any Box props for an individual group
- Adds `theme.menu.group.separator` --> Color and size of separator

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [x] `screen` is used for querying.
- [x] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [x] `userEvent` is used in place of `fireEvent`.
- [x] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Related to https://github.com/grommet/hpe-design-system/issues/2621

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Yes.

#### Should this PR be mentioned in the release notes?
Yes.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.