### PR TITLE
Changed Meter to handle floating point precision issues better

### DIFF
--- a/src/js/components/Meter/Circle.js
+++ b/src/js/components/Meter/Circle.js
@@ -20,7 +20,10 @@ const Circle = forwardRef((props, ref) => {
   const centerX = width / 2;
   const centerY = width / 2;
   const radius = width / 2 - strokeWidth / 2;
-  const anglePer = (type === 'semicircle' ? 180 : 360) / max;
+  // truncate to avoid floating point arithmetic errors
+  // see: https://github.com/grommet/grommet/issues/6190
+  const anglePer =
+    Math.floor(((type === 'semicircle' ? 180 : 360) / max) * 10000) / 10000;
   const someHighlight = (values || []).some((v) => v.highlight);
 
   let startValue = 0;

--- a/src/js/components/Meter/__tests__/Meter-test.tsx
+++ b/src/js/components/Meter/__tests__/Meter-test.tsx
@@ -59,6 +59,21 @@ describe('Meter', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  test('boundary values', () => {
+    // for https://github.com/grommet/grommet/issues/6190
+    const { container } = render(
+      <Grommet>
+        <Meter
+          type="circle"
+          values={[{ value: 2.26 }, { value: 8.04 }]}
+          max={10.3}
+        />
+      </Grommet>,
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
   test('type', () => {
     const { container } = render(
       <Grommet>

--- a/src/js/components/Meter/__tests__/__snapshots__/Meter-test.tsx.snap
+++ b/src/js/components/Meter/__tests__/__snapshots__/Meter-test.tsx.snap
@@ -192,6 +192,64 @@ exports[`Meter basic 1`] = `
 </div>
 `;
 
+exports[`Meter boundary values 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  max-width: 100%;
+  overflow: hidden;
+}
+
+.c1 path {
+  -webkit-transition: stroke 0.3s,stroke-width 0.3s;
+  transition: stroke 0.3s,stroke-width 0.3s;
+}
+
+<div
+  class="c0"
+>
+  <svg
+    class="c1"
+    height="384"
+    viewBox="0 0 384 384"
+    width="384"
+  >
+    <circle
+      cx="192"
+      cy="192"
+      fill="none"
+      r="180"
+      stroke="#F2F2F2"
+      stroke-linecap="square"
+      stroke-opacity="0.4"
+      stroke-width="24"
+    />
+    <path
+      d="M 368.6869942844 157.6240483661 A 180.0000000000 180.0000000000 0 0 0 192.0000000000 12.0000000000"
+      fill="none"
+      stroke="#00873D"
+      stroke-linecap="butt"
+      stroke-width="24"
+    />
+    <path
+      d="M 191.9981778763 12.0000000092 A 180.0000000000 180.0000000000 0 1 0 368.6869942844 157.6240483661"
+      fill="none"
+      stroke="#6FFFB0"
+      stroke-linecap="butt"
+      stroke-width="24"
+    />
+  </svg>
+</div>
+`;
+
 exports[`Meter default 1`] = `
 .c0 {
   font-size: 18px;


### PR DESCRIPTION
#### What does this PR do?

Adds some truncation to deal with floating point precision issues in javascript.

From the test case shown below, `2.26 + 8.04 === 10.299999999999999` instead of `10.3`.

See this post for some details on the underlying shortcomings of javascript: https://stackoverflow.com/questions/1458633/how-to-deal-with-floating-point-number-precision-in-javascript

#### Where should the reviewer start?

Meter.js

#### What testing has been done on this PR?

The test scenario from the issue involves:
```
<Meter
  type="circle"
  values={[{ value: 2.26 }, { value: 8.04 }]}
  max={10.3}
/>
```

A unit test has been added.

#### How should this be manually tested?

see ^^^

#### Do Jest tests follow these best practices?

follows existing test patterns

#### What are the relevant issues?

#6190 

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
