### PR TITLE
[Typescript] Support focus shadow as a string

### DIFF
--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -368,7 +368,8 @@ export interface ThemeType {
         color?: ColorType;
         size?: string;
       };
-      shadow?: {
+      shadow?: 
+        string | {
         color?: ColorType;
         size?: string;
       };


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Supports the theme's `focus.shadow` to accept a string.

#### Where should the reviewer start?
theme file with types
#### What testing has been done on this PR?
local tests.
#### How should this be manually tested?
locally.
#### Do Jest tests follow these best practices?
N/A

#### Any background context you want to provide?
On src/js/utils/styles.js we use:
```
return `
      outline: none;
      box-shadow: ${focus.shadow};
    `;
```
and since `box-shadow` accepts the type of string, it [should be accepted as a valid input type](https://developer.mozilla.org/en-US/docs/Web/CSS/box-shadow) as well.

#### What are the relevant issues?
#5446 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Where are the global theme types are documented? the new type should be added there.
#### Should this PR be mentioned in the release notes?
yep, as a TS fix.
#### Is this change backward compatible or is it a breaking change?
 backward compatible