### PR TITLE
Added id prop to typescript prop definitions

### DIFF
--- a/src/js/components/Chart/index.d.ts
+++ b/src/js/components/Chart/index.d.ts
@@ -25,6 +25,7 @@ export interface ChartProps {
         color?: ColorType;
         opacity?: 'weak' | 'medium' | 'strong' | boolean | number;
       };
+  id?: string;
   dash?: boolean;
   gap?: GapType;
   onClick?: (...args: any[]) => any;

--- a/src/js/components/Chart/index.d.ts
+++ b/src/js/components/Chart/index.d.ts
@@ -25,7 +25,6 @@ export interface ChartProps {
         color?: ColorType;
         opacity?: 'weak' | 'medium' | 'strong' | boolean | number;
       };
-  id?: string;
   dash?: boolean;
   gap?: GapType;
   onClick?: (...args: any[]) => any;

--- a/src/js/components/Chart/index.d.ts
+++ b/src/js/components/Chart/index.d.ts
@@ -97,7 +97,11 @@ export interface ChartProps {
   )[];
 }
 
-declare const Chart: React.FC<ChartProps>;
+export interface ChartExtendedProps
+  extends ChartProps,
+    Omit<JSX.IntrinsicElements['svg'], keyof ChartProps> {}
+
+declare const Chart: React.FC<ChartExtendedProps>;
 
 type Bounds = [[number, number], [number, number]] | [[], []];
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Adds the `id` prop to the typescript prop definitions.

#### Where should the reviewer start?

`index.d.ts`

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

Closes #6149 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No

#### Should this PR be mentioned in the release notes?

Yes

#### Is this change backwards compatible or is it a breaking change?

Compatible
