### PR TITLE
Rename HeaderProps to CalendarHeaderProps

### DIFF
--- a/src/js/components/Calendar/index.d.ts
+++ b/src/js/components/Calendar/index.d.ts
@@ -14,7 +14,7 @@ export interface RenderProps {
   isSelected: boolean;
 }
 
-export interface HeaderProps {
+export interface CalendarHeaderProps {
   date: Date;
   locale?: string;
   onPreviousMonth: () => void;
@@ -38,7 +38,7 @@ export interface CalendarProps {
   disabled?: (string | string[])[];
   fill?: boolean;
   firstDayOfWeek?: 0 | 1;
-  header?: (args: HeaderProps) => React.ReactNode;
+  header?: (args: CalendarHeaderProps) => React.ReactNode;
   locale?: string;
   messages?: {
     previous?: string;


### PR DESCRIPTION
#### What does this PR do?
Fixes typescript error caused but having two `HeaderProps` one in Calendar and one in Header. I renamed the Calendar one to `CalendarHeaderProps`.

See slack conversation: https://grommet.slack.com/archives/C09QQEG69/p1655286991166619

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No
#### Should this PR be mentioned in the release notes?
No
#### Is this change backwards compatible or is it a breaking change?
Backwards compatible