### PR TITLE
Fix Datatable conflicting paginated step

### DIFF
--- a/src/js/components/DataTable/DataTable.js
+++ b/src/js/components/DataTable/DataTable.js
@@ -338,6 +338,7 @@ const DataTable = ({
     step,
     ...paginate, // let any specifications from paginate prop override component
   });
+  const { step: paginationStep } = paginationProps;
 
   const Container = paginate ? StyledContainer : Fragment;
   const containterProps = paginate
@@ -392,12 +393,12 @@ const DataTable = ({
                   expanded: Object.keys(groupState).filter(
                     (k) => groupState[k].expanded,
                   ),
-                  count: limit + step,
+                  count: limit + paginationStep,
                 };
                 if (sort?.property) opts.sort = sort;
                 if (showProp) opts.show = showProp;
                 onUpdate(opts);
-                setLimit((prev) => prev + step);
+                setLimit((prev) => prev + paginationStep);
               }
             }
           : onMore
@@ -416,7 +417,7 @@ const DataTable = ({
       rowProps={rowProps}
       selected={selected}
       size={size}
-      step={step}
+      step={paginationStep}
       verticalAlign={
         typeof verticalAlign === 'string' ? verticalAlign : verticalAlign?.body
       }
@@ -433,12 +434,12 @@ const DataTable = ({
           ? () => {
               if (adjustedData.length === limit) {
                 const opts = {
-                  count: limit + step,
+                  count: limit + paginationStep,
                 };
                 if (sort?.property) opts.sort = sort;
                 if (showProp) opts.show = showProp;
                 onUpdate(opts);
-                setLimit((prev) => prev + step);
+                setLimit((prev) => prev + paginationStep);
               }
             }
           : onMore
@@ -460,7 +461,7 @@ const DataTable = ({
       selected={selected}
       show={!paginate ? showProp : undefined}
       size={size}
-      step={step}
+      step={paginationStep}
       rowDetails={rowDetails}
       rowExpand={rowExpand}
       setRowExpand={setRowExpand}
@@ -559,7 +560,10 @@ const DataTable = ({
           )}
         </StyledDataTable>
       </OverflowContainer>
-      {paginate && adjustedData.length > step && items && items.length ? (
+      {paginate &&
+      adjustedData.length > paginationStep &&
+      items &&
+      items.length ? (
         <Pagination alignSelf="end" {...paginationProps} />
       ) : null}
     </Container>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Uses the usePagination util so the Datatable component step can be defined with either `step` prop or inside `paginate` prop when used as an object.

#### Where should the reviewer start?
`src/js/components/DataTable/DataTable.js`

#### What testing has been done on this PR?
`yarn test`

#### How should this be manually tested?
Use or create a datatable story in storybook using the paginate prop
https://storybook.grommet.io/?path=/story/visualizations-datatable-paginated--paginated

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

Issue #6221 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
backwards compatible