### PR TITLE
fix spinner size by taking off pad when to large for size

### DIFF
--- a/src/js/components/Spinner/Spinner.js
+++ b/src/js/components/Spinner/Spinner.js
@@ -61,9 +61,9 @@ const Spinner = forwardRef(
       {
         side: 'all',
         color: 'background-contrast',
-        size: size === undefined ? 'small' : size,
+        size: normalizedSize,
       },
-      { side: 'top', color, size: size === undefined ? 'small' : size },
+      { side: 'top', color, size: normalizedSize },
     ];
     const spinnerBorder = Array.isArray(borderThemeProp)
       ? borderThemeProp.map((borderSide) => ({
@@ -76,24 +76,17 @@ const Spinner = forwardRef(
       : borderThemeProp;
 
     // check the size of the pad plus border
+    // than multiple by 2 in order to compare to it to theme sizes
     let spinnerPadBorder;
     if (!rest.border) {
-      if (size !== undefined) {
-        spinnerPadBorder =
+      spinnerPadBorder =
+        2 *
+        (parseMetricToNum(
+          theme?.global?.edgeSize && theme.global.edgeSize[spinnerPad],
+        ) +
           parseMetricToNum(
-            theme?.global?.edgeSize && theme.global.edgeSize[spinnerPad],
-          ) +
-          parseMetricToNum(
-            theme?.global?.edgeSize && theme.global.borderSize[size],
-          );
-      } else
-        spinnerPadBorder =
-          parseMetricToNum(
-            theme?.global?.edgeSize && theme.global.edgeSize[spinnerPad],
-          ) +
-          parseMetricToNum(
-            theme?.global?.edgeSize && theme.global.borderSize.small,
-          );
+            theme?.global?.edgeSize && theme.global.borderSize[normalizedSize],
+          ));
     }
 
     // children will take prsecedence over theme attributes
@@ -128,7 +121,7 @@ const Spinner = forwardRef(
         {...themeProps}
         // If border plus pad is larger than spinnerSize there should be no pad.
         pad={
-          spinnerPadBorder * 2 > spinnerSize.replace(/px/, '') * 1
+          spinnerPadBorder > spinnerSize.replace('px', '')
             ? 'none'
             : theme.spinner.container.pad
         }

--- a/src/js/components/Spinner/Spinner.js
+++ b/src/js/components/Spinner/Spinner.js
@@ -10,6 +10,7 @@ import { AnnounceContext } from '../../contexts/AnnounceContext';
 import { Box } from '../Box';
 import { defaultProps } from '../../default-props';
 import { SpinnerPropTypes } from './propTypes';
+import { parseMetricToNum } from '../../utils';
 
 const BasicSpinner = ({ ref, size, ...rest }) => (
   <Box height={size} width={size} ref={ref} {...rest} />
@@ -48,6 +49,8 @@ const Spinner = forwardRef(
       ...themeProps
     } = theme.spinner.container;
 
+    const spinnerPad = theme?.spinner?.container?.pad;
+
     const normalizedSize = size || sizeThemeProp;
     const spinnerSize = theme.spinner.size[normalizedSize] || normalizedSize;
 
@@ -55,8 +58,12 @@ const Spinner = forwardRef(
     const Icon = theme.spinner.icon;
 
     const defaultBorder = [
-      { side: 'all', color: 'background-contrast', size },
-      { side: 'top', color, size },
+      {
+        side: 'all',
+        color: 'background-contrast',
+        size: size === undefined ? 'small' : size,
+      },
+      { side: 'top', color, size: size === undefined ? 'small' : size },
     ];
     const spinnerBorder = Array.isArray(borderThemeProp)
       ? borderThemeProp.map((borderSide) => ({
@@ -68,7 +75,23 @@ const Spinner = forwardRef(
         }))
       : borderThemeProp;
 
-    // children will take precedence over theme attributes
+    // check the size of the pad plus border
+    let spinnerPadBorder;
+    if (size !== undefined) {
+      spinnerPadBorder =
+        parseMetricToNum(
+          theme?.global?.edgeSize && theme.global.edgeSize[spinnerPad],
+        ) +
+        parseMetricToNum(
+          theme?.global?.edgeSize && theme.global.borderSize[size],
+        );
+    }else spinnerPadBorder = parseMetricToNum(
+      theme?.global?.edgeSize && theme.global.edgeSize[spinnerPad],
+    ) +  parseMetricToNum(
+      theme?.global?.edgeSize && theme.global.borderSize.small,
+    );
+
+    // children will take prsecedence over theme attributes
     if (children) {
       return (
         <BasicSpinner size={spinnerSize} ref={ref} {...rest}>
@@ -98,6 +121,12 @@ const Spinner = forwardRef(
           typeof borderThemeProp === 'undefined' ? defaultBorder : spinnerBorder
         }
         {...themeProps}
+        // If border plus pad is larger than spinnerSize there should be no pad.
+        pad={
+          spinnerPadBorder * 2 > spinnerSize.replace(/px/, '') * 1
+            ? 'none'
+            : theme.spinner.container.pad
+        }
         {...rest}
       />
     );

--- a/src/js/components/Spinner/Spinner.js
+++ b/src/js/components/Spinner/Spinner.js
@@ -77,19 +77,24 @@ const Spinner = forwardRef(
 
     // check the size of the pad plus border
     let spinnerPadBorder;
-    if (size !== undefined) {
-      spinnerPadBorder =
-        parseMetricToNum(
-          theme?.global?.edgeSize && theme.global.edgeSize[spinnerPad],
-        ) +
-        parseMetricToNum(
-          theme?.global?.edgeSize && theme.global.borderSize[size],
-        );
-    }else spinnerPadBorder = parseMetricToNum(
-      theme?.global?.edgeSize && theme.global.edgeSize[spinnerPad],
-    ) +  parseMetricToNum(
-      theme?.global?.edgeSize && theme.global.borderSize.small,
-    );
+    if (!rest.border) {
+      if (size !== undefined) {
+        spinnerPadBorder =
+          parseMetricToNum(
+            theme?.global?.edgeSize && theme.global.edgeSize[spinnerPad],
+          ) +
+          parseMetricToNum(
+            theme?.global?.edgeSize && theme.global.borderSize[size],
+          );
+      } else
+        spinnerPadBorder =
+          parseMetricToNum(
+            theme?.global?.edgeSize && theme.global.edgeSize[spinnerPad],
+          ) +
+          parseMetricToNum(
+            theme?.global?.edgeSize && theme.global.borderSize.small,
+          );
+    }
 
     // children will take prsecedence over theme attributes
     if (children) {

--- a/src/js/components/Spinner/Spinner.js
+++ b/src/js/components/Spinner/Spinner.js
@@ -49,7 +49,7 @@ const Spinner = forwardRef(
       ...themeProps
     } = theme.spinner.container;
 
-    const spinnerPad = theme?.spinner?.container?.pad;
+    const pad = theme?.spinner?.container?.pad;
 
     const normalizedSize = size || sizeThemeProp;
     const spinnerSize = theme.spinner.size[normalizedSize] || normalizedSize;
@@ -77,16 +77,33 @@ const Spinner = forwardRef(
 
     // check the size of the pad plus border
     // than multiple by 2 in order to compare to it to theme sizes
+    const spinnerPad = parseMetricToNum(
+      theme?.global?.edgeSize && theme.global.edgeSize[pad],
+    );
+
     let spinnerPadBorder;
+    // if a user passes border as a prop we should assume they want the pad
     if (!rest.border) {
-      spinnerPadBorder =
-        2 *
-        (parseMetricToNum(
-          theme?.global?.edgeSize && theme.global.edgeSize[spinnerPad],
-        ) +
-          parseMetricToNum(
-            theme?.global?.edgeSize && theme.global.borderSize[normalizedSize],
-          ));
+      // if  borderthemeProp is provided need to map through and use
+      // the sizes given for the border
+      if (borderThemeProp) {
+        spinnerPadBorder = borderThemeProp.map(
+          (item) =>
+            2 *
+            (spinnerPad +
+              parseMetricToNum(
+                theme?.global?.edgeSize && theme.global.borderSize[item.size],
+              )),
+        );
+      } else {
+        spinnerPadBorder =
+          2 *
+          (spinnerPad +
+            parseMetricToNum(
+              theme?.global?.edgeSize &&
+                theme.global.borderSize[normalizedSize],
+            ));
+      }
     }
 
     // children will take prsecedence over theme attributes

--- a/src/js/components/Spinner/__tests__/__snapshots__/Spinner-test.tsx.snap
+++ b/src/js/components/Spinner/__tests__/__snapshots__/Spinner-test.tsx.snap
@@ -26,7 +26,7 @@ exports[`Spinner border renders 1`] = `
   flex-direction: column;
   height: 24px;
   width: 24px;
-  padding: 0px;
+  padding: 12px;
   border-radius: 100%;
   -webkit-transform: rotate(0deg);
   -ms-transform: rotate(0deg);
@@ -51,7 +51,7 @@ exports[`Spinner border renders 1`] = `
   flex-direction: column;
   height: 24px;
   width: 24px;
-  padding: 0px;
+  padding: 12px;
   border-radius: 100%;
   -webkit-transform: rotate(0deg);
   -ms-transform: rotate(0deg);
@@ -77,7 +77,7 @@ exports[`Spinner border renders 1`] = `
   flex-direction: column;
   height: 24px;
   width: 24px;
-  padding: 0px;
+  padding: 12px;
   border-radius: 100%;
   -webkit-transform: rotate(0deg);
   -ms-transform: rotate(0deg);
@@ -104,7 +104,7 @@ exports[`Spinner border renders 1`] = `
   flex-direction: column;
   height: 24px;
   width: 24px;
-  padding: 0px;
+  padding: 12px;
   border-radius: 100%;
   -webkit-transform: rotate(0deg);
   -ms-transform: rotate(0deg);
@@ -129,7 +129,7 @@ exports[`Spinner border renders 1`] = `
   flex-direction: column;
   height: 24px;
   width: 24px;
-  padding: 0px;
+  padding: 12px;
   border-radius: 100%;
   -webkit-transform: rotate(0deg);
   -ms-transform: rotate(0deg);
@@ -146,7 +146,7 @@ exports[`Spinner border renders 1`] = `
 
 @media only screen and (max-width:768px) {
   .c1 {
-    padding: 0px;
+    padding: 6px;
   }
 }
 
@@ -159,7 +159,7 @@ exports[`Spinner border renders 1`] = `
 
 @media only screen and (max-width:768px) {
   .c2 {
-    padding: 0px;
+    padding: 6px;
   }
 }
 
@@ -178,7 +178,7 @@ exports[`Spinner border renders 1`] = `
 
 @media only screen and (max-width:768px) {
   .c3 {
-    padding: 0px;
+    padding: 6px;
   }
 }
 
@@ -208,7 +208,7 @@ exports[`Spinner border renders 1`] = `
 
 @media only screen and (max-width:768px) {
   .c4 {
-    padding: 0px;
+    padding: 6px;
   }
 }
 
@@ -221,7 +221,7 @@ exports[`Spinner border renders 1`] = `
 
 @media only screen and (max-width:768px) {
   .c5 {
-    padding: 0px;
+    padding: 6px;
   }
 }
 

--- a/src/js/components/Spinner/__tests__/__snapshots__/Spinner-test.tsx.snap
+++ b/src/js/components/Spinner/__tests__/__snapshots__/Spinner-test.tsx.snap
@@ -26,7 +26,7 @@ exports[`Spinner border renders 1`] = `
   flex-direction: column;
   height: 24px;
   width: 24px;
-  padding: 12px;
+  padding: 0px;
   border-radius: 100%;
   -webkit-transform: rotate(0deg);
   -ms-transform: rotate(0deg);
@@ -51,7 +51,7 @@ exports[`Spinner border renders 1`] = `
   flex-direction: column;
   height: 24px;
   width: 24px;
-  padding: 12px;
+  padding: 0px;
   border-radius: 100%;
   -webkit-transform: rotate(0deg);
   -ms-transform: rotate(0deg);
@@ -77,7 +77,7 @@ exports[`Spinner border renders 1`] = `
   flex-direction: column;
   height: 24px;
   width: 24px;
-  padding: 12px;
+  padding: 0px;
   border-radius: 100%;
   -webkit-transform: rotate(0deg);
   -ms-transform: rotate(0deg);
@@ -104,7 +104,7 @@ exports[`Spinner border renders 1`] = `
   flex-direction: column;
   height: 24px;
   width: 24px;
-  padding: 12px;
+  padding: 0px;
   border-radius: 100%;
   -webkit-transform: rotate(0deg);
   -ms-transform: rotate(0deg);
@@ -129,7 +129,7 @@ exports[`Spinner border renders 1`] = `
   flex-direction: column;
   height: 24px;
   width: 24px;
-  padding: 12px;
+  padding: 0px;
   border-radius: 100%;
   -webkit-transform: rotate(0deg);
   -ms-transform: rotate(0deg);
@@ -146,7 +146,7 @@ exports[`Spinner border renders 1`] = `
 
 @media only screen and (max-width:768px) {
   .c1 {
-    padding: 6px;
+    padding: 0px;
   }
 }
 
@@ -159,7 +159,7 @@ exports[`Spinner border renders 1`] = `
 
 @media only screen and (max-width:768px) {
   .c2 {
-    padding: 6px;
+    padding: 0px;
   }
 }
 
@@ -178,7 +178,7 @@ exports[`Spinner border renders 1`] = `
 
 @media only screen and (max-width:768px) {
   .c3 {
-    padding: 6px;
+    padding: 0px;
   }
 }
 
@@ -208,7 +208,7 @@ exports[`Spinner border renders 1`] = `
 
 @media only screen and (max-width:768px) {
   .c4 {
-    padding: 6px;
+    padding: 0px;
   }
 }
 
@@ -221,7 +221,7 @@ exports[`Spinner border renders 1`] = `
 
 @media only screen and (max-width:768px) {
   .c5 {
-    padding: 6px;
+    padding: 0px;
   }
 }
 
@@ -264,8 +264,8 @@ exports[`Spinner round renders 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  border: solid 1px #33333310;
-  border-top: solid 1px #7D4CDB;
+  border: solid 2px #33333310;
+  border-top: solid 2px #7D4CDB;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -273,7 +273,7 @@ exports[`Spinner round renders 1`] = `
   flex-direction: column;
   height: 24px;
   width: 24px;
-  padding: 12px;
+  padding: 0px;
   -webkit-transform: rotate(0deg);
   -ms-transform: rotate(0deg);
   transform: rotate(0deg);
@@ -288,8 +288,8 @@ exports[`Spinner round renders 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  border: solid 1px #33333310;
-  border-top: solid 1px #7D4CDB;
+  border: solid 2px #33333310;
+  border-top: solid 2px #7D4CDB;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -297,7 +297,7 @@ exports[`Spinner round renders 1`] = `
   flex-direction: column;
   height: 24px;
   width: 24px;
-  padding: 12px;
+  padding: 0px;
   border-radius: 12px;
   -webkit-transform: rotate(0deg);
   -ms-transform: rotate(0deg);
@@ -313,8 +313,8 @@ exports[`Spinner round renders 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  border: solid 1px #33333310;
-  border-top: solid 1px #7D4CDB;
+  border: solid 2px #33333310;
+  border-top: solid 2px #7D4CDB;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -322,7 +322,7 @@ exports[`Spinner round renders 1`] = `
   flex-direction: column;
   height: 24px;
   width: 24px;
-  padding: 12px;
+  padding: 0px;
   border-radius: 24px;
   -webkit-transform: rotate(0deg);
   -ms-transform: rotate(0deg);
@@ -338,8 +338,8 @@ exports[`Spinner round renders 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  border: solid 1px #33333310;
-  border-top: solid 1px #7D4CDB;
+  border: solid 2px #33333310;
+  border-top: solid 2px #7D4CDB;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -347,7 +347,7 @@ exports[`Spinner round renders 1`] = `
   flex-direction: column;
   height: 24px;
   width: 24px;
-  padding: 12px;
+  padding: 0px;
   border-radius: 48px;
   -webkit-transform: rotate(0deg);
   -ms-transform: rotate(0deg);
@@ -358,37 +358,37 @@ exports[`Spinner round renders 1`] = `
 
 @media only screen and (max-width:768px) {
   .c1 {
-    border: solid 1px #33333310;
+    border: solid 2px #33333310;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c1 {
-    border-top: solid 1px #7D4CDB;
+    border-top: solid 2px #7D4CDB;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c1 {
-    padding: 6px;
+    padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c2 {
-    border: solid 1px #33333310;
+    border: solid 2px #33333310;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c2 {
-    border-top: solid 1px #7D4CDB;
+    border-top: solid 2px #7D4CDB;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c2 {
-    padding: 6px;
+    padding: 0px;
   }
 }
 
@@ -400,19 +400,19 @@ exports[`Spinner round renders 1`] = `
 
 @media only screen and (max-width:768px) {
   .c3 {
-    border: solid 1px #33333310;
+    border: solid 2px #33333310;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c3 {
-    border-top: solid 1px #7D4CDB;
+    border-top: solid 2px #7D4CDB;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c3 {
-    padding: 6px;
+    padding: 0px;
   }
 }
 
@@ -424,19 +424,19 @@ exports[`Spinner round renders 1`] = `
 
 @media only screen and (max-width:768px) {
   .c4 {
-    border: solid 1px #33333310;
+    border: solid 2px #33333310;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c4 {
-    border-top: solid 1px #7D4CDB;
+    border-top: solid 2px #7D4CDB;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c4 {
-    padding: 6px;
+    padding: 0px;
   }
 }
 
@@ -482,8 +482,8 @@ exports[`Spinner should have no accessibility violations 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  border: solid 1px #33333310;
-  border-top: solid 1px #7D4CDB;
+  border: solid 2px #33333310;
+  border-top: solid 2px #7D4CDB;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -491,7 +491,7 @@ exports[`Spinner should have no accessibility violations 1`] = `
   flex-direction: column;
   height: 24px;
   width: 24px;
-  padding: 12px;
+  padding: 0px;
   border-radius: 100%;
   -webkit-transform: rotate(0deg);
   -ms-transform: rotate(0deg);
@@ -502,19 +502,19 @@ exports[`Spinner should have no accessibility violations 1`] = `
 
 @media only screen and (max-width:768px) {
   .c1 {
-    border: solid 1px #33333310;
+    border: solid 2px #33333310;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c1 {
-    border-top: solid 1px #7D4CDB;
+    border-top: solid 2px #7D4CDB;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c1 {
-    padding: 6px;
+    padding: 0px;
   }
 }
 
@@ -554,7 +554,7 @@ exports[`Spinner size renders 1`] = `
   flex-direction: column;
   height: 18px;
   width: 18px;
-  padding: 12px;
+  padding: 0px;
   border-radius: 100%;
   -webkit-transform: rotate(0deg);
   -ms-transform: rotate(0deg);
@@ -579,7 +579,7 @@ exports[`Spinner size renders 1`] = `
   flex-direction: column;
   height: 24px;
   width: 24px;
-  padding: 12px;
+  padding: 0px;
   border-radius: 100%;
   -webkit-transform: rotate(0deg);
   -ms-transform: rotate(0deg);
@@ -677,7 +677,7 @@ exports[`Spinner size renders 1`] = `
 
 @media only screen and (max-width:768px) {
   .c1 {
-    padding: 6px;
+    padding: 0px;
   }
 }
 
@@ -695,7 +695,7 @@ exports[`Spinner size renders 1`] = `
 
 @media only screen and (max-width:768px) {
   .c2 {
-    padding: 6px;
+    padding: 0px;
   }
 }
 
@@ -792,8 +792,8 @@ exports[`Spinner size renders 2`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  border: solid 1px #33333310;
-  border-top: solid 1px #6FFFB0;
+  border: solid 2px #33333310;
+  border-top: solid 2px #6FFFB0;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -801,7 +801,7 @@ exports[`Spinner size renders 2`] = `
   flex-direction: column;
   height: 24px;
   width: 24px;
-  padding: 12px;
+  padding: 0px;
   border-radius: 100%;
   -webkit-transform: rotate(0deg);
   -ms-transform: rotate(0deg);
@@ -817,8 +817,8 @@ exports[`Spinner size renders 2`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  border: solid 1px #33333310;
-  border-top: solid 1px #00873D;
+  border: solid 2px #33333310;
+  border-top: solid 2px #00873D;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -826,7 +826,7 @@ exports[`Spinner size renders 2`] = `
   flex-direction: column;
   height: 24px;
   width: 24px;
-  padding: 12px;
+  padding: 0px;
   border-radius: 100%;
   -webkit-transform: rotate(0deg);
   -ms-transform: rotate(0deg);
@@ -842,8 +842,8 @@ exports[`Spinner size renders 2`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  border: solid 1px #33333310;
-  border-top: solid 1px #3D138D;
+  border: solid 2px #33333310;
+  border-top: solid 2px #3D138D;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -851,7 +851,7 @@ exports[`Spinner size renders 2`] = `
   flex-direction: column;
   height: 24px;
   width: 24px;
-  padding: 12px;
+  padding: 0px;
   border-radius: 100%;
   -webkit-transform: rotate(0deg);
   -ms-transform: rotate(0deg);
@@ -867,8 +867,8 @@ exports[`Spinner size renders 2`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  border: solid 1px #33333310;
-  border-top: solid 1px #00739D;
+  border: solid 2px #33333310;
+  border-top: solid 2px #00739D;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -876,7 +876,7 @@ exports[`Spinner size renders 2`] = `
   flex-direction: column;
   height: 24px;
   width: 24px;
-  padding: 12px;
+  padding: 0px;
   border-radius: 100%;
   -webkit-transform: rotate(0deg);
   -ms-transform: rotate(0deg);
@@ -892,8 +892,8 @@ exports[`Spinner size renders 2`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  border: solid 1px #33333310;
-  border-top: solid 1px #A2423D;
+  border: solid 2px #33333310;
+  border-top: solid 2px #A2423D;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -901,7 +901,7 @@ exports[`Spinner size renders 2`] = `
   flex-direction: column;
   height: 24px;
   width: 24px;
-  padding: 12px;
+  padding: 0px;
   border-radius: 100%;
   -webkit-transform: rotate(0deg);
   -ms-transform: rotate(0deg);
@@ -912,91 +912,91 @@ exports[`Spinner size renders 2`] = `
 
 @media only screen and (max-width:768px) {
   .c1 {
-    border: solid 1px #33333310;
+    border: solid 2px #33333310;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c1 {
-    border-top: solid 1px #6FFFB0;
+    border-top: solid 2px #6FFFB0;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c1 {
-    padding: 6px;
+    padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c2 {
-    border: solid 1px #33333310;
+    border: solid 2px #33333310;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c2 {
-    border-top: solid 1px #00873D;
+    border-top: solid 2px #00873D;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c2 {
-    padding: 6px;
+    padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c3 {
-    border: solid 1px #33333310;
+    border: solid 2px #33333310;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c3 {
-    border-top: solid 1px #3D138D;
+    border-top: solid 2px #3D138D;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c3 {
-    padding: 6px;
+    padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c4 {
-    border: solid 1px #33333310;
+    border: solid 2px #33333310;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c4 {
-    border-top: solid 1px #00739D;
+    border-top: solid 2px #00739D;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c4 {
-    padding: 6px;
+    padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c5 {
-    border: solid 1px #33333310;
+    border: solid 2px #33333310;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c5 {
-    border-top: solid 1px #A2423D;
+    border-top: solid 2px #A2423D;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c5 {
-    padding: 6px;
+    padding: 0px;
   }
 }
 
@@ -1047,7 +1047,7 @@ exports[`Spinner spinner changes according to theme 1`] = `
   flex-direction: column;
   height: 30px;
   width: 30px;
-  padding: 48px;
+  padding: 0px;
   border-radius: 24px;
   -webkit-transform: rotate(0deg);
   -ms-transform: rotate(0deg);
@@ -1058,7 +1058,7 @@ exports[`Spinner spinner changes according to theme 1`] = `
 
 @media only screen and (max-width:768px) {
   .c1 {
-    padding: 24px;
+    padding: 0px;
   }
 }
 
@@ -1106,7 +1106,7 @@ exports[`Spinner spinner color renders over theme settings 1`] = `
   flex-direction: column;
   height: 24px;
   width: 24px;
-  padding: 12px;
+  padding: 0px;
   border-radius: 100%;
   -webkit-transform: rotate(0deg);
   -ms-transform: rotate(0deg);
@@ -1141,7 +1141,7 @@ exports[`Spinner spinner color renders over theme settings 1`] = `
 
 @media only screen and (max-width:768px) {
   .c1 {
-    padding: 6px;
+    padding: 0px;
   }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR checks to see if the `pad` plus the `border` is larger than the intended size for the spinner and if it is then do not add `pad` so the theme sizes stay true to the size of the spinner.

#### Where should the reviewer start?
spinner.js
#### What testing has been done on this PR?
storybook 
#### How should this be manually tested?
storybook 
#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
<img width="803" alt="Screen Shot 2022-07-21 at 2 12 34 PM" src="https://user-images.githubusercontent.com/42451602/180306695-470b5d8e-3b1e-4b31-86be-09f15820090b.png">
In the image above you can see that `xsmall` and `small` are very close in size with each other. 
The reasoning behind this is because we have `pad` set in our theme to be `small` 
for the `xsmall` you can see that we have a `pad` of `12px` and a border of `1px` so together we have a `box` that is 26px X 26px this is not true to our size in which we have 
`xsmall` to be 18px stated in our theme. 

```
      size: {
        xsmall: `${baseSpacing * 0.75}px`,
        small: `${baseSpacing}px`, // default 24
        medium: `${baseSpacing * 2}px`,
        large: `${baseSpacing * 3}px`,
        xlarge: `${baseSpacing * 4}px`,
      },

```


<img width="212" alt="Screen Shot 2022-07-21 at 2 13 59 PM" src="https://user-images.githubusercontent.com/42451602/180306910-726425ba-0cac-4fe7-a0ef-1a010fc4e415.png">

<img width="360" alt="Screen Shot 2022-07-21 at 2 14 59 PM" src="https://user-images.githubusercontent.com/42451602/180307056-644fcc52-1760-4c08-827e-b08527d39271.png">


The same issue is also happening to make our `small` be 28 X 28 instead of our default of 24px 

I realize this would not be backwards compatible because it may change the size in which teams are using but I also think that this is a bug since it does not represent our theme sizes. 

Another issue I found was when `size` was not being used as a prop there was inconsistency with the border size. For instance if you use Spinner with `size = 'small'` you get a border of `2px` but if you use Spinner without passing `small` (which is our default) the border size is `1px`  This should be consistent so I added a check if `size` is not given we will assume it is the default `small` 

<img width="328" alt="Screen Shot 2022-07-21 at 2 21 46 PM" src="https://user-images.githubusercontent.com/42451602/180308131-b2d1673d-042c-4eea-8a5e-98cf79affe20.png">


#### What are the relevant issues?
closes #6210 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
maybe
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
read above