### PR TITLE
fix page header typescript export

### DIFF
--- a/src/js/index.d.ts
+++ b/src/js/index.d.ts
@@ -42,6 +42,7 @@ export * from './components/Menu';
 export * from './components/Meter';
 export * from './components/Page';
 export * from './components/PageContent';
+export * from './components/PageHeader';
 export * from './components/Pagination';
 export * from './components/Paragraph';
 export * from './components/NameValueList';


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Added missing page header export to index.d.ts

#### Where should the reviewer start?
src/js/index.d.ts

#### What testing has been done on this PR?
Checked on a local typescript story

#### How should this be manually tested?
Locally on typescript story

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
closes #6178 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No functionality was changed

#### Should this PR be mentioned in the release notes?
Yes, fix typescript page header export

#### Is this change backwards compatible or is it a breaking change?
Yes, backwards compatible