### PR TITLE
(Spinner) fix: keep the correct size

### DIFF
--- a/src/js/components/Spinner/Spinner.js
+++ b/src/js/components/Spinner/Spinner.js
@@ -12,7 +12,7 @@ import { defaultProps } from '../../default-props';
 import { SpinnerPropTypes } from './propTypes';
 
 const BasicSpinner = ({ ref, size, ...rest }) => (
-  <Box height={size} width={size} ref={ref} {...rest} />
+  <Box flex={false} height={size} width={size} ref={ref} {...rest} />
 );
 /**
  * If the user is calling <Spinner>…</Spinner> with children, it will take

--- a/src/js/components/Spinner/__tests__/__snapshots__/Spinner-test.tsx.snap
+++ b/src/js/components/Spinner/__tests__/__snapshots__/Spinner-test.tsx.snap
@@ -26,6 +26,9 @@ exports[`Spinner border renders 1`] = `
   flex-direction: column;
   height: 24px;
   width: 24px;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
   padding: 12px;
   border-radius: 100%;
   -webkit-transform: rotate(0deg);
@@ -51,6 +54,9 @@ exports[`Spinner border renders 1`] = `
   flex-direction: column;
   height: 24px;
   width: 24px;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
   padding: 12px;
   border-radius: 100%;
   -webkit-transform: rotate(0deg);
@@ -77,6 +83,9 @@ exports[`Spinner border renders 1`] = `
   flex-direction: column;
   height: 24px;
   width: 24px;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
   padding: 12px;
   border-radius: 100%;
   -webkit-transform: rotate(0deg);
@@ -104,6 +113,9 @@ exports[`Spinner border renders 1`] = `
   flex-direction: column;
   height: 24px;
   width: 24px;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
   padding: 12px;
   border-radius: 100%;
   -webkit-transform: rotate(0deg);
@@ -129,6 +141,9 @@ exports[`Spinner border renders 1`] = `
   flex-direction: column;
   height: 24px;
   width: 24px;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
   padding: 12px;
   border-radius: 100%;
   -webkit-transform: rotate(0deg);
@@ -273,6 +288,9 @@ exports[`Spinner round renders 1`] = `
   flex-direction: column;
   height: 24px;
   width: 24px;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
   padding: 12px;
   -webkit-transform: rotate(0deg);
   -ms-transform: rotate(0deg);
@@ -297,6 +315,9 @@ exports[`Spinner round renders 1`] = `
   flex-direction: column;
   height: 24px;
   width: 24px;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
   padding: 12px;
   border-radius: 12px;
   -webkit-transform: rotate(0deg);
@@ -322,6 +343,9 @@ exports[`Spinner round renders 1`] = `
   flex-direction: column;
   height: 24px;
   width: 24px;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
   padding: 12px;
   border-radius: 24px;
   -webkit-transform: rotate(0deg);
@@ -347,6 +371,9 @@ exports[`Spinner round renders 1`] = `
   flex-direction: column;
   height: 24px;
   width: 24px;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
   padding: 12px;
   border-radius: 48px;
   -webkit-transform: rotate(0deg);
@@ -491,6 +518,9 @@ exports[`Spinner should have no accessibility violations 1`] = `
   flex-direction: column;
   height: 24px;
   width: 24px;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
   padding: 12px;
   border-radius: 100%;
   -webkit-transform: rotate(0deg);
@@ -554,6 +584,9 @@ exports[`Spinner size renders 1`] = `
   flex-direction: column;
   height: 18px;
   width: 18px;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
   padding: 12px;
   border-radius: 100%;
   -webkit-transform: rotate(0deg);
@@ -579,6 +612,9 @@ exports[`Spinner size renders 1`] = `
   flex-direction: column;
   height: 24px;
   width: 24px;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
   padding: 12px;
   border-radius: 100%;
   -webkit-transform: rotate(0deg);
@@ -604,6 +640,9 @@ exports[`Spinner size renders 1`] = `
   flex-direction: column;
   height: 48px;
   width: 48px;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
   padding: 12px;
   border-radius: 100%;
   -webkit-transform: rotate(0deg);
@@ -629,6 +668,9 @@ exports[`Spinner size renders 1`] = `
   flex-direction: column;
   height: 72px;
   width: 72px;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
   padding: 12px;
   border-radius: 100%;
   -webkit-transform: rotate(0deg);
@@ -654,6 +696,9 @@ exports[`Spinner size renders 1`] = `
   flex-direction: column;
   height: 96px;
   width: 96px;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
   padding: 12px;
   border-radius: 100%;
   -webkit-transform: rotate(0deg);
@@ -801,6 +846,9 @@ exports[`Spinner size renders 2`] = `
   flex-direction: column;
   height: 24px;
   width: 24px;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
   padding: 12px;
   border-radius: 100%;
   -webkit-transform: rotate(0deg);
@@ -826,6 +874,9 @@ exports[`Spinner size renders 2`] = `
   flex-direction: column;
   height: 24px;
   width: 24px;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
   padding: 12px;
   border-radius: 100%;
   -webkit-transform: rotate(0deg);
@@ -851,6 +902,9 @@ exports[`Spinner size renders 2`] = `
   flex-direction: column;
   height: 24px;
   width: 24px;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
   padding: 12px;
   border-radius: 100%;
   -webkit-transform: rotate(0deg);
@@ -876,6 +930,9 @@ exports[`Spinner size renders 2`] = `
   flex-direction: column;
   height: 24px;
   width: 24px;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
   padding: 12px;
   border-radius: 100%;
   -webkit-transform: rotate(0deg);
@@ -901,6 +958,9 @@ exports[`Spinner size renders 2`] = `
   flex-direction: column;
   height: 24px;
   width: 24px;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
   padding: 12px;
   border-radius: 100%;
   -webkit-transform: rotate(0deg);
@@ -1047,6 +1107,9 @@ exports[`Spinner spinner changes according to theme 1`] = `
   flex-direction: column;
   height: 30px;
   width: 30px;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
   padding: 48px;
   border-radius: 24px;
   -webkit-transform: rotate(0deg);
@@ -1106,6 +1169,9 @@ exports[`Spinner spinner color renders over theme settings 1`] = `
   flex-direction: column;
   height: 24px;
   width: 24px;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
   padding: 12px;
   border-radius: 100%;
   -webkit-transform: rotate(0deg);
@@ -1217,6 +1283,9 @@ exports[`Spinner spinner icon changes according to theme 1`] = `
   flex-direction: column;
   height: 72px;
   width: 72px;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds `min-width` css rule to Spinner to keep correct size. Usually, the issue is visible on mobile devices where content can squeeze Spinner component.

#### Where should the reviewer start?
Spinner.js

#### What testing has been done on this PR?
Manual/snapshot

#### How should this be manually tested?
Enable Responsive Design mode in dev tools and validate Storybook

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
Spinner is not keeping its original size.

#### What are the relevant issues?

#### Screenshots (if a appropriate)
![Screenshot 2022-08-13 at 11 42 36](https://user-images.githubusercontent.com/891392/184478586-463293fd-805c-49a5-afa9-3c0fa4ffb947.png)

with `min-width`
![Screenshot 2022-08-13 at 11 53 16](https://user-images.githubusercontent.com/891392/184478686-2a46a9d7-0cbc-4ccf-b401-26fa9cfd56c3.png)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
backwards compatible