### PR TITLE
omit border for table

### DIFF
--- a/src/js/components/DataTable/index.d.ts
+++ b/src/js/components/DataTable/index.d.ts
@@ -129,7 +129,10 @@ export interface DataTableProps<TRowType = any> {
 
 export interface DataTableExtendedProps<TRowType = any>
   extends DataTableProps<TRowType>,
-    Omit<JSX.IntrinsicElements['table'], 'onSelect' | 'placeholder'> {}
+    Omit<
+      JSX.IntrinsicElements['table'],
+      'onSelect' | 'placeholder' | 'border'
+    > {}
 
 declare class DataTable<TRowType = any> extends React.Component<
   DataTableExtendedProps<TRowType>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR omits the HTML table `border` 
#### Where should the reviewer start?
DataTable/index.d.ts
#### What testing has been done on this PR?
locally 
#### How should this be manually tested?
storybook
#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
```
src/js/components/DataTable/index.d.ts:130:18 - error TS2320: Interface 'DataTableExtendedProps<TRowType>' cannot simultaneously extend types 'DataTableProps<TRowType>' and 'Omit<DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement>, "placeholder" | "onSelect">'.
  Named property 'border' of types 'DataTableProps<TRowType>' and 'Omit<DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement>, "placeholder" | "onSelect">' are not identical.

```
since we are extending our DataTable props while vomiting some of the `html` table props there was an issue with `border` 

#### What are the relevant issues?
closes #6236 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
sure
#### Is this change backwards compatible or is it a breaking change?
 backwards compatible