### PR TITLE
Fix TS definition on Menu items

### DIFF
--- a/src/js/components/Menu/index.d.ts
+++ b/src/js/components/Menu/index.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { DropProps } from '../Drop';
-import { ButtonProps, ButtonType } from '../Button';
+import { ButtonExtendedProps, ButtonType } from '../Button';
 import {
   A11yTitleType,
   AlignSelfType,
@@ -31,7 +31,7 @@ export interface MenuProps {
   dropProps?: DropProps;
   gridArea?: GridAreaType;
   icon?: boolean | React.ReactNode;
-  items: ButtonProps[] | ButtonProps[][];
+  items: ButtonExtendedProps[] | ButtonExtendedProps[][];
   justifyContent?: JustifyContentType;
   label?: string | React.ReactNode;
   margin?: MarginType;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Fixes Menu `items` typescript definition to use ButtonExtendedProps which includes intrinsic properties.

#### Where should the reviewer start?
src/js/components/Menu/index.d.ts

#### What testing has been done on this PR?
TS example

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?
Yes. Fixed Menu `items` typescript definition.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.