### PR TITLE
Changed Tab to be resilient to not be contains in Tabs

### DIFF
--- a/src/js/components/Tab/Tab.js
+++ b/src/js/components/Tab/Tab.js
@@ -49,7 +49,7 @@ const Tab = forwardRef(
     const tabRef = useForwardedRef(ref);
 
     useLayoutEffect(() => {
-      if (tabRef.current) {
+      if (tabRef.current && tabsContextRef) {
         tabsContextRef.current = tabRef.current;
       }
     });

--- a/src/js/components/Tabs/__tests__/Tabs-test.tsx
+++ b/src/js/components/Tabs/__tests__/Tabs-test.tsx
@@ -37,6 +37,16 @@ describe('Tabs', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  test('no Tabs', () => {
+    const { container } = render(
+      <Grommet>
+        <Tab />
+      </Grommet>,
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
   test('Tab', () => {
     const { container } = render(
       <Grommet>
@@ -314,10 +324,10 @@ describe('Tabs', () => {
     const { getByText, container } = render(
       <Grommet>
         <Tabs>
-          <Tab title="Tab 1">
-            Tab body 1
+          <Tab title="Tab 1">Tab body 1</Tab>
+          <Tab title="Tab 2" onClick={onClick}>
+            Tab body 2
           </Tab>
-          <Tab title="Tab 2" onClick={onClick}>Tab body 2</Tab>
         </Tabs>
       </Grommet>,
     );

--- a/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.tsx.snap
+++ b/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.tsx.snap
@@ -1804,6 +1804,152 @@ exports[`Tabs no Tab 1`] = `
 </div>
 `;
 
+exports[`Tabs no Tabs 1`] = `
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-left: 12px;
+  margin-right: 12px;
+  margin-top: 3px;
+  margin-bottom: 3px;
+  border-bottom: solid 2px #7D4CDB;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-bottom: 6px;
+}
+
+.c1 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c1:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c1:focus > circle,
+.c1:focus > ellipse,
+.c1:focus > line,
+.c1:focus > path,
+.c1:focus > polygon,
+.c1:focus > polyline,
+.c1:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c1:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c1:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c1:focus:not(:focus-visible) > circle,
+.c1:focus:not(:focus-visible) > ellipse,
+.c1:focus:not(:focus-visible) > line,
+.c1:focus:not(:focus-visible) > path,
+.c1:focus:not(:focus-visible) > polygon,
+.c1:focus:not(:focus-visible) > polyline,
+.c1:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c1:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c3 {
+  white-space: nowrap;
+  margin-left: 12px;
+  margin-right: 12px;
+  margin-top: 3px;
+  margin-bottom: 3px;
+}
+
+.c3:hover {
+  color: #000000;
+}
+
+.c3:focus {
+  z-index: 1;
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    margin-left: 6px;
+    margin-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    margin-top: 2px;
+    margin-bottom: 2px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    border-bottom: solid 2px #7D4CDB;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    padding-bottom: 3px;
+  }
+}
+
+<div
+  class="c0"
+>
+  <button
+    class="c1"
+    role="tab"
+    type="button"
+  >
+    <div
+      class="c2 c3"
+    />
+  </button>
+</div>
+`;
+
 exports[`Tabs onClick 1`] = `
 .c1 {
   display: -webkit-box;


### PR DESCRIPTION
#### What does this PR do?

Changed Tab to be resilient to not be contains in Tabs.
This showed up when someone added a Tab to a Box in grommet designer, where it crashed.

#### Where should the reviewer start?

Tab.js

#### What testing has been done on this PR?

Added a unit test.

#### How should this be manually tested?

Tab with Tabs

#### Do Jest tests follow these best practices?

preserved existing test structure

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
