### PR TITLE
Adjust menu grouped separator

### DIFF
--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
         "branches": 76.3,
         "functions": 88,
         "lines": 87.5,
-        "statements": 86.7
+        "statements": 86.6
       }
     },
     "modulePathIgnorePatterns": [

--- a/src/js/components/Menu/Menu.js
+++ b/src/js/components/Menu/Menu.js
@@ -368,19 +368,17 @@ const Menu = forwardRef((props, ref) => {
         // eslint-disable-next-line react/no-array-index-key
         key={groupIndex}
       >
-        <Box pad={theme.menu.group.separator.pad}>
-          <Box
-            border={
-              groupIndex > 0
-                ? {
-                    side: 'top',
-                    color: theme.menu.group?.separator?.color,
-                    size: theme.menu.group?.separator?.size,
-                  }
-                : undefined
-            }
-          />
-        </Box>
+        {groupIndex > 0 && (
+          <Box pad={theme.menu.group.separator.pad}>
+            <Box
+              border={{
+                side: 'top',
+                color: theme.menu.group?.separator?.color,
+                size: theme.menu.group?.separator?.size,
+              }}
+            />
+          </Box>
+        )}
         <Box {...theme.menu.group?.container}>
           {group.map((item) => {
             // item index needs to be its index in the entire menu as if

--- a/src/js/components/Menu/Menu.js
+++ b/src/js/components/Menu/Menu.js
@@ -367,31 +367,30 @@ const Menu = forwardRef((props, ref) => {
       <Box
         // eslint-disable-next-line react/no-array-index-key
         key={groupIndex}
-        {...theme.menu.group?.container}
       >
-        <Box
-          margin={{
-            horizontal: 'small',
-            bottom: index === 0 ? 'none' : 'small',
-          }}
-          border={
-            groupIndex > 0
-              ? {
-                  side: 'top',
-                  color: theme.menu.group?.separator?.color,
-                  size: theme.menu.group?.separator?.size,
-                }
-              : undefined
-          }
-        />
-        {group.map((item) => {
-          // item index needs to be its index in the entire menu as if
-          // it were a flat array
-          const currentIndex = index;
-          index += 1;
+        <Box pad={theme.menu.group.separator.pad}>
+          <Box
+            border={
+              groupIndex > 0
+                ? {
+                    side: 'top',
+                    color: theme.menu.group?.separator?.color,
+                    size: theme.menu.group?.separator?.size,
+                  }
+                : undefined
+            }
+          />
+        </Box>
+        <Box {...theme.menu.group?.container}>
+          {group.map((item) => {
+            // item index needs to be its index in the entire menu as if
+            // it were a flat array
+            const currentIndex = index;
+            index += 1;
 
-          return menuItem(item, currentIndex);
-        })}
+            return menuItem(item, currentIndex);
+          })}
+        </Box>
       </Box>
     ));
   } else menuContent = items.map((item, index) => menuItem(item, index));

--- a/src/js/components/Menu/Menu.js
+++ b/src/js/components/Menu/Menu.js
@@ -368,16 +368,22 @@ const Menu = forwardRef((props, ref) => {
         // eslint-disable-next-line react/no-array-index-key
         key={groupIndex}
         {...theme.menu.group?.container}
-        border={
-          groupIndex > 0
-            ? {
-                side: 'top',
-                color: theme.menu.group?.separator?.color,
-                size: theme.menu.group?.separator?.size,
-              }
-            : undefined
-        }
       >
+        <Box
+          margin={{
+            horizontal: 'small',
+            bottom: index === 0 ? 'none' : 'small',
+          }}
+          border={
+            groupIndex > 0
+              ? {
+                  side: 'top',
+                  color: theme.menu.group?.separator?.color,
+                  size: theme.menu.group?.separator?.size,
+                }
+              : undefined
+          }
+        />
         {group.map((item) => {
           // item index needs to be its index in the entire menu as if
           // it were a flat array

--- a/src/js/components/Menu/__tests__/Menu-test.js
+++ b/src/js/components/Menu/__tests__/Menu-test.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { getByText as getByTextDOM } from '@testing-library/dom';
-import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 
 import 'jest-axe/extend-expect';
@@ -593,26 +592,25 @@ describe('Menu', () => {
   });
 
   test('should group items', async () => {
-    const user = userEvent.setup();
-
     window.scrollTo = jest.fn();
-    const onClick = jest.fn();
-    const { asFragment } = render(
+    render(
       <Grommet>
         <Menu
+          id="test-menu"
           label="Test Menu"
           items={[
-            [{ label: 'Item 1' }, { label: 'Item 2', onClick }],
+            [{ label: 'Item 1' }, { label: 'Item 2' }],
             [{ label: 'Item 3' }],
           ]}
-          open
         />
       </Grommet>,
     );
+    fireEvent.keyDown(screen.getByText('Test Menu'), {
+      key: 'Down',
+      keyCode: 40,
+      which: 40,
+    });
 
-    await user.click(screen.getByRole('menuitem', { name: 'Item 2' }));
-    expect(onClick).toBeCalledTimes(1);
-
-    expect(asFragment()).toMatchSnapshot();
+    expectPortal('test-menu__drop').toMatchSnapshot();
   });
 });

--- a/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
+++ b/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
@@ -5180,18 +5180,6 @@ exports[`Menu should group items 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
   .c4 {
     width: 6px;
   }

--- a/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
+++ b/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
@@ -5180,6 +5180,18 @@ exports[`Menu should group items 1`] = `
 }
 
 @media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
   .c4 {
     width: 6px;
   }

--- a/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
+++ b/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
@@ -5016,8 +5016,7 @@ exports[`Menu should apply themed drop props 1`] = `
 `;
 
 exports[`Menu should group items 1`] = `
-<DocumentFragment>
-  .c5 {
+.c9 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -5028,30 +5027,30 @@ exports[`Menu should group items 1`] = `
   stroke: #7D4CDB;
 }
 
-.c5 g {
+.c9 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c5 *:not([stroke])[fill="none"] {
+.c9 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c5 *[stroke*="#"],
-.c5 *[STROKE*="#"] {
+.c9 *[stroke*="#"],
+.c9 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c5 *[fill-rule],
-.c5 *[FILL-RULE],
-.c5 *[fill*="#"],
-.c5 *[FILL*="#"] {
+.c9 *[fill-rule],
+.c9 *[FILL-RULE],
+.c9 *[fill*="#"],
+.c9 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
 
-.c2 {
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5074,7 +5073,135 @@ exports[`Menu should group items 1`] = `
   padding: 12px;
 }
 
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  overflow: auto;
+  box-shadow: 0px 2px 4px rgba(0,0,0,0.20);
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  overflow: auto;
+}
+
+.c11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
 .c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c12 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  padding: 12px;
+}
+
+.c13 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-left: 12px;
+  padding-right: 12px;
+}
+
+.c14 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border-top: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c8 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -5084,12 +5211,36 @@ exports[`Menu should group items 1`] = `
   width: 12px;
 }
 
-.c3 {
+.c1 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  border-radius: 0px;
+  position: fixed;
+  z-index: 20;
+  outline: none;
+  background-color: #FFFFFF;
+  color: #444444;
+  opacity: 0;
+  -webkit-transform-origin: top left;
+  -ms-transform-origin: top left;
+  transform-origin: top left;
+  -webkit-animation: kPQHBD 0.1s forwards;
+  animation: kPQHBD 0.1s forwards;
+  -webkit-animation-delay: 0.01s;
+  animation-delay: 0.01s;
+}
+
+.c7 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c1 {
+.c5 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -5107,129 +5258,228 @@ exports[`Menu should group items 1`] = `
   text-align: inherit;
 }
 
-.c1:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
+.c5:hover {
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
 }
 
-.c1:focus > circle,
-.c1:focus > ellipse,
-.c1:focus > line,
-.c1:focus > path,
-.c1:focus > polygon,
-.c1:focus > polyline,
-.c1:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c1:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c1:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible) > circle,
-.c1:focus:not(:focus-visible) > ellipse,
-.c1:focus:not(:focus-visible) > line,
-.c1:focus:not(:focus-visible) > path,
-.c1:focus:not(:focus-visible) > polygon,
-.c1:focus:not(:focus-visible) > polyline,
-.c1:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible) > circle,
+.c5:focus:not(:focus-visible) > ellipse,
+.c5:focus:not(:focus-visible) > line,
+.c5:focus:not(:focus-visible) > path,
+.c5:focus:not(:focus-visible) > polygon,
+.c5:focus:not(:focus-visible) > polyline,
+.c5:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c1:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c0 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
+.c3 {
+  max-height: inherit;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
-  .c2 {
+  .c6 {
     padding: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-
+  .c11 {
+    padding-top: 3px;
+    padding-bottom: 3px;
+  }
 }
 
 @media only screen and (max-width:768px) {
-
+  .c12 {
+    padding: 6px;
+  }
 }
 
 @media only screen and (max-width:768px) {
-
+  .c13 {
+    padding-left: 6px;
+    padding-right: 6px;
+  }
 }
 
 @media only screen and (max-width:768px) {
-
+  .c14 {
+    border-top: solid 1px rgba(0,0,0,0.33);
+  }
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c8 {
     width: 6px;
   }
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-
+  .c1 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+  }
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-
+  .c3 {
+    width: 100%;
+  }
 }
 
 <div
-    class="c0"
+  class="c0 c1"
+  data-g-portal-id="0"
+  id="test-menu__drop"
+  style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
+  tabindex="-1"
+>
+  <div
+    class="c2 c3"
+    tabindex="-1"
   >
-    <button
-      aria-expanded="false"
-      aria-haspopup="menu"
-      aria-label="Open Menu"
-      class="c1"
-      type="button"
+    <div
+      class="c4"
+    >
+      <button
+        aria-label="Close Menu"
+        class="c5"
+        tabindex="-1"
+        type="button"
+      >
+        <div
+          class="c6"
+        >
+          <span
+            class="c7"
+          >
+            Test Menu
+          </span>
+          <div
+            class="c8"
+          />
+          <svg
+            aria-label="FormDown"
+            class="c9"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="m18 9-6 6-6-6"
+              fill="none"
+              stroke="#000"
+              stroke-width="2"
+            />
+          </svg>
+        </div>
+      </button>
+    </div>
+    <div
+      class="c10"
+      role="menu"
     >
       <div
         class="c2"
       >
-        <span
-          class="c3"
-        >
-          Test Menu
-        </span>
         <div
-          class="c4"
-        />
-        <svg
-          aria-label="FormDown"
-          class="c5"
-          viewBox="0 0 24 24"
+          class="c11"
         >
-          <path
-            d="m18 9-6 6-6-6"
-            fill="none"
-            stroke="#000"
-            stroke-width="2"
-          />
-        </svg>
+          <div
+            class="c4"
+            role="none"
+          >
+            <button
+              class="c5"
+              role="menuitem"
+              type="button"
+            >
+              <div
+                class="c12"
+              >
+                Item 1
+              </div>
+            </button>
+          </div>
+          <div
+            class="c4"
+            role="none"
+          >
+            <button
+              class="c5"
+              role="menuitem"
+              type="button"
+            >
+              <div
+                class="c12"
+              >
+                Item 2
+              </div>
+            </button>
+          </div>
+        </div>
       </div>
-    </button>
+      <div
+        class="c2"
+      >
+        <div
+          class="c13"
+        >
+          <div
+            class="c14"
+          />
+        </div>
+        <div
+          class="c11"
+        >
+          <div
+            class="c4"
+            role="none"
+          >
+            <button
+              class="c5"
+              role="menuitem"
+              type="button"
+            >
+              <div
+                class="c12"
+              >
+                Item 3
+              </div>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
-</DocumentFragment>
+</div>
+`;
+
+exports[`Menu should group items 2`] = `
+"@media only screen and (max-width: 768px) {
+  .hOAJOL {
+    padding: 6px;
+  }
+}"
 `;
 
 exports[`Menu should have no accessibility violations 1`] = `

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -1711,6 +1711,9 @@ Object {
             },
             "separator": Object {
               "color": "border",
+              "pad": Object {
+                "horizontal": "small",
+              },
               "size": "xsmall",
             },
           },

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -1046,6 +1046,7 @@ export interface ThemeType {
       separator?: {
         color?: ColorType;
         size?: string;
+        pad?: PadType;
       };
     };
     icons?: {

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1059,6 +1059,9 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         separator: {
           color: 'border',
           size: 'xsmall',
+          pad: {
+            horizontal: 'small',
+          },
         },
       },
       icons: {


### PR DESCRIPTION
#### What does this PR do?
Adjusts the Menu grouped separator to have the same amount of padding/margin as the menu options.

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`. (Note I had to use firEvent instead of userEvent for the down arrow. User Event wasn't opening the menu)
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes https://github.com/grommet/grommet/issues/6188

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Yes

#### Should this PR be mentioned in the release notes?
No
#### Is this change backwards compatible or is it a breaking change?
Backwards compatible