### PR TITLE
Implement Paragraph maxLines

### DIFF
--- a/src/js/components/Paragraph/StyledParagraph.js
+++ b/src/js/components/Paragraph/StyledParagraph.js
@@ -21,8 +21,18 @@ const fontFamily = css`
   font-family: ${(props) => props.theme.paragraph.font.family};
 `;
 
+const maxlinesStyle = (props) =>
+  props.maxLines &&
+  css`
+    display: -webkit-box;
+    -webkit-line-clamp: ${props.maxLines};
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  `;
+
 const StyledParagraph = styled.p`
   ${genericStyles}
+  ${(props) => maxlinesStyle(props)}
   ${(props) => sizeStyle(props)}
   ${(props) => props.textAlign && textAlignStyle}
   ${(props) => props.colorProp && colorStyle}

--- a/src/js/components/Paragraph/__tests__/Paragraph-test.tsx
+++ b/src/js/components/Paragraph/__tests__/Paragraph-test.tsx
@@ -59,3 +59,13 @@ test('Paragraph textAlign renders', () => {
 
   expect(container.firstChild).toMatchSnapshot();
 });
+
+test('Paragraph maxLines renders', () => {
+  const { container } = render(
+    <Grommet>
+      <Paragraph maxLines={3} />
+    </Grommet>,
+  );
+
+  expect(container.firstChild).toMatchSnapshot();
+});

--- a/src/js/components/Paragraph/__tests__/__snapshots__/Paragraph-test.tsx.snap
+++ b/src/js/components/Paragraph/__tests__/__snapshots__/Paragraph-test.tsx.snap
@@ -77,6 +77,36 @@ exports[`Paragraph margin renders 1`] = `
 </div>
 `;
 
+exports[`Paragraph maxLines renders 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  font-size: 18px;
+  line-height: 24px;
+  max-width: 432px;
+}
+
+<div
+  class="c0"
+>
+  <p
+    class="c1"
+  />
+</div>
+`;
+
 exports[`Paragraph renders 1`] = `
 .c0 {
   font-size: 18px;

--- a/src/js/components/Paragraph/index.d.ts
+++ b/src/js/components/Paragraph/index.d.ts
@@ -16,6 +16,7 @@ export interface ParagraphProps {
   fill?: boolean;
   gridArea?: GridAreaType;
   margin?: MarginType;
+  maxLines?: number;
   responsive?: boolean;
   size?: 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge' | string;
   textAlign?: TextAlignType;

--- a/src/js/components/Paragraph/propTypes.js
+++ b/src/js/components/Paragraph/propTypes.js
@@ -7,6 +7,7 @@ if (process.env.NODE_ENV !== 'production') {
     ...genericProps,
     color: colorPropType,
     fill: PropTypes.bool,
+    maxLines: PropTypes.number,
     responsive: PropTypes.bool,
     size: PropTypes.oneOfType([
       PropTypes.oneOf(['small', 'medium', 'large', 'xlarge', 'xxlarge']),

--- a/src/js/components/Paragraph/stories/MaxLines.js
+++ b/src/js/components/Paragraph/stories/MaxLines.js
@@ -1,0 +1,21 @@
+import React from 'react';
+
+import { Box, Paragraph } from 'grommet';
+
+const text = `
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+tempor incididunt ut labore et dolore magna aliqua.
+`;
+
+export const Maxlines = () => (
+  <Box fill align="center" justify="center" pad="large">
+    <Box border width="small" pad={{ horizontal: 'small' }}>
+      <Paragraph maxLines={3}>{text}</Paragraph>
+    </Box>
+    <Paragraph maxLines={3}>{text}</Paragraph>
+  </Box>
+);
+
+export default {
+  title: 'Type/Paragraph/Maxlines',
+};

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -673,6 +673,7 @@ Object {
       "fill": [Function],
       "gridArea": [Function],
       "margin": [Function],
+      "maxLines": [Function],
       "responsive": [Function],
       "size": [Function],
       "textAlign": [Function],


### PR DESCRIPTION
Many designs have situations where they put a paragraph of text on a card or some other space-restricted area. Often that content comes from a dynamic source like external product descriptions, etc. This designs typically would like to truncate this content at a certain number of lines. Our current `<Text>` component can truncate a single line with an ellipsis, but we have no convenient solution for truncating something that is multiple lines with an ellipsis in an effecient way.

#### What does this PR do?
This adds a `maxLines` property to `<Paragraph>`. When the `<Paragraph>` gets constrained by a parent container or its max width restriction the content will get cleanly truncated with an ellipsis using an efficient browser css-supported mechanism much like `<Text truncate>`

![image](https://user-images.githubusercontent.com/12054362/176000222-31256029-bff1-4609-9913-e3dafb7400bc.png)

#### Where should the reviewer start?
Storybook Paragraph->Maxlines

#### What testing has been done on this PR?
Storybook and jest

#### How should this be manually tested?
Storybook

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Yes

#### Should this PR be mentioned in the release notes?
Yes

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible