### PR TITLE
Fix isSafari to check if window exists

### DIFF
--- a/src/js/components/Tabs/Tabs.js
+++ b/src/js/components/Tabs/Tabs.js
@@ -57,9 +57,10 @@ const Tabs = forwardRef(
     // and scroll-behavior='smooth'. For now we are detecting if the browser
     // is safari to workaround this issue. The issue should be resolved soon
     // and we can remove this. https://github.com/WebKit/WebKit/pull/1387
-    const isSafari = /^((?!chrome|android).)*safari/i.test(
-      window.navigator.userAgent,
-    );
+    const isSafari =
+      typeof window !== 'undefined'
+        ? /^((?!chrome|android).)*safari/i.test(window.navigator.userAgent)
+        : true;
 
     /* eslint-disable no-param-reassign */
     delete rest.activeIndex;


### PR DESCRIPTION
#### What does this PR do?
While adding responsive tabs to the design system site where 'window' was not defined. This PR adds a check to see if window is defined before we try and use it.

#### Where should the reviewer start?

#### What testing has been done on this PR?
Tested this code on the DS site

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No
#### Should this PR be mentioned in the release notes?
No
#### Is this change backwards compatible or is it a breaking change?
Backwards compatible