### PR TITLE
Fix image onLoad not being called

### DIFF
--- a/src/js/components/Image/Image.js
+++ b/src/js/components/Image/Image.js
@@ -3,7 +3,10 @@ import { StyledImage } from './StyledImage';
 import { ImagePropTypes } from './propTypes';
 
 const Image = forwardRef(
-  ({ a11yTitle, fallback, onError, opacity, fill, src, ...rest }, ref) => {
+  (
+    { a11yTitle, fallback, onError, onLoad, opacity, fill, src, ...rest },
+    ref,
+  ) => {
     const [isFallbackInUse, setFallbackInUse] = useState(false);
 
     const handleError = (event) => {
@@ -15,7 +18,8 @@ const Image = forwardRef(
       }
     };
 
-    const handleOnLoad = () => {
+    const handleOnLoad = (event) => {
+      if (onLoad) onLoad(event);
       setFallbackInUse(false);
     };
 

--- a/src/js/components/Image/__tests__/Image-test.tsx
+++ b/src/js/components/Image/__tests__/Image-test.tsx
@@ -97,6 +97,22 @@ test('Image onError', () => {
   expect(onError).toHaveBeenCalledTimes(1);
 });
 
+test('Image onLoad', () => {
+  const onLoad = jest.fn();
+  render(
+    <Grommet>
+      <Image alt="test" onLoad={onLoad} />
+    </Grommet>,
+  );
+
+  expect(onLoad).not.toHaveBeenCalled();
+
+  const image = screen.getByRole('img', { name: 'test' });
+  fireEvent.load(image);
+
+  expect(onLoad).toHaveBeenCalledTimes(1);
+});
+
 test('Image fallback', async () => {
   const user = userEvent.setup();
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Image's onLoad prop is not provided to an Img tag

#### Where should the reviewer start?

```
src/js/components/Image/Image.js
```

#### What testing has been done on this PR?

```sh
yarn test
```

#### How should this be manually tested?

1. You can change the Image storybook story in `src/js/components/Image/stories/Simple.js` to:
```js
export const Simple = () => (
  <Image
    src="//v2.grommet.io/assets/IMG_4245.jpg"
    onLoad={() => console.log('onLoad')}
  />
);
```

2. Run the Storybook,
3. Go to the Image Simple story
4. Open the browser console to check if the `onLoad` message appears

#### Do Jest tests follow these best practices?

- [x] `screen` is used for querying.
- [x] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#6202

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible