### PR TITLE
Typescript - include info as status type on Notification

### DIFF
--- a/src/js/components/Notification/index.d.ts
+++ b/src/js/components/Notification/index.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { LayerPositionType } from '../Layer';
 import { AnchorType } from '..';
-export type StatusType = 'critical' | 'warning' | 'normal' | 'unknown';
+export type StatusType = 'critical' | 'warning' | 'normal' | 'info' | 'unknown';
 
 export interface NotificationProps {
   actions?: AnchorType[];

--- a/src/js/components/Notification/propTypes.js
+++ b/src/js/components/Notification/propTypes.js
@@ -8,7 +8,13 @@ if (process.env.NODE_ENV !== 'production') {
     global: PropTypes.bool,
     title: PropTypes.string,
     message: PropTypes.string,
-    status: PropTypes.oneOf(['critical', 'warning', 'normal', 'unknown']),
+    status: PropTypes.oneOf([
+      'critical',
+      'warning',
+      'normal',
+      'info',
+      'unknown',
+    ]),
     toast: PropTypes.oneOfType([
       PropTypes.bool,
       PropTypes.shape({


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Adds `info` as a StatusType type definition for Notification.

#### Where should the reviewer start?
src/js/components/Notification/index.d.ts

#### What testing has been done on this PR?

Locally on TS storybook.

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
https://github.com/grommet/grommet-site/pull/396

#### Should this PR be mentioned in the release notes?
Yes.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.