### PR TITLE
Implement basic Analytics

### DIFF
--- a/package.json
+++ b/package.json
@@ -202,7 +202,7 @@
   "bundlesize": [
     {
       "path": "./dist/grommet.min.js",
-      "maxSize": "132 kB"
+      "maxSize": "133 kB"
     }
   ],
   "keywords": [

--- a/src/js/components/Anchor/Anchor.js
+++ b/src/js/components/Anchor/Anchor.js
@@ -1,6 +1,7 @@
 import React, {
   cloneElement,
   forwardRef,
+  useCallback,
   useContext,
   useEffect,
   useState,
@@ -15,6 +16,7 @@ import { Box } from '../Box';
 
 import { StyledAnchor } from './StyledAnchor';
 import { AnchorPropTypes } from './propTypes';
+import { useAnalytics } from '../../contexts/AnalyticsContext';
 
 const Anchor = forwardRef(
   (
@@ -29,7 +31,7 @@ const Anchor = forwardRef(
       icon,
       label,
       onBlur,
-      onClick,
+      onClick: onClickProp,
       onFocus,
       reverse,
       ...rest
@@ -38,6 +40,22 @@ const Anchor = forwardRef(
   ) => {
     const theme = useContext(ThemeContext) || defaultProps.theme;
     const [focus, setFocus] = useState();
+
+    const sendAnalytics = useAnalytics();
+
+    const onClick = useCallback(
+      (event) => {
+        sendAnalytics({
+          type: 'anchorClick',
+          element: event.target,
+          event,
+          href,
+          label: typeof label === 'string' ? label: undefined,
+        });
+        if (onClickProp) onClickProp(event);
+      },
+      [onClickProp, sendAnalytics, label, href],
+    );
 
     useEffect(() => {
       if ((icon || label) && children) {

--- a/src/js/components/Anchor/__tests__/__snapshots__/Anchor-test.tsx.snap
+++ b/src/js/components/Anchor/__tests__/__snapshots__/Anchor-test.tsx.snap
@@ -748,6 +748,7 @@ exports[`Anchor shows no error for component used in as prop 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  cursor: pointer;
 }
 
 .c2 {
@@ -772,6 +773,7 @@ exports[`Anchor shows no error for component used in as prop 1`] = `
   <div
     class="c1 c2"
     href="#"
+    tabindex="0"
   />
 </div>
 `;

--- a/src/js/components/Button/Button.js
+++ b/src/js/components/Button/Button.js
@@ -178,11 +178,13 @@ const Button = forwardRef(
         sendAnalytics({
           type: 'buttonClick',
           element: event.target,
-          data: event,
+          event,
+          href,
+          label: typeof label === 'string' ? label: undefined,
         });
         if (onClickProp) onClickProp(event);
       },
-      [onClickProp, sendAnalytics],
+      [onClickProp, sendAnalytics, href, label],
     );
 
     // kindArg is object if we are referencing a theme object

--- a/src/js/components/Button/Button.js
+++ b/src/js/components/Button/Button.js
@@ -5,6 +5,7 @@ import React, {
   useContext,
   useMemo,
   useState,
+  useCallback,
 } from 'react';
 
 import { ThemeContext } from 'styled-components';
@@ -23,6 +24,7 @@ import { Tip } from '../Tip';
 import { Badge } from './Badge';
 import { StyledButton } from './StyledButton';
 import { StyledButtonKind } from './StyledButtonKind';
+import { useAnalytics } from '../../contexts/AnalyticsContext';
 
 // We have two Styled* components to separate
 // the newer default|primary|secondary approach,
@@ -140,7 +142,7 @@ const Button = forwardRef(
       kind: kindArg,
       label,
       onBlur,
-      onClick,
+      onClick: onClickProp,
       onFocus,
       onMouseOut,
       onMouseOver,
@@ -168,6 +170,20 @@ const Button = forwardRef(
         'Button should not have children if icon or label is provided',
       );
     }
+
+    const sendAnalytics = useAnalytics();
+
+    const onClick = useCallback(
+      (event) => {
+        sendAnalytics({
+          type: 'buttonClick',
+          element: event.target,
+          data: event,
+        });
+        if (onClickProp) onClickProp(event);
+      },
+      [onClickProp, sendAnalytics],
+    );
 
     // kindArg is object if we are referencing a theme object
     // outside of theme.button
@@ -375,7 +391,7 @@ const Button = forwardRef(
           href={href}
           kind={kind}
           themePaths={themePaths}
-          onClick={onClick}
+          onClick={onClickProp ? onClick : undefined}
           onFocus={(event) => {
             setFocus(true);
             if (onFocus) onFocus(event);

--- a/src/js/components/Form/Form.js
+++ b/src/js/components/Form/Form.js
@@ -361,12 +361,15 @@ const Form = forwardRef(
         element,
       });
       return () => {
-        sendAnalytics({
-          type: 'formClose',
-          element,
-          errors: analyticsRef.current.errors,
-          elapsed: new Date().getTime() - analyticsRef.current.start.getTime(),
-        });
+        if (!analyticsRef.current.submitted) {
+          sendAnalytics({
+            type: 'formClose',
+            element,
+            errors: analyticsRef.current.errors,
+            elapsed: 
+              new Date().getTime() - analyticsRef.current.start.getTime(),
+          });
+        }
       };
     }, [sendAnalytics, formRef]);
 
@@ -648,6 +651,7 @@ const Form = forwardRef(
                 new Date().getTime() - analyticsRef.current.start.getTime(),
             });
             analyticsRef.current.errors = {};
+            analyticsRef.current.submitted = true;
           }
         }}
       >

--- a/src/js/components/Form/Form.js
+++ b/src/js/components/Form/Form.js
@@ -7,7 +7,10 @@ import React, {
   useRef,
   useState,
 } from 'react';
+import { useAnalytics } from '../../contexts';
 import { MessageContext } from '../../contexts/MessageContext';
+import { useForwardedRef } from '../../utils';
+
 import { FormContext } from './FormContext';
 import { FormPropTypes } from './propTypes';
 
@@ -173,6 +176,7 @@ const Form = forwardRef(
     },
     ref,
   ) => {
+    const formRef = useForwardedRef(ref);
     const { format } = useContext(MessageContext);
     const [valueState, setValueState] = useState(valueProp || defaultValue);
     const value = useMemo(
@@ -201,6 +205,9 @@ const Form = forwardRef(
 
     const validationRulesRef = useRef({});
     const requiredFields = useRef([]);
+    const analyticsRef = useRef({ start: new Date(), errors: {} });
+
+    const sendAnalytics = useAnalytics();
 
     const buildValid = useCallback(
       (nextErrors) => {
@@ -229,6 +236,17 @@ const Form = forwardRef(
             !validationRulesRef.current[n] || nextValidations[n] === undefined,
         )
         .forEach((n) => delete nextValidations[n]);
+    };
+
+    const updateAnalytics = () => {
+      const errorFields = Object.keys(validationResultsRef.current?.errors);
+      const errorCounts = analyticsRef.current.errors;
+
+      if (errorFields.length > 0) {
+        errorFields.forEach((key) => {
+          errorCounts[key] = (errorCounts[key] || 0) + 1;
+        });
+      }
     };
 
     const applyValidationRules = useCallback(
@@ -265,6 +283,7 @@ const Form = forwardRef(
               valid: buildValid(nextErrors),
             });
           validationResultsRef.current = nextValidationResults;
+          updateAnalytics();
           return nextValidationResults;
         });
       },
@@ -333,6 +352,23 @@ const Form = forwardRef(
         );
       }
     }, [applyValidationRules, touched]);
+
+    useEffect(() => {
+      const element = formRef.current;
+      analyticsRef.current = { start: new Date(), errors: {} };
+      sendAnalytics({
+        type: 'formOpen',
+        element,
+      });
+      return () => {
+        sendAnalytics({
+          type: 'formClose',
+          element,
+          errors: analyticsRef.current.errors,
+          elapsed: new Date().getTime() - analyticsRef.current.start.getTime(),
+        });
+      };
+    }, [sendAnalytics, formRef]);
 
     // There are three basic patterns of handling form input value state:
     //
@@ -544,9 +580,17 @@ const Form = forwardRef(
 
     return (
       <form
-        ref={ref}
+        ref={formRef}
         {...rest}
         onReset={(event) => {
+          sendAnalytics({
+            type: 'formReset',
+            element: formRef.current,
+            data: event,
+            errors: analyticsRef.current.errors,
+            elapsed:
+              new Date().getTime() - analyticsRef.current.start.getTime(),
+          });
           setPendingValidation(undefined);
           if (!valueProp) {
             setValueState(defaultValue);
@@ -554,6 +598,7 @@ const Form = forwardRef(
           }
           setTouched(defaultTouched);
           setValidationResults(defaultValidationResults);
+          analyticsRef.current = { start: new Date(), errors: {} };
           if (onReset) {
             event.persist(); // extract from React's synthetic event pool
             const adjustedEvent = event;
@@ -584,6 +629,7 @@ const Form = forwardRef(
             };
             if (onValidate) onValidate(nextValidationResults);
             validationResultsRef.current = nextValidationResults;
+            updateAnalytics();
             return nextValidationResults;
           });
 
@@ -593,6 +639,15 @@ const Form = forwardRef(
             adjustedEvent.value = value;
             adjustedEvent.touched = touched;
             onSubmit(adjustedEvent);
+            sendAnalytics({
+              type: 'formSubmit',
+              element: formRef.current,
+              data: adjustedEvent,
+              errors: analyticsRef.current.errors,
+              elapsed:
+                new Date().getTime() - analyticsRef.current.start.getTime(),
+            });
+            analyticsRef.current.errors = {};
           }
         }}
       >

--- a/src/js/components/Grommet/Grommet.js
+++ b/src/js/components/Grommet/Grommet.js
@@ -22,6 +22,7 @@ import { OptionsContext } from '../../contexts/OptionsContext';
 import { format, MessageContext } from '../../contexts/MessageContext';
 import defaultMessages from '../../languages/default.json';
 import { GrommetPropTypes } from './propTypes';
+import { AnalyticsProvider } from '../../contexts/AnalyticsContext';
 
 const FullGlobalStyle = createGlobalStyle`
   body { margin: 0; }
@@ -58,6 +59,7 @@ const Grommet = forwardRef((props, ref) => {
     theme: themeProp,
     options = defaultOptions,
     messages: messagesProp,
+    onAnalytics,
     ...rest
   } = props;
   const { background, dir, themeMode, userAgent } = props;
@@ -145,10 +147,12 @@ const Grommet = forwardRef((props, ref) => {
           <ContainerTargetContext.Provider value={containerTarget}>
             <OptionsContext.Provider value={options}>
               <MessageContext.Provider value={messages}>
-                <StyledGrommet full={full} {...rest} ref={grommetRef}>
-                  {children}
-                </StyledGrommet>
-                {full && <FullGlobalStyle />}
+                <AnalyticsProvider onAnalytics={onAnalytics}>
+                  <StyledGrommet full={full} {...rest} ref={grommetRef}>
+                    {children}
+                  </StyledGrommet>
+                  {full && <FullGlobalStyle />}
+                </AnalyticsProvider>
               </MessageContext.Provider>
             </OptionsContext.Provider>
           </ContainerTargetContext.Provider>

--- a/src/js/components/Grommet/index.d.ts
+++ b/src/js/components/Grommet/index.d.ts
@@ -64,6 +64,7 @@ export interface GrommetProps {
     };
     format: (...args: any[]) => void;
   };
+  onAnalytics?: (data: any) => void;
   plain?: boolean;
   theme?: ThemeType;
   themeMode?: 'dark' | 'light';

--- a/src/js/components/Grommet/propTypes.js
+++ b/src/js/components/Grommet/propTypes.js
@@ -66,6 +66,7 @@ if (process.env.NODE_ENV !== 'production') {
           volumeUp: PropTypes.string,
         }),
       }),
+      onAnalytics: PropTypes.func,
     }),
   };
 }

--- a/src/js/components/Layer/LayerContainer.js
+++ b/src/js/components/Layer/LayerContainer.js
@@ -13,6 +13,8 @@ import { Keyboard } from '../Keyboard';
 import { ResponsiveContext } from '../../contexts/ResponsiveContext';
 import { OptionsContext } from '../../contexts/OptionsContext';
 import { ContainerTargetContext } from '../../contexts/ContainerTargetContext';
+import { useAnalytics } from '../../contexts/AnalyticsContext';
+
 import {
   backgroundIsDark,
   findVisibleParent,
@@ -64,6 +66,24 @@ const LayerContainer = forwardRef(
       () => [...portalContext, portalId],
       [portalContext, portalId],
     );
+
+    const sendAnalytics = useAnalytics();
+
+    useEffect(() => {
+      const start = new Date();
+      const element = layerRef.current;
+      sendAnalytics({
+        type: 'layerOpen',
+        element,
+      });
+      return () => {
+        sendAnalytics({
+          type: 'layerClose',
+          element,
+          elapsed: new Date().getTime() - start.getTime(),
+        });
+      };
+    }, [sendAnalytics, layerRef]);
 
     useEffect(() => {
       if (position !== 'hidden') {

--- a/src/js/components/Tabs/Tabs.js
+++ b/src/js/components/Tabs/Tabs.js
@@ -22,6 +22,7 @@ import { StyledTabPanel, StyledTabs, StyledTabsHeader } from './StyledTabs';
 import { normalizeColor } from '../../utils';
 import { MessageContext } from '../../contexts/MessageContext';
 import { TabsPropTypes } from './propTypes';
+import { useAnalytics } from '../../contexts/AnalyticsContext/AnalyticsContext';
 
 const Tabs = forwardRef(
   (
@@ -48,6 +49,8 @@ const Tabs = forwardRef(
     const [focusIndex, setFocusIndex] = useState(-1);
     const headerRef = useRef();
     const size = useContext(ResponsiveContext);
+
+    const sendAnalytics = useAnalytics();
 
     if (activeIndex !== propsActiveIndex && propsActiveIndex !== undefined) {
       setActiveIndex(propsActiveIndex);
@@ -260,6 +263,10 @@ const Tabs = forwardRef(
     const getTabsContext = useCallback(
       (index) => {
         const activateTab = (nextIndex) => {
+          sendAnalytics({
+            type: 'activateTab',
+            element: tabRefs[nextIndex].current,
+          });
           if (propsActiveIndex === undefined) {
             setActiveIndex(nextIndex);
           }
@@ -279,7 +286,7 @@ const Tabs = forwardRef(
           setFocusIndex,
         };
       },
-      [activeIndex, onActive, propsActiveIndex, tabRefs],
+      [activeIndex, onActive, propsActiveIndex, sendAnalytics, tabRefs],
     );
 
     const tabs = React.Children.map(children, (child, index) => (

--- a/src/js/contexts/AnalyticsContext/AnalyticsContext.js
+++ b/src/js/contexts/AnalyticsContext/AnalyticsContext.js
@@ -1,0 +1,40 @@
+import React, { useCallback, useContext, useEffect, useRef } from 'react';
+
+export const AnalyticsContext = React.createContext(() => {});
+
+export const useAnalytics = () => useContext(AnalyticsContext);
+
+export const AnalyticsProvider = ({ onAnalytics, children }) => {
+  const pathInfoRef = useRef({
+    lastUrl: window.location.href,
+    observer: undefined,
+  });
+
+  const sendAnalytics = useCallback(
+    (data) => onAnalytics && onAnalytics(data),
+    [onAnalytics],
+  );
+
+  useEffect(() => {
+    let observer;
+    if (onAnalytics) {
+      observer = new window.MutationObserver(() => {
+        const url = window.location.href;
+        if (url !== pathInfoRef.current.lastUrl) {
+          pathInfoRef.current.lastUrl = url;
+          sendAnalytics({ type: 'pageView', data: url });
+        }
+      });
+      observer.observe(document, { subtree: true, childList: true });
+    }
+    pathInfoRef.current.observer = observer;
+
+    return () => observer?.disconnect();
+  }, [sendAnalytics, onAnalytics]);
+
+  return (
+    <AnalyticsContext.Provider value={sendAnalytics}>
+      {children}
+    </AnalyticsContext.Provider>
+  );
+};

--- a/src/js/contexts/AnalyticsContext/AnalyticsContext.js
+++ b/src/js/contexts/AnalyticsContext/AnalyticsContext.js
@@ -5,10 +5,7 @@ export const AnalyticsContext = React.createContext(() => {});
 export const useAnalytics = () => useContext(AnalyticsContext);
 
 export const AnalyticsProvider = ({ onAnalytics, children }) => {
-  const pathInfoRef = useRef({
-    lastUrl: window.location.href,
-    observer: undefined,
-  });
+  const lastUrlRef = useRef();
 
   const sendAnalytics = useCallback(
     (data) => onAnalytics && onAnalytics(data),
@@ -19,15 +16,15 @@ export const AnalyticsProvider = ({ onAnalytics, children }) => {
     let observer;
     if (onAnalytics) {
       observer = new window.MutationObserver(() => {
-        const url = window.location.href;
-        if (url !== pathInfoRef.current.lastUrl) {
-          pathInfoRef.current.lastUrl = url;
-          sendAnalytics({ type: 'pageView', data: url });
+        const url = window?.location?.href;
+        const previousUrl = lastUrlRef.current;
+        if (url !== previousUrl) {
+          lastUrlRef.current = url;
+          sendAnalytics({ type: 'pageView', url, previousUrl });
         }
       });
       observer.observe(document, { subtree: true, childList: true });
     }
-    pathInfoRef.current.observer = observer;
 
     return () => observer?.disconnect();
   }, [sendAnalytics, onAnalytics]);

--- a/src/js/contexts/AnalyticsContext/index.d.ts
+++ b/src/js/contexts/AnalyticsContext/index.d.ts
@@ -1,0 +1,7 @@
+import * as React from 'react';
+
+export type AnalyticsValue = Node;
+
+declare const AnalyticsContext: React.Context<AnalyticsValue>;
+
+export { AnalyticsContext };

--- a/src/js/contexts/AnalyticsContext/index.js
+++ b/src/js/contexts/AnalyticsContext/index.js
@@ -1,0 +1,1 @@
+export * from './AnalyticsContext';

--- a/src/js/contexts/index.js
+++ b/src/js/contexts/index.js
@@ -1,3 +1,4 @@
+export * from './AnalyticsContext';
 export * from './AnnounceContext';
 export * from './ContainerTargetContext';
 export * from './ResponsiveContext';


### PR DESCRIPTION

#### What does this PR do?
Implement the onAnalytics instrumentation in <Grommet>.

This is a follow on to https://github.com/grommet/hpe-design-system/issues/2714

```jsx
<Grommet onAnalytics={(evt) => { ... } } />
```
onAnalytics called with events in situations like:

- Form onSubmit and in a form
  - evt contains touched, the form element, number of failed validations per field, time spent in the form.
- Form open and close. This can help detect form cancel
- Layer open and close.
- Tabs activated
- Button onClick - send button element to track actions and other usages
- URL changes (e.g. pageViews.) Use the MutationObserver trick to track url changes and send events for page views.
- const sendAnalytics = useAnalytics() API available for external use (as well as internal)

Some example data sent to `onAnalytics`:
![image](https://user-images.githubusercontent.com/12054362/184987503-a1f58eda-28e0-4bcd-9400-4e9b0a4eb50f.png)

#### Where should the reviewer start?
AnalyticsContext.js

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
closes https://github.com/grommet/hpe-design-system/issues/2818

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Not yet

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible