### PR TITLE
6273 pageheader size

### DIFF
--- a/src/js/components/PageHeader/PageHeader.js
+++ b/src/js/components/PageHeader/PageHeader.js
@@ -8,6 +8,11 @@ import { Grid } from '../Grid';
 import { Paragraph } from '../Paragraph';
 import { ResponsiveContext } from '../../contexts/ResponsiveContext';
 
+const sizeStyle = (size, style, theme) =>
+  size && theme.pageHeader.size[size]?.[style]
+    ? theme.pageHeader.size[size]?.[style]
+    : theme.pageHeader[style];
+
 const PageHeader = forwardRef(
   (
     {
@@ -15,6 +20,7 @@ const PageHeader = forwardRef(
       gridProps: gridPropsProp,
       parent,
       responsive,
+      size,
       subtitle,
       title,
       ...rest
@@ -45,7 +51,7 @@ const PageHeader = forwardRef(
         ref={ref}
         direction="column"
         gap="none"
-        pad={theme.pageHeader.pad}
+        pad={sizeStyle(size, 'pad', theme)}
         {...rest}
       >
         <Grid
@@ -61,14 +67,16 @@ const PageHeader = forwardRef(
           </Box>
           <Box gridArea="title">
             {typeof title === 'string' ? (
-              <Heading {...theme.pageHeader.title}>{title}</Heading>
+              <Heading {...sizeStyle(size, 'title', theme)}>{title}</Heading>
             ) : (
               title
             )}
           </Box>
           <Box gridArea="subtitle">
             {typeof subtitle === 'string' ? (
-              <Paragraph {...theme.pageHeader.subtitle}>{subtitle}</Paragraph>
+              <Paragraph {...sizeStyle(size, 'subtitle', theme)}>
+                {subtitle}
+              </Paragraph>
             ) : (
               subtitle
             )}

--- a/src/js/components/PageHeader/__tests__/PageHeader-test.tsx
+++ b/src/js/components/PageHeader/__tests__/PageHeader-test.tsx
@@ -26,6 +26,24 @@ describe('PageHeader', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
+  test('size', () => {
+    const { asFragment } = render(
+      <Grommet>
+        <PageHeader
+          title="Grommet"
+          subtitle={`Grommet helps you build responsive and accessible 
+          mobile-first projects for the web with an easy to use component 
+          library.`}
+          actions={<Button label="Get Started" primary />}
+          parent={<Anchor label="Parent Page" />}
+          size="large"
+        />
+      </Grommet>,
+    );
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+
   test('custom theme', () => {
     const customTheme = {
       pageHeader: {

--- a/src/js/components/PageHeader/__tests__/__snapshots__/PageHeader-test.tsx.snap
+++ b/src/js/components/PageHeader/__tests__/__snapshots__/PageHeader-test.tsx.snap
@@ -618,3 +618,303 @@ exports[`PageHeader custom theme 1`] = `
   </div>
 </DocumentFragment>
 `;
+
+exports[`PageHeader size 1`] = `
+<DocumentFragment>
+  .c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-top: 96px;
+  padding-bottom: 48px;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  grid-area: parent;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  grid-area: title;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  grid-area: subtitle;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  grid-area: actions;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c4 {
+  box-sizing: border-box;
+  font-size: inherit;
+  line-height: inherit;
+  color: #7D4CDB;
+  font-weight: 600;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.c4:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c10 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: 2px solid #7D4CDB;
+  border-radius: 18px;
+  color: #444444;
+  padding: 4px 22px;
+  font-size: 18px;
+  line-height: 24px;
+  background-color: #7D4CDB;
+  color: #f8f8f8;
+  border-radius: 18px;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+}
+
+.c10:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c10:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus > circle,
+.c10:focus > ellipse,
+.c10:focus > line,
+.c10:focus > path,
+.c10:focus > polygon,
+.c10:focus > polyline,
+.c10:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c10:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c10:focus:not(:focus-visible) > circle,
+.c10:focus:not(:focus-visible) > ellipse,
+.c10:focus:not(:focus-visible) > line,
+.c10:focus:not(:focus-visible) > path,
+.c10:focus:not(:focus-visible) > polygon,
+.c10:focus:not(:focus-visible) > polyline,
+.c10:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c10:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c6 {
+  margin: 0px;
+  font-size: 82px;
+  line-height: 88px;
+  max-width: 1968px;
+  font-weight: 600;
+}
+
+.c2 {
+  display: grid;
+  box-sizing: border-box;
+  width: 100%;
+  grid-template-areas: "parent parent" "title actions" "subtitle actions";
+  grid-template-columns: minmax(192px,1fr) auto;
+  grid-gap: 6px 48px;
+  grid-template-rows: auto auto auto;
+}
+
+.c8 {
+  margin: 0px;
+  font-size: 22px;
+  line-height: 28px;
+  max-width: 528px;
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    padding-top: 48px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    padding-bottom: 24px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    font-size: 50px;
+    line-height: 56px;
+    max-width: 1200px;
+  }
+}
+
+<div
+    class="c0"
+  >
+    <header
+      class="c1"
+    >
+      <div
+        class="c2"
+      >
+        <div
+          class="c3"
+        >
+          <a
+            class="c4"
+          >
+            Parent Page
+          </a>
+        </div>
+        <div
+          class="c5"
+        >
+          <h1
+            class="c6"
+          >
+            Grommet
+          </h1>
+        </div>
+        <div
+          class="c7"
+        >
+          <p
+            class="c8"
+          >
+            Grommet helps you build responsive and accessible 
+          mobile-first projects for the web with an easy to use component 
+          library.
+          </p>
+        </div>
+        <div
+          class="c9"
+        >
+          <button
+            class="c10"
+            type="button"
+          >
+            Get Started
+          </button>
+        </div>
+      </div>
+    </header>
+  </div>
+</DocumentFragment>
+`;

--- a/src/js/components/PageHeader/index.d.ts
+++ b/src/js/components/PageHeader/index.d.ts
@@ -5,6 +5,7 @@ import {
   GridAreaType,
   MarginType,
 } from '../../utils';
+import { BoxProps } from '../Box/index';
 
 import { GridProps } from '../Grid';
 export interface PageHeaderProps {
@@ -16,11 +17,19 @@ export interface PageHeaderProps {
   gridProps?: GridProps;
   parent?: JSX.Element;
   responsive?: boolean;
+  size?: 'small' | 'medium' | 'large';
   subtitle?: string | JSX.Element;
   title?: string | JSX.Element;
 }
 
-declare const PageHeader: React.FC<PageHeaderProps>;
+type divProps = Omit<JSX.IntrinsicElements['div'], 'onClick' | 'title'>;
+
+export interface PageHeaderExtendedProps
+  extends BoxProps,
+    PageHeaderProps,
+    divProps {}
+
+declare const PageHeader: React.FC<PageHeaderExtendedProps>;
 export type PageHeaderType = PageHeaderProps;
 
 export { PageHeader };

--- a/src/js/components/PageHeader/propTypes.js
+++ b/src/js/components/PageHeader/propTypes.js
@@ -10,6 +10,7 @@ if (process.env.NODE_ENV !== 'production') {
     gridProps: GridPropTypes,
     parent: PropTypes.element,
     responsive: PropTypes.bool,
+    size: PropTypes.oneOf(['small', 'medium', 'large']),
     subtitle: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
     title: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   };

--- a/src/js/components/PageHeader/stories/Size.js
+++ b/src/js/components/PageHeader/stories/Size.js
@@ -1,0 +1,53 @@
+import React, { useState } from 'react';
+
+import {
+  Anchor,
+  Form,
+  FormField,
+  PageHeader,
+  Page,
+  PageContent,
+  Select,
+} from 'grommet';
+
+export const Size = () => {
+  const [size, setSize] = useState('medium');
+  return (
+    // Uncomment <Grommet> lines when using outside of storybook
+    // <Grommet theme={...}>
+    <Page>
+      <PageContent>
+        <PageHeader
+          title="Grommet"
+          subtitle={`Grommet helps you build responsive and accessible 
+          mobile-first projects for the web with an easy to use component 
+          library.`}
+          actions={
+            <Form>
+              <FormField
+                label="Choose PageHeader size"
+                htmlFor="size-select"
+                name="size-select"
+              >
+                <Select
+                  id="size-select__input"
+                  name="size-select"
+                  options={['small', 'medium', 'large']}
+                  value={size}
+                  onChange={({ option }) => setSize(option)}
+                />
+              </FormField>
+            </Form>
+          }
+          parent={<Anchor label="Parent Page" />}
+          size={size}
+        />
+      </PageContent>
+    </Page>
+    // </Grommet>
+  );
+};
+
+export default {
+  title: 'Layout/PageHeader/Size',
+};

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -2055,6 +2055,36 @@ Object {
               "auto",
             ],
           },
+          "size": Object {
+            "large": Object {
+              "pad": Object {
+                "bottom": "large",
+                "top": "xlarge",
+              },
+              "subtitle": Object {
+                "margin": "none",
+                "size": "large",
+              },
+              "title": Object {
+                "margin": "none",
+                "size": "large",
+              },
+            },
+            "small": Object {
+              "pad": Object {
+                "bottom": "small",
+                "top": "medium",
+              },
+              "subtitle": Object {
+                "margin": "none",
+                "size": "small",
+              },
+              "title": Object {
+                "margin": "none",
+                "size": "small",
+              },
+            },
+          },
           "small": Object {
             "areas": Array [
               Array [

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -368,11 +368,12 @@ export interface ThemeType {
         color?: ColorType;
         size?: string;
       };
-      shadow?: 
-        string | {
-        color?: ColorType;
-        size?: string;
-      };
+      shadow?:
+        | string
+        | {
+            color?: ColorType;
+            size?: string;
+          };
     };
     font?: {
       face?: string;
@@ -1163,6 +1164,23 @@ export interface ThemeType {
     };
     subtitle?: ParagraphProps;
     title?: HeadingProps;
+    size?: {
+      small?: {
+        pad?: PadType;
+        subtitle?: ParagraphProps;
+        title?: ParagraphProps;
+      };
+      medium?: {
+        pad?: PadType;
+        subtitle?: ParagraphProps;
+        title?: ParagraphProps;
+      };
+      large?: {
+        pad?: PadType;
+        subtitle?: ParagraphProps;
+        title?: ParagraphProps;
+      };
+    };
     small?: {
       areas?: AreasType;
       columns?: GridColumnsType;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1321,6 +1321,41 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         margin: 'none',
         fill: true,
       },
+      size: {
+        small: {
+          pad: {
+            top: 'medium',
+            bottom: 'small',
+          },
+          subtitle: {
+            size: 'small',
+            margin: 'none',
+          },
+          title: {
+            size: 'small',
+            margin: 'none',
+          },
+        },
+        // medium: {
+        //   // pad: undefined,
+        //   // subtitle: {},
+        //   // title: {},
+        // },
+        large: {
+          pad: {
+            top: 'xlarge',
+            bottom: 'large',
+          },
+          subtitle: {
+            size: 'large',
+            margin: 'none',
+          },
+          title: {
+            size: 'large',
+            margin: 'none',
+          },
+        },
+      },
       small: {
         areas: [
           ['parent', 'parent'],


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Adds `size` prop to PageHeader and related theming of `theme.pageHeader.size.small`, `theme.pageHeader.size.medium`, `theme.pageHeader.size.large` which can set title, subtitle, and pad values for each size.

Discussion:
- [ ] Are `small`, `medium`, and `large` the right sizes to support out of the box? Designs we have seen only really necessitate a "large" variant in additional to the default, but felt that "small" could be reasonable also.

#### Where should the reviewer start?

PageHeader.js / base.js

#### What testing has been done on this PR?
Storybook and unit test.

#### How should this be manually tested?
Use "Size" PageHeader storybook example.

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [x] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

Closes #6273 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Yes.

#### Should this PR be mentioned in the release notes?
Yes. Added `size` to PageHeader.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.