### PR TITLE
Tabs - Fix isVisible to ignore if focusIndicator is visible

### DIFF
--- a/src/js/components/Tabs/Tabs.js
+++ b/src/js/components/Tabs/Tabs.js
@@ -79,18 +79,6 @@ const Tabs = forwardRef(
           const tabRect = tabRefs[index].current.getBoundingClientRect();
           const headerRect = headerRef.current?.getBoundingClientRect();
           if (tabRect && headerRect) {
-            if (
-              (tabRect.left >= headerRect.left &&
-                tabRect.right <= headerRect.right &&
-                tabRect.right + 2 >= headerRect.right &&
-                index !== tabRefs.length - 1) ||
-              (tabRect.right <= headerRect.right &&
-                tabRect.left >= headerRect.left &&
-                tabRect.left - 2 <= headerRect.left &&
-                index !== 0)
-            )
-              return false;
-
             // the -1 and +1 allow a little leniency when calculating if a tab
             // is in view. Without the -1 and +1 a tab could be fully in view
             // but isVisible will return false.
@@ -136,20 +124,8 @@ const Tabs = forwardRef(
         // ensure the focusIndicator is visible when navigating
         // by keyboard
         if (keyboard) {
-          if (
-            amountHidden <= -1 ||
-            (tabRect.right <= headerRect.right &&
-              tabRect.left >= headerRect.left &&
-              tabRect.left - 2 <= headerRect.left)
-          )
-            amountHidden -= 2;
-          else if (
-            amountHidden >= 1 ||
-            (tabRect.left >= headerRect.left &&
-              tabRect.right <= headerRect.right &&
-              tabRect.right + 2 >= headerRect.right)
-          )
-            amountHidden += 2;
+          if (amountHidden < 0) amountHidden -= 2;
+          if (amountHidden > 0) amountHidden += 2;
         }
         if (isSafari) {
           headerRef.current.scrollBy({
@@ -235,6 +211,29 @@ const Tabs = forwardRef(
       // scroll focus item into view if it is not already visible
       if (overflow && focusIndex !== -1 && !isVisible(focusIndex))
         scrollTo(focusIndex, true);
+      else if (overflow && focusIndex !== -1) {
+        // If the browser scrolled the focused item into view and
+        // the focusedTab is on the edge of the header container
+        // scroll slightly further to show the focusIndicator
+        const tabRect = tabRefs[focusIndex].current.getBoundingClientRect();
+        const headerRect = headerRef.current.getBoundingClientRect();
+        let amountHidden = 0;
+        if (
+          tabRect.left >= headerRect.left &&
+          tabRect.right <= headerRect.right &&
+          tabRect.right + 2 >= headerRect.right
+        )
+          amountHidden = 2;
+        else if (
+          tabRect.right <= headerRect.right &&
+          tabRect.left >= headerRect.left &&
+          tabRect.left - 2 <= headerRect.left
+        )
+          amountHidden = -2;
+        headerRef.current.scrollBy({
+          left: amountHidden,
+        });
+      }
     }, [overflow, tabRefs, focusIndex, isVisible, scrollTo]);
 
     useLayoutEffect(() => {


### PR DESCRIPTION
#### What does this PR do?
The `isVisible` function is returning false is a tab is visible but it's focus indicator is not. If we are navigating through the tabs with the left and right arrow buttons `isVisible` returning false when a tab is visible but the focus indicator is not causes an issue where sometimes we scroll further than we want to. In the video below we are on a small screen and should only be advancing or moving back by 1 tab. Sometime we move by multiple tabs.

https://user-images.githubusercontent.com/54560994/173963077-988ccd65-a70c-4c85-8d96-6d4ba1e7355b.mp4

This pull request changes the `isVisible` function to return true if a tab is visible even if the focusIndicator is not. FocusIndicator visibility is only handled if we are navigating with the keyboard.

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?
This can be tested with the storybook [Tabs/Responsive](https://storybook.grommet.io/?path=/story/controls-tabs-responsive--responsive&globals=theme:hpe) story. If you view the story with a small screen, clicking the left and right arrows should only advance or move us back by one tab. Sometimes the tabs will move further than by 1.

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No
#### Should this PR be mentioned in the release notes?
No (responsive tabs hasn't been released yet)
#### Is this change backwards compatible or is it a breaking change?
Backwards compatible