### PR TITLE
Changed DataChart to improve how swatches are rendered for detail and legend

### DIFF
--- a/src/js/components/DataChart/DataChart.js
+++ b/src/js/components/DataChart/DataChart.js
@@ -19,7 +19,13 @@ import { XAxis } from './XAxis';
 import { YAxis } from './YAxis';
 import { XGuide } from './XGuide';
 import { YGuide } from './YGuide';
-import { createDateFormat, halfPad, heightYGranularity, points } from './utils';
+import {
+  createDateFormat,
+  halfPad,
+  heightYGranularity,
+  largestSize,
+  points,
+} from './utils';
 import { DataChartPropTypes } from './propTypes';
 
 const stackedChartType = {
@@ -329,30 +335,37 @@ const DataChart = forwardRef(
     const seriesStyles = useMemo(() => {
       const result = {};
       // start from what we were explicitly given
-      charts.forEach(({ color, point, property, thickness, type }, index) => {
-        const { thickness: calcThickness } = chartProps[index];
+      charts.forEach(
+        ({ color, dash, point, property, round, thickness, type }, index) => {
+          const { thickness: calcThickness } = chartProps[index];
 
-        if (typeof property === 'object' && !Array.isArray(property)) {
-          // data driven point chart
-          Object.keys(property).forEach((aspect) => {
-            const prop = property[aspect];
-            if (!result[prop.property || prop])
-              result[prop.property || prop] = { aspect };
-          });
-        } else {
-          const props = Array.isArray(property) ? property : [property];
-          props.forEach((prop) => {
-            const p = prop.property || prop;
-            const pColor = prop.color || color;
-            if (!result[p]) result[p] = {};
-            if (pColor && !result[p].color) result[p].color = pColor;
-            if (point && !result[p].point) result[p].point = point;
-            else if (type === 'point') result[p].point = false;
-            if ((thickness || calcThickness) && !result[p].thickness)
-              result[p].thickness = thickness || calcThickness;
-          });
-        }
-      });
+          if (typeof property === 'object' && !Array.isArray(property)) {
+            // data driven point chart
+            Object.keys(property).forEach((aspect) => {
+              const prop = property[aspect];
+              if (!result[prop.property || prop])
+                result[prop.property || prop] = { aspect };
+            });
+          } else {
+            const props = Array.isArray(property) ? property : [property];
+            props.forEach((prop) => {
+              const p = prop.property || prop;
+              const pColor = prop.color || color;
+              if (!result[p]) result[p] = {};
+              if (pColor && !result[p].color) result[p].color = pColor;
+              if (point && !result[p].point) result[p].point = point;
+              else if (type === 'point') result[p].point = false;
+              if ((thickness || calcThickness) && !result[p].thickness)
+                result[p].thickness = thickness || calcThickness;
+              if (round !== undefined && result[p].round === undefined)
+                result[p].round = round;
+              if (dash !== undefined && result[p].dash === undefined)
+                result[p].dash = dash;
+              if (result[p].type === undefined) result[p].type = type;
+            });
+          }
+        },
+      );
 
       // set color for any non-aspect properties we don't have one for yet
       let colorIndex = 0;
@@ -413,8 +426,9 @@ const DataChart = forwardRef(
 
       charts.forEach(({ type }, index) => {
         const { thickness } = chartProps[index];
-        result.horizontal = halfPad[thickness];
-        if (type && type !== 'bar') result.vertical = halfPad[thickness];
+        result.horizontal = largestSize(result.horizontal, halfPad[thickness]);
+        if (type && type !== 'bar')
+          result.vertical = largestSize(result.vertical, halfPad[thickness]);
       });
       return result;
     }, [chartProps, charts, padProp]);
@@ -666,7 +680,6 @@ const DataChart = forwardRef(
             activeProperty={activeProperty}
             axis={axis}
             data={data}
-            pad={pad}
             series={series}
             seriesStyles={seriesStyles}
             renderValue={renderValue}

--- a/src/js/components/DataChart/Swatch.js
+++ b/src/js/components/DataChart/Swatch.js
@@ -60,6 +60,9 @@ const Swatch = ({ aspect, color, dash, point, round, thickness, type }) => {
         d = `M 0 0 L ${dim} 0 L ${dim} ${dim} L 0 ${dim} Z`;
       if (d) content = <path d={d} />;
     }
+  } else if (type === 'area') {
+    if (round) content = <circle cx={half} cy={half} r={half} />;
+    else content = <rect x={0} y={0} width={width} height={height} />;
   } else {
     // draw a line oriented based on the type and then match style
     const strokeWidth =

--- a/src/js/components/DataChart/Swatch.js
+++ b/src/js/components/DataChart/Swatch.js
@@ -2,12 +2,19 @@ import React, { useContext } from 'react';
 import { ThemeContext } from 'styled-components';
 import { normalizeColor, parseMetricToNum } from '../../utils';
 
-const Swatch = ({ aspect, color, point, thickness }) => {
+const Swatch = ({ aspect, color, dash, point, round, thickness, type }) => {
   const theme = useContext(ThemeContext);
   const dim = parseInt(theme.global.spacing, 10) / 2;
   const half = dim / 2;
+  let height = dim;
   let width = dim;
+  const normalizedColor = color
+    ? normalizeColor(color.color || color, theme)
+    : undefined;
+  let fill = normalizedColor;
+  let stroke = 'none';
   let content;
+
   if (aspect === 'x')
     content = <path d={`M 0 ${half} L ${dim} ${half}`} stroke="#000" />;
   else if (aspect === 'y')
@@ -33,41 +40,63 @@ const Swatch = ({ aspect, color, point, thickness }) => {
         />
       </g>
     );
-  else if (point === 'circle')
-    content = <circle cx={half} cy={half} r={half} />;
-  else {
+  else if (point) {
+    if (point === 'circle') content = <circle cx={half} cy={half} r={half} />;
+    else {
+      let d;
+      if (point === 'diamond')
+        d = `M ${half} 0 L ${dim} ${half} L ${half} ${dim} L 0 ${half} Z`;
+      else if (point === 'star') {
+        const off1 = half / 3;
+        const off2 = off1 * 2;
+        d = `M ${half} 0 L ${half - off2} ${dim} L ${dim} ${half - off1} L 0 ${
+          half - off1
+        } L ${half + off2} ${dim} Z`;
+      } else if (point === 'triangle')
+        d = `M ${half} 0 L ${dim} ${dim} L 0 ${dim} Z`;
+      else if (point === 'triangleDown')
+        d = `M 0 0 L ${dim} 0 L ${half} ${dim} Z`;
+      else if (point === 'square')
+        d = `M 0 0 L ${dim} 0 L ${dim} ${dim} L 0 ${dim} Z`;
+      if (d) content = <path d={d} />;
+    }
+  } else {
+    // draw a line oriented based on the type and then match style
+    const strokeWidth =
+      parseMetricToNum(theme.global.edgeSize[thickness]) || dim;
     let d;
-    if (point === 'diamond')
-      d = `M ${half} 0 L ${dim} ${half} L ${half} ${dim} L 0 ${half} Z`;
-    else if (point === 'star') {
-      const off1 = half / 3;
-      const off2 = off1 * 2;
-      d = `M ${half} 0 L ${half - off2} ${dim} L ${dim} ${half -
-        off1} L 0 ${half - off1} L ${half + off2} ${dim} Z`;
-    } else if (point === 'triangle')
-      d = `M ${half} 0 L ${dim} ${dim} L 0 ${dim} Z`;
-    else if (point === 'triangleDown')
-      d = `M 0 0 L ${dim} 0 L ${half} ${dim} Z`;
-    else if (point === 'square')
-      d = `M 0 0 L ${dim} 0 L ${dim} ${dim} L 0 ${dim} Z`;
-    // TODO: dash
-    else if (thickness) {
-      width = parseMetricToNum(theme.global.edgeSize[thickness]) || dim;
-      d = `M 0 0 L ${width} 0 L ${width} ${dim} L 0 ${dim} Z`;
-    } // box
-    else d = `M 0 0 L ${dim} 0 L ${dim} ${dim} L 0 ${dim} Z`;
-    content = <path d={d} />;
+    if (type === 'line' || type === 'area') {
+      width = Math.max(width, strokeWidth * 4);
+      height = strokeWidth;
+      d = `M 0 ${height / 2} L ${width} ${height / 2}`;
+    } else {
+      width = strokeWidth;
+      d = `M ${width / 2} 0 L ${width / 2} ${dim}`;
+    }
+
+    fill = 'none';
+    stroke = normalizedColor;
+    const strokeProps = {};
+    if (round) strokeProps.strokeLinecap = 'round';
+    if (dash)
+      strokeProps.strokeDasharray = round
+        ? `${strokeWidth} ${strokeWidth * 1.5}`
+        : `${strokeWidth * 2} ${strokeWidth / 2}`;
+
+    content = <path d={d} strokeWidth={strokeWidth} {...strokeProps} />;
   }
+
   const opacity =
     color && color.opacity ? theme.global.opacity[color.opacity] : undefined;
+
   return (
     <svg
       width={width}
-      height={dim}
-      viewBox={`0 0 ${width} ${dim}`}
-      fill={color ? normalizeColor(color.color || color, theme) : undefined}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      fill={fill}
       opacity={opacity}
-      stroke="none"
+      stroke={stroke}
     >
       {content}
     </svg>

--- a/src/js/components/DataChart/__tests__/__snapshots__/DataChart-test.js.snap
+++ b/src/js/components/DataChart/__tests__/__snapshots__/DataChart-test.js.snap
@@ -5181,8 +5181,6 @@ exports[`DataChart detail 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  padding-left: 24px;
-  padding-right: 24px;
 }
 
 .c12 {
@@ -6886,14 +6884,15 @@ exports[`DataChart legend 1`] = `
         class="c11"
       >
         <svg
-          fill="#6FFFB0"
+          fill="none"
           height="12"
-          stroke="none"
+          stroke="#6FFFB0"
           viewBox="0 0 96 12"
           width="96"
         >
           <path
-            d="M 0 0 L 96 0 L 96 12 L 0 12 Z"
+            d="M 48 0 L 48 12"
+            stroke-width="96"
           />
         </svg>
         <div

--- a/src/js/components/DataChart/stories/Legend.js
+++ b/src/js/components/DataChart/stories/Legend.js
@@ -8,7 +8,7 @@ for (let i = 1; i < 8; i += 1) {
   data.push({
     date: `2020-07-${((i % 30) + 1).toString().padStart(2, 0)}`,
     percent: Math.abs(v * 100),
-    amount: i,
+    amount: Math.round(Math.abs(v * 50)),
   });
 }
 
@@ -30,8 +30,18 @@ export const Legend = () => (
           label: 'Amount',
         },
       ]}
-      chart={['percent', { property: 'amount', thickness: 'small' }]}
+      chart={[
+        'percent',
+        {
+          type: 'line',
+          property: 'amount',
+          thickness: 'xsmall',
+          dash: true,
+          round: true,
+        },
+      ]}
       legend
+      detail
       axis={{ x: { property: 'date', granularity: 'medium' } }}
     />
   </Box>

--- a/src/js/components/DataChart/utils.js
+++ b/src/js/components/DataChart/utils.js
@@ -32,6 +32,23 @@ export const doublePad = {
   xxsmall: 'xsmall',
 };
 
+const orderedSizes = [
+  'xlarge',
+  'large',
+  'medium',
+  'small',
+  'xsmall',
+  'xxsmall',
+  'hair',
+];
+
+export const largestSize = (size1, size2) => {
+  if (size1 && !size2) return size1;
+  if (size2 && !size1) return size2;
+  if (orderedSizes.indexOf(size1) < orderedSizes.indexOf(size2)) return size1;
+  return size2;
+};
+
 export const createDateFormat = (firstValue, lastValue, full) => {
   let dateFormat;
   const startDate = new Date(firstValue);


### PR DESCRIPTION
#### What does this PR do?

Changed DataChart to improve how swatches are rendered for detail and legend.

The key concept is that instead of always drawing a path and filling it, we now draw a line and style the stroke to align better with how the Chart renders.

#### Where should the reviewer start?

DataChart.js

#### What testing has been done on this PR?

Check Detail and Legend stories.
Enhanced Legend story to include dash and round.
Verified that unit test snapshots changes are expected.

#### How should this be manually tested?

Detail and Legend stories

#### Do Jest tests follow these best practices?

no test changes

#### What are the relevant issues?

#6119 

#### Screenshots (if appropriate)

<img width="411" alt="Screen Shot 2022-06-09 at 8 51 30 PM" src="https://user-images.githubusercontent.com/11637956/172986844-db224a40-09eb-440e-ad9c-8933d255a013.png">

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
