### PR TITLE
Removed grid.available since IE is no longer supported

### DIFF
--- a/src/js/all/stories/AllComponents.js
+++ b/src/js/all/stories/AllComponents.js
@@ -131,26 +131,26 @@ const Components = () => {
         name="check"
         checked={checkBox}
         label="CheckBox"
-        onChange={event => setCheckBox(event.target.checked)}
+        onChange={(event) => setCheckBox(event.target.checked)}
       />
       <CheckBox
         name="toggle"
         toggle
         checked={checkBox}
         label="CheckBox toggle"
-        onChange={event => setCheckBox(event.target.checked)}
+        onChange={(event) => setCheckBox(event.target.checked)}
       />
       <RadioButtonGroup
         name="radio"
         options={['RadioButton 1', 'RadioButton 2']}
         value={radioButton}
-        onChange={event => setRadioButton(event.target.value)}
+        onChange={(event) => setRadioButton(event.target.value)}
       />
       <TextInput
         placeholder="TextInput"
         suggestions={['a', 'b', 'c']}
         value={textInput}
-        onChange={event => setTextInput(event.target.value)}
+        onChange={(event) => setTextInput(event.target.value)}
         onSelect={({ suggestion }) => setTextInput(suggestion)}
       />
       <MaskedInput
@@ -170,13 +170,13 @@ const Components = () => {
           },
         ]}
         value={maskedInput}
-        onChange={event => setMaskedInput(event.target.value)}
+        onChange={(event) => setMaskedInput(event.target.value)}
       />
       <TextArea placeholder="TextArea" />
       <RangeInput value={24} onChange={() => {}} />
       <Stack>
         <Box direction="row" justify="between">
-          {[0, 1, 2, 3].map(value => (
+          {[0, 1, 2, 3].map((value) => (
             <Box key={value} pad="small">
               <Text style={{ fontFamily: 'monospace' }}>{value}</Text>
             </Box>
@@ -190,7 +190,7 @@ const Components = () => {
           size="full"
           round="small"
           values={rangeSelector}
-          onChange={values => setRangeSelector(values)}
+          onChange={(values) => setRangeSelector(values)}
         />
       </Stack>
       <FormField label="FormField">
@@ -228,7 +228,7 @@ const Components = () => {
           { value: 5, color: 'light-4' },
         ]}
       >
-        {value => (
+        {(value) => (
           <Box pad="xsmall" background={value.color} fill>
             <Text size="large">{value.value}</Text>
           </Box>
@@ -237,12 +237,12 @@ const Components = () => {
       <Stack>
         <Box>
           <Box direction="row">
-            {[1, 2].map(id => (
+            {[1, 2].map((id) => (
               <Node key={id} id={id} />
             ))}
           </Box>
           <Box direction="row">
-            {[3, 4].map(id => (
+            {[3, 4].map((id) => (
               <Node key={id} id={id} />
             ))}
           </Box>
@@ -279,7 +279,7 @@ const Components = () => {
       </Accordion>
     </Box>,
     <Box key="tabs">
-      <Tabs activeIndex={tabIndex} onActive={index => setTabIndex(index)}>
+      <Tabs activeIndex={tabIndex} onActive={(index) => setTabIndex(index)}>
         <Tab title="Tab 1">
           <Box pad="small">
             <Text>Tab 1 content</Text>
@@ -327,7 +327,7 @@ const Components = () => {
               size="small"
               options={Object.keys(themes)}
               value={themeName}
-              onChange={event => setThemeName(event.option)}
+              onChange={(event) => setThemeName(event.option)}
             />
           </Box>
           {themeCanMode && (
@@ -347,7 +347,7 @@ const Components = () => {
                 size="small"
                 options={['default', 'dark-1', 'light-1']}
                 value={background}
-                onChange={event => setBackground(event.option)}
+                onChange={(event) => setBackground(event.option)}
               />
             </Box>
           )}
@@ -357,7 +357,9 @@ const Components = () => {
               max={36}
               step={2}
               value={baseSize}
-              onChange={event => setBaseSize(parseInt(event.target.value, 10))}
+              onChange={(event) =>
+                setBaseSize(parseInt(event.target.value, 10))
+              }
             />
           </Box>
           <Text size="small">{`${baseSize}px base spacing`}</Text>
@@ -370,15 +372,9 @@ const Components = () => {
           background={background || theme.global.colors.background}
           overflow="auto"
         >
-          {Grid.available ? (
-            <Grid columns="small" gap="medium">
-              {content}
-            </Grid>
-          ) : (
-            <Box direction="row" wrap align="start" gap="large">
-              {content}
-            </Box>
-          )}
+          <Grid columns="small" gap="medium">
+            {content}
+          </Grid>
         </Box>
       </Grommet>
     </div>

--- a/src/js/components/DataChart/DataChart.js
+++ b/src/js/components/DataChart/DataChart.js
@@ -698,39 +698,6 @@ const DataChart = forwardRef(
       />
     ) : null;
 
-    // IE11
-    if (!Grid.available) {
-      let content = stackElement;
-      if (xAxisElement) {
-        content = (
-          <Box>
-            {content}
-            {xAxisElement}
-          </Box>
-        );
-      }
-      if (yAxisElement) {
-        content = (
-          <Box direction="row">
-            <Box>
-              {yAxisElement}
-              <Box ref={spacerRef} flex={false} />
-            </Box>
-            {content}
-          </Box>
-        );
-      }
-      if (legendElement) {
-        content = (
-          <Box>
-            {content}
-            {legendElement}
-          </Box>
-        );
-      }
-      return content;
-    }
-
     let content = (
       <Grid
         ref={ref}

--- a/src/js/components/DataChart/__tests__/__snapshots__/DataChart-test.js.snap
+++ b/src/js/components/DataChart/__tests__/__snapshots__/DataChart-test.js.snap
@@ -11,21 +11,28 @@ exports[`DataChart areas 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c1 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  grid-area: xAxis;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-left: 48px;
+  padding-right: 48px;
 }
 
-.c2 {
+.c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -39,7 +46,7 @@ exports[`DataChart areas 1`] = `
   flex-direction: column;
 }
 
-.c3 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -61,7 +68,7 @@ exports[`DataChart areas 1`] = `
   justify-content: space-between;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -88,48 +95,19 @@ exports[`DataChart areas 1`] = `
   justify-content: center;
 }
 
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-}
-
-.c10 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  grid-area: xAxis;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  padding-left: 48px;
-  padding-right: 48px;
-}
-
 .c8 {
   display: block;
   max-width: 100%;
   overflow: visible;
+}
+
+.c1 {
+  display: grid;
+  box-sizing: border-box;
+  grid-template-areas: "yAxis charts" ". xAxis";
+  grid-template-columns: auto auto;
+  grid-gap: 12px 12px;
+  grid-template-rows: auto auto;
 }
 
 .c6 {
@@ -151,7 +129,7 @@ exports[`DataChart areas 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c10 {
+  .c2 {
     padding-left: 24px;
     padding-right: 24px;
   }
@@ -169,95 +147,83 @@ exports[`DataChart areas 1`] = `
       <div
         class="c3"
       >
-        <div
-          class="c4"
-        >
-          240K
-        </div>
-        <div
-          class="c4"
-        >
-          0K
-        </div>
+        0
+      </div>
+      <div
+        class="c3"
+      >
+        1
+      </div>
+    </div>
+    <div
+      class="c4"
+    >
+      <div
+        class="c5"
+      >
+        240K
       </div>
       <div
         class="c5"
-        style="height: 0px;"
-      />
+      >
+        0K
+      </div>
     </div>
     <div
-      class="c2"
+      class="c6"
     >
       <div
-        class="c6"
+        class="c7"
       >
-        <div
-          class="c7"
-        >
-          <svg
-            class="c8"
-            height="192"
-            preserveAspectRatio="none"
-            viewBox="0 0 384 192"
-            width="384"
-          >
-            0
-            <g
-              fill="#00873D"
-              stroke="#00873D"
-              stroke-linecap="butt"
-              stroke-linejoin="miter"
-              stroke-width="96"
-            >
-              <g>
-                <path
-                  d="M 48,99.5552 L 336,55.1104 L 336,143.9992 L 48,143.9996 Z"
-                />
-              </g>
-            </g>
-          </svg>
-        </div>
-        <div
-          class="c9"
-        >
-          <svg
-            class="c8"
-            height="192"
-            preserveAspectRatio="none"
-            viewBox="0 0 384 192"
-            width="384"
-          >
-            0
-            <g
-              fill="#6FFFB0"
-              opacity="0.4"
-              stroke="#6FFFB0"
-              stroke-linecap="butt"
-              stroke-linejoin="miter"
-              stroke-width="1"
-            >
-              <g>
-                <path
-                  d="M 48,143.9996 L 336,143.9992 L 336,144 L 48,144 Z"
-                />
-              </g>
-            </g>
-          </svg>
-        </div>
-      </div>
-      <div
-        class="c10"
-      >
-        <div
-          class="c2"
+        <svg
+          class="c8"
+          height="192"
+          preserveAspectRatio="none"
+          viewBox="0 0 384 192"
+          width="384"
         >
           0
-        </div>
-        <div
-          class="c2"
+          <g
+            fill="#00873D"
+            stroke="#00873D"
+            stroke-linecap="butt"
+            stroke-linejoin="miter"
+            stroke-width="96"
+          >
+            <g>
+              <path
+                d="M 48,99.5552 L 336,55.1104 L 336,143.9992 L 48,143.9996 Z"
+              />
+            </g>
+          </g>
+        </svg>
+      </div>
+      <div
+        class="c9"
+      >
+        <svg
+          class="c8"
+          height="192"
+          preserveAspectRatio="none"
+          viewBox="0 0 384 192"
+          width="384"
         >
-          1
-        </div>
+          0
+          <g
+            fill="#6FFFB0"
+            opacity="0.4"
+            stroke="#6FFFB0"
+            stroke-linecap="butt"
+            stroke-linejoin="miter"
+            stroke-width="1"
+          >
+            <g>
+              <path
+                d="M 48,143.9996 L 336,143.9992 L 336,144 L 48,144 Z"
+              />
+            </g>
+          </g>
+        </svg>
       </div>
     </div>
   </div>
@@ -275,21 +241,28 @@ exports[`DataChart axis 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c1 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  grid-area: xAxis;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-left: 48px;
+  padding-right: 48px;
 }
 
-.c2 {
+.c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -303,7 +276,7 @@ exports[`DataChart axis 1`] = `
   flex-direction: column;
 }
 
-.c3 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -325,7 +298,7 @@ exports[`DataChart axis 1`] = `
   justify-content: space-between;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -346,48 +319,19 @@ exports[`DataChart axis 1`] = `
   flex: 0 1 auto;
 }
 
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-}
-
-.c9 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  grid-area: xAxis;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  padding-left: 48px;
-  padding-right: 48px;
-}
-
 .c8 {
   display: block;
   max-width: 100%;
   overflow: visible;
+}
+
+.c1 {
+  display: grid;
+  box-sizing: border-box;
+  grid-template-areas: "yAxis charts" ". xAxis";
+  grid-template-columns: auto auto;
+  grid-gap: 12px 12px;
+  grid-template-rows: auto auto;
 }
 
 .c6 {
@@ -401,7 +345,7 @@ exports[`DataChart axis 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c9 {
+  .c2 {
     padding-left: 24px;
     padding-right: 24px;
   }
@@ -419,126 +363,28 @@ exports[`DataChart axis 1`] = `
       <div
         class="c3"
       >
-        <div
-          class="c4"
-        >
-          2
-        </div>
-        <div
-          class="c4"
-        >
-          0.8
-        </div>
+        0
+      </div>
+      <div
+        class="c3"
+      >
+        1
+      </div>
+    </div>
+    <div
+      class="c4"
+    >
+      <div
+        class="c5"
+      >
+        2
       </div>
       <div
         class="c5"
-        style="height: 0px;"
-      />
-    </div>
-    <div
-      class="c2"
-    >
-      <div
-        class="c6"
       >
-        <div
-          class="c7"
-        >
-          <svg
-            class="c8"
-            height="192"
-            preserveAspectRatio="none"
-            viewBox="0 0 384 192"
-            width="384"
-          >
-            0
-            <g
-              fill="none"
-              stroke="#6FFFB0"
-              stroke-linecap="butt"
-              stroke-linejoin="miter"
-              stroke-width="96"
-            >
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 48,192 L 48,160"
-                />
-              </g>
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 336,192 L 336,0"
-                />
-              </g>
-            </g>
-          </svg>
-        </div>
-      </div>
-      <div
-        class="c9"
-      >
-        <div
-          class="c2"
-        >
-          0
-        </div>
-        <div
-          class="c2"
-        >
-          1
-        </div>
+        0.8
       </div>
     </div>
-  </div>
-  <div
-    class="c6"
-  >
-    <div
-      class="c7"
-    >
-      <svg
-        class="c8"
-        height="192"
-        preserveAspectRatio="none"
-        viewBox="0 0 384 192"
-        width="384"
-      >
-        0
-        <g
-          fill="none"
-          stroke="#6FFFB0"
-          stroke-linecap="butt"
-          stroke-linejoin="miter"
-          stroke-width="96"
-        >
-          <g
-            fill="none"
-          >
-            <title />
-            <path
-              d="M 48,192 L 48,160"
-            />
-          </g>
-          <g
-            fill="none"
-          >
-            <title />
-            <path
-              d="M 336,192 L 336,0"
-            />
-          </g>
-        </g>
-      </svg>
-    </div>
-  </div>
-  <div
-    class="c2"
-  >
     <div
       class="c6"
     >
@@ -580,18 +426,49 @@ exports[`DataChart axis 1`] = `
         </svg>
       </div>
     </div>
+  </div>
+  <div
+    class="c1"
+  >
     <div
-      class="c9"
+      class="c6"
     >
       <div
-        class="c2"
+        class="c7"
       >
-        0
-      </div>
-      <div
-        class="c2"
-      >
-        1
+        <svg
+          class="c8"
+          height="192"
+          preserveAspectRatio="none"
+          viewBox="0 0 384 192"
+          width="384"
+        >
+          0
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            stroke-linecap="butt"
+            stroke-linejoin="miter"
+            stroke-width="96"
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 48,192 L 48,160"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 336,192 L 336,0"
+              />
+            </g>
+          </g>
+        </svg>
       </div>
     </div>
   </div>
@@ -604,20 +481,13 @@ exports[`DataChart axis 1`] = `
       <div
         class="c3"
       >
-        <div
-          class="c4"
-        >
-          2
-        </div>
-        <div
-          class="c4"
-        >
-          0.8
-        </div>
+        0
       </div>
       <div
-        class="c5"
-      />
+        class="c3"
+      >
+        1
+      </div>
     </div>
     <div
       class="c6"
@@ -662,8 +532,22 @@ exports[`DataChart axis 1`] = `
     </div>
   </div>
   <div
-    class="c2"
+    class="c1"
   >
+    <div
+      class="c4"
+    >
+      <div
+        class="c5"
+      >
+        2
+      </div>
+      <div
+        class="c5"
+      >
+        0.8
+      </div>
+    </div>
     <div
       class="c6"
     >
@@ -703,20 +587,6 @@ exports[`DataChart axis 1`] = `
             </g>
           </g>
         </svg>
-      </div>
-    </div>
-    <div
-      class="c9"
-    >
-      <div
-        class="c2"
-      >
-        0
-      </div>
-      <div
-        class="c2"
-      >
-        1
       </div>
     </div>
   </div>
@@ -729,35 +599,87 @@ exports[`DataChart axis 1`] = `
       <div
         class="c3"
       >
-        <div
-          class="c4"
+        0
+      </div>
+      <div
+        class="c3"
+      >
+        1
+      </div>
+    </div>
+    <div
+      class="c6"
+    >
+      <div
+        class="c7"
+      >
+        <svg
+          class="c8"
+          height="192"
+          preserveAspectRatio="none"
+          viewBox="0 0 384 192"
+          width="384"
         >
-          2
-        </div>
-        <div
-          class="c4"
-        >
-          1.7
-        </div>
-        <div
-          class="c4"
-        >
-          1.4
-        </div>
-        <div
-          class="c4"
-        >
-          1.1
-        </div>
-        <div
-          class="c4"
-        >
-          0.8
-        </div>
+          0
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            stroke-linecap="butt"
+            stroke-linejoin="miter"
+            stroke-width="96"
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 48,192 L 48,160"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 336,192 L 336,0"
+              />
+            </g>
+          </g>
+        </svg>
+      </div>
+    </div>
+  </div>
+  <div
+    class="c1"
+  >
+    <div
+      class="c4"
+    >
+      <div
+        class="c5"
+      >
+        2
       </div>
       <div
         class="c5"
-      />
+      >
+        1.7
+      </div>
+      <div
+        class="c5"
+      >
+        1.4
+      </div>
+      <div
+        class="c5"
+      >
+        1.1
+      </div>
+      <div
+        class="c5"
+      >
+        0.8
+      </div>
     </div>
     <div
       class="c6"
@@ -815,21 +737,7 @@ exports[`DataChart axis x granularity 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c5 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -877,6 +785,20 @@ exports[`DataChart axis x granularity 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
   grid-area: xAxis;
   min-width: 0;
   min-height: 0;
@@ -891,7 +813,7 @@ exports[`DataChart axis x granularity 1`] = `
   padding-right: 24px;
 }
 
-.c8 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -912,38 +834,47 @@ exports[`DataChart axis x granularity 1`] = `
   padding-right: 12px;
 }
 
-.c4 {
+.c5 {
   display: block;
   max-width: 100%;
   overflow: visible;
 }
 
-.c2 {
+.c1 {
+  display: grid;
+  box-sizing: border-box;
+  grid-template-areas: "yAxis charts" ". xAxis";
+  grid-template-columns: auto auto;
+  grid-gap: 12px 12px;
+  grid-template-rows: auto auto;
+}
+
+.c3 {
   position: relative;
   grid-area: charts;
 }
 
-.c3 {
+.c4 {
   position: relative;
   display: block;
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c2 {
     padding-left: 24px;
     padding-right: 24px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c7 {
+  .c8 {
     padding-left: 12px;
     padding-right: 12px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c9 {
     padding-left: 6px;
     padding-right: 6px;
   }
@@ -957,12 +888,15 @@ exports[`DataChart axis x granularity 1`] = `
   >
     <div
       class="c2"
+    />
+    <div
+      class="c3"
     >
       <div
-        class="c3"
+        class="c4"
       >
         <svg
-          class="c4"
+          class="c5"
           height="192"
           preserveAspectRatio="none"
           viewBox="0 0 384 192"
@@ -979,9 +913,6 @@ exports[`DataChart axis x granularity 1`] = `
         </svg>
       </div>
     </div>
-    <div
-      class="c5"
-    />
   </div>
   <div
     class="c1"
@@ -990,10 +921,19 @@ exports[`DataChart axis x granularity 1`] = `
       class="c2"
     >
       <div
-        class="c3"
+        class="c6"
+      >
+        0
+      </div>
+    </div>
+    <div
+      class="c3"
+    >
+      <div
+        class="c4"
       >
         <svg
-          class="c4"
+          class="c5"
           height="192"
           preserveAspectRatio="none"
           viewBox="0 0 384 192"
@@ -1019,15 +959,6 @@ exports[`DataChart axis x granularity 1`] = `
         </svg>
       </div>
     </div>
-    <div
-      class="c5"
-    >
-      <div
-        class="c6"
-      >
-        0
-      </div>
-    </div>
   </div>
   <div
     class="c1"
@@ -1036,10 +967,24 @@ exports[`DataChart axis x granularity 1`] = `
       class="c2"
     >
       <div
-        class="c3"
+        class="c7"
+      >
+        0
+      </div>
+      <div
+        class="c7"
+      >
+        1
+      </div>
+    </div>
+    <div
+      class="c3"
+    >
+      <div
+        class="c4"
       >
         <svg
-          class="c4"
+          class="c5"
           height="192"
           preserveAspectRatio="none"
           viewBox="0 0 384 192"
@@ -1073,20 +1018,6 @@ exports[`DataChart axis x granularity 1`] = `
         </svg>
       </div>
     </div>
-    <div
-      class="c5"
-    >
-      <div
-        class="c1"
-      >
-        0
-      </div>
-      <div
-        class="c1"
-      >
-        1
-      </div>
-    </div>
   </div>
   <div
     class="c1"
@@ -1095,10 +1026,29 @@ exports[`DataChart axis x granularity 1`] = `
       class="c2"
     >
       <div
-        class="c3"
+        class="c6"
+      >
+        0
+      </div>
+      <div
+        class="c6"
+      >
+        1
+      </div>
+      <div
+        class="c6"
+      >
+        2
+      </div>
+    </div>
+    <div
+      class="c3"
+    >
+      <div
+        class="c4"
       >
         <svg
-          class="c4"
+          class="c5"
           height="192"
           preserveAspectRatio="none"
           viewBox="0 0 384 192"
@@ -1140,8 +1090,12 @@ exports[`DataChart axis x granularity 1`] = `
         </svg>
       </div>
     </div>
+  </div>
+  <div
+    class="c1"
+  >
     <div
-      class="c5"
+      class="c2"
     >
       <div
         class="c6"
@@ -1158,19 +1112,20 @@ exports[`DataChart axis x granularity 1`] = `
       >
         2
       </div>
+      <div
+        class="c6"
+      >
+        3
+      </div>
     </div>
-  </div>
-  <div
-    class="c1"
-  >
     <div
-      class="c2"
+      class="c3"
     >
       <div
-        class="c3"
+        class="c4"
       >
         <svg
-          class="c4"
+          class="c5"
           height="192"
           preserveAspectRatio="none"
           viewBox="0 0 384 192"
@@ -1220,8 +1175,12 @@ exports[`DataChart axis x granularity 1`] = `
         </svg>
       </div>
     </div>
+  </div>
+  <div
+    class="c1"
+  >
     <div
-      class="c5"
+      class="c8"
     >
       <div
         class="c6"
@@ -1231,31 +1190,22 @@ exports[`DataChart axis x granularity 1`] = `
       <div
         class="c6"
       >
-        1
-      </div>
-      <div
-        class="c6"
-      >
         2
       </div>
       <div
         class="c6"
       >
-        3
+        4
       </div>
     </div>
-  </div>
-  <div
-    class="c1"
-  >
     <div
-      class="c2"
+      class="c3"
     >
       <div
-        class="c3"
+        class="c4"
       >
         <svg
-          class="c4"
+          class="c5"
           height="192"
           preserveAspectRatio="none"
           viewBox="0 0 384 192"
@@ -1313,37 +1263,32 @@ exports[`DataChart axis x granularity 1`] = `
         </svg>
       </div>
     </div>
-    <div
-      class="c7"
-    >
-      <div
-        class="c6"
-      >
-        0
-      </div>
-      <div
-        class="c6"
-      >
-        2
-      </div>
-      <div
-        class="c6"
-      >
-        4
-      </div>
-    </div>
   </div>
   <div
     class="c1"
   >
     <div
-      class="c2"
+      class="c8"
     >
       <div
-        class="c3"
+        class="c7"
+      >
+        0
+      </div>
+      <div
+        class="c7"
+      >
+        5
+      </div>
+    </div>
+    <div
+      class="c3"
+    >
+      <div
+        class="c4"
       >
         <svg
-          class="c4"
+          class="c5"
           height="192"
           preserveAspectRatio="none"
           viewBox="0 0 384 192"
@@ -1409,32 +1354,42 @@ exports[`DataChart axis x granularity 1`] = `
         </svg>
       </div>
     </div>
-    <div
-      class="c7"
-    >
-      <div
-        class="c1"
-      >
-        0
-      </div>
-      <div
-        class="c1"
-      >
-        5
-      </div>
-    </div>
   </div>
   <div
     class="c1"
   >
     <div
-      class="c2"
+      class="c8"
     >
       <div
-        class="c3"
+        class="c6"
+      >
+        0
+      </div>
+      <div
+        class="c6"
+      >
+        2
+      </div>
+      <div
+        class="c6"
+      >
+        4
+      </div>
+      <div
+        class="c6"
+      >
+        6
+      </div>
+    </div>
+    <div
+      class="c3"
+    >
+      <div
+        class="c4"
       >
         <svg
-          class="c4"
+          class="c5"
           height="192"
           preserveAspectRatio="none"
           viewBox="0 0 384 192"
@@ -1508,42 +1463,32 @@ exports[`DataChart axis x granularity 1`] = `
         </svg>
       </div>
     </div>
-    <div
-      class="c7"
-    >
-      <div
-        class="c6"
-      >
-        0
-      </div>
-      <div
-        class="c6"
-      >
-        2
-      </div>
-      <div
-        class="c6"
-      >
-        4
-      </div>
-      <div
-        class="c6"
-      >
-        6
-      </div>
-    </div>
   </div>
   <div
     class="c1"
   >
     <div
-      class="c2"
+      class="c8"
     >
       <div
-        class="c3"
+        class="c7"
+      >
+        0
+      </div>
+      <div
+        class="c7"
+      >
+        7
+      </div>
+    </div>
+    <div
+      class="c3"
+    >
+      <div
+        class="c4"
       >
         <svg
-          class="c4"
+          class="c5"
           height="192"
           preserveAspectRatio="none"
           viewBox="0 0 384 192"
@@ -1625,32 +1570,47 @@ exports[`DataChart axis x granularity 1`] = `
         </svg>
       </div>
     </div>
-    <div
-      class="c7"
-    >
-      <div
-        class="c1"
-      >
-        0
-      </div>
-      <div
-        class="c1"
-      >
-        7
-      </div>
-    </div>
   </div>
   <div
     class="c1"
   >
     <div
-      class="c2"
+      class="c8"
     >
       <div
-        class="c3"
+        class="c6"
+      >
+        0
+      </div>
+      <div
+        class="c6"
+      >
+        2
+      </div>
+      <div
+        class="c6"
+      >
+        4
+      </div>
+      <div
+        class="c6"
+      >
+        6
+      </div>
+      <div
+        class="c6"
+      >
+        8
+      </div>
+    </div>
+    <div
+      class="c3"
+    >
+      <div
+        class="c4"
       >
         <svg
-          class="c4"
+          class="c5"
           height="192"
           preserveAspectRatio="none"
           viewBox="0 0 384 192"
@@ -1740,8 +1700,12 @@ exports[`DataChart axis x granularity 1`] = `
         </svg>
       </div>
     </div>
+  </div>
+  <div
+    class="c1"
+  >
     <div
-      class="c7"
+      class="c8"
     >
       <div
         class="c6"
@@ -1751,12 +1715,7 @@ exports[`DataChart axis x granularity 1`] = `
       <div
         class="c6"
       >
-        2
-      </div>
-      <div
-        class="c6"
-      >
-        4
+        3
       </div>
       <div
         class="c6"
@@ -1766,21 +1725,17 @@ exports[`DataChart axis x granularity 1`] = `
       <div
         class="c6"
       >
-        8
+        9
       </div>
     </div>
-  </div>
-  <div
-    class="c1"
-  >
     <div
-      class="c2"
+      class="c3"
     >
       <div
-        class="c3"
+        class="c4"
       >
         <svg
-          class="c4"
+          class="c5"
           height="192"
           preserveAspectRatio="none"
           viewBox="0 0 384 192"
@@ -1878,8 +1833,12 @@ exports[`DataChart axis x granularity 1`] = `
         </svg>
       </div>
     </div>
+  </div>
+  <div
+    class="c1"
+  >
     <div
-      class="c7"
+      class="c9"
     >
       <div
         class="c6"
@@ -1889,31 +1848,22 @@ exports[`DataChart axis x granularity 1`] = `
       <div
         class="c6"
       >
-        3
+        5
       </div>
       <div
         class="c6"
       >
-        6
-      </div>
-      <div
-        class="c6"
-      >
-        9
+        10
       </div>
     </div>
-  </div>
-  <div
-    class="c1"
-  >
     <div
-      class="c2"
+      class="c3"
     >
       <div
-        class="c3"
+        class="c4"
       >
         <svg
-          class="c4"
+          class="c5"
           height="192"
           preserveAspectRatio="none"
           viewBox="0 0 384 192"
@@ -2019,37 +1969,32 @@ exports[`DataChart axis x granularity 1`] = `
         </svg>
       </div>
     </div>
-    <div
-      class="c8"
-    >
-      <div
-        class="c6"
-      >
-        0
-      </div>
-      <div
-        class="c6"
-      >
-        5
-      </div>
-      <div
-        class="c6"
-      >
-        10
-      </div>
-    </div>
   </div>
   <div
     class="c1"
   >
     <div
-      class="c2"
+      class="c9"
     >
       <div
-        class="c3"
+        class="c7"
+      >
+        0
+      </div>
+      <div
+        class="c7"
+      >
+        11
+      </div>
+    </div>
+    <div
+      class="c3"
+    >
+      <div
+        class="c4"
       >
         <svg
-          class="c4"
+          class="c5"
           height="192"
           preserveAspectRatio="none"
           viewBox="0 0 384 192"
@@ -2163,32 +2108,47 @@ exports[`DataChart axis x granularity 1`] = `
         </svg>
       </div>
     </div>
-    <div
-      class="c8"
-    >
-      <div
-        class="c1"
-      >
-        0
-      </div>
-      <div
-        class="c1"
-      >
-        11
-      </div>
-    </div>
   </div>
   <div
     class="c1"
   >
     <div
-      class="c2"
+      class="c9"
     >
       <div
-        class="c3"
+        class="c6"
+      >
+        0
+      </div>
+      <div
+        class="c6"
+      >
+        3
+      </div>
+      <div
+        class="c6"
+      >
+        6
+      </div>
+      <div
+        class="c6"
+      >
+        9
+      </div>
+      <div
+        class="c6"
+      >
+        12
+      </div>
+    </div>
+    <div
+      class="c3"
+    >
+      <div
+        class="c4"
       >
         <svg
-          class="c4"
+          class="c5"
           height="192"
           preserveAspectRatio="none"
           viewBox="0 0 384 192"
@@ -2310,35 +2270,6 @@ exports[`DataChart axis x granularity 1`] = `
         </svg>
       </div>
     </div>
-    <div
-      class="c8"
-    >
-      <div
-        class="c6"
-      >
-        0
-      </div>
-      <div
-        class="c6"
-      >
-        3
-      </div>
-      <div
-        class="c6"
-      >
-        6
-      </div>
-      <div
-        class="c6"
-      >
-        9
-      </div>
-      <div
-        class="c6"
-      >
-        12
-      </div>
-    </div>
   </div>
 </div>
 `;
@@ -2354,21 +2285,28 @@ exports[`DataChart bars 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c1 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  grid-area: xAxis;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-left: 48px;
+  padding-right: 48px;
 }
 
-.c2 {
+.c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2382,7 +2320,7 @@ exports[`DataChart bars 1`] = `
   flex-direction: column;
 }
 
-.c3 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2404,7 +2342,7 @@ exports[`DataChart bars 1`] = `
   justify-content: space-between;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2431,48 +2369,19 @@ exports[`DataChart bars 1`] = `
   justify-content: center;
 }
 
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-}
-
-.c10 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  grid-area: xAxis;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  padding-left: 48px;
-  padding-right: 48px;
-}
-
 .c8 {
   display: block;
   max-width: 100%;
   overflow: visible;
+}
+
+.c1 {
+  display: grid;
+  box-sizing: border-box;
+  grid-template-areas: "yAxis charts" ". xAxis";
+  grid-template-columns: auto auto;
+  grid-gap: 12px 12px;
+  grid-template-rows: auto auto;
 }
 
 .c6 {
@@ -2494,7 +2403,7 @@ exports[`DataChart bars 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c10 {
+  .c2 {
     padding-left: 24px;
     padding-right: 24px;
   }
@@ -2512,116 +2421,104 @@ exports[`DataChart bars 1`] = `
       <div
         class="c3"
       >
-        <div
-          class="c4"
-        >
-          240K
-        </div>
-        <div
-          class="c4"
-        >
-          0K
-        </div>
+        0
+      </div>
+      <div
+        class="c3"
+      >
+        1
+      </div>
+    </div>
+    <div
+      class="c4"
+    >
+      <div
+        class="c5"
+      >
+        240K
       </div>
       <div
         class="c5"
-        style="height: 0px;"
-      />
+      >
+        0K
+      </div>
     </div>
     <div
-      class="c2"
+      class="c6"
     >
       <div
-        class="c6"
+        class="c7"
       >
-        <div
-          class="c7"
-        >
-          <svg
-            class="c8"
-            height="192"
-            preserveAspectRatio="none"
-            viewBox="0 0 384 192"
-            width="384"
-          >
-            0
-            <g
-              fill="none"
-              stroke="#00873D"
-              stroke-linecap="butt"
-              stroke-linejoin="miter"
-              stroke-width="96"
-            >
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 48,143.9996 L 48,99.5552"
-                />
-              </g>
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 336,143.9992 L 336,55.1104"
-                />
-              </g>
-            </g>
-          </svg>
-        </div>
-        <div
-          class="c9"
-        >
-          <svg
-            class="c8"
-            height="192"
-            preserveAspectRatio="none"
-            viewBox="0 0 384 192"
-            width="384"
-          >
-            0
-            <g
-              fill="none"
-              stroke="#6FFFB0"
-              stroke-linecap="butt"
-              stroke-linejoin="miter"
-              stroke-width="96"
-            >
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 48,144 L 48,143.9996"
-                />
-              </g>
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 336,144 L 336,143.9992"
-                />
-              </g>
-            </g>
-          </svg>
-        </div>
-      </div>
-      <div
-        class="c10"
-      >
-        <div
-          class="c2"
+        <svg
+          class="c8"
+          height="192"
+          preserveAspectRatio="none"
+          viewBox="0 0 384 192"
+          width="384"
         >
           0
-        </div>
-        <div
-          class="c2"
+          <g
+            fill="none"
+            stroke="#00873D"
+            stroke-linecap="butt"
+            stroke-linejoin="miter"
+            stroke-width="96"
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 48,143.9996 L 48,99.5552"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 336,143.9992 L 336,55.1104"
+              />
+            </g>
+          </g>
+        </svg>
+      </div>
+      <div
+        class="c9"
+      >
+        <svg
+          class="c8"
+          height="192"
+          preserveAspectRatio="none"
+          viewBox="0 0 384 192"
+          width="384"
         >
-          1
-        </div>
+          0
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            stroke-linecap="butt"
+            stroke-linejoin="miter"
+            stroke-width="96"
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 48,144 L 48,143.9996"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 336,144 L 336,143.9992"
+              />
+            </g>
+          </g>
+        </svg>
       </div>
     </div>
   </div>
@@ -2639,21 +2536,28 @@ exports[`DataChart bars colors 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c1 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  grid-area: xAxis;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-left: 48px;
+  padding-right: 48px;
 }
 
-.c2 {
+.c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2667,7 +2571,7 @@ exports[`DataChart bars colors 1`] = `
   flex-direction: column;
 }
 
-.c3 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2689,7 +2593,7 @@ exports[`DataChart bars colors 1`] = `
   justify-content: space-between;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2716,48 +2620,19 @@ exports[`DataChart bars colors 1`] = `
   justify-content: center;
 }
 
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-}
-
-.c10 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  grid-area: xAxis;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  padding-left: 48px;
-  padding-right: 48px;
-}
-
 .c8 {
   display: block;
   max-width: 100%;
   overflow: visible;
+}
+
+.c1 {
+  display: grid;
+  box-sizing: border-box;
+  grid-template-areas: "yAxis charts" ". xAxis";
+  grid-template-columns: auto auto;
+  grid-gap: 12px 12px;
+  grid-template-rows: auto auto;
 }
 
 .c6 {
@@ -2779,7 +2654,7 @@ exports[`DataChart bars colors 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c10 {
+  .c2 {
     padding-left: 24px;
     padding-right: 24px;
   }
@@ -2797,116 +2672,104 @@ exports[`DataChart bars colors 1`] = `
       <div
         class="c3"
       >
-        <div
-          class="c4"
-        >
-          240K
-        </div>
-        <div
-          class="c4"
-        >
-          0K
-        </div>
+        0
+      </div>
+      <div
+        class="c3"
+      >
+        1
+      </div>
+    </div>
+    <div
+      class="c4"
+    >
+      <div
+        class="c5"
+      >
+        240K
       </div>
       <div
         class="c5"
-        style="height: 0px;"
-      />
+      >
+        0K
+      </div>
     </div>
     <div
-      class="c2"
+      class="c6"
     >
       <div
-        class="c6"
+        class="c7"
       >
-        <div
-          class="c7"
-        >
-          <svg
-            class="c8"
-            height="192"
-            preserveAspectRatio="none"
-            viewBox="0 0 384 192"
-            width="384"
-          >
-            0
-            <g
-              fill="none"
-              stroke="#00739D"
-              stroke-linecap="butt"
-              stroke-linejoin="miter"
-              stroke-width="96"
-            >
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 48,143.9996 L 48,99.5552"
-                />
-              </g>
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 336,143.9992 L 336,55.1104"
-                />
-              </g>
-            </g>
-          </svg>
-        </div>
-        <div
-          class="c9"
-        >
-          <svg
-            class="c8"
-            height="192"
-            preserveAspectRatio="none"
-            viewBox="0 0 384 192"
-            width="384"
-          >
-            0
-            <g
-              fill="none"
-              stroke="#00873D"
-              stroke-linecap="butt"
-              stroke-linejoin="miter"
-              stroke-width="96"
-            >
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 48,144 L 48,143.9996"
-                />
-              </g>
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 336,144 L 336,143.9992"
-                />
-              </g>
-            </g>
-          </svg>
-        </div>
-      </div>
-      <div
-        class="c10"
-      >
-        <div
-          class="c2"
+        <svg
+          class="c8"
+          height="192"
+          preserveAspectRatio="none"
+          viewBox="0 0 384 192"
+          width="384"
         >
           0
-        </div>
-        <div
-          class="c2"
+          <g
+            fill="none"
+            stroke="#00739D"
+            stroke-linecap="butt"
+            stroke-linejoin="miter"
+            stroke-width="96"
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 48,143.9996 L 48,99.5552"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 336,143.9992 L 336,55.1104"
+              />
+            </g>
+          </g>
+        </svg>
+      </div>
+      <div
+        class="c9"
+      >
+        <svg
+          class="c8"
+          height="192"
+          preserveAspectRatio="none"
+          viewBox="0 0 384 192"
+          width="384"
         >
-          1
-        </div>
+          0
+          <g
+            fill="none"
+            stroke="#00873D"
+            stroke-linecap="butt"
+            stroke-linejoin="miter"
+            stroke-width="96"
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 48,144 L 48,143.9996"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 336,144 L 336,143.9992"
+              />
+            </g>
+          </g>
+        </svg>
       </div>
     </div>
   </div>
@@ -2924,74 +2787,7 @@ exports[`DataChart bars empty 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-}
-
 .c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  grid-area: yAxis;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 1 1;
-  -ms-flex: 1 1;
-  flex: 1 1;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-}
-
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-}
-
-.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3012,88 +2808,6 @@ exports[`DataChart bars empty 1`] = `
   padding-right: 48px;
 }
 
-.c5 {
-  position: relative;
-  grid-area: charts;
-}
-
-@media only screen and (max-width:768px) {
-  .c6 {
-    padding-left: 24px;
-    padding-right: 24px;
-  }
-}
-
-<div
-  class="c0"
->
-  <div
-    class="c1"
-  >
-    <div
-      class="c2"
-    >
-      <div
-        class="c3"
-      />
-      <div
-        class="c4"
-        style="height: 0px;"
-      />
-    </div>
-    <div
-      class="c2"
-    >
-      <div
-        class="c5"
-      />
-      <div
-        class="c6"
-      />
-    </div>
-  </div>
-</div>
-`;
-
-exports[`DataChart bars invalid 1`] = `
-.c0 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-}
-
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
 .c3 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -3116,7 +2830,115 @@ exports[`DataChart bars invalid 1`] = `
   justify-content: space-between;
 }
 
+.c1 {
+  display: grid;
+  box-sizing: border-box;
+  grid-template-areas: "yAxis charts" ". xAxis";
+  grid-template-columns: auto auto;
+  grid-gap: 12px 12px;
+  grid-template-rows: auto auto;
+}
+
 .c4 {
+  position: relative;
+  grid-area: charts;
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    padding-left: 24px;
+    padding-right: 24px;
+  }
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+  >
+    <div
+      class="c2"
+    />
+    <div
+      class="c3"
+    />
+    <div
+      class="c4"
+    />
+  </div>
+</div>
+`;
+
+exports[`DataChart bars invalid 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  grid-area: xAxis;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-left: 48px;
+  padding-right: 48px;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  grid-area: yAxis;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3143,48 +2965,19 @@ exports[`DataChart bars invalid 1`] = `
   justify-content: center;
 }
 
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-}
-
-.c10 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  grid-area: xAxis;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  padding-left: 48px;
-  padding-right: 48px;
-}
-
 .c8 {
   display: block;
   max-width: 100%;
   overflow: visible;
+}
+
+.c1 {
+  display: grid;
+  box-sizing: border-box;
+  grid-template-areas: "yAxis charts" ". xAxis";
+  grid-template-columns: auto auto;
+  grid-gap: 12px 12px;
+  grid-template-rows: auto auto;
 }
 
 .c6 {
@@ -3206,7 +2999,7 @@ exports[`DataChart bars invalid 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c10 {
+  .c2 {
     padding-left: 24px;
     padding-right: 24px;
   }
@@ -3224,119 +3017,107 @@ exports[`DataChart bars invalid 1`] = `
       <div
         class="c3"
       >
-        <div
-          class="c4"
-        >
-          2
-        </div>
-        <div
-          class="c4"
-        >
-          0
-        </div>
+        0
+      </div>
+      <div
+        class="c3"
+      >
+        1
+      </div>
+    </div>
+    <div
+      class="c4"
+    >
+      <div
+        class="c5"
+      >
+        2
       </div>
       <div
         class="c5"
-        style="height: 0px;"
-      />
+      >
+        0
+      </div>
     </div>
     <div
-      class="c2"
+      class="c6"
     >
       <div
-        class="c6"
+        class="c7"
       >
-        <div
-          class="c7"
-        >
-          <svg
-            class="c8"
-            height="192"
-            preserveAspectRatio="none"
-            viewBox="0 0 384 192"
-            width="384"
-          >
-            0
-            <g
-              fill="none"
-              stroke="#3D138D"
-              stroke-linecap="butt"
-              stroke-linejoin="miter"
-              stroke-width="96"
-            />
-          </svg>
-        </div>
-        <div
-          class="c9"
-        >
-          <svg
-            class="c8"
-            height="192"
-            preserveAspectRatio="none"
-            viewBox="0 0 384 192"
-            width="384"
-          >
-            0
-            <g
-              fill="none"
-              stroke="#00873D"
-              stroke-linecap="butt"
-              stroke-linejoin="miter"
-              stroke-width="96"
-            />
-          </svg>
-        </div>
-        <div
-          class="c9"
-        >
-          <svg
-            class="c8"
-            height="192"
-            preserveAspectRatio="none"
-            viewBox="0 0 384 192"
-            width="384"
-          >
-            0
-            <g
-              fill="none"
-              stroke="#6FFFB0"
-              stroke-linecap="butt"
-              stroke-linejoin="miter"
-              stroke-width="96"
-            >
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 48,144 L 48,96"
-                />
-              </g>
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 336,144 L 336,48"
-                />
-              </g>
-            </g>
-          </svg>
-        </div>
-      </div>
-      <div
-        class="c10"
-      >
-        <div
-          class="c2"
+        <svg
+          class="c8"
+          height="192"
+          preserveAspectRatio="none"
+          viewBox="0 0 384 192"
+          width="384"
         >
           0
-        </div>
-        <div
-          class="c2"
+          <g
+            fill="none"
+            stroke="#3D138D"
+            stroke-linecap="butt"
+            stroke-linejoin="miter"
+            stroke-width="96"
+          />
+        </svg>
+      </div>
+      <div
+        class="c9"
+      >
+        <svg
+          class="c8"
+          height="192"
+          preserveAspectRatio="none"
+          viewBox="0 0 384 192"
+          width="384"
         >
-          1
-        </div>
+          0
+          <g
+            fill="none"
+            stroke="#00873D"
+            stroke-linecap="butt"
+            stroke-linejoin="miter"
+            stroke-width="96"
+          />
+        </svg>
+      </div>
+      <div
+        class="c9"
+      >
+        <svg
+          class="c8"
+          height="192"
+          preserveAspectRatio="none"
+          viewBox="0 0 384 192"
+          width="384"
+        >
+          0
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            stroke-linecap="butt"
+            stroke-linejoin="miter"
+            stroke-width="96"
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 48,144 L 48,96"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 336,144 L 336,48"
+              />
+            </g>
+          </g>
+        </svg>
       </div>
     </div>
   </div>
@@ -3354,21 +3135,28 @@ exports[`DataChart bounds align 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c1 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  grid-area: xAxis;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-left: 48px;
+  padding-right: 48px;
 }
 
-.c2 {
+.c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3382,7 +3170,7 @@ exports[`DataChart bounds align 1`] = `
   flex-direction: column;
 }
 
-.c3 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3404,7 +3192,7 @@ exports[`DataChart bounds align 1`] = `
   justify-content: space-between;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3425,48 +3213,19 @@ exports[`DataChart bounds align 1`] = `
   flex: 0 1 auto;
 }
 
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-}
-
-.c9 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  grid-area: xAxis;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  padding-left: 48px;
-  padding-right: 48px;
-}
-
 .c8 {
   display: block;
   max-width: 100%;
   overflow: visible;
+}
+
+.c1 {
+  display: grid;
+  box-sizing: border-box;
+  grid-template-areas: "yAxis charts" ". xAxis";
+  grid-template-columns: auto auto;
+  grid-gap: 12px 12px;
+  grid-template-rows: auto auto;
 }
 
 .c6 {
@@ -3480,7 +3239,7 @@ exports[`DataChart bounds align 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c9 {
+  .c2 {
     padding-left: 24px;
     padding-right: 24px;
   }
@@ -3498,79 +3257,67 @@ exports[`DataChart bounds align 1`] = `
       <div
         class="c3"
       >
-        <div
-          class="c4"
-        >
-          240K
-        </div>
-        <div
-          class="c4"
-        >
-          100K
-        </div>
+        0
+      </div>
+      <div
+        class="c3"
+      >
+        1
+      </div>
+    </div>
+    <div
+      class="c4"
+    >
+      <div
+        class="c5"
+      >
+        240K
       </div>
       <div
         class="c5"
-        style="height: 0px;"
-      />
+      >
+        100K
+      </div>
     </div>
     <div
-      class="c2"
+      class="c6"
     >
       <div
-        class="c6"
+        class="c7"
       >
-        <div
-          class="c7"
-        >
-          <svg
-            class="c8"
-            height="192"
-            preserveAspectRatio="none"
-            viewBox="0 0 384 192"
-            width="384"
-          >
-            0
-            <g
-              fill="none"
-              stroke="#6FFFB0"
-              stroke-linecap="butt"
-              stroke-linejoin="miter"
-              stroke-width="96"
-            >
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 48,192 L 48,176.76205714285715"
-                />
-              </g>
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 336,192 L 336,24.38125714285715"
-                />
-              </g>
-            </g>
-          </svg>
-        </div>
-      </div>
-      <div
-        class="c9"
-      >
-        <div
-          class="c2"
+        <svg
+          class="c8"
+          height="192"
+          preserveAspectRatio="none"
+          viewBox="0 0 384 192"
+          width="384"
         >
           0
-        </div>
-        <div
-          class="c2"
-        >
-          1
-        </div>
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            stroke-linecap="butt"
+            stroke-linejoin="miter"
+            stroke-width="96"
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 48,192 L 48,176.76205714285715"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 336,192 L 336,24.38125714285715"
+              />
+            </g>
+          </g>
+        </svg>
       </div>
     </div>
   </div>
@@ -3588,95 +3335,7 @@ exports[`DataChart bounds explicit 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-}
-
 .c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  grid-area: yAxis;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 1 1;
-  -ms-flex: 1 1;
-  flex: 1 1;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-}
-
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 1 auto;
-  -ms-flex: 0 1 auto;
-  flex: 0 1 auto;
-}
-
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-}
-
-.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3697,146 +3356,7 @@ exports[`DataChart bounds explicit 1`] = `
   padding-right: 48px;
 }
 
-.c8 {
-  display: block;
-  max-width: 100%;
-  overflow: visible;
-}
-
-.c6 {
-  position: relative;
-  grid-area: charts;
-}
-
-.c7 {
-  position: relative;
-  display: block;
-}
-
-@media only screen and (max-width:768px) {
-  .c9 {
-    padding-left: 24px;
-    padding-right: 24px;
-  }
-}
-
-<div
-  class="c0"
->
-  <div
-    class="c1"
-  >
-    <div
-      class="c2"
-    >
-      <div
-        class="c3"
-      >
-        <div
-          class="c4"
-        >
-          100
-        </div>
-        <div
-          class="c4"
-        >
-          0
-        </div>
-      </div>
-      <div
-        class="c5"
-        style="height: 0px;"
-      />
-    </div>
-    <div
-      class="c2"
-    >
-      <div
-        class="c6"
-      >
-        <div
-          class="c7"
-        >
-          <svg
-            class="c8"
-            height="192"
-            preserveAspectRatio="none"
-            viewBox="0 0 384 192"
-            width="384"
-          >
-            0
-            <g
-              fill="none"
-              stroke="#6FFFB0"
-              stroke-linecap="butt"
-              stroke-linejoin="miter"
-              stroke-width="96"
-            >
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 48,192 L 48,-213141.12"
-                />
-              </g>
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 336,192 L 336,-426474.24"
-                />
-              </g>
-            </g>
-          </svg>
-        </div>
-      </div>
-      <div
-        class="c9"
-      >
-        <div
-          class="c2"
-        >
-          0
-        </div>
-        <div
-          class="c2"
-        >
-          1
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`DataChart dates 1`] = `
-.c0 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-}
-
-.c2 {
+.c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3850,7 +3370,7 @@ exports[`DataChart dates 1`] = `
   flex-direction: column;
 }
 
-.c3 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3872,7 +3392,7 @@ exports[`DataChart dates 1`] = `
   justify-content: space-between;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3893,7 +3413,150 @@ exports[`DataChart dates 1`] = `
   flex: 0 1 auto;
 }
 
-.c5 {
+.c8 {
+  display: block;
+  max-width: 100%;
+  overflow: visible;
+}
+
+.c1 {
+  display: grid;
+  box-sizing: border-box;
+  grid-template-areas: "yAxis charts" ". xAxis";
+  grid-template-columns: auto auto;
+  grid-gap: 12px 12px;
+  grid-template-rows: auto auto;
+}
+
+.c6 {
+  position: relative;
+  grid-area: charts;
+}
+
+.c7 {
+  position: relative;
+  display: block;
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    padding-left: 24px;
+    padding-right: 24px;
+  }
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+  >
+    <div
+      class="c2"
+    >
+      <div
+        class="c3"
+      >
+        0
+      </div>
+      <div
+        class="c3"
+      >
+        1
+      </div>
+    </div>
+    <div
+      class="c4"
+    >
+      <div
+        class="c5"
+      >
+        100
+      </div>
+      <div
+        class="c5"
+      >
+        0
+      </div>
+    </div>
+    <div
+      class="c6"
+    >
+      <div
+        class="c7"
+      >
+        <svg
+          class="c8"
+          height="192"
+          preserveAspectRatio="none"
+          viewBox="0 0 384 192"
+          width="384"
+        >
+          0
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            stroke-linecap="butt"
+            stroke-linejoin="miter"
+            stroke-width="96"
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 48,192 L 48,-213141.12"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 336,192 L 336,-426474.24"
+              />
+            </g>
+          </g>
+        </svg>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DataChart dates 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  grid-area: xAxis;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-left: 48px;
+  padding-right: 48px;
+}
+
+.c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3905,9 +3568,49 @@ exports[`DataChart dates 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  grid-area: yAxis;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
 }
 
 .c8 {
@@ -3986,31 +3689,19 @@ exports[`DataChart dates 1`] = `
   flex-direction: column;
 }
 
-.c14 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  grid-area: xAxis;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  padding-left: 48px;
-  padding-right: 48px;
-}
-
 .c13 {
   display: block;
   max-width: 100%;
   overflow: visible;
+}
+
+.c1 {
+  display: grid;
+  box-sizing: border-box;
+  grid-template-areas: "yAxis charts" ". xAxis";
+  grid-template-columns: auto auto;
+  grid-gap: 12px 12px;
+  grid-template-rows: auto auto;
 }
 
 .c6 {
@@ -4032,6 +3723,13 @@ exports[`DataChart dates 1`] = `
 }
 
 @media only screen and (max-width:768px) {
+  .c2 {
+    padding-left: 24px;
+    padding-right: 24px;
+  }
+}
+
+@media only screen and (max-width:768px) {
   .c9 {
     border-left: solid 1px rgba(0,0,0,0.33);
   }
@@ -4040,13 +3738,6 @@ exports[`DataChart dates 1`] = `
 @media only screen and (max-width:768px) {
   .c11 {
     border-top: solid 1px rgba(0,0,0,0.33);
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c14 {
-    padding-left: 24px;
-    padding-right: 24px;
   }
 }
 
@@ -4062,123 +3753,111 @@ exports[`DataChart dates 1`] = `
       <div
         class="c3"
       >
-        <div
-          class="c4"
-        >
-          350K
-        </div>
-        <div
-          class="c4"
-        >
-          0K
-        </div>
+        0
+      </div>
+      <div
+        class="c3"
+      >
+        3
+      </div>
+    </div>
+    <div
+      class="c4"
+    >
+      <div
+        class="c5"
+      >
+        350K
       </div>
       <div
         class="c5"
-        style="height: 0px;"
-      />
+      >
+        0K
+      </div>
     </div>
     <div
-      class="c2"
+      class="c6"
     >
       <div
-        class="c6"
+        class="c7"
       >
         <div
-          class="c7"
+          class="c8"
         >
           <div
-            class="c8"
-          >
-            <div
-              class="c9"
-            />
-            <div
-              class="c9"
-            />
-          </div>
-        </div>
-        <div
-          class="c7"
-        >
+            class="c9"
+          />
           <div
-            class="c10"
-          >
-            <div
-              class="c11"
-            />
-            <div
-              class="c11"
-            />
-          </div>
-        </div>
-        <div
-          class="c12"
-        >
-          <svg
-            class="c13"
-            height="192"
-            preserveAspectRatio="none"
-            viewBox="0 0 384 192"
-            width="384"
-          >
-            0
-            <g
-              fill="none"
-              stroke="#6FFFB0"
-              stroke-linecap="butt"
-              stroke-linejoin="miter"
-              stroke-width="96"
-            >
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 48,192 L 48,192"
-                />
-              </g>
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 144,192 L 144,131.04768"
-                />
-              </g>
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 240,192 L 240,70.09536000000001"
-                />
-              </g>
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 336,192 L 336,9.143040000000013"
-                />
-              </g>
-            </g>
-          </svg>
+            class="c9"
+          />
         </div>
       </div>
       <div
-        class="c14"
+        class="c7"
       >
         <div
-          class="c2"
+          class="c10"
+        >
+          <div
+            class="c11"
+          />
+          <div
+            class="c11"
+          />
+        </div>
+      </div>
+      <div
+        class="c12"
+      >
+        <svg
+          class="c13"
+          height="192"
+          preserveAspectRatio="none"
+          viewBox="0 0 384 192"
+          width="384"
         >
           0
-        </div>
-        <div
-          class="c2"
-        >
-          3
-        </div>
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            stroke-linecap="butt"
+            stroke-linejoin="miter"
+            stroke-width="96"
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 48,192 L 48,192"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 144,192 L 144,131.04768"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 240,192 L 240,70.09536000000001"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 336,192 L 336,9.143040000000013"
+              />
+            </g>
+          </g>
+        </svg>
       </div>
     </div>
   </div>
@@ -4191,123 +3870,111 @@ exports[`DataChart dates 1`] = `
       <div
         class="c3"
       >
-        <div
-          class="c4"
-        >
-          350K
-        </div>
-        <div
-          class="c4"
-        >
-          0K
-        </div>
+        0
+      </div>
+      <div
+        class="c3"
+      >
+        3
+      </div>
+    </div>
+    <div
+      class="c4"
+    >
+      <div
+        class="c5"
+      >
+        350K
       </div>
       <div
         class="c5"
-        style="height: 0px;"
-      />
+      >
+        0K
+      </div>
     </div>
     <div
-      class="c2"
+      class="c6"
     >
       <div
-        class="c6"
+        class="c7"
       >
         <div
-          class="c7"
+          class="c8"
         >
           <div
-            class="c8"
-          >
-            <div
-              class="c9"
-            />
-            <div
-              class="c9"
-            />
-          </div>
-        </div>
-        <div
-          class="c7"
-        >
+            class="c9"
+          />
           <div
-            class="c10"
-          >
-            <div
-              class="c11"
-            />
-            <div
-              class="c11"
-            />
-          </div>
-        </div>
-        <div
-          class="c12"
-        >
-          <svg
-            class="c13"
-            height="192"
-            preserveAspectRatio="none"
-            viewBox="0 0 384 192"
-            width="384"
-          >
-            0
-            <g
-              fill="none"
-              stroke="#6FFFB0"
-              stroke-linecap="butt"
-              stroke-linejoin="miter"
-              stroke-width="96"
-            >
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 48,192 L 48,192"
-                />
-              </g>
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 144,192 L 144,131.04768"
-                />
-              </g>
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 240,192 L 240,70.09536000000001"
-                />
-              </g>
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 336,192 L 336,9.143040000000013"
-                />
-              </g>
-            </g>
-          </svg>
+            class="c9"
+          />
         </div>
       </div>
       <div
-        class="c14"
+        class="c7"
       >
         <div
-          class="c2"
+          class="c10"
+        >
+          <div
+            class="c11"
+          />
+          <div
+            class="c11"
+          />
+        </div>
+      </div>
+      <div
+        class="c12"
+      >
+        <svg
+          class="c13"
+          height="192"
+          preserveAspectRatio="none"
+          viewBox="0 0 384 192"
+          width="384"
         >
           0
-        </div>
-        <div
-          class="c2"
-        >
-          3
-        </div>
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            stroke-linecap="butt"
+            stroke-linejoin="miter"
+            stroke-width="96"
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 48,192 L 48,192"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 144,192 L 144,131.04768"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 240,192 L 240,70.09536000000001"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 336,192 L 336,9.143040000000013"
+              />
+            </g>
+          </g>
+        </svg>
       </div>
     </div>
   </div>
@@ -4320,123 +3987,111 @@ exports[`DataChart dates 1`] = `
       <div
         class="c3"
       >
-        <div
-          class="c4"
-        >
-          350K
-        </div>
-        <div
-          class="c4"
-        >
-          0K
-        </div>
+        0
+      </div>
+      <div
+        class="c3"
+      >
+        3
+      </div>
+    </div>
+    <div
+      class="c4"
+    >
+      <div
+        class="c5"
+      >
+        350K
       </div>
       <div
         class="c5"
-        style="height: 0px;"
-      />
+      >
+        0K
+      </div>
     </div>
     <div
-      class="c2"
+      class="c6"
     >
       <div
-        class="c6"
+        class="c7"
       >
         <div
-          class="c7"
+          class="c8"
         >
           <div
-            class="c8"
-          >
-            <div
-              class="c9"
-            />
-            <div
-              class="c9"
-            />
-          </div>
-        </div>
-        <div
-          class="c7"
-        >
+            class="c9"
+          />
           <div
-            class="c10"
-          >
-            <div
-              class="c11"
-            />
-            <div
-              class="c11"
-            />
-          </div>
-        </div>
-        <div
-          class="c12"
-        >
-          <svg
-            class="c13"
-            height="192"
-            preserveAspectRatio="none"
-            viewBox="0 0 384 192"
-            width="384"
-          >
-            0
-            <g
-              fill="none"
-              stroke="#6FFFB0"
-              stroke-linecap="butt"
-              stroke-linejoin="miter"
-              stroke-width="96"
-            >
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 48,192 L 48,192"
-                />
-              </g>
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 144,192 L 144,131.04768"
-                />
-              </g>
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 240,192 L 240,70.09536000000001"
-                />
-              </g>
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 336,192 L 336,9.143040000000013"
-                />
-              </g>
-            </g>
-          </svg>
+            class="c9"
+          />
         </div>
       </div>
       <div
-        class="c14"
+        class="c7"
       >
         <div
-          class="c2"
+          class="c10"
+        >
+          <div
+            class="c11"
+          />
+          <div
+            class="c11"
+          />
+        </div>
+      </div>
+      <div
+        class="c12"
+      >
+        <svg
+          class="c13"
+          height="192"
+          preserveAspectRatio="none"
+          viewBox="0 0 384 192"
+          width="384"
         >
           0
-        </div>
-        <div
-          class="c2"
-        >
-          3
-        </div>
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            stroke-linecap="butt"
+            stroke-linejoin="miter"
+            stroke-width="96"
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 48,192 L 48,192"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 144,192 L 144,131.04768"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 240,192 L 240,70.09536000000001"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 336,192 L 336,9.143040000000013"
+              />
+            </g>
+          </g>
+        </svg>
       </div>
     </div>
   </div>
@@ -4449,123 +4104,111 @@ exports[`DataChart dates 1`] = `
       <div
         class="c3"
       >
-        <div
-          class="c4"
-        >
-          350K
-        </div>
-        <div
-          class="c4"
-        >
-          0K
-        </div>
+        0
+      </div>
+      <div
+        class="c3"
+      >
+        3
+      </div>
+    </div>
+    <div
+      class="c4"
+    >
+      <div
+        class="c5"
+      >
+        350K
       </div>
       <div
         class="c5"
-        style="height: 0px;"
-      />
+      >
+        0K
+      </div>
     </div>
     <div
-      class="c2"
+      class="c6"
     >
       <div
-        class="c6"
+        class="c7"
       >
         <div
-          class="c7"
+          class="c8"
         >
           <div
-            class="c8"
-          >
-            <div
-              class="c9"
-            />
-            <div
-              class="c9"
-            />
-          </div>
-        </div>
-        <div
-          class="c7"
-        >
+            class="c9"
+          />
           <div
-            class="c10"
-          >
-            <div
-              class="c11"
-            />
-            <div
-              class="c11"
-            />
-          </div>
-        </div>
-        <div
-          class="c12"
-        >
-          <svg
-            class="c13"
-            height="192"
-            preserveAspectRatio="none"
-            viewBox="0 0 384 192"
-            width="384"
-          >
-            0
-            <g
-              fill="none"
-              stroke="#6FFFB0"
-              stroke-linecap="butt"
-              stroke-linejoin="miter"
-              stroke-width="96"
-            >
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 48,192 L 48,192"
-                />
-              </g>
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 144,192 L 144,131.04768"
-                />
-              </g>
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 240,192 L 240,70.09536000000001"
-                />
-              </g>
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 336,192 L 336,9.143040000000013"
-                />
-              </g>
-            </g>
-          </svg>
+            class="c9"
+          />
         </div>
       </div>
       <div
-        class="c14"
+        class="c7"
       >
         <div
-          class="c2"
+          class="c10"
+        >
+          <div
+            class="c11"
+          />
+          <div
+            class="c11"
+          />
+        </div>
+      </div>
+      <div
+        class="c12"
+      >
+        <svg
+          class="c13"
+          height="192"
+          preserveAspectRatio="none"
+          viewBox="0 0 384 192"
+          width="384"
         >
           0
-        </div>
-        <div
-          class="c2"
-        >
-          3
-        </div>
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            stroke-linecap="butt"
+            stroke-linejoin="miter"
+            stroke-width="96"
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 48,192 L 48,192"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 144,192 L 144,131.04768"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 240,192 L 240,70.09536000000001"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 336,192 L 336,9.143040000000013"
+              />
+            </g>
+          </g>
+        </svg>
       </div>
     </div>
   </div>
@@ -4578,123 +4221,111 @@ exports[`DataChart dates 1`] = `
       <div
         class="c3"
       >
-        <div
-          class="c4"
-        >
-          350K
-        </div>
-        <div
-          class="c4"
-        >
-          0K
-        </div>
+        0
+      </div>
+      <div
+        class="c3"
+      >
+        3
+      </div>
+    </div>
+    <div
+      class="c4"
+    >
+      <div
+        class="c5"
+      >
+        350K
       </div>
       <div
         class="c5"
-        style="height: 0px;"
-      />
+      >
+        0K
+      </div>
     </div>
     <div
-      class="c2"
+      class="c6"
     >
       <div
-        class="c6"
+        class="c7"
       >
         <div
-          class="c7"
+          class="c8"
         >
           <div
-            class="c8"
-          >
-            <div
-              class="c9"
-            />
-            <div
-              class="c9"
-            />
-          </div>
-        </div>
-        <div
-          class="c7"
-        >
+            class="c9"
+          />
           <div
-            class="c10"
-          >
-            <div
-              class="c11"
-            />
-            <div
-              class="c11"
-            />
-          </div>
-        </div>
-        <div
-          class="c12"
-        >
-          <svg
-            class="c13"
-            height="192"
-            preserveAspectRatio="none"
-            viewBox="0 0 384 192"
-            width="384"
-          >
-            0
-            <g
-              fill="none"
-              stroke="#6FFFB0"
-              stroke-linecap="butt"
-              stroke-linejoin="miter"
-              stroke-width="96"
-            >
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 48,192 L 48,192"
-                />
-              </g>
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 144,192 L 144,131.04768"
-                />
-              </g>
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 240,192 L 240,70.09536000000001"
-                />
-              </g>
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 336,192 L 336,9.143040000000013"
-                />
-              </g>
-            </g>
-          </svg>
+            class="c9"
+          />
         </div>
       </div>
       <div
-        class="c14"
+        class="c7"
       >
         <div
-          class="c2"
+          class="c10"
+        >
+          <div
+            class="c11"
+          />
+          <div
+            class="c11"
+          />
+        </div>
+      </div>
+      <div
+        class="c12"
+      >
+        <svg
+          class="c13"
+          height="192"
+          preserveAspectRatio="none"
+          viewBox="0 0 384 192"
+          width="384"
         >
           0
-        </div>
-        <div
-          class="c2"
-        >
-          3
-        </div>
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            stroke-linecap="butt"
+            stroke-linejoin="miter"
+            stroke-width="96"
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 48,192 L 48,192"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 144,192 L 144,131.04768"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 240,192 L 240,70.09536000000001"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 336,192 L 336,9.143040000000013"
+              />
+            </g>
+          </g>
+        </svg>
       </div>
     </div>
   </div>
@@ -4707,123 +4338,111 @@ exports[`DataChart dates 1`] = `
       <div
         class="c3"
       >
-        <div
-          class="c4"
-        >
-          350K
-        </div>
-        <div
-          class="c4"
-        >
-          0K
-        </div>
+        0
+      </div>
+      <div
+        class="c3"
+      >
+        3
+      </div>
+    </div>
+    <div
+      class="c4"
+    >
+      <div
+        class="c5"
+      >
+        350K
       </div>
       <div
         class="c5"
-        style="height: 0px;"
-      />
+      >
+        0K
+      </div>
     </div>
     <div
-      class="c2"
+      class="c6"
     >
       <div
-        class="c6"
+        class="c7"
       >
         <div
-          class="c7"
+          class="c8"
         >
           <div
-            class="c8"
-          >
-            <div
-              class="c9"
-            />
-            <div
-              class="c9"
-            />
-          </div>
-        </div>
-        <div
-          class="c7"
-        >
+            class="c9"
+          />
           <div
-            class="c10"
-          >
-            <div
-              class="c11"
-            />
-            <div
-              class="c11"
-            />
-          </div>
-        </div>
-        <div
-          class="c12"
-        >
-          <svg
-            class="c13"
-            height="192"
-            preserveAspectRatio="none"
-            viewBox="0 0 384 192"
-            width="384"
-          >
-            0
-            <g
-              fill="none"
-              stroke="#6FFFB0"
-              stroke-linecap="butt"
-              stroke-linejoin="miter"
-              stroke-width="96"
-            >
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 48,192 L 48,192"
-                />
-              </g>
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 144,192 L 144,131.04768"
-                />
-              </g>
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 240,192 L 240,70.09536000000001"
-                />
-              </g>
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 336,192 L 336,9.143040000000013"
-                />
-              </g>
-            </g>
-          </svg>
+            class="c9"
+          />
         </div>
       </div>
       <div
-        class="c14"
+        class="c7"
       >
         <div
-          class="c2"
+          class="c10"
+        >
+          <div
+            class="c11"
+          />
+          <div
+            class="c11"
+          />
+        </div>
+      </div>
+      <div
+        class="c12"
+      >
+        <svg
+          class="c13"
+          height="192"
+          preserveAspectRatio="none"
+          viewBox="0 0 384 192"
+          width="384"
         >
           0
-        </div>
-        <div
-          class="c2"
-        >
-          3
-        </div>
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            stroke-linecap="butt"
+            stroke-linejoin="miter"
+            stroke-width="96"
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 48,192 L 48,192"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 144,192 L 144,131.04768"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 240,192 L 240,70.09536000000001"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 336,192 L 336,9.143040000000013"
+              />
+            </g>
+          </g>
+        </svg>
       </div>
     </div>
   </div>
@@ -4841,95 +4460,7 @@ exports[`DataChart default 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-}
-
 .c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  grid-area: yAxis;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 1 1;
-  -ms-flex: 1 1;
-  flex: 1 1;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-}
-
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 1 auto;
-  -ms-flex: 0 1 auto;
-  flex: 0 1 auto;
-}
-
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-}
-
-.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4950,146 +4481,7 @@ exports[`DataChart default 1`] = `
   padding-right: 48px;
 }
 
-.c8 {
-  display: block;
-  max-width: 100%;
-  overflow: visible;
-}
-
-.c6 {
-  position: relative;
-  grid-area: charts;
-}
-
-.c7 {
-  position: relative;
-  display: block;
-}
-
-@media only screen and (max-width:768px) {
-  .c9 {
-    padding-left: 24px;
-    padding-right: 24px;
-  }
-}
-
-<div
-  class="c0"
->
-  <div
-    class="c1"
-  >
-    <div
-      class="c2"
-    >
-      <div
-        class="c3"
-      >
-        <div
-          class="c4"
-        >
-          2
-        </div>
-        <div
-          class="c4"
-        >
-          0.8
-        </div>
-      </div>
-      <div
-        class="c5"
-        style="height: 0px;"
-      />
-    </div>
-    <div
-      class="c2"
-    >
-      <div
-        class="c6"
-      >
-        <div
-          class="c7"
-        >
-          <svg
-            class="c8"
-            height="192"
-            preserveAspectRatio="none"
-            viewBox="0 0 384 192"
-            width="384"
-          >
-            0
-            <g
-              fill="none"
-              stroke="#6FFFB0"
-              stroke-linecap="butt"
-              stroke-linejoin="miter"
-              stroke-width="96"
-            >
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 48,192 L 48,160"
-                />
-              </g>
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 336,192 L 336,0"
-                />
-              </g>
-            </g>
-          </svg>
-        </div>
-      </div>
-      <div
-        class="c9"
-      >
-        <div
-          class="c2"
-        >
-          0
-        </div>
-        <div
-          class="c2"
-        >
-          1
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`DataChart detail 1`] = `
-.c0 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-}
-
-.c2 {
+.c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5103,7 +4495,7 @@ exports[`DataChart detail 1`] = `
   flex-direction: column;
 }
 
-.c3 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5125,7 +4517,7 @@ exports[`DataChart detail 1`] = `
   justify-content: space-between;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5146,7 +4538,150 @@ exports[`DataChart detail 1`] = `
   flex: 0 1 auto;
 }
 
-.c5 {
+.c8 {
+  display: block;
+  max-width: 100%;
+  overflow: visible;
+}
+
+.c1 {
+  display: grid;
+  box-sizing: border-box;
+  grid-template-areas: "yAxis charts" ". xAxis";
+  grid-template-columns: auto auto;
+  grid-gap: 12px 12px;
+  grid-template-rows: auto auto;
+}
+
+.c6 {
+  position: relative;
+  grid-area: charts;
+}
+
+.c7 {
+  position: relative;
+  display: block;
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    padding-left: 24px;
+    padding-right: 24px;
+  }
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+  >
+    <div
+      class="c2"
+    >
+      <div
+        class="c3"
+      >
+        0
+      </div>
+      <div
+        class="c3"
+      >
+        1
+      </div>
+    </div>
+    <div
+      class="c4"
+    >
+      <div
+        class="c5"
+      >
+        2
+      </div>
+      <div
+        class="c5"
+      >
+        0.8
+      </div>
+    </div>
+    <div
+      class="c6"
+    >
+      <div
+        class="c7"
+      >
+        <svg
+          class="c8"
+          height="192"
+          preserveAspectRatio="none"
+          viewBox="0 0 384 192"
+          width="384"
+        >
+          0
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            stroke-linecap="butt"
+            stroke-linejoin="miter"
+            stroke-width="96"
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 48,192 L 48,160"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 336,192 L 336,0"
+              />
+            </g>
+          </g>
+        </svg>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DataChart detail 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  grid-area: xAxis;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-left: 48px;
+  padding-right: 48px;
+}
+
+.c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5158,9 +4693,49 @@ exports[`DataChart detail 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  grid-area: yAxis;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
 }
 
 .c10 {
@@ -5217,31 +4792,19 @@ exports[`DataChart detail 1`] = `
   height: 100%;
 }
 
-.c14 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  grid-area: xAxis;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  padding-left: 48px;
-  padding-right: 48px;
-}
-
 .c8 {
   display: block;
   max-width: 100%;
   overflow: visible;
+}
+
+.c1 {
+  display: grid;
+  box-sizing: border-box;
+  grid-template-areas: "yAxis charts" ". xAxis";
+  grid-template-columns: auto auto;
+  grid-gap: 12px 12px;
+  grid-template-rows: auto auto;
 }
 
 .c6 {
@@ -5303,7 +4866,7 @@ exports[`DataChart detail 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c14 {
+  .c2 {
     padding-left: 24px;
     padding-right: 24px;
   }
@@ -5321,101 +4884,89 @@ exports[`DataChart detail 1`] = `
       <div
         class="c3"
       >
-        <div
-          class="c4"
-        >
-          2
-        </div>
-        <div
-          class="c4"
-        >
-          0.8
-        </div>
+        0
+      </div>
+      <div
+        class="c3"
+      >
+        1
+      </div>
+    </div>
+    <div
+      class="c4"
+    >
+      <div
+        class="c5"
+      >
+        2
       </div>
       <div
         class="c5"
-        style="height: 0px;"
-      />
+      >
+        0.8
+      </div>
     </div>
     <div
-      class="c2"
+      class="c6"
     >
       <div
-        class="c6"
+        class="c7"
       >
-        <div
-          class="c7"
-        >
-          <svg
-            class="c8"
-            height="192"
-            preserveAspectRatio="none"
-            viewBox="0 0 384 192"
-            width="384"
-          >
-            0
-            <g
-              fill="none"
-              stroke="#6FFFB0"
-              stroke-linecap="butt"
-              stroke-linejoin="miter"
-              stroke-width="96"
-            >
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 48,192 L 48,160"
-                />
-              </g>
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 336,192 L 336,0"
-                />
-              </g>
-            </g>
-          </svg>
-        </div>
-        <div
-          class="c9"
-        >
-          <div
-            class="c10 c11"
-            tabindex="0"
-          >
-            <div
-              class="c12"
-            >
-              <div
-                class="c13"
-              />
-            </div>
-            <div
-              class="c12"
-            >
-              <div
-                class="c13"
-              />
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        class="c14"
-      >
-        <div
-          class="c2"
+        <svg
+          class="c8"
+          height="192"
+          preserveAspectRatio="none"
+          viewBox="0 0 384 192"
+          width="384"
         >
           0
-        </div>
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            stroke-linecap="butt"
+            stroke-linejoin="miter"
+            stroke-width="96"
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 48,192 L 48,160"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 336,192 L 336,0"
+              />
+            </g>
+          </g>
+        </svg>
+      </div>
+      <div
+        class="c9"
+      >
         <div
-          class="c2"
+          class="c10 c11"
+          tabindex="0"
         >
-          1
+          <div
+            class="c12"
+          >
+            <div
+              class="c13"
+            />
+          </div>
+          <div
+            class="c12"
+          >
+            <div
+              class="c13"
+            />
+          </div>
         </div>
       </div>
     </div>
@@ -5429,79 +4980,67 @@ exports[`DataChart detail 1`] = `
       <div
         class="c3"
       >
-        <div
-          class="c4"
-        >
-          2
-        </div>
-        <div
-          class="c4"
-        >
-          0.8
-        </div>
+        0
+      </div>
+      <div
+        class="c3"
+      >
+        1
+      </div>
+    </div>
+    <div
+      class="c4"
+    >
+      <div
+        class="c5"
+      >
+        2
       </div>
       <div
         class="c5"
-        style="height: 0px;"
-      />
+      >
+        0.8
+      </div>
     </div>
     <div
-      class="c2"
+      class="c6"
     >
       <div
-        class="c6"
+        class="c7"
       >
-        <div
-          class="c7"
-        >
-          <svg
-            class="c8"
-            height="192"
-            preserveAspectRatio="none"
-            viewBox="0 0 384 192"
-            width="384"
-          >
-            0
-            <g
-              fill="none"
-              stroke="#6FFFB0"
-              stroke-linecap="butt"
-              stroke-linejoin="miter"
-              stroke-width="96"
-            >
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 48,192 L 48,160"
-                />
-              </g>
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 336,192 L 336,0"
-                />
-              </g>
-            </g>
-          </svg>
-        </div>
-      </div>
-      <div
-        class="c14"
-      >
-        <div
-          class="c2"
+        <svg
+          class="c8"
+          height="192"
+          preserveAspectRatio="none"
+          viewBox="0 0 384 192"
+          width="384"
         >
           0
-        </div>
-        <div
-          class="c2"
-        >
-          1
-        </div>
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            stroke-linecap="butt"
+            stroke-linejoin="miter"
+            stroke-width="96"
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 48,192 L 48,160"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 336,192 L 336,0"
+              />
+            </g>
+          </g>
+        </svg>
       </div>
     </div>
   </div>
@@ -5519,95 +5058,7 @@ exports[`DataChart gap 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-}
-
 .c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  grid-area: yAxis;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 1 1;
-  -ms-flex: 1 1;
-  flex: 1 1;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-}
-
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 1 auto;
-  -ms-flex: 0 1 auto;
-  flex: 0 1 auto;
-}
-
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-}
-
-.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5628,316 +5079,7 @@ exports[`DataChart gap 1`] = `
   padding-right: 48px;
 }
 
-.c8 {
-  display: block;
-  max-width: 100%;
-  overflow: visible;
-}
-
-.c6 {
-  position: relative;
-  grid-area: charts;
-}
-
-.c7 {
-  position: relative;
-  display: block;
-}
-
-@media only screen and (max-width:768px) {
-  .c9 {
-    padding-left: 24px;
-    padding-right: 24px;
-  }
-}
-
-<div
-  class="c0"
->
-  <div
-    class="c1"
-  >
-    <div
-      class="c2"
-    >
-      <div
-        class="c3"
-      >
-        <div
-          class="c4"
-        >
-          2
-        </div>
-        <div
-          class="c4"
-        >
-          0.8
-        </div>
-      </div>
-      <div
-        class="c5"
-        style="height: 0px;"
-      />
-    </div>
-    <div
-      class="c2"
-    >
-      <div
-        class="c6"
-      >
-        <div
-          class="c7"
-        >
-          <svg
-            class="c8"
-            height="192"
-            preserveAspectRatio="none"
-            viewBox="0 0 384 192"
-            width="384"
-          >
-            0
-            <g
-              fill="none"
-              stroke="#6FFFB0"
-              stroke-linecap="butt"
-              stroke-linejoin="miter"
-              stroke-width="96"
-            >
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 48,192 L 48,160"
-                />
-              </g>
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 336,192 L 336,0"
-                />
-              </g>
-            </g>
-          </svg>
-        </div>
-      </div>
-      <div
-        class="c9"
-      >
-        <div
-          class="c2"
-        >
-          0
-        </div>
-        <div
-          class="c2"
-        >
-          1
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="c1"
-  >
-    <div
-      class="c2"
-    >
-      <div
-        class="c3"
-      >
-        <div
-          class="c4"
-        >
-          2
-        </div>
-        <div
-          class="c4"
-        >
-          0.8
-        </div>
-      </div>
-      <div
-        class="c5"
-        style="height: 0px;"
-      />
-    </div>
-    <div
-      class="c2"
-    >
-      <div
-        class="c6"
-      >
-        <div
-          class="c7"
-        >
-          <svg
-            class="c8"
-            height="192"
-            preserveAspectRatio="none"
-            viewBox="0 0 384 192"
-            width="384"
-          >
-            0
-            <g
-              fill="none"
-              stroke="#6FFFB0"
-              stroke-linecap="butt"
-              stroke-linejoin="miter"
-              stroke-width="96"
-            >
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 48,192 L 48,160"
-                />
-              </g>
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 336,192 L 336,0"
-                />
-              </g>
-            </g>
-          </svg>
-        </div>
-      </div>
-      <div
-        class="c9"
-      >
-        <div
-          class="c2"
-        >
-          0
-        </div>
-        <div
-          class="c2"
-        >
-          1
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="c1"
-  >
-    <div
-      class="c2"
-    >
-      <div
-        class="c3"
-      >
-        <div
-          class="c4"
-        >
-          2
-        </div>
-        <div
-          class="c4"
-        >
-          0.8
-        </div>
-      </div>
-      <div
-        class="c5"
-        style="height: 0px;"
-      />
-    </div>
-    <div
-      class="c2"
-    >
-      <div
-        class="c6"
-      >
-        <div
-          class="c7"
-        >
-          <svg
-            class="c8"
-            height="192"
-            preserveAspectRatio="none"
-            viewBox="0 0 384 192"
-            width="384"
-          >
-            0
-            <g
-              fill="none"
-              stroke="#6FFFB0"
-              stroke-linecap="butt"
-              stroke-linejoin="miter"
-              stroke-width="96"
-            >
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 48,192 L 48,160"
-                />
-              </g>
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 336,192 L 336,0"
-                />
-              </g>
-            </g>
-          </svg>
-        </div>
-      </div>
-      <div
-        class="c9"
-      >
-        <div
-          class="c2"
-        >
-          0
-        </div>
-        <div
-          class="c2"
-        >
-          1
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`DataChart guide 1`] = `
-.c0 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-}
-
-.c2 {
+.c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5951,7 +5093,7 @@ exports[`DataChart guide 1`] = `
   flex-direction: column;
 }
 
-.c3 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5973,7 +5115,7 @@ exports[`DataChart guide 1`] = `
   justify-content: space-between;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5994,7 +5136,314 @@ exports[`DataChart guide 1`] = `
   flex: 0 1 auto;
 }
 
-.c5 {
+.c8 {
+  display: block;
+  max-width: 100%;
+  overflow: visible;
+}
+
+.c1 {
+  display: grid;
+  box-sizing: border-box;
+  grid-template-areas: "yAxis charts" ". xAxis";
+  grid-template-columns: auto auto;
+  grid-gap: 12px 12px;
+  grid-template-rows: auto auto;
+}
+
+.c9 {
+  display: grid;
+  box-sizing: border-box;
+  grid-template-areas: "yAxis charts" ". xAxis";
+  grid-template-columns: auto auto;
+  grid-gap: 24px 24px;
+  grid-template-rows: auto auto;
+}
+
+.c10 {
+  display: grid;
+  box-sizing: border-box;
+  grid-template-areas: "yAxis charts" ". xAxis";
+  grid-template-columns: auto auto;
+  grid-gap: 48px 48px;
+  grid-template-rows: auto auto;
+}
+
+.c6 {
+  position: relative;
+  grid-area: charts;
+}
+
+.c7 {
+  position: relative;
+  display: block;
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    padding-left: 24px;
+    padding-right: 24px;
+  }
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+  >
+    <div
+      class="c2"
+    >
+      <div
+        class="c3"
+      >
+        0
+      </div>
+      <div
+        class="c3"
+      >
+        1
+      </div>
+    </div>
+    <div
+      class="c4"
+    >
+      <div
+        class="c5"
+      >
+        2
+      </div>
+      <div
+        class="c5"
+      >
+        0.8
+      </div>
+    </div>
+    <div
+      class="c6"
+    >
+      <div
+        class="c7"
+      >
+        <svg
+          class="c8"
+          height="192"
+          preserveAspectRatio="none"
+          viewBox="0 0 384 192"
+          width="384"
+        >
+          0
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            stroke-linecap="butt"
+            stroke-linejoin="miter"
+            stroke-width="96"
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 48,192 L 48,160"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 336,192 L 336,0"
+              />
+            </g>
+          </g>
+        </svg>
+      </div>
+    </div>
+  </div>
+  <div
+    class="c9"
+  >
+    <div
+      class="c2"
+    >
+      <div
+        class="c3"
+      >
+        0
+      </div>
+      <div
+        class="c3"
+      >
+        1
+      </div>
+    </div>
+    <div
+      class="c4"
+    >
+      <div
+        class="c5"
+      >
+        2
+      </div>
+      <div
+        class="c5"
+      >
+        0.8
+      </div>
+    </div>
+    <div
+      class="c6"
+    >
+      <div
+        class="c7"
+      >
+        <svg
+          class="c8"
+          height="192"
+          preserveAspectRatio="none"
+          viewBox="0 0 384 192"
+          width="384"
+        >
+          0
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            stroke-linecap="butt"
+            stroke-linejoin="miter"
+            stroke-width="96"
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 48,192 L 48,160"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 336,192 L 336,0"
+              />
+            </g>
+          </g>
+        </svg>
+      </div>
+    </div>
+  </div>
+  <div
+    class="c10"
+  >
+    <div
+      class="c2"
+    >
+      <div
+        class="c3"
+      >
+        0
+      </div>
+      <div
+        class="c3"
+      >
+        1
+      </div>
+    </div>
+    <div
+      class="c4"
+    >
+      <div
+        class="c5"
+      >
+        2
+      </div>
+      <div
+        class="c5"
+      >
+        0.8
+      </div>
+    </div>
+    <div
+      class="c6"
+    >
+      <div
+        class="c7"
+      >
+        <svg
+          class="c8"
+          height="192"
+          preserveAspectRatio="none"
+          viewBox="0 0 384 192"
+          width="384"
+        >
+          0
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            stroke-linecap="butt"
+            stroke-linejoin="miter"
+            stroke-width="96"
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 48,192 L 48,160"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 336,192 L 336,0"
+              />
+            </g>
+          </g>
+        </svg>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DataChart guide 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  grid-area: xAxis;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-left: 48px;
+  padding-right: 48px;
+}
+
+.c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6006,9 +5455,49 @@ exports[`DataChart guide 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  grid-area: yAxis;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
 }
 
 .c8 {
@@ -6087,31 +5576,19 @@ exports[`DataChart guide 1`] = `
   flex-direction: column;
 }
 
-.c14 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  grid-area: xAxis;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  padding-left: 48px;
-  padding-right: 48px;
-}
-
 .c13 {
   display: block;
   max-width: 100%;
   overflow: visible;
+}
+
+.c1 {
+  display: grid;
+  box-sizing: border-box;
+  grid-template-areas: "yAxis charts" ". xAxis";
+  grid-template-columns: auto auto;
+  grid-gap: 12px 12px;
+  grid-template-rows: auto auto;
 }
 
 .c6 {
@@ -6133,6 +5610,13 @@ exports[`DataChart guide 1`] = `
 }
 
 @media only screen and (max-width:768px) {
+  .c2 {
+    padding-left: 24px;
+    padding-right: 24px;
+  }
+}
+
+@media only screen and (max-width:768px) {
   .c9 {
     border-left: solid 1px rgba(0,0,0,0.33);
   }
@@ -6141,13 +5625,6 @@ exports[`DataChart guide 1`] = `
 @media only screen and (max-width:768px) {
   .c11 {
     border-top: solid 1px rgba(0,0,0,0.33);
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c14 {
-    padding-left: 24px;
-    padding-right: 24px;
   }
 }
 
@@ -6163,107 +5640,95 @@ exports[`DataChart guide 1`] = `
       <div
         class="c3"
       >
-        <div
-          class="c4"
-        >
-          2
-        </div>
-        <div
-          class="c4"
-        >
-          0.8
-        </div>
+        0
+      </div>
+      <div
+        class="c3"
+      >
+        1
+      </div>
+    </div>
+    <div
+      class="c4"
+    >
+      <div
+        class="c5"
+      >
+        2
       </div>
       <div
         class="c5"
-        style="height: 0px;"
-      />
+      >
+        0.8
+      </div>
     </div>
     <div
-      class="c2"
+      class="c6"
     >
       <div
-        class="c6"
+        class="c7"
       >
         <div
-          class="c7"
+          class="c8"
         >
           <div
-            class="c8"
-          >
-            <div
-              class="c9"
-            />
-            <div
-              class="c9"
-            />
-          </div>
-        </div>
-        <div
-          class="c7"
-        >
+            class="c9"
+          />
           <div
-            class="c10"
-          >
-            <div
-              class="c11"
-            />
-            <div
-              class="c11"
-            />
-          </div>
-        </div>
-        <div
-          class="c12"
-        >
-          <svg
-            class="c13"
-            height="192"
-            preserveAspectRatio="none"
-            viewBox="0 0 384 192"
-            width="384"
-          >
-            0
-            <g
-              fill="none"
-              stroke="#6FFFB0"
-              stroke-linecap="butt"
-              stroke-linejoin="miter"
-              stroke-width="96"
-            >
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 48,192 L 48,160"
-                />
-              </g>
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 336,192 L 336,0"
-                />
-              </g>
-            </g>
-          </svg>
+            class="c9"
+          />
         </div>
       </div>
       <div
-        class="c14"
+        class="c7"
       >
         <div
-          class="c2"
+          class="c10"
+        >
+          <div
+            class="c11"
+          />
+          <div
+            class="c11"
+          />
+        </div>
+      </div>
+      <div
+        class="c12"
+      >
+        <svg
+          class="c13"
+          height="192"
+          preserveAspectRatio="none"
+          viewBox="0 0 384 192"
+          width="384"
         >
           0
-        </div>
-        <div
-          class="c2"
-        >
-          1
-        </div>
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            stroke-linecap="butt"
+            stroke-linejoin="miter"
+            stroke-width="96"
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 48,192 L 48,160"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 336,192 L 336,0"
+              />
+            </g>
+          </g>
+        </svg>
       </div>
     </div>
   </div>
@@ -6276,79 +5741,67 @@ exports[`DataChart guide 1`] = `
       <div
         class="c3"
       >
-        <div
-          class="c4"
-        >
-          2
-        </div>
-        <div
-          class="c4"
-        >
-          0.8
-        </div>
+        0
+      </div>
+      <div
+        class="c3"
+      >
+        1
+      </div>
+    </div>
+    <div
+      class="c4"
+    >
+      <div
+        class="c5"
+      >
+        2
       </div>
       <div
         class="c5"
-        style="height: 0px;"
-      />
+      >
+        0.8
+      </div>
     </div>
     <div
-      class="c2"
+      class="c6"
     >
       <div
-        class="c6"
+        class="c12"
       >
-        <div
-          class="c12"
-        >
-          <svg
-            class="c13"
-            height="192"
-            preserveAspectRatio="none"
-            viewBox="0 0 384 192"
-            width="384"
-          >
-            0
-            <g
-              fill="none"
-              stroke="#6FFFB0"
-              stroke-linecap="butt"
-              stroke-linejoin="miter"
-              stroke-width="96"
-            >
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 48,192 L 48,160"
-                />
-              </g>
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 336,192 L 336,0"
-                />
-              </g>
-            </g>
-          </svg>
-        </div>
-      </div>
-      <div
-        class="c14"
-      >
-        <div
-          class="c2"
+        <svg
+          class="c13"
+          height="192"
+          preserveAspectRatio="none"
+          viewBox="0 0 384 192"
+          width="384"
         >
           0
-        </div>
-        <div
-          class="c2"
-        >
-          1
-        </div>
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            stroke-linecap="butt"
+            stroke-linejoin="miter"
+            stroke-width="96"
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 48,192 L 48,160"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 336,192 L 336,0"
+              />
+            </g>
+          </g>
+        </svg>
       </div>
     </div>
   </div>
@@ -6361,93 +5814,81 @@ exports[`DataChart guide 1`] = `
       <div
         class="c3"
       >
-        <div
-          class="c4"
-        >
-          2
-        </div>
-        <div
-          class="c4"
-        >
-          0.8
-        </div>
+        0
+      </div>
+      <div
+        class="c3"
+      >
+        1
+      </div>
+    </div>
+    <div
+      class="c4"
+    >
+      <div
+        class="c5"
+      >
+        2
       </div>
       <div
         class="c5"
-        style="height: 0px;"
-      />
+      >
+        0.8
+      </div>
     </div>
     <div
-      class="c2"
+      class="c6"
     >
       <div
-        class="c6"
+        class="c7"
       >
         <div
-          class="c7"
+          class="c8"
         >
           <div
-            class="c8"
-          >
-            <div
-              class="c9"
-            />
-            <div
-              class="c9"
-            />
-          </div>
-        </div>
-        <div
-          class="c12"
-        >
-          <svg
-            class="c13"
-            height="192"
-            preserveAspectRatio="none"
-            viewBox="0 0 384 192"
-            width="384"
-          >
-            0
-            <g
-              fill="none"
-              stroke="#6FFFB0"
-              stroke-linecap="butt"
-              stroke-linejoin="miter"
-              stroke-width="96"
-            >
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 48,192 L 48,160"
-                />
-              </g>
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 336,192 L 336,0"
-                />
-              </g>
-            </g>
-          </svg>
+            class="c9"
+          />
+          <div
+            class="c9"
+          />
         </div>
       </div>
       <div
-        class="c14"
+        class="c12"
       >
-        <div
-          class="c2"
+        <svg
+          class="c13"
+          height="192"
+          preserveAspectRatio="none"
+          viewBox="0 0 384 192"
+          width="384"
         >
           0
-        </div>
-        <div
-          class="c2"
-        >
-          1
-        </div>
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            stroke-linecap="butt"
+            stroke-linejoin="miter"
+            stroke-width="96"
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 48,192 L 48,160"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 336,192 L 336,0"
+              />
+            </g>
+          </g>
+        </svg>
       </div>
     </div>
   </div>
@@ -6460,102 +5901,90 @@ exports[`DataChart guide 1`] = `
       <div
         class="c3"
       >
-        <div
-          class="c4"
-        >
-          2
-        </div>
-        <div
-          class="c4"
-        >
-          0.8
-        </div>
+        0
+      </div>
+      <div
+        class="c3"
+      >
+        1
+      </div>
+    </div>
+    <div
+      class="c4"
+    >
+      <div
+        class="c5"
+      >
+        2
       </div>
       <div
         class="c5"
-        style="height: 0px;"
-      />
+      >
+        0.8
+      </div>
     </div>
     <div
-      class="c2"
+      class="c6"
     >
       <div
-        class="c6"
+        class="c7"
       >
         <div
-          class="c7"
+          class="c10"
         >
           <div
-            class="c10"
-          >
-            <div
-              class="c11"
-            />
-            <div
-              class="c11"
-            />
-            <div
-              class="c11"
-            />
-            <div
-              class="c11"
-            />
-            <div
-              class="c11"
-            />
-          </div>
-        </div>
-        <div
-          class="c12"
-        >
-          <svg
-            class="c13"
-            height="192"
-            preserveAspectRatio="none"
-            viewBox="0 0 384 192"
-            width="384"
-          >
-            0
-            <g
-              fill="none"
-              stroke="#6FFFB0"
-              stroke-linecap="butt"
-              stroke-linejoin="miter"
-              stroke-width="96"
-            >
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 48,192 L 48,160"
-                />
-              </g>
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 336,192 L 336,0"
-                />
-              </g>
-            </g>
-          </svg>
+            class="c11"
+          />
+          <div
+            class="c11"
+          />
+          <div
+            class="c11"
+          />
+          <div
+            class="c11"
+          />
+          <div
+            class="c11"
+          />
         </div>
       </div>
       <div
-        class="c14"
+        class="c12"
       >
-        <div
-          class="c2"
+        <svg
+          class="c13"
+          height="192"
+          preserveAspectRatio="none"
+          viewBox="0 0 384 192"
+          width="384"
         >
           0
-        </div>
-        <div
-          class="c2"
-        >
-          1
-        </div>
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            stroke-linecap="butt"
+            stroke-linejoin="miter"
+            stroke-width="96"
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 48,192 L 48,160"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 336,192 L 336,0"
+              />
+            </g>
+          </g>
+        </svg>
       </div>
     </div>
   </div>
@@ -6580,6 +6009,10 @@ exports[`DataChart legend 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -6587,7 +6020,28 @@ exports[`DataChart legend 1`] = `
   flex-direction: column;
 }
 
-.c2 {
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  grid-area: xAxis;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-left: 48px;
+  padding-right: 48px;
+}
+
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6596,12 +6050,12 @@ exports[`DataChart legend 1`] = `
   max-width: 100%;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
 }
 
-.c3 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6623,7 +6077,7 @@ exports[`DataChart legend 1`] = `
   justify-content: space-between;
 }
 
-.c4 {
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6642,44 +6096,6 @@ exports[`DataChart legend 1`] = `
   -webkit-flex: 0 1 auto;
   -ms-flex: 0 1 auto;
   flex: 0 1 auto;
-}
-
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-}
-
-.c9 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  grid-area: xAxis;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  padding-left: 48px;
-  padding-right: 48px;
 }
 
 .c10 {
@@ -6737,24 +6153,33 @@ exports[`DataChart legend 1`] = `
   line-height: 24px;
 }
 
-.c8 {
+.c9 {
   display: block;
   max-width: 100%;
   overflow: visible;
 }
 
-.c6 {
+.c2 {
+  display: grid;
+  box-sizing: border-box;
+  grid-template-areas: "yAxis charts" ". xAxis";
+  grid-template-columns: auto auto;
+  grid-gap: 12px 12px;
+  grid-template-rows: auto auto;
+}
+
+.c7 {
   position: relative;
   grid-area: charts;
 }
 
-.c7 {
+.c8 {
   position: relative;
   display: block;
 }
 
 @media only screen and (max-width:768px) {
-  .c9 {
+  .c3 {
     padding-left: 24px;
     padding-right: 24px;
   }
@@ -6796,84 +6221,72 @@ exports[`DataChart legend 1`] = `
       class="c2"
     >
       <div
-        class="c1"
+        class="c3"
       >
         <div
-          class="c3"
+          class="c4"
         >
-          <div
-            class="c4"
-          >
-            2
-          </div>
-          <div
-            class="c4"
-          >
-            0.8
-          </div>
+          0
         </div>
         <div
-          class="c5"
-          style="height: 0px;"
-        />
+          class="c4"
+        >
+          1
+        </div>
       </div>
       <div
-        class="c1"
+        class="c5"
       >
         <div
           class="c6"
         >
-          <div
-            class="c7"
-          >
-            <svg
-              class="c8"
-              height="192"
-              preserveAspectRatio="none"
-              viewBox="0 0 384 192"
-              width="384"
-            >
-              0
-              <g
-                fill="none"
-                stroke="#6FFFB0"
-                stroke-linecap="butt"
-                stroke-linejoin="miter"
-                stroke-width="96"
-              >
-                <g
-                  fill="none"
-                >
-                  <title />
-                  <path
-                    d="M 48,192 L 48,160"
-                  />
-                </g>
-                <g
-                  fill="none"
-                >
-                  <title />
-                  <path
-                    d="M 336,192 L 336,0"
-                  />
-                </g>
-              </g>
-            </svg>
-          </div>
+          2
         </div>
         <div
-          class="c9"
+          class="c6"
         >
-          <div
-            class="c1"
+          0.8
+        </div>
+      </div>
+      <div
+        class="c7"
+      >
+        <div
+          class="c8"
+        >
+          <svg
+            class="c9"
+            height="192"
+            preserveAspectRatio="none"
+            viewBox="0 0 384 192"
+            width="384"
           >
             0
-          </div>
-          <div
-            class="c1"
-          >
-            1
-          </div>
+            <g
+              fill="none"
+              stroke="#6FFFB0"
+              stroke-linecap="butt"
+              stroke-linejoin="miter"
+              stroke-width="96"
+            >
+              <g
+                fill="none"
+              >
+                <title />
+                <path
+                  d="M 48,192 L 48,160"
+                />
+              </g>
+              <g
+                fill="none"
+              >
+                <title />
+                <path
+                  d="M 336,192 L 336,0"
+                />
+              </g>
+            </g>
+          </svg>
         </div>
       </div>
     </div>
@@ -6910,84 +6323,72 @@ exports[`DataChart legend 1`] = `
     class="c2"
   >
     <div
-      class="c1"
+      class="c3"
     >
       <div
-        class="c3"
+        class="c4"
       >
-        <div
-          class="c4"
-        >
-          2
-        </div>
-        <div
-          class="c4"
-        >
-          0.8
-        </div>
+        0
       </div>
       <div
-        class="c5"
-        style="height: 0px;"
-      />
+        class="c4"
+      >
+        1
+      </div>
     </div>
     <div
-      class="c1"
+      class="c5"
     >
       <div
         class="c6"
       >
-        <div
-          class="c7"
-        >
-          <svg
-            class="c8"
-            height="192"
-            preserveAspectRatio="none"
-            viewBox="0 0 384 192"
-            width="384"
-          >
-            0
-            <g
-              fill="none"
-              stroke="#6FFFB0"
-              stroke-linecap="butt"
-              stroke-linejoin="miter"
-              stroke-width="96"
-            >
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 48,192 L 48,160"
-                />
-              </g>
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 336,192 L 336,0"
-                />
-              </g>
-            </g>
-          </svg>
-        </div>
+        2
       </div>
       <div
-        class="c9"
+        class="c6"
       >
-        <div
-          class="c1"
+        0.8
+      </div>
+    </div>
+    <div
+      class="c7"
+    >
+      <div
+        class="c8"
+      >
+        <svg
+          class="c9"
+          height="192"
+          preserveAspectRatio="none"
+          viewBox="0 0 384 192"
+          width="384"
         >
           0
-        </div>
-        <div
-          class="c1"
-        >
-          1
-        </div>
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            stroke-linecap="butt"
+            stroke-linejoin="miter"
+            stroke-width="96"
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 48,192 L 48,160"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 336,192 L 336,0"
+              />
+            </g>
+          </g>
+        </svg>
       </div>
     </div>
   </div>
@@ -7005,21 +6406,28 @@ exports[`DataChart lines 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c1 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  grid-area: xAxis;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-left: 48px;
+  padding-right: 48px;
 }
 
-.c2 {
+.c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7033,7 +6441,7 @@ exports[`DataChart lines 1`] = `
   flex-direction: column;
 }
 
-.c3 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7055,7 +6463,7 @@ exports[`DataChart lines 1`] = `
   justify-content: space-between;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7082,48 +6490,19 @@ exports[`DataChart lines 1`] = `
   justify-content: center;
 }
 
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-}
-
-.c10 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  grid-area: xAxis;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  padding-left: 48px;
-  padding-right: 48px;
-}
-
 .c8 {
   display: block;
   max-width: 100%;
   overflow: visible;
+}
+
+.c1 {
+  display: grid;
+  box-sizing: border-box;
+  grid-template-areas: "yAxis charts" ". xAxis";
+  grid-template-columns: auto auto;
+  grid-gap: 12px 12px;
+  grid-template-rows: auto auto;
 }
 
 .c6 {
@@ -7145,7 +6524,7 @@ exports[`DataChart lines 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c10 {
+  .c2 {
     padding-left: 24px;
     padding-right: 24px;
   }
@@ -7163,98 +6542,86 @@ exports[`DataChart lines 1`] = `
       <div
         class="c3"
       >
-        <div
-          class="c4"
-        >
-          240K
-        </div>
-        <div
-          class="c4"
-        >
-          0K
-        </div>
+        0
+      </div>
+      <div
+        class="c3"
+      >
+        1
+      </div>
+    </div>
+    <div
+      class="c4"
+    >
+      <div
+        class="c5"
+      >
+        240K
       </div>
       <div
         class="c5"
-        style="height: 0px;"
-      />
+      >
+        0K
+      </div>
     </div>
     <div
-      class="c2"
+      class="c6"
     >
       <div
-        class="c6"
+        class="c7"
       >
-        <div
-          class="c7"
-        >
-          <svg
-            class="c8"
-            height="192"
-            preserveAspectRatio="none"
-            viewBox="0 0 384 192"
-            width="384"
-          >
-            0
-            <g
-              fill="none"
-              stroke="#00873D"
-              stroke-linecap="butt"
-              stroke-linejoin="miter"
-              stroke-width="96"
-            >
-              <g
-                fill="none"
-              >
-                <path
-                  d="M 48,99.5552 L 336,55.1104"
-                />
-              </g>
-            </g>
-          </svg>
-        </div>
-        <div
-          class="c9"
-        >
-          <svg
-            class="c8"
-            height="192"
-            preserveAspectRatio="none"
-            viewBox="0 0 384 192"
-            width="384"
-          >
-            0
-            <g
-              fill="none"
-              stroke="#6FFFB0"
-              stroke-linecap="butt"
-              stroke-linejoin="miter"
-              stroke-width="96"
-            >
-              <g
-                fill="none"
-              >
-                <path
-                  d="M 48,143.9996 L 336,143.9992"
-                />
-              </g>
-            </g>
-          </svg>
-        </div>
-      </div>
-      <div
-        class="c10"
-      >
-        <div
-          class="c2"
+        <svg
+          class="c8"
+          height="192"
+          preserveAspectRatio="none"
+          viewBox="0 0 384 192"
+          width="384"
         >
           0
-        </div>
-        <div
-          class="c2"
+          <g
+            fill="none"
+            stroke="#00873D"
+            stroke-linecap="butt"
+            stroke-linejoin="miter"
+            stroke-width="96"
+          >
+            <g
+              fill="none"
+            >
+              <path
+                d="M 48,99.5552 L 336,55.1104"
+              />
+            </g>
+          </g>
+        </svg>
+      </div>
+      <div
+        class="c9"
+      >
+        <svg
+          class="c8"
+          height="192"
+          preserveAspectRatio="none"
+          viewBox="0 0 384 192"
+          width="384"
         >
-          1
-        </div>
+          0
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            stroke-linecap="butt"
+            stroke-linejoin="miter"
+            stroke-width="96"
+          >
+            <g
+              fill="none"
+            >
+              <path
+                d="M 48,143.9996 L 336,143.9992"
+              />
+            </g>
+          </g>
+        </svg>
       </div>
     </div>
   </div>
@@ -7272,95 +6639,7 @@ exports[`DataChart nothing 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-}
-
 .c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  grid-area: yAxis;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 1 1;
-  -ms-flex: 1 1;
-  flex: 1 1;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-}
-
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 1 auto;
-  -ms-flex: 0 1 auto;
-  flex: 0 1 auto;
-}
-
-.c6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-}
-
-.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7381,161 +6660,7 @@ exports[`DataChart nothing 1`] = `
   padding-right: 48px;
 }
 
-.c8 {
-  display: block;
-  max-width: 100%;
-  overflow: visible;
-}
-
-.c1 {
-  position: relative;
-  grid-area: charts;
-}
-
-.c7 {
-  position: relative;
-  display: block;
-}
-
-@media only screen and (max-width:768px) {
-  .c9 {
-    padding-left: 24px;
-    padding-right: 24px;
-  }
-}
-
-<div
-  class="c0"
->
-  <div
-    class="c1"
-  />
-  <div
-    class="c1"
-  />
-  <div
-    class="c1"
-  />
-  <div
-    class="c2"
-  >
-    <div
-      class="c3"
-    >
-      <div
-        class="c4"
-      >
-        <div
-          class="c5"
-        >
-          2
-        </div>
-        <div
-          class="c5"
-        >
-          0.8
-        </div>
-      </div>
-      <div
-        class="c6"
-        style="height: 0px;"
-      />
-    </div>
-    <div
-      class="c3"
-    >
-      <div
-        class="c1"
-      >
-        <div
-          class="c7"
-        >
-          <svg
-            class="c8"
-            height="192"
-            preserveAspectRatio="none"
-            viewBox="0 0 384 192"
-            width="384"
-          >
-            0
-            <g
-              fill="none"
-              stroke="#6FFFB0"
-              stroke-linecap="butt"
-              stroke-linejoin="miter"
-              stroke-width="96"
-            >
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 48,192 L 48,160"
-                />
-              </g>
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 336,192 L 336,0"
-                />
-              </g>
-            </g>
-          </svg>
-        </div>
-      </div>
-      <div
-        class="c9"
-      >
-        <div
-          class="c3"
-        >
-          0
-        </div>
-        <div
-          class="c3"
-        >
-          1
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="c1"
-  />
-  <div
-    class="c1"
-  />
-</div>
-`;
-
-exports[`DataChart offset 1`] = `
-.c0 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-}
-
-.c2 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7549,7 +6674,7 @@ exports[`DataChart offset 1`] = `
   flex-direction: column;
 }
 
-.c3 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7571,7 +6696,7 @@ exports[`DataChart offset 1`] = `
   justify-content: space-between;
 }
 
-.c4 {
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7592,24 +6717,164 @@ exports[`DataChart offset 1`] = `
   flex: 0 1 auto;
 }
 
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
+.c8 {
+  display: block;
   max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
+  overflow: visible;
 }
 
-.c9 {
+.c1 {
+  display: grid;
+  box-sizing: border-box;
+  grid-template-areas: "yAxis charts" ". xAxis";
+  grid-template-columns: auto auto;
+  grid-gap: 12px 12px;
+  grid-template-rows: auto auto;
+}
+
+.c2 {
+  position: relative;
+  grid-area: charts;
+}
+
+.c7 {
+  position: relative;
+  display: block;
+}
+
+@media only screen and (max-width:768px) {
+  .c3 {
+    padding-left: 24px;
+    padding-right: 24px;
+  }
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+  >
+    <div
+      class="c2"
+    />
+  </div>
+  <div
+    class="c1"
+  >
+    <div
+      class="c2"
+    />
+  </div>
+  <div
+    class="c1"
+  >
+    <div
+      class="c2"
+    />
+  </div>
+  <div
+    class="c1"
+  >
+    <div
+      class="c3"
+    >
+      <div
+        class="c4"
+      >
+        0
+      </div>
+      <div
+        class="c4"
+      >
+        1
+      </div>
+    </div>
+    <div
+      class="c5"
+    >
+      <div
+        class="c6"
+      >
+        2
+      </div>
+      <div
+        class="c6"
+      >
+        0.8
+      </div>
+    </div>
+    <div
+      class="c2"
+    >
+      <div
+        class="c7"
+      >
+        <svg
+          class="c8"
+          height="192"
+          preserveAspectRatio="none"
+          viewBox="0 0 384 192"
+          width="384"
+        >
+          0
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            stroke-linecap="butt"
+            stroke-linejoin="miter"
+            stroke-width="96"
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 48,192 L 48,160"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 336,192 L 336,0"
+              />
+            </g>
+          </g>
+        </svg>
+      </div>
+    </div>
+  </div>
+  <div
+    class="c1"
+  >
+    <div
+      class="c2"
+    />
+  </div>
+  <div
+    class="c1"
+  >
+    <div
+      class="c2"
+    />
+  </div>
+</div>
+`;
+
+exports[`DataChart offset 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7631,10 +6896,76 @@ exports[`DataChart offset 1`] = `
   padding-inline-end: 96px;
 }
 
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  grid-area: yAxis;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
+}
+
 .c8 {
   display: block;
   max-width: 100%;
   overflow: visible;
+}
+
+.c1 {
+  display: grid;
+  box-sizing: border-box;
+  grid-template-areas: "yAxis charts" ". xAxis";
+  grid-template-columns: auto auto;
+  grid-gap: 12px 12px;
+  grid-template-rows: auto auto;
 }
 
 .c6 {
@@ -7648,14 +6979,14 @@ exports[`DataChart offset 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c9 {
+  .c2 {
     padding-left: 24px;
     padding-right: 24px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c9 {
+  .c2 {
     padding-inline-end: 96px;
   }
 }
@@ -7668,85 +6999,73 @@ exports[`DataChart offset 1`] = `
   >
     <div
       class="c2"
+      style="transform: translate(0px, 0px);"
     >
       <div
         class="c3"
       >
-        <div
-          class="c4"
-        >
-          240K
-        </div>
-        <div
-          class="c4"
-        >
-          100K
-        </div>
+        0
+      </div>
+      <div
+        class="c3"
+      >
+        1
+      </div>
+    </div>
+    <div
+      class="c4"
+    >
+      <div
+        class="c5"
+      >
+        240K
       </div>
       <div
         class="c5"
-        style="height: 0px;"
-      />
+      >
+        100K
+      </div>
     </div>
     <div
-      class="c2"
+      class="c6"
     >
       <div
-        class="c6"
+        class="c7"
       >
-        <div
-          class="c7"
-        >
-          <svg
-            class="c8"
-            height="192"
-            preserveAspectRatio="none"
-            style="transform: translate(0px, 0px);"
-            viewBox="0 0 384 192"
-            width="384"
-          >
-            0
-            <g
-              fill="none"
-              stroke="#6FFFB0"
-              stroke-linecap="butt"
-              stroke-linejoin="miter"
-              stroke-width="96"
-            >
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 48,192 L 48,176.76205714285715"
-                />
-              </g>
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 288,192 L 288,24.38125714285715"
-                />
-              </g>
-            </g>
-          </svg>
-        </div>
-      </div>
-      <div
-        class="c9"
-        style="transform: translate(0px, 0px);"
-      >
-        <div
-          class="c2"
+        <svg
+          class="c8"
+          height="192"
+          preserveAspectRatio="none"
+          style="transform: translate(0px, 0px);"
+          viewBox="0 0 384 192"
+          width="384"
         >
           0
-        </div>
-        <div
-          class="c2"
-        >
-          1
-        </div>
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            stroke-linecap="butt"
+            stroke-linejoin="miter"
+            stroke-width="96"
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 48,192 L 48,176.76205714285715"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 288,192 L 288,24.38125714285715"
+              />
+            </g>
+          </g>
+        </svg>
       </div>
     </div>
   </div>
@@ -7764,95 +7083,7 @@ exports[`DataChart offset gap 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-}
-
 .c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  grid-area: yAxis;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 1 1;
-  -ms-flex: 1 1;
-  flex: 1 1;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-}
-
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 1 auto;
-  -ms-flex: 0 1 auto;
-  flex: 0 1 auto;
-}
-
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-}
-
-.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7874,154 +7105,7 @@ exports[`DataChart offset gap 1`] = `
   padding-inline-end: 96px;
 }
 
-.c8 {
-  display: block;
-  max-width: 100%;
-  overflow: visible;
-}
-
-.c6 {
-  position: relative;
-  grid-area: charts;
-}
-
-.c7 {
-  position: relative;
-  display: block;
-}
-
-@media only screen and (max-width:768px) {
-  .c9 {
-    padding-left: 24px;
-    padding-right: 24px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c9 {
-    padding-inline-end: 96px;
-  }
-}
-
-<div
-  class="c0"
->
-  <div
-    class="c1"
-  >
-    <div
-      class="c2"
-    >
-      <div
-        class="c3"
-      >
-        <div
-          class="c4"
-        >
-          240K
-        </div>
-        <div
-          class="c4"
-        >
-          100K
-        </div>
-      </div>
-      <div
-        class="c5"
-        style="height: 0px;"
-      />
-    </div>
-    <div
-      class="c2"
-    >
-      <div
-        class="c6"
-      >
-        <div
-          class="c7"
-        >
-          <svg
-            class="c8"
-            height="192"
-            preserveAspectRatio="none"
-            style="transform: translate(0px, 0px);"
-            viewBox="0 0 384 192"
-            width="384"
-          >
-            0
-            <g
-              fill="none"
-              stroke="#6FFFB0"
-              stroke-linecap="butt"
-              stroke-linejoin="miter"
-              stroke-width="96"
-            >
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 48,192 L 48,176.76205714285715"
-                />
-              </g>
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 288,192 L 288,24.38125714285715"
-                />
-              </g>
-            </g>
-          </svg>
-        </div>
-      </div>
-      <div
-        class="c9"
-        style="transform: translate(0px, 0px);"
-      >
-        <div
-          class="c2"
-        >
-          0
-        </div>
-        <div
-          class="c2"
-        >
-          1
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`DataChart pad 1`] = `
-.c0 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-}
-
-.c2 {
+.c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8035,7 +7119,7 @@ exports[`DataChart pad 1`] = `
   flex-direction: column;
 }
 
-.c3 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8057,7 +7141,213 @@ exports[`DataChart pad 1`] = `
   justify-content: space-between;
 }
 
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
+}
+
+.c8 {
+  display: block;
+  max-width: 100%;
+  overflow: visible;
+}
+
+.c1 {
+  display: grid;
+  box-sizing: border-box;
+  grid-template-areas: "yAxis charts" ". xAxis";
+  grid-template-columns: auto auto;
+  grid-gap: 12px 12px;
+  grid-template-rows: auto auto;
+}
+
+.c6 {
+  position: relative;
+  grid-area: charts;
+}
+
+.c7 {
+  position: relative;
+  display: block;
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    padding-left: 24px;
+    padding-right: 24px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    padding-inline-end: 96px;
+  }
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+  >
+    <div
+      class="c2"
+      style="transform: translate(0px, 0px);"
+    >
+      <div
+        class="c3"
+      >
+        0
+      </div>
+      <div
+        class="c3"
+      >
+        1
+      </div>
+    </div>
+    <div
+      class="c4"
+    >
+      <div
+        class="c5"
+      >
+        240K
+      </div>
+      <div
+        class="c5"
+      >
+        100K
+      </div>
+    </div>
+    <div
+      class="c6"
+    >
+      <div
+        class="c7"
+      >
+        <svg
+          class="c8"
+          height="192"
+          preserveAspectRatio="none"
+          style="transform: translate(0px, 0px);"
+          viewBox="0 0 384 192"
+          width="384"
+        >
+          0
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            stroke-linecap="butt"
+            stroke-linejoin="miter"
+            stroke-width="96"
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 48,192 L 48,176.76205714285715"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 288,192 L 288,24.38125714285715"
+              />
+            </g>
+          </g>
+        </svg>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DataChart pad 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  grid-area: xAxis;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
 .c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  grid-area: yAxis;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8084,43 +7374,7 @@ exports[`DataChart pad 1`] = `
   justify-content: center;
 }
 
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-}
-
 .c9 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  grid-area: xAxis;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-}
-
-.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8147,7 +7401,7 @@ exports[`DataChart pad 1`] = `
   justify-content: center;
 }
 
-.c11 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8180,6 +7434,15 @@ exports[`DataChart pad 1`] = `
   overflow: visible;
 }
 
+.c1 {
+  display: grid;
+  box-sizing: border-box;
+  grid-template-areas: "yAxis charts" ". xAxis";
+  grid-template-columns: auto auto;
+  grid-gap: 12px 12px;
+  grid-template-rows: auto auto;
+}
+
 .c6 {
   position: relative;
   grid-area: charts;
@@ -8202,79 +7465,67 @@ exports[`DataChart pad 1`] = `
       <div
         class="c3"
       >
-        <div
-          class="c4"
-        >
-          2
-        </div>
-        <div
-          class="c4"
-        >
-          0.8
-        </div>
+        0
+      </div>
+      <div
+        class="c3"
+      >
+        1
+      </div>
+    </div>
+    <div
+      class="c4"
+    >
+      <div
+        class="c5"
+      >
+        2
       </div>
       <div
         class="c5"
-        style="height: 0px;"
-      />
+      >
+        0.8
+      </div>
     </div>
     <div
-      class="c2"
+      class="c6"
     >
       <div
-        class="c6"
+        class="c7"
       >
-        <div
-          class="c7"
-        >
-          <svg
-            class="c8"
-            height="192"
-            preserveAspectRatio="none"
-            viewBox="0 0 384 192"
-            width="384"
-          >
-            0
-            <g
-              fill="none"
-              stroke="#6FFFB0"
-              stroke-linecap="butt"
-              stroke-linejoin="miter"
-              stroke-width="96"
-            >
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 12,180 L 12,152"
-                />
-              </g>
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 372,180 L 372,12"
-                />
-              </g>
-            </g>
-          </svg>
-        </div>
-      </div>
-      <div
-        class="c9"
-      >
-        <div
-          class="c2"
+        <svg
+          class="c8"
+          height="192"
+          preserveAspectRatio="none"
+          viewBox="0 0 384 192"
+          width="384"
         >
           0
-        </div>
-        <div
-          class="c2"
-        >
-          1
-        </div>
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            stroke-linecap="butt"
+            stroke-linejoin="miter"
+            stroke-width="96"
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 12,180 L 12,152"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 372,180 L 372,12"
+              />
+            </g>
+          </g>
+        </svg>
       </div>
     </div>
   </div>
@@ -8287,79 +7538,67 @@ exports[`DataChart pad 1`] = `
       <div
         class="c3"
       >
-        <div
-          class="c10"
-        >
-          2
-        </div>
-        <div
-          class="c10"
-        >
-          0.8
-        </div>
+        0
       </div>
       <div
-        class="c5"
-        style="height: 0px;"
-      />
+        class="c3"
+      >
+        1
+      </div>
     </div>
     <div
-      class="c2"
+      class="c4"
     >
       <div
-        class="c6"
+        class="c9"
       >
-        <div
-          class="c7"
-        >
-          <svg
-            class="c8"
-            height="192"
-            preserveAspectRatio="none"
-            viewBox="0 0 384 192"
-            width="384"
-          >
-            0
-            <g
-              fill="none"
-              stroke="#6FFFB0"
-              stroke-linecap="butt"
-              stroke-linejoin="miter"
-              stroke-width="96"
-            >
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 24,168 L 24,144"
-                />
-              </g>
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 360,168 L 360,24"
-                />
-              </g>
-            </g>
-          </svg>
-        </div>
+        2
       </div>
       <div
         class="c9"
       >
-        <div
-          class="c2"
+        0.8
+      </div>
+    </div>
+    <div
+      class="c6"
+    >
+      <div
+        class="c7"
+      >
+        <svg
+          class="c8"
+          height="192"
+          preserveAspectRatio="none"
+          viewBox="0 0 384 192"
+          width="384"
         >
           0
-        </div>
-        <div
-          class="c2"
-        >
-          1
-        </div>
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            stroke-linecap="butt"
+            stroke-linejoin="miter"
+            stroke-width="96"
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 24,168 L 24,144"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 360,168 L 360,24"
+              />
+            </g>
+          </g>
+        </svg>
       </div>
     </div>
   </div>
@@ -8372,79 +7611,67 @@ exports[`DataChart pad 1`] = `
       <div
         class="c3"
       >
-        <div
-          class="c11"
-        >
-          2
-        </div>
-        <div
-          class="c11"
-        >
-          0.8
-        </div>
+        0
       </div>
       <div
-        class="c5"
-        style="height: 0px;"
-      />
+        class="c3"
+      >
+        1
+      </div>
     </div>
     <div
-      class="c2"
+      class="c4"
     >
       <div
-        class="c6"
+        class="c10"
       >
-        <div
-          class="c7"
-        >
-          <svg
-            class="c8"
-            height="192"
-            preserveAspectRatio="none"
-            viewBox="0 0 384 192"
-            width="384"
-          >
-            0
-            <g
-              fill="none"
-              stroke="#6FFFB0"
-              stroke-linecap="butt"
-              stroke-linejoin="miter"
-              stroke-width="96"
-            >
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 48,144 L 48,128"
-                />
-              </g>
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 336,144 L 336,48"
-                />
-              </g>
-            </g>
-          </svg>
-        </div>
+        2
       </div>
       <div
-        class="c9"
+        class="c10"
       >
-        <div
-          class="c2"
+        0.8
+      </div>
+    </div>
+    <div
+      class="c6"
+    >
+      <div
+        class="c7"
+      >
+        <svg
+          class="c8"
+          height="192"
+          preserveAspectRatio="none"
+          viewBox="0 0 384 192"
+          width="384"
         >
           0
-        </div>
-        <div
-          class="c2"
-        >
-          1
-        </div>
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            stroke-linecap="butt"
+            stroke-linejoin="miter"
+            stroke-width="96"
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 48,144 L 48,128"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 336,144 L 336,48"
+              />
+            </g>
+          </g>
+        </svg>
       </div>
     </div>
   </div>
@@ -8462,21 +7689,28 @@ exports[`DataChart placeholder node 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c1 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  grid-area: xAxis;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-left: 48px;
+  padding-right: 48px;
 }
 
-.c2 {
+.c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8490,7 +7724,7 @@ exports[`DataChart placeholder node 1`] = `
   flex-direction: column;
 }
 
-.c3 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8512,7 +7746,7 @@ exports[`DataChart placeholder node 1`] = `
   justify-content: space-between;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8531,23 +7765,6 @@ exports[`DataChart placeholder node 1`] = `
   -webkit-flex: 0 1 auto;
   -ms-flex: 0 1 auto;
   flex: 0 1 auto;
-}
-
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c10 {
@@ -8576,27 +7793,6 @@ exports[`DataChart placeholder node 1`] = `
   justify-content: center;
 }
 
-.c12 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  grid-area: xAxis;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  padding-left: 48px;
-  padding-right: 48px;
-}
-
 .c11 {
   font-size: 18px;
   line-height: 24px;
@@ -8606,6 +7802,15 @@ exports[`DataChart placeholder node 1`] = `
   display: block;
   max-width: 100%;
   overflow: visible;
+}
+
+.c1 {
+  display: grid;
+  box-sizing: border-box;
+  grid-template-areas: "yAxis charts" ". xAxis";
+  grid-template-columns: auto auto;
+  grid-gap: 12px 12px;
+  grid-template-rows: auto auto;
 }
 
 .c6 {
@@ -8627,7 +7832,7 @@ exports[`DataChart placeholder node 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c12 {
+  .c2 {
     padding-left: 24px;
     padding-right: 24px;
   }
@@ -8645,74 +7850,62 @@ exports[`DataChart placeholder node 1`] = `
       <div
         class="c3"
       >
-        <div
-          class="c4"
-        >
-          100
-        </div>
-        <div
-          class="c4"
-        >
-          0
-        </div>
+        0
+      </div>
+      <div
+        class="c3"
+      >
+        1
+      </div>
+    </div>
+    <div
+      class="c4"
+    >
+      <div
+        class="c5"
+      >
+        100
       </div>
       <div
         class="c5"
-        style="height: 0px;"
-      />
+      >
+        0
+      </div>
     </div>
     <div
-      class="c2"
+      class="c6"
     >
       <div
-        class="c6"
+        class="c7"
       >
-        <div
-          class="c7"
-        >
-          <svg
-            class="c8"
-            height="192"
-            preserveAspectRatio="none"
-            viewBox="0 0 384 192"
-            width="384"
-          >
-            0
-            <g
-              fill="none"
-              stroke="#6FFFB0"
-              stroke-linecap="butt"
-              stroke-linejoin="miter"
-              stroke-width="96"
-            />
-          </svg>
-        </div>
-        <div
-          class="c9"
-        >
-          <div
-            class="c10"
-          >
-            <span
-              class="c11"
-            >
-              no data
-            </span>
-          </div>
-        </div>
-      </div>
-      <div
-        class="c12"
-      >
-        <div
-          class="c2"
+        <svg
+          class="c8"
+          height="192"
+          preserveAspectRatio="none"
+          viewBox="0 0 384 192"
+          width="384"
         >
           0
-        </div>
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            stroke-linecap="butt"
+            stroke-linejoin="miter"
+            stroke-width="96"
+          />
+        </svg>
+      </div>
+      <div
+        class="c9"
+      >
         <div
-          class="c2"
+          class="c10"
         >
-          1
+          <span
+            class="c11"
+          >
+            no data
+          </span>
         </div>
       </div>
     </div>
@@ -8731,21 +7924,28 @@ exports[`DataChart placeholder text 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c1 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  grid-area: xAxis;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-left: 48px;
+  padding-right: 48px;
 }
 
-.c2 {
+.c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8759,7 +7959,7 @@ exports[`DataChart placeholder text 1`] = `
   flex-direction: column;
 }
 
-.c3 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8781,7 +7981,7 @@ exports[`DataChart placeholder text 1`] = `
   justify-content: space-between;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8800,23 +8000,6 @@ exports[`DataChart placeholder text 1`] = `
   -webkit-flex: 0 1 auto;
   -ms-flex: 0 1 auto;
   flex: 0 1 auto;
-}
-
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c10 {
@@ -8846,27 +8029,6 @@ exports[`DataChart placeholder text 1`] = `
   justify-content: center;
 }
 
-.c12 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  grid-area: xAxis;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  padding-left: 48px;
-  padding-right: 48px;
-}
-
 .c11 {
   font-size: 18px;
   line-height: 24px;
@@ -8877,6 +8039,15 @@ exports[`DataChart placeholder text 1`] = `
   display: block;
   max-width: 100%;
   overflow: visible;
+}
+
+.c1 {
+  display: grid;
+  box-sizing: border-box;
+  grid-template-areas: "yAxis charts" ". xAxis";
+  grid-template-columns: auto auto;
+  grid-gap: 12px 12px;
+  grid-template-rows: auto auto;
 }
 
 .c6 {
@@ -8898,16 +8069,16 @@ exports[`DataChart placeholder text 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c10 {
-    margin-left: 24px;
-    margin-right: 24px;
+  .c2 {
+    padding-left: 24px;
+    padding-right: 24px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c12 {
-    padding-left: 24px;
-    padding-right: 24px;
+  .c10 {
+    margin-left: 24px;
+    margin-right: 24px;
   }
 }
 
@@ -8923,74 +8094,62 @@ exports[`DataChart placeholder text 1`] = `
       <div
         class="c3"
       >
-        <div
-          class="c4"
-        >
-          100
-        </div>
-        <div
-          class="c4"
-        >
-          0
-        </div>
+        0
+      </div>
+      <div
+        class="c3"
+      >
+        1
+      </div>
+    </div>
+    <div
+      class="c4"
+    >
+      <div
+        class="c5"
+      >
+        100
       </div>
       <div
         class="c5"
-        style="height: 0px;"
-      />
+      >
+        0
+      </div>
     </div>
     <div
-      class="c2"
+      class="c6"
     >
       <div
-        class="c6"
+        class="c7"
       >
-        <div
-          class="c7"
-        >
-          <svg
-            class="c8"
-            height="192"
-            preserveAspectRatio="none"
-            viewBox="0 0 384 192"
-            width="384"
-          >
-            0
-            <g
-              fill="none"
-              stroke="#6FFFB0"
-              stroke-linecap="butt"
-              stroke-linejoin="miter"
-              stroke-width="96"
-            />
-          </svg>
-        </div>
-        <div
-          class="c9"
-        >
-          <div
-            class="c10"
-          >
-            <span
-              class="c11"
-            >
-              no data
-            </span>
-          </div>
-        </div>
-      </div>
-      <div
-        class="c12"
-      >
-        <div
-          class="c2"
+        <svg
+          class="c8"
+          height="192"
+          preserveAspectRatio="none"
+          viewBox="0 0 384 192"
+          width="384"
         >
           0
-        </div>
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            stroke-linecap="butt"
+            stroke-linejoin="miter"
+            stroke-width="96"
+          />
+        </svg>
+      </div>
+      <div
+        class="c9"
+      >
         <div
-          class="c2"
+          class="c10"
         >
-          1
+          <span
+            class="c11"
+          >
+            no data
+          </span>
         </div>
       </div>
     </div>
@@ -9009,95 +8168,7 @@ exports[`DataChart single 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-}
-
 .c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  grid-area: yAxis;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 1 1;
-  -ms-flex: 1 1;
-  flex: 1 1;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-}
-
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 1 auto;
-  -ms-flex: 0 1 auto;
-  flex: 0 1 auto;
-}
-
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-}
-
-.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -9118,7 +8189,7 @@ exports[`DataChart single 1`] = `
   padding-right: 48px;
 }
 
-.c10 {
+.c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -9138,10 +8209,62 @@ exports[`DataChart single 1`] = `
   overflow: visible;
 }
 
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  grid-area: yAxis;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
+}
+
 .c8 {
   display: block;
   max-width: 100%;
   overflow: visible;
+}
+
+.c1 {
+  display: grid;
+  box-sizing: border-box;
+  grid-template-areas: "yAxis charts" ". xAxis";
+  grid-template-columns: auto auto;
+  grid-gap: 12px 12px;
+  grid-template-rows: auto auto;
 }
 
 .c6 {
@@ -9155,7 +8278,7 @@ exports[`DataChart single 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c9 {
+  .c2 {
     padding-left: 24px;
     padding-right: 24px;
   }
@@ -9173,66 +8296,54 @@ exports[`DataChart single 1`] = `
       <div
         class="c3"
       >
-        <div
-          class="c4"
-        >
-          1
-        </div>
-        <div
-          class="c4"
-        >
-          0
-        </div>
+        2020-06-24
+      </div>
+    </div>
+    <div
+      class="c4"
+    >
+      <div
+        class="c5"
+      >
+        1
       </div>
       <div
         class="c5"
-        style="height: 0px;"
-      />
+      >
+        0
+      </div>
     </div>
     <div
-      class="c2"
+      class="c6"
     >
       <div
-        class="c6"
+        class="c7"
       >
-        <div
-          class="c7"
+        <svg
+          class="c8"
+          height="192"
+          preserveAspectRatio="none"
+          viewBox="0 0 384 192"
+          width="384"
         >
-          <svg
-            class="c8"
-            height="192"
-            preserveAspectRatio="none"
-            viewBox="0 0 384 192"
-            width="384"
+          0
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            stroke-linecap="butt"
+            stroke-linejoin="miter"
+            stroke-width="96"
           >
-            0
             <g
               fill="none"
-              stroke="#6FFFB0"
-              stroke-linecap="butt"
-              stroke-linejoin="miter"
-              stroke-width="96"
             >
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 48,192 L 48,0"
-                />
-              </g>
+              <title />
+              <path
+                d="M 48,192 L 48,0"
+              />
             </g>
-          </svg>
-        </div>
-      </div>
-      <div
-        class="c9"
-      >
-        <div
-          class="c10"
-        >
-          2020-06-24
-        </div>
+          </g>
+        </svg>
       </div>
     </div>
   </div>
@@ -9250,21 +8361,28 @@ exports[`DataChart size 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c1 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  grid-area: xAxis;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-left: 48px;
+  padding-right: 48px;
 }
 
-.c2 {
+.c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -9278,7 +8396,7 @@ exports[`DataChart size 1`] = `
   flex-direction: column;
 }
 
-.c3 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -9300,7 +8418,7 @@ exports[`DataChart size 1`] = `
   justify-content: space-between;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -9321,48 +8439,40 @@ exports[`DataChart size 1`] = `
   flex: 0 1 auto;
 }
 
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-}
-
-.c9 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  grid-area: xAxis;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  padding-left: 48px;
-  padding-right: 48px;
-}
-
 .c8 {
   display: block;
   max-width: 100%;
   overflow: visible;
+}
+
+.c1 {
+  display: grid;
+  box-sizing: border-box;
+  width: 100%;
+  height: 100%;
+  grid-template-areas: "yAxis charts" ". xAxis";
+  grid-template-columns: auto 1fr;
+  grid-gap: 12px 12px;
+  grid-template-rows: 1fr auto;
+}
+
+.c9 {
+  display: grid;
+  box-sizing: border-box;
+  width: 100%;
+  grid-template-areas: "yAxis charts" ". xAxis";
+  grid-template-columns: auto 1fr;
+  grid-gap: 12px 12px;
+  grid-template-rows: auto auto;
+}
+
+.c11 {
+  display: grid;
+  box-sizing: border-box;
+  grid-template-areas: "yAxis charts" ". xAxis";
+  grid-template-columns: auto auto;
+  grid-gap: 12px 12px;
+  grid-template-rows: auto auto;
 }
 
 .c6 {
@@ -9396,7 +8506,7 @@ exports[`DataChart size 1`] = `
   display: flex;
 }
 
-.c11 {
+.c12 {
   position: relative;
   grid-area: charts;
 }
@@ -9408,13 +8518,13 @@ exports[`DataChart size 1`] = `
   height: 100%;
 }
 
-.c12 {
+.c13 {
   position: relative;
   display: block;
 }
 
 @media only screen and (max-width:768px) {
-  .c9 {
+  .c2 {
     padding-left: 24px;
     padding-right: 24px;
   }
@@ -9432,84 +8542,72 @@ exports[`DataChart size 1`] = `
       <div
         class="c3"
       >
-        <div
-          class="c4"
-        >
-          2
-        </div>
-        <div
-          class="c4"
-        >
-          0.8
-        </div>
+        0
+      </div>
+      <div
+        class="c3"
+      >
+        1
+      </div>
+    </div>
+    <div
+      class="c4"
+    >
+      <div
+        class="c5"
+      >
+        2
       </div>
       <div
         class="c5"
-        style="height: 0px;"
-      />
+      >
+        0.8
+      </div>
     </div>
     <div
-      class="c2"
+      class="c6"
     >
       <div
-        class="c6"
+        class="c7"
       >
-        <div
-          class="c7"
-        >
-          <svg
-            class="c8"
-            height="0"
-            preserveAspectRatio="none"
-            viewBox="0 0 0 0"
-            width="0"
-          >
-            0
-            <g
-              fill="none"
-              stroke="#6FFFB0"
-              stroke-linecap="butt"
-              stroke-linejoin="miter"
-              stroke-width="96"
-            >
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 48,0 L 48,0"
-                />
-              </g>
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M -48,0 L -48,0"
-                />
-              </g>
-            </g>
-          </svg>
-        </div>
-      </div>
-      <div
-        class="c9"
-      >
-        <div
-          class="c2"
+        <svg
+          class="c8"
+          height="0"
+          preserveAspectRatio="none"
+          viewBox="0 0 0 0"
+          width="0"
         >
           0
-        </div>
-        <div
-          class="c2"
-        >
-          1
-        </div>
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            stroke-linecap="butt"
+            stroke-linejoin="miter"
+            stroke-width="96"
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 48,0 L 48,0"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M -48,0 L -48,0"
+              />
+            </g>
+          </g>
+        </svg>
       </div>
     </div>
   </div>
   <div
-    class="c1"
+    class="c9"
   >
     <div
       class="c2"
@@ -9517,84 +8615,72 @@ exports[`DataChart size 1`] = `
       <div
         class="c3"
       >
-        <div
-          class="c4"
-        >
-          2
-        </div>
-        <div
-          class="c4"
-        >
-          0.8
-        </div>
+        0
+      </div>
+      <div
+        class="c3"
+      >
+        1
+      </div>
+    </div>
+    <div
+      class="c4"
+    >
+      <div
+        class="c5"
+      >
+        2
       </div>
       <div
         class="c5"
-        style="height: 0px;"
-      />
+      >
+        0.8
+      </div>
     </div>
     <div
-      class="c2"
+      class="c10"
     >
       <div
-        class="c10"
+        class="c7"
       >
-        <div
-          class="c7"
-        >
-          <svg
-            class="c8"
-            height="192"
-            preserveAspectRatio="none"
-            viewBox="0 0 0 192"
-            width="0"
-          >
-            0
-            <g
-              fill="none"
-              stroke="#6FFFB0"
-              stroke-linecap="butt"
-              stroke-linejoin="miter"
-              stroke-width="96"
-            >
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 48,192 L 48,160"
-                />
-              </g>
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M -48,192 L -48,0"
-                />
-              </g>
-            </g>
-          </svg>
-        </div>
-      </div>
-      <div
-        class="c9"
-      >
-        <div
-          class="c2"
+        <svg
+          class="c8"
+          height="192"
+          preserveAspectRatio="none"
+          viewBox="0 0 0 192"
+          width="0"
         >
           0
-        </div>
-        <div
-          class="c2"
-        >
-          1
-        </div>
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            stroke-linecap="butt"
+            stroke-linejoin="miter"
+            stroke-width="96"
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 48,192 L 48,160"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M -48,192 L -48,0"
+              />
+            </g>
+          </g>
+        </svg>
       </div>
     </div>
   </div>
   <div
-    class="c1"
+    class="c11"
   >
     <div
       class="c2"
@@ -9602,79 +8688,67 @@ exports[`DataChart size 1`] = `
       <div
         class="c3"
       >
-        <div
-          class="c4"
-        >
-          2
-        </div>
-        <div
-          class="c4"
-        >
-          0.8
-        </div>
+        0
+      </div>
+      <div
+        class="c3"
+      >
+        1
+      </div>
+    </div>
+    <div
+      class="c4"
+    >
+      <div
+        class="c5"
+      >
+        2
       </div>
       <div
         class="c5"
-        style="height: 0px;"
-      />
+      >
+        0.8
+      </div>
     </div>
     <div
-      class="c2"
+      class="c12"
     >
       <div
-        class="c11"
+        class="c13"
       >
-        <div
-          class="c12"
-        >
-          <svg
-            class="c8"
-            height="192"
-            preserveAspectRatio="none"
-            viewBox="0 0 288 192"
-            width="288"
-          >
-            0
-            <g
-              fill="none"
-              stroke="#6FFFB0"
-              stroke-linecap="butt"
-              stroke-linejoin="miter"
-              stroke-width="96"
-            >
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 48,192 L 48,160"
-                />
-              </g>
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 240,192 L 240,0"
-                />
-              </g>
-            </g>
-          </svg>
-        </div>
-      </div>
-      <div
-        class="c9"
-      >
-        <div
-          class="c2"
+        <svg
+          class="c8"
+          height="192"
+          preserveAspectRatio="none"
+          viewBox="0 0 288 192"
+          width="288"
         >
           0
-        </div>
-        <div
-          class="c2"
-        >
-          1
-        </div>
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            stroke-linecap="butt"
+            stroke-linejoin="miter"
+            stroke-width="96"
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 48,192 L 48,160"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 240,192 L 240,0"
+              />
+            </g>
+          </g>
+        </svg>
       </div>
     </div>
   </div>
@@ -9692,21 +8766,28 @@ exports[`DataChart type 1`] = `
   -webkit-font-smoothing: antialiased;
 }
 
-.c1 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  grid-area: xAxis;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-left: 48px;
+  padding-right: 48px;
 }
 
-.c2 {
+.c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -9720,7 +8801,7 @@ exports[`DataChart type 1`] = `
   flex-direction: column;
 }
 
-.c3 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -9742,7 +8823,7 @@ exports[`DataChart type 1`] = `
   justify-content: space-between;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -9763,45 +8844,7 @@ exports[`DataChart type 1`] = `
   flex: 0 1 auto;
 }
 
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-}
-
 .c9 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  grid-area: xAxis;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  padding-left: 48px;
-  padding-right: 48px;
-}
-
-.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -9834,6 +8877,15 @@ exports[`DataChart type 1`] = `
   overflow: visible;
 }
 
+.c1 {
+  display: grid;
+  box-sizing: border-box;
+  grid-template-areas: "yAxis charts" ". xAxis";
+  grid-template-columns: auto auto;
+  grid-gap: 12px 12px;
+  grid-template-rows: auto auto;
+}
+
 .c6 {
   position: relative;
   grid-area: charts;
@@ -9845,7 +8897,7 @@ exports[`DataChart type 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c9 {
+  .c2 {
     padding-left: 24px;
     padding-right: 24px;
   }
@@ -9863,79 +8915,67 @@ exports[`DataChart type 1`] = `
       <div
         class="c3"
       >
-        <div
-          class="c4"
-        >
-          2
-        </div>
-        <div
-          class="c4"
-        >
-          0.8
-        </div>
+        0
+      </div>
+      <div
+        class="c3"
+      >
+        1
+      </div>
+    </div>
+    <div
+      class="c4"
+    >
+      <div
+        class="c5"
+      >
+        2
       </div>
       <div
         class="c5"
-        style="height: 0px;"
-      />
+      >
+        0.8
+      </div>
     </div>
     <div
-      class="c2"
+      class="c6"
     >
       <div
-        class="c6"
+        class="c7"
       >
-        <div
-          class="c7"
-        >
-          <svg
-            class="c8"
-            height="192"
-            preserveAspectRatio="none"
-            viewBox="0 0 384 192"
-            width="384"
-          >
-            0
-            <g
-              fill="none"
-              stroke="#6FFFB0"
-              stroke-linecap="butt"
-              stroke-linejoin="miter"
-              stroke-width="96"
-            >
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 48,192 L 48,160"
-                />
-              </g>
-              <g
-                fill="none"
-              >
-                <title />
-                <path
-                  d="M 336,192 L 336,0"
-                />
-              </g>
-            </g>
-          </svg>
-        </div>
-      </div>
-      <div
-        class="c9"
-      >
-        <div
-          class="c2"
+        <svg
+          class="c8"
+          height="192"
+          preserveAspectRatio="none"
+          viewBox="0 0 384 192"
+          width="384"
         >
           0
-        </div>
-        <div
-          class="c2"
-        >
-          1
-        </div>
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            stroke-linecap="butt"
+            stroke-linejoin="miter"
+            stroke-width="96"
+          >
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 48,192 L 48,160"
+              />
+            </g>
+            <g
+              fill="none"
+            >
+              <title />
+              <path
+                d="M 336,192 L 336,0"
+              />
+            </g>
+          </g>
+        </svg>
       </div>
     </div>
   </div>
@@ -9948,70 +8988,58 @@ exports[`DataChart type 1`] = `
       <div
         class="c3"
       >
-        <div
-          class="c10"
-        >
-          2
-        </div>
-        <div
-          class="c10"
-        >
-          0.8
-        </div>
+        0
       </div>
       <div
-        class="c5"
-        style="height: 0px;"
-      />
+        class="c3"
+      >
+        1
+      </div>
     </div>
     <div
-      class="c2"
+      class="c4"
     >
       <div
-        class="c6"
+        class="c9"
       >
-        <div
-          class="c7"
-        >
-          <svg
-            class="c8"
-            height="192"
-            preserveAspectRatio="none"
-            viewBox="0 0 384 192"
-            width="384"
-          >
-            0
-            <g
-              fill="none"
-              stroke="#6FFFB0"
-              stroke-linecap="butt"
-              stroke-linejoin="miter"
-              stroke-width="96"
-            >
-              <g
-                fill="none"
-              >
-                <path
-                  d="M 48,128 L 336,48"
-                />
-              </g>
-            </g>
-          </svg>
-        </div>
+        2
       </div>
       <div
         class="c9"
       >
-        <div
-          class="c2"
+        0.8
+      </div>
+    </div>
+    <div
+      class="c6"
+    >
+      <div
+        class="c7"
+      >
+        <svg
+          class="c8"
+          height="192"
+          preserveAspectRatio="none"
+          viewBox="0 0 384 192"
+          width="384"
         >
           0
-        </div>
-        <div
-          class="c2"
-        >
-          1
-        </div>
+          <g
+            fill="none"
+            stroke="#6FFFB0"
+            stroke-linecap="butt"
+            stroke-linejoin="miter"
+            stroke-width="96"
+          >
+            <g
+              fill="none"
+            >
+              <path
+                d="M 48,128 L 336,48"
+              />
+            </g>
+          </g>
+        </svg>
       </div>
     </div>
   </div>
@@ -10024,68 +9052,56 @@ exports[`DataChart type 1`] = `
       <div
         class="c3"
       >
-        <div
-          class="c10"
-        >
-          2
-        </div>
-        <div
-          class="c10"
-        >
-          0.8
-        </div>
+        0
       </div>
       <div
-        class="c5"
-        style="height: 0px;"
-      />
+        class="c3"
+      >
+        1
+      </div>
     </div>
     <div
-      class="c2"
+      class="c4"
     >
       <div
-        class="c6"
+        class="c9"
       >
-        <div
-          class="c7"
-        >
-          <svg
-            class="c8"
-            height="192"
-            preserveAspectRatio="none"
-            viewBox="0 0 384 192"
-            width="384"
-          >
-            0
-            <g
-              fill="#6FFFB0"
-              stroke="#6FFFB0"
-              stroke-linecap="butt"
-              stroke-linejoin="miter"
-              stroke-width="96"
-            >
-              <g>
-                <path
-                  d="M 48,128 L 336,48 L 336,144 L 48,144 Z"
-                />
-              </g>
-            </g>
-          </svg>
-        </div>
+        2
       </div>
       <div
         class="c9"
       >
-        <div
-          class="c2"
+        0.8
+      </div>
+    </div>
+    <div
+      class="c6"
+    >
+      <div
+        class="c7"
+      >
+        <svg
+          class="c8"
+          height="192"
+          preserveAspectRatio="none"
+          viewBox="0 0 384 192"
+          width="384"
         >
           0
-        </div>
-        <div
-          class="c2"
-        >
-          1
-        </div>
+          <g
+            fill="#6FFFB0"
+            stroke="#6FFFB0"
+            stroke-linecap="butt"
+            stroke-linejoin="miter"
+            stroke-width="96"
+          >
+            <g>
+              <path
+                d="M 48,128 L 336,48 L 336,144 L 48,144 Z"
+              />
+            </g>
+          </g>
+        </svg>
       </div>
     </div>
   </div>

--- a/src/js/components/Grid/Grid.js
+++ b/src/js/components/Grid/Grid.js
@@ -37,6 +37,8 @@ const Grid = forwardRef((props, ref) => {
 Grid.displayName = 'Grid';
 Grid.propTypes = GridPropTypes;
 
+// Defualting to true to support existing code that relies on
+// grid.available to create a fallback option
 Grid.available = true;
 
 export { Grid };

--- a/src/js/components/Grid/Grid.js
+++ b/src/js/components/Grid/Grid.js
@@ -37,4 +37,6 @@ const Grid = forwardRef((props, ref) => {
 Grid.displayName = 'Grid';
 Grid.propTypes = GridPropTypes;
 
+Grid.available = true;
+
 export { Grid };

--- a/src/js/components/Grid/Grid.js
+++ b/src/js/components/Grid/Grid.js
@@ -37,10 +37,4 @@ const Grid = forwardRef((props, ref) => {
 Grid.displayName = 'Grid';
 Grid.propTypes = GridPropTypes;
 
-Grid.available =
-  typeof window !== 'undefined' &&
-  window.CSS &&
-  window.CSS.supports &&
-  window.CSS.supports('display', 'grid');
-
 export { Grid };

--- a/src/js/components/Grid/README.md
+++ b/src/js/components/Grid/README.md
@@ -5,5 +5,3 @@ A grid system for laying out content. To use, define the
 rows and columns, create area names for adjacent cells, and then
 place Box components inside those areas using the gridArea property.
 See https://css-tricks.com/snippets/css/complete-guide-grid/.
-The availability of Grid can be tested via `Grid.available`. Use this
-to create fallback rendering for older browsers, like ie11.

--- a/src/js/components/Grid/index.d.ts
+++ b/src/js/components/Grid/index.d.ts
@@ -44,7 +44,9 @@ export type GridColumnsType =
 
 export type GridGapType = GapType | { row?: GapType; column?: GapType };
 
-export type AreasType = { name?: string; start?: number[]; end?: number[] }[] | string[][];
+export type AreasType =
+  | { name?: string; start?: number[]; end?: number[] }[]
+  | string[][];
 export interface GridProps {
   a11yTitle?: A11yTitleType;
   alignSelf?: AlignSelfType;
@@ -72,6 +74,6 @@ type divProps = JSX.IntrinsicElements['div'];
 
 export interface GridExtendedProps extends GridProps, divProps {}
 
-declare const Grid: React.FC<GridExtendedProps> & { available?: boolean };
+declare const Grid: React.FC<GridExtendedProps>;
 
 export { Grid };

--- a/src/js/components/Grid/stories/typescript/App.tsx
+++ b/src/js/components/Grid/stories/typescript/App.tsx
@@ -8,58 +8,52 @@ export const AppGrid = () => {
   return (
     // Uncomment <Grommet> lines when using outside of storybook
     // <Grommet theme={...}>
-    <>
-      {Grid.available ? (
-        <Grid
-          fill
-          rows={['auto', 'flex']}
-          columns={['auto', 'flex']}
-          areas={[
-            { name: 'header', start: [0, 0], end: [1, 0] },
-            { name: 'sidebar', start: [0, 1], end: [0, 1] },
-            { name: 'main', start: [1, 1], end: [1, 1] },
+    <Grid
+      fill
+      rows={['auto', 'flex']}
+      columns={['auto', 'flex']}
+      areas={[
+        { name: 'header', start: [0, 0], end: [1, 0] },
+        { name: 'sidebar', start: [0, 1], end: [0, 1] },
+        { name: 'main', start: [1, 1], end: [1, 1] },
+      ]}
+    >
+      <Box
+        gridArea="header"
+        direction="row"
+        align="center"
+        justify="between"
+        pad={{ horizontal: 'medium', vertical: 'small' }}
+        background="dark-2"
+      >
+        <Button onClick={() => setSidebar(!sidebar)}>
+          <Text size="large">Title</Text>
+        </Button>
+        <Text>my@email</Text>
+      </Box>
+      {sidebar && (
+        <Box
+          gridArea="sidebar"
+          background="dark-3"
+          width="small"
+          animation={[
+            { type: 'fadeIn', duration: 300 },
+            { type: 'slideRight', size: 'xlarge', duration: 150 },
           ]}
         >
-          <Box
-            gridArea="header"
-            direction="row"
-            align="center"
-            justify="between"
-            pad={{ horizontal: 'medium', vertical: 'small' }}
-            background="dark-2"
-          >
-            <Button onClick={() => setSidebar(!sidebar)}>
-              <Text size="large">Title</Text>
+          {['First', 'Second', 'Third'].map((name) => (
+            <Button key={name} href="#" hoverIndicator>
+              <Box pad={{ horizontal: 'medium', vertical: 'small' }}>
+                <Text>{name}</Text>
+              </Box>
             </Button>
-            <Text>my@email</Text>
-          </Box>
-          {sidebar && (
-            <Box
-              gridArea="sidebar"
-              background="dark-3"
-              width="small"
-              animation={[
-                { type: 'fadeIn', duration: 300 },
-                { type: 'slideRight', size: 'xlarge', duration: 150 },
-              ]}
-            >
-              {['First', 'Second', 'Third'].map((name) => (
-                <Button key={name} href="#" hoverIndicator>
-                  <Box pad={{ horizontal: 'medium', vertical: 'small' }}>
-                    <Text>{name}</Text>
-                  </Box>
-                </Button>
-              ))}
-            </Box>
-          )}
-          <Box gridArea="main" justify="center" align="center">
-            <Text>main</Text>
-          </Box>
-        </Grid>
-      ) : (
-        <Text>Grid is not supported by your browser</Text>
+          ))}
+        </Box>
       )}
-    </>
+      <Box gridArea="main" justify="center" align="center">
+        <Text>main</Text>
+      </Box>
+    </Grid>
     // </Grommet>
   );
 };

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -408,7 +408,6 @@ Object {
   },
   "Grid": Object {
     "$$typeof": Symbol(react.forward_ref),
-    "available": undefined,
     "propTypes": Object {
       "a11yTitle": [Function],
       "align": [Function],

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -408,6 +408,7 @@ Object {
   },
   "Grid": Object {
     "$$typeof": Symbol(react.forward_ref),
+    "available": true,
     "propTypes": Object {
       "a11yTitle": [Function],
       "align": [Function],


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Removes `grid.available` from Grid which affects DataTable as well

#### Where should the reviewer start?

`Grid.js`

#### What testing has been done on this PR?

Testing through Storybook and updating tests.

#### How should this be manually tested?

Ensure Storybook examples are still working

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

Closes #6116 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No

#### Should this PR be mentioned in the release notes?

Yes

#### Is this change backwards compatible or is it a breaking change?

Compatible
