### PR TITLE
Add accordion.hover.background to theme

### DIFF
--- a/src/js/components/Accordion/__tests__/Accordion-test.tsx
+++ b/src/js/components/Accordion/__tests__/Accordion-test.tsx
@@ -14,7 +14,7 @@ const customTheme = {
     heading: { level: '3' },
     hover: {
       background: 'background-contrast',
-    }
+    },
   },
 };
 
@@ -176,7 +176,7 @@ describe('Accordion', () => {
     expect(asFragment()).toMatchSnapshot();
 
     await user.hover(screen.getByRole('tab', { name: 'Panel 1 FormDown' }));
-    expect(asFragment()).toMatchSnapshot()
+    expect(asFragment()).toMatchSnapshot();
   });
 
   test('accordion border', () => {

--- a/src/js/components/Accordion/__tests__/Accordion-test.tsx
+++ b/src/js/components/Accordion/__tests__/Accordion-test.tsx
@@ -12,6 +12,9 @@ import { Accordion, AccordionPanel, Box, Grommet } from '../..';
 const customTheme = {
   accordion: {
     heading: { level: '3' },
+    hover: {
+      background: 'background-contrast',
+    }
   },
 };
 
@@ -160,7 +163,9 @@ describe('Accordion', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
-  test('custom accordion', () => {
+  test('custom accordion', async () => {
+    const user = userEvent.setup();
+
     const { asFragment } = render(
       <Grommet theme={customTheme}>
         <Accordion>
@@ -169,6 +174,9 @@ describe('Accordion', () => {
       </Grommet>,
     );
     expect(asFragment()).toMatchSnapshot();
+
+    await user.hover(screen.getByRole('tab', { name: 'Panel 1 FormDown' }));
+    expect(asFragment()).toMatchSnapshot()
   });
 
   test('accordion border', () => {

--- a/src/js/components/Accordion/__tests__/__snapshots__/Accordion-test.tsx.snap
+++ b/src/js/components/Accordion/__tests__/__snapshots__/Accordion-test.tsx.snap
@@ -4278,6 +4278,10 @@ exports[`Accordion custom accordion 1`] = `
   text-align: inherit;
 }
 
+.c3:hover {
+  background: #33333310;
+}
+
 .c3:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
@@ -4360,6 +4364,325 @@ exports[`Accordion custom accordion 1`] = `
   .c9 {
     border-bottom: solid 1px rgba(0,0,0,0.33);
   }
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    font-size: 18px;
+    line-height: 24px;
+    max-width: 432px;
+  }
+}
+
+<div
+    class="c0"
+  >
+    <div
+      class="c1"
+      role="tablist"
+    >
+      <div
+        class="c2"
+      >
+        <button
+          aria-expanded="false"
+          aria-selected="false"
+          class="c3"
+          role="tab"
+          type="button"
+        >
+          <div
+            class="c4"
+          >
+            <div
+              class="c5"
+            >
+              <h3
+                class="c6"
+              >
+                Panel 1
+              </h3>
+            </div>
+            <div
+              class="c7"
+            >
+              <svg
+                aria-label="FormDown"
+                class="c8"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m18 9-6 6-6-6"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
+          </div>
+        </button>
+        <div
+          class="c9"
+        >
+          <div
+            aria-hidden="true"
+            class="c1 c10"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Accordion custom accordion 2`] = `
+<DocumentFragment>
+  .c8 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #7D4CDB;
+  stroke: #7D4CDB;
+}
+
+.c8 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c8 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c8 *[stroke*="#"],
+.c8 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c8 *[fill-rule],
+.c8 *[FILL-RULE],
+.c8 *[fill*="#"],
+.c8 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-left: 6px;
+  padding-right: 6px;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  min-width: -webkit-fit-content;
+  min-width: -moz-fit-content;
+  min-width: fit-content;
+  padding-left: 12px;
+  padding-right: 12px;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c3:hover {
+  background: #33333310;
+}
+
+.c3:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus > circle,
+.c3:focus > ellipse,
+.c3:focus > line,
+.c3:focus > path,
+.c3:focus > polygon,
+.c3:focus > polyline,
+.c3:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c3:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c3:focus:not(:focus-visible) > circle,
+.c3:focus:not(:focus-visible) > ellipse,
+.c3:focus:not(:focus-visible) > line,
+.c3:focus:not(:focus-visible) > path,
+.c3:focus:not(:focus-visible) > polygon,
+.c3:focus:not(:focus-visible) > polyline,
+.c3:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c3:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c10 {
+  -webkit-transition: max-height 200ms,opacity 200ms;
+  transition: max-height 200ms,opacity 200ms;
+  opacity: 0;
+  overflow: hidden;
+}
+
+.c6 {
+  font-size: 26px;
+  line-height: 32px;
+  max-width: 624px;
+  font-weight: 600;
+  color: #777777;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+@media only screen and (max-width:768px) {
+  .c5 {
+    padding-left: 3px;
+    padding-right: 3px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    padding-left: 6px;
+    padding-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c9 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+
 }
 
 @media only screen and (max-width:768px) {

--- a/src/js/components/Accordion/stories/CustomThemed/Custom.js
+++ b/src/js/components/Accordion/stories/CustomThemed/Custom.js
@@ -22,6 +22,7 @@ const customAccordionTheme = {
       heading: {
         color: 'accent-2',
       },
+      background: 'background-contrast',
     },
     icons: {
       collapse: SubtractCircle,

--- a/src/js/components/AccordionPanel/AccordionPanel.js
+++ b/src/js/components/AccordionPanel/AccordionPanel.js
@@ -94,6 +94,7 @@ const AccordionPanel = forwardRef(
           aria-expanded={active}
           plain={theme.button.default ? true : undefined}
           onClick={onPanelChange}
+          hoverIndicator={theme.accordion.hover.background}
           onMouseOver={(event) => {
             setHover(headingColor);
             if (onMouseOver) onMouseOver(event);

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -430,6 +430,7 @@ export interface ThemeType {
       margin?: MarginType;
     };
     hover?: {
+      background?: BackgroundType;
       color?: ColorType; // deprecated
       heading?: {
         color?: ColorType;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -346,6 +346,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         // margin: undefined
       },
       hover: {
+        // background: undefined,
         color: { dark: 'light-4', light: 'dark-3' }, // deprecated
         heading: {
           color: { dark: 'light-4', light: 'dark-3' },


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Adds `accordion.hover.background` to theme.

#### Where should the reviewer start?
AccordionPanel

#### What testing has been done on this PR?
Adjusted Custom story and added jest test.

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [x] `screen` is used for querying.
- [x] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [x] `userEvent` is used in place of `fireEvent`.
- [x] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #6176 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Yes.

#### Should this PR be mentioned in the release notes?
Yes.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.