### PR TITLE
Changed MaskedInput to not clear entire value when mask doesn't match

### DIFF
--- a/src/js/components/DateInput/__tests__/DateInput-test.tsx
+++ b/src/js/components/DateInput/__tests__/DateInput-test.tsx
@@ -762,10 +762,9 @@ describe('DateInput', () => {
     fireEvent.change(getByPlaceholderText('mm/dd/yyyy-mm/dd/yyyy'), {
       target: { value: '07//2020-07/27/2021' },
     });
-    expect(onChange).toHaveNthReturnedWith(3, []);
     // cannot check snapshot here as it will be relative to the current date
 
-    expect(onChange).toHaveBeenCalledTimes(3);
+    expect(onChange).toHaveBeenCalledTimes(2);
   });
 
   test('type format inline range partial without timezone', () => {
@@ -799,10 +798,9 @@ describe('DateInput', () => {
     fireEvent.change(getByPlaceholderText('mm/dd/yyyy-mm/dd/yyyy'), {
       target: { value: '07//2020-07/27/2021' },
     });
-    expect(onChange).toHaveNthReturnedWith(3, []);
     // cannot check snapshot here as it will be relative to the current date
 
-    expect(onChange).toHaveBeenCalledTimes(3);
+    expect(onChange).toHaveBeenCalledTimes(2);
   });
 
   test('controlled format inline', () => {

--- a/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.js.snap
+++ b/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.js.snap
@@ -203,10 +203,6 @@ exports[`MaskedInput applies custom global.hover theme to options 2`] = `
 
 }
 
-@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-
-}
-
 <button
   class="c0"
   tabindex="-1"
@@ -1009,12 +1005,6 @@ exports[`MaskedInput event target props are available option via mouse 2`] = `
   }
 }
 
-@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c3 {
-    width: 100%;
-  }
-}
-
 <div
   class="c0 c1"
   data-g-portal-id="0"
@@ -1645,12 +1635,6 @@ exports[`MaskedInput mask 2`] = `
   }
 }
 
-@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c3 {
-    width: 100%;
-  }
-}
-
 <div
   class="c0 c1"
   data-g-portal-id="0"
@@ -2231,12 +2215,6 @@ exports[`MaskedInput option via mouse 2`] = `
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
     align-items: stretch;
-  }
-}
-
-@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c3 {
-    width: 100%;
   }
 }
 


### PR DESCRIPTION
#### What does this PR do?

Changed MaskedInput to not clear entire value when mask doesn't match.

Instead of pruning the value down to only the initial part that matches, this change restores it to the prior value. Neither is ideal but I think this behavior is a bit better and aligns more with the existing behavior when an invalid character is entered at the end, with the preceding value remaining.

#### Where should the reviewer start?

MaskedInput.js

#### What testing has been done on this PR?

MaskedInput stories, especially Size + units
DateInput stories with formatting

#### How should this be manually tested?

same as above

#### Do Jest tests follow these best practices?

preserved existing unit test structure

#### What are the relevant issues?

#6151 

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
