### PR TITLE
Allow Button to accept elementType for as

### DIFF
--- a/src/js/components/Button/__tests__/Button-test.tsx
+++ b/src/js/components/Button/__tests__/Button-test.tsx
@@ -444,14 +444,17 @@ describe('Button', () => {
   });
 
   test('as', () => {
-    const { container } = render(
+    const Anchor = () => <a />;
+
+    const { asFragment } = render(
       <Grommet>
         <Button as="span" />
+        <Button as={Anchor} />
       </Grommet>,
     );
 
     expect(screen.queryByRole('button')).not.toBeInTheDocument();
-    expect(container.firstChild).toMatchSnapshot();
+    expect(asFragment()).toMatchSnapshot();
   });
 
   test('a11yTitle', () => {

--- a/src/js/components/Button/__tests__/__snapshots__/Button-test.tsx.snap
+++ b/src/js/components/Button/__tests__/__snapshots__/Button-test.tsx.snap
@@ -288,7 +288,8 @@ exports[`Button active 1`] = `
 `;
 
 exports[`Button as 1`] = `
-.c1 {
+<DocumentFragment>
+  .c1 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -368,13 +369,15 @@ exports[`Button as 1`] = `
 }
 
 <div
-  class="c0"
->
-  <span
-    class="c1"
-    type="button"
-  />
-</div>
+    class="c0"
+  >
+    <span
+      class="c1"
+      type="button"
+    />
+    <a />
+  </div>
+</DocumentFragment>
 `;
 
 exports[`Button badge should apply background 1`] = `

--- a/src/js/components/Button/propTypes.js
+++ b/src/js/components/Button/propTypes.js
@@ -16,7 +16,11 @@ if (process.env.NODE_ENV !== 'production') {
       PropTypes.node,
     ]),
     active: PropTypes.bool,
-    as: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+    as: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.func,
+      PropTypes.elementType,
+    ]),
     badge: PropTypes.oneOfType([
       PropTypes.bool,
       PropTypes.element,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Allows Button `as` to accept elementType. This is important for cases when someone uses a router like react-router-dom and wants to do something like:

```
<Button
   as={Link}
   to="/home" (to is the prop for react-router-dom link)
   label="Home"
/>
```

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [x] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?
Yes.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.