### PR TITLE
Fix Select to load all options even when clear={true}

### DIFF
--- a/src/js/components/Select/SelectContainer.js
+++ b/src/js/components/Select/SelectContainer.js
@@ -75,7 +75,7 @@ const ClearButton = forwardRef(
     const buttonLabel = label || `Clear ${name || 'selection'}`;
     return (
       <StyledButton
-        a11yTitle={`${buttonLabel}, press ${
+        a11yTitle={`${buttonLabel}. Or, press ${
           position === 'bottom' ? 'shift tab' : 'down arrow'
         } to move to select options`}
         fill="horizontal"

--- a/src/js/components/Select/SelectContainer.js
+++ b/src/js/components/Select/SelectContainer.js
@@ -49,6 +49,7 @@ const SelectOption = styled(Button)`
   // visible to keyboard users
   &:focus {
     ${(props) =>
+      props.active &&
       getHoverIndicatorStyle(
         !props.children && !props.theme.select.options
           ? undefined
@@ -67,26 +68,29 @@ const StyledButton = styled(Button)`
   }
 `;
 
-const ClearButton = forwardRef(({ clear, onClear, name, theme }, ref) => {
-  const { label, position } = clear;
-  const align = position !== 'bottom' ? 'start' : 'center';
-  const buttonLabel = label || `Clear ${name || 'selection'}`;
-  return (
-    <StyledButton
-      a11yTitle={`${buttonLabel}, press ${
-        position === 'bottom' ? 'shift tab' : 'down arrow'
-      } to move to select options`}
-      fill="horizontal"
-      ref={ref}
-      onClick={onClear}
-      focusIndicator={false}
-    >
-      <Box {...theme.select.clear.container} align={align}>
-        <Text {...theme.select.clear.text}>{buttonLabel}</Text>
-      </Box>
-    </StyledButton>
-  );
-});
+const ClearButton = forwardRef(
+  ({ clear, onClear, name, theme, ...rest }, ref) => {
+    const { label, position } = clear;
+    const align = position !== 'bottom' ? 'start' : 'center';
+    const buttonLabel = label || `Clear ${name || 'selection'}`;
+    return (
+      <StyledButton
+        a11yTitle={`${buttonLabel}, press ${
+          position === 'bottom' ? 'shift tab' : 'down arrow'
+        } to move to select options`}
+        fill="horizontal"
+        ref={ref}
+        onClick={onClear}
+        focusIndicator={false}
+        {...rest}
+      >
+        <Box {...theme.select.clear.container} align={align}>
+          <Text {...theme.select.clear.text}>{buttonLabel}</Text>
+        </Box>
+      </StyledButton>
+    );
+  },
+);
 
 const SelectContainer = forwardRef(
   (
@@ -425,6 +429,8 @@ const SelectContainer = forwardRef(
               clear={clear}
               name={name}
               onClear={onClear}
+              onFocus={() => setActiveIndex(-1)}
+              onMouseOver={() => setActiveIndex(-1)}
               theme={theme}
             />
           )}
@@ -538,6 +544,8 @@ const SelectContainer = forwardRef(
               clear={clear}
               name={name}
               onClear={onClear}
+              onFocus={() => setActiveIndex(-1)}
+              onMouseOver={() => setActiveIndex(-1)}
               theme={theme}
             />
           )}

--- a/src/js/components/Select/SelectContainer.js
+++ b/src/js/components/Select/SelectContainer.js
@@ -313,7 +313,15 @@ const SelectContainer = forwardRef(
 
         if (nextActiveIndex === -1) {
           const searchInput = searchRef.current;
-          if (searchInput && searchInput.focus) {
+          const clearButton = clearRef.current;
+          if (
+            clearButton &&
+            clearButton.focus &&
+            shouldShowClearButton('top')
+          ) {
+            setActiveIndex(nextActiveIndex);
+            setFocusWithoutScroll(clearButton);
+          } else if (searchInput && searchInput.focus) {
             setActiveIndex(nextActiveIndex);
             setFocusWithoutScroll(searchInput);
           }
@@ -327,7 +335,7 @@ const SelectContainer = forwardRef(
           setKeyboardNavigation(true);
         }
       },
-      [activeIndex, isDisabled],
+      [activeIndex, isDisabled, shouldShowClearButton],
     );
 
     const onKeyDownOption = useCallback(

--- a/src/js/components/Select/SelectContainer.js
+++ b/src/js/components/Select/SelectContainer.js
@@ -25,6 +25,7 @@ import { TextInput } from '../TextInput';
 
 import { StyledContainer } from './StyledSelect';
 import { applyKey } from './utils';
+import { containsFocus } from '../../utils/DOM';
 
 // position relative is so scroll can be managed correctly
 const OptionsBox = styled.div`
@@ -44,8 +45,26 @@ const SelectOption = styled(Button)`
       !props.children && !props.theme.select.options ? undefined : 'background',
       props.theme,
     )}
+  // apply hover styling when option receives tab focus so it's
+  // visible to keyboard users
+  &:focus {
+    ${(props) =>
+      getHoverIndicatorStyle(
+        !props.children && !props.theme.select.options
+          ? undefined
+          : 'background',
+        props.theme,
+      )}
+  }
   display: block;
   width: 100%;
+`;
+
+// ensure ClearButton receives visual indication of keyboard
+const StyledButton = styled(Button)`
+  &:focus {
+    ${(props) => getHoverIndicatorStyle('background', props.theme)}
+  }
 `;
 
 const ClearButton = forwardRef(({ clear, onClear, name, theme }, ref) => {
@@ -53,7 +72,10 @@ const ClearButton = forwardRef(({ clear, onClear, name, theme }, ref) => {
   const align = position !== 'bottom' ? 'start' : 'center';
   const buttonLabel = label || `Clear ${name || 'selection'}`;
   return (
-    <Button
+    <StyledButton
+      a11yTitle={`${buttonLabel}, press ${
+        position === 'bottom' ? 'shift tab' : 'down arrow'
+      } to move to select options`}
       fill="horizontal"
       ref={ref}
       onClick={onClear}
@@ -62,7 +84,7 @@ const ClearButton = forwardRef(({ clear, onClear, name, theme }, ref) => {
       <Box {...theme.select.clear.container} align={align}>
         <Text {...theme.select.clear.text}>{buttonLabel}</Text>
       </Box>
-    </Button>
+    </StyledButton>
   );
 });
 
@@ -98,7 +120,22 @@ const SelectContainer = forwardRef(
     ref,
   ) => {
     const theme = useContext(ThemeContext) || defaultProps.theme;
-    const [activeIndex, setActiveIndex] = useState(usingKeyboard ? 0 : -1);
+    const shouldShowClearButton = useCallback(
+      (position) => {
+        const hasValue = Boolean(multiple ? value.length : value);
+        const showAtPosition =
+          position === 'bottom'
+            ? clear?.position === 'bottom'
+            : clear?.position !== 'bottom';
+
+        return clear && hasValue && showAtPosition;
+      },
+      [clear, multiple, value],
+    );
+
+    const [activeIndex, setActiveIndex] = useState(
+      usingKeyboard && !shouldShowClearButton('top') ? 0 : -1,
+    );
     const [keyboardNavigation, setKeyboardNavigation] = useState(usingKeyboard);
     const searchRef = useRef();
     const optionsRef = useRef();
@@ -107,7 +144,7 @@ const SelectContainer = forwardRef(
 
     // for keyboard/screenreader, keep the active option in focus
     useEffect(() => {
-      if (activeIndex) activeRef.current?.focus();
+      if (activeIndex >= 0) activeRef.current?.focus();
     }, [activeIndex]);
 
     // set initial focus
@@ -251,7 +288,6 @@ const SelectContainer = forwardRef(
       (event) => {
         event.preventDefault();
         let nextActiveIndex = activeIndex + 1;
-        const clearButton = clearRef.current;
         while (
           nextActiveIndex < options.length &&
           isDisabled(nextActiveIndex)
@@ -262,24 +298,14 @@ const SelectContainer = forwardRef(
           setActiveIndex(nextActiveIndex);
           setKeyboardNavigation(true);
         }
-        if (
-          clear &&
-          clear.position === 'bottom' &&
-          clearButton &&
-          nextActiveIndex >= options.length
-        ) {
-          setActiveIndex(options.length);
-          setFocusWithoutScroll(clearButton);
-        }
       },
-      [activeIndex, isDisabled, options, clear],
+      [activeIndex, isDisabled, options],
     );
 
     const onPreviousOption = useCallback(
       (event) => {
         event.preventDefault();
         let nextActiveIndex = activeIndex - 1;
-        const clearButton = clearRef.current;
 
         if (nextActiveIndex === -1) {
           const searchInput = searchRef.current;
@@ -296,16 +322,8 @@ const SelectContainer = forwardRef(
           setActiveIndex(nextActiveIndex);
           setKeyboardNavigation(true);
         }
-        if (
-          clear &&
-          clear.position !== 'bottom' &&
-          clearButton &&
-          activeIndex === 0
-        ) {
-          setActiveIndex(-1);
-        }
       },
-      [activeIndex, isDisabled, clear],
+      [activeIndex, isDisabled],
     );
 
     const onKeyDownOption = useCallback(
@@ -347,23 +365,18 @@ const SelectContainer = forwardRef(
 
     const onSelectOption = useCallback(
       (event) => {
-        if (activeIndex >= 0 && activeIndex < options.length) {
+        if (
+          (shouldShowClearButton('bottom') || shouldShowClearButton('top')) &&
+          containsFocus(clearRef.current)
+        ) {
+          onChange(event, { option: undefined, value: '', selected: '' });
+        } else if (activeIndex >= 0 && activeIndex < options.length) {
           event.preventDefault(); // prevent submitting forms
           selectOption(activeIndex)(event);
         }
       },
-      [activeIndex, selectOption, options],
+      [activeIndex, selectOption, options, onChange, shouldShowClearButton],
     );
-
-    const shouldShowClearButton = (position) => {
-      const hasValue = Boolean(multiple ? value.length : value);
-      const showAtPosition =
-        position === 'bottom'
-          ? clear?.position === 'bottom'
-          : clear?.position !== 'bottom';
-
-      return clear && hasValue && showAtPosition;
-    };
 
     const customSearchInput = theme.select.searchInput;
     const SelectTextInput = customSearchInput || TextInput;
@@ -406,6 +419,15 @@ const SelectContainer = forwardRef(
               />
             </Box>
           )}
+          {shouldShowClearButton('top') && (
+            <ClearButton
+              ref={clearRef}
+              clear={clear}
+              name={name}
+              onClear={onClear}
+              theme={theme}
+            />
+          )}
           <OptionsBox
             role="listbox"
             tabIndex="-1"
@@ -413,15 +435,6 @@ const SelectContainer = forwardRef(
             aria-multiselectable={multiple}
             onMouseMove={() => setKeyboardNavigation(false)}
           >
-            {shouldShowClearButton('top') && (
-              <ClearButton
-                ref={clearRef}
-                clear={clear}
-                name={name}
-                onClear={onClear}
-                theme={theme}
-              />
-            )}
             {options.length > 0 ? (
               <InfiniteScroll
                 items={options}
@@ -487,6 +500,9 @@ const SelectContainer = forwardRef(
                       disabled={optionDisabled || undefined}
                       active={optionActive}
                       selected={optionSelected}
+                      // allow keyboard navigation to start from
+                      // selected option after tabbing to it
+                      onFocus={() => setActiveIndex(index)}
                       onMouseOver={
                         !optionDisabled ? onActiveOption(index) : undefined
                       }
@@ -515,16 +531,16 @@ const SelectContainer = forwardRef(
                 </Box>
               </SelectOption>
             )}
-            {shouldShowClearButton('bottom') && (
-              <ClearButton
-                ref={clearRef}
-                clear={clear}
-                name={name}
-                onClear={onClear}
-                theme={theme}
-              />
-            )}
           </OptionsBox>
+          {shouldShowClearButton('bottom') && (
+            <ClearButton
+              ref={clearRef}
+              clear={clear}
+              name={name}
+              onClear={onClear}
+              theme={theme}
+            />
+          )}
         </StyledContainer>
       </Keyboard>
     );

--- a/src/js/components/Select/__tests__/Select-test.js
+++ b/src/js/components/Select/__tests__/Select-test.js
@@ -1143,6 +1143,68 @@ describe('Select', () => {
     expectPortal('test-select__drop').toMatchSnapshot();
   });
 
+  // test('Clear option renders- top', async () => {
+  //   const user = userEvent.setup();
+
+  //   const Test = () => {
+  //     const [value] = React.useState();
+  //     return (
+  //       <Select
+  //         id="test-select"
+  //         placeholder="test select"
+  //         value={value}
+  //         options={['one', 'two']}
+  //         clear
+  //       />
+  //     );
+  //   };
+  //   render(
+  //     <Grommet>
+  //       <Test />
+  //     </Grommet>,
+  //   );
+
+  //   await user.click(screen.getByPlaceholderText('test select'));
+  //   await user.click(screen.getByRole('option', { name: 'one' }));
+  //   await user.click(screen.getByPlaceholderText('test select'));
+  //   const clearButton = screen.getByRole('button', {
+  //     name: 'Clear selection, press down arrow to move to select options',
+  //   });
+  //   expect(clearButton).toBeTruthy();
+  //   expectPortal('test-select__drop').toMatchSnapshot();
+  // });
+
+  // test('Clear option renders - bottom', async () => {
+  //   const user = userEvent.setup();
+  //   const Test = () => {
+  //     const [value] = React.useState();
+  //     return (
+  //       <Select
+  //         id="test-select"
+  //         placeholder="test select"
+  //         value={value}
+  //         options={['one', 'two']}
+  //         clear={{ position: 'bottom' }}
+  //       />
+  //     );
+  //   };
+  //   render(
+  //     <Grommet>
+  //       <Test />
+  //     </Grommet>,
+  //   );
+
+  //   await user.click(screen.getByPlaceholderText('test select'));
+  //   await user.click(screen.getByRole('option', { name: 'one' }));
+  //   await user.click(screen.getByPlaceholderText('test select'));
+  //   const clearButton = screen.getByRole('button', {
+  //     name: 'Clear selection, press shift tab to move to select options',
+  //   });
+  //   expect(clearButton).toBeTruthy();
+
+  //   expectPortal('test-select__drop').toMatchSnapshot();
+  // });
+
   test('Clear option renders custom label', () => {
     const Test = () => {
       const [value] = React.useState();

--- a/src/js/components/Select/__tests__/Select-test.js
+++ b/src/js/components/Select/__tests__/Select-test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent, act } from '@testing-library/react';
+import { render, fireEvent, act, screen } from '@testing-library/react';
 import { axe } from 'jest-axe';
 import 'jest-axe/extend-expect';
 import 'jest-styled-components';
@@ -1110,13 +1110,19 @@ describe('Select', () => {
         />
       );
     };
-    const { getByPlaceholderText } = render(
+    render(
       <Grommet>
         <Test />
       </Grommet>,
     );
-    fireEvent.click(getByPlaceholderText('test select'));
 
+    fireEvent.click(screen.getByPlaceholderText('test select'));
+    fireEvent.click(screen.getByRole('option', { name: 'one' }));
+    fireEvent.click(screen.getByPlaceholderText('test select'));
+    const clearButton = screen.getByRole('button', {
+      name: 'Clear selection. Or, press down arrow to move to select options',
+    });
+    expect(clearButton).toBeTruthy();
     expectPortal('test-select__drop').toMatchSnapshot();
   });
 
@@ -1133,77 +1139,22 @@ describe('Select', () => {
         />
       );
     };
-    const { getByPlaceholderText } = render(
+    render(
       <Grommet>
         <Test />
       </Grommet>,
     );
-    fireEvent.click(getByPlaceholderText('test select'));
+
+    fireEvent.click(screen.getByPlaceholderText('test select'));
+    fireEvent.click(screen.getByRole('option', { name: 'one' }));
+    fireEvent.click(screen.getByPlaceholderText('test select'));
+    const clearButton = screen.getByRole('button', {
+      name: 'Clear selection. Or, press shift tab to move to select options',
+    });
+    expect(clearButton).toBeTruthy();
 
     expectPortal('test-select__drop').toMatchSnapshot();
   });
-
-  // test('Clear option renders- top', async () => {
-  //   const user = userEvent.setup();
-
-  //   const Test = () => {
-  //     const [value] = React.useState();
-  //     return (
-  //       <Select
-  //         id="test-select"
-  //         placeholder="test select"
-  //         value={value}
-  //         options={['one', 'two']}
-  //         clear
-  //       />
-  //     );
-  //   };
-  //   render(
-  //     <Grommet>
-  //       <Test />
-  //     </Grommet>,
-  //   );
-
-  //   await user.click(screen.getByPlaceholderText('test select'));
-  //   await user.click(screen.getByRole('option', { name: 'one' }));
-  //   await user.click(screen.getByPlaceholderText('test select'));
-  //   const clearButton = screen.getByRole('button', {
-  //     name: 'Clear selection, press down arrow to move to select options',
-  //   });
-  //   expect(clearButton).toBeTruthy();
-  //   expectPortal('test-select__drop').toMatchSnapshot();
-  // });
-
-  // test('Clear option renders - bottom', async () => {
-  //   const user = userEvent.setup();
-  //   const Test = () => {
-  //     const [value] = React.useState();
-  //     return (
-  //       <Select
-  //         id="test-select"
-  //         placeholder="test select"
-  //         value={value}
-  //         options={['one', 'two']}
-  //         clear={{ position: 'bottom' }}
-  //       />
-  //     );
-  //   };
-  //   render(
-  //     <Grommet>
-  //       <Test />
-  //     </Grommet>,
-  //   );
-
-  //   await user.click(screen.getByPlaceholderText('test select'));
-  //   await user.click(screen.getByRole('option', { name: 'one' }));
-  //   await user.click(screen.getByPlaceholderText('test select'));
-  //   const clearButton = screen.getByRole('button', {
-  //     name: 'Clear selection, press shift tab to move to select options',
-  //   });
-  //   expect(clearButton).toBeTruthy();
-
-  //   expectPortal('test-select__drop').toMatchSnapshot();
-  // });
 
   test('Clear option renders custom label', () => {
     const Test = () => {

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -318,7 +318,7 @@ exports[`Select Clear option renders - bottom 1`] = `
   padding: 12px;
 }
 
-.c9 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -334,6 +334,26 @@ exports[`Select Clear option renders - bottom 1`] = `
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
+}
+
+.c14 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #33333310;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 12px;
 }
 
 .c1 {
@@ -364,6 +384,50 @@ exports[`Select Clear option renders - bottom 1`] = `
   margin: 0px;
   font-size: 18px;
   line-height: 24px;
+}
+
+.c15 {
+  font-size: 18px;
+  line-height: 24px;
+  color: #555555;
+}
+
+.c9 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c9:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c9:focus:not(:focus-visible) > circle,
+.c9:focus:not(:focus-visible) > ellipse,
+.c9:focus:not(:focus-visible) > line,
+.c9:focus:not(:focus-visible) > path,
+.c9:focus:not(:focus-visible) > polygon,
+.c9:focus:not(:focus-visible) > polyline,
+.c9:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c9:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
 }
 
 .c5 {
@@ -404,6 +468,45 @@ exports[`Select Clear option renders - bottom 1`] = `
   border: 0;
 }
 
+.c12 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  width: 100%;
+}
+
+.c12:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c12:focus:not(:focus-visible) > circle,
+.c12:focus:not(:focus-visible) > ellipse,
+.c12:focus:not(:focus-visible) > line,
+.c12:focus:not(:focus-visible) > path,
+.c12:focus:not(:focus-visible) > polygon,
+.c12:focus:not(:focus-visible) > polyline,
+.c12:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c12:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
 .c3 {
   max-height: inherit;
 }
@@ -418,9 +521,21 @@ exports[`Select Clear option renders - bottom 1`] = `
   outline: none;
 }
 
-.c6 {
+.c10 {
   display: block;
   width: 100%;
+}
+
+.c6 {
+  background-color: #7D4CDB;
+  color: #FFFFFF;
+  display: block;
+  width: 100%;
+}
+
+.c13:focus {
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
 }
 
 @media only screen and (max-width:768px) {
@@ -429,6 +544,12 @@ exports[`Select Clear option renders - bottom 1`] = `
 
 @media only screen and (max-width:768px) {
   .c7 {
+    padding: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c14 {
     padding: 6px;
   }
 }
@@ -470,11 +591,11 @@ exports[`Select Clear option renders - bottom 1`] = `
     >
       <button
         aria-posinset="1"
-        aria-selected="false"
+        aria-selected="true"
         aria-setsize="2"
         class="c5 c6"
         role="option"
-        tabindex="-1"
+        tabindex="0"
         type="button"
       >
         <div
@@ -491,7 +612,7 @@ exports[`Select Clear option renders - bottom 1`] = `
         aria-posinset="2"
         aria-selected="false"
         aria-setsize="2"
-        class="c5 c6"
+        class="c9 c10"
         role="option"
         tabindex="-1"
         type="button"
@@ -507,9 +628,24 @@ exports[`Select Clear option renders - bottom 1`] = `
         </div>
       </button>
       <div
-        class="c9"
+        class="c11"
       />
     </div>
+    <button
+      aria-label="Clear selection. Or, press shift tab to move to select options"
+      class="c12 c13"
+      type="button"
+    >
+      <div
+        class="c14"
+      >
+        <span
+          class="c15"
+        >
+          Clear selection
+        </span>
+      </div>
+    </button>
   </div>
 </div>
 `;
@@ -1072,7 +1208,7 @@ exports[`Select Clear option renders- top 1`] = `
   flex-direction: column;
 }
 
-.c7 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1091,7 +1227,7 @@ exports[`Select Clear option renders- top 1`] = `
   padding: 12px;
 }
 
-.c9 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1107,6 +1243,26 @@ exports[`Select Clear option renders- top 1`] = `
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  background: #33333310;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 12px;
 }
 
 .c1 {
@@ -1133,13 +1289,19 @@ exports[`Select Clear option renders- top 1`] = `
   animation-delay: 0.01s;
 }
 
-.c8 {
+.c12 {
   margin: 0px;
   font-size: 18px;
   line-height: 24px;
 }
 
-.c5 {
+.c7 {
+  font-size: 18px;
+  line-height: 24px;
+  color: #555555;
+}
+
+.c13 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -1157,23 +1319,100 @@ exports[`Select Clear option renders- top 1`] = `
   text-align: inherit;
 }
 
-.c5:focus:not(:focus-visible) {
+.c13:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c13:focus:not(:focus-visible) > circle,
+.c13:focus:not(:focus-visible) > ellipse,
+.c13:focus:not(:focus-visible) > line,
+.c13:focus:not(:focus-visible) > path,
+.c13:focus:not(:focus-visible) > polygon,
+.c13:focus:not(:focus-visible) > polyline,
+.c13:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c13:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c4 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  width: 100%;
+}
+
+.c4:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c4:focus:not(:focus-visible) > circle,
+.c4:focus:not(:focus-visible) > ellipse,
+.c4:focus:not(:focus-visible) > line,
+.c4:focus:not(:focus-visible) > path,
+.c4:focus:not(:focus-visible) > polygon,
+.c4:focus:not(:focus-visible) > polyline,
+.c4:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c4:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c9 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c9:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c9:focus:not(:focus-visible) > circle,
+.c9:focus:not(:focus-visible) > ellipse,
+.c9:focus:not(:focus-visible) > line,
+.c9:focus:not(:focus-visible) > path,
+.c9:focus:not(:focus-visible) > polygon,
+.c9:focus:not(:focus-visible) > polyline,
+.c9:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c9:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
@@ -1181,7 +1420,7 @@ exports[`Select Clear option renders- top 1`] = `
   max-height: inherit;
 }
 
-.c4 {
+.c8 {
   position: relative;
   -webkit-scroll-behavior: smooth;
   -moz-scroll-behavior: smooth;
@@ -1191,17 +1430,35 @@ exports[`Select Clear option renders- top 1`] = `
   outline: none;
 }
 
-.c6 {
+.c14 {
   display: block;
   width: 100%;
 }
 
+.c10 {
+  background-color: #7D4CDB;
+  color: #FFFFFF;
+  display: block;
+  width: 100%;
+}
+
+.c5:focus {
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
+}
+
 @media only screen and (max-width:768px) {
 
 }
 
 @media only screen and (max-width:768px) {
-  .c7 {
+  .c11 {
+    padding: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
     padding: 6px;
   }
 }
@@ -1236,25 +1493,40 @@ exports[`Select Clear option renders- top 1`] = `
     class="c2 c3"
     id="test-select__select-drop"
   >
+    <button
+      aria-label="Clear selection. Or, press down arrow to move to select options"
+      class="c4 c5"
+      type="button"
+    >
+      <div
+        class="c6"
+      >
+        <span
+          class="c7"
+        >
+          Clear selection
+        </span>
+      </div>
+    </button>
     <div
-      class="c4"
+      class="c8"
       role="listbox"
       tabindex="-1"
     >
       <button
         aria-posinset="1"
-        aria-selected="false"
+        aria-selected="true"
         aria-setsize="2"
-        class="c5 c6"
+        class="c9 c10"
         role="option"
-        tabindex="-1"
+        tabindex="0"
         type="button"
       >
         <div
-          class="c7"
+          class="c11"
         >
           <span
-            class="c8"
+            class="c12"
           >
             one
           </span>
@@ -1264,23 +1536,23 @@ exports[`Select Clear option renders- top 1`] = `
         aria-posinset="2"
         aria-selected="false"
         aria-setsize="2"
-        class="c5 c6"
+        class="c13 c14"
         role="option"
         tabindex="-1"
         type="button"
       >
         <div
-          class="c7"
+          class="c11"
         >
           <span
-            class="c8"
+            class="c12"
           >
             two
           </span>
         </div>
       </button>
       <div
-        class="c9"
+        class="c15"
       />
     </div>
   </div>
@@ -3799,7 +4071,7 @@ exports[`Select default value clear 1`] = `
     id="test-select__select-drop"
   >
     <button
-      aria-label="Clear selection, press down arrow to move to select options"
+      aria-label="Clear selection. Or, press down arrow to move to select options"
       class="c4 c5"
       type="button"
     >

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -423,11 +423,6 @@ exports[`Select Clear option renders - bottom 1`] = `
   width: 100%;
 }
 
-.c6:focus {
-  background-color: rgba(221,221,221,0.4);
-  color: #000000;
-}
-
 @media only screen and (max-width:768px) {
 
 }
@@ -681,11 +676,6 @@ exports[`Select Clear option renders correct label when wrapped in FormField 1`]
 .c6 {
   display: block;
   width: 100%;
-}
-
-.c6:focus {
-  background-color: rgba(221,221,221,0.4);
-  color: #000000;
 }
 
 @media only screen and (max-width:768px) {
@@ -951,11 +941,6 @@ exports[`Select Clear option renders custom label 1`] = `
   width: 100%;
 }
 
-.c6:focus {
-  background-color: rgba(221,221,221,0.4);
-  color: #000000;
-}
-
 @media only screen and (max-width:768px) {
 
 }
@@ -1209,11 +1194,6 @@ exports[`Select Clear option renders- top 1`] = `
 .c6 {
   display: block;
   width: 100%;
-}
-
-.c6:focus {
-  background-color: rgba(221,221,221,0.4);
-  color: #000000;
 }
 
 @media only screen and (max-width:768px) {
@@ -2828,11 +2808,6 @@ exports[`Select complex options and children 3`] = `
   width: 100%;
 }
 
-.c6:focus {
-  background-color: rgba(221,221,221,0.4);
-  color: #000000;
-}
-
 @media only screen and (max-width:768px) {
 
 }
@@ -3765,21 +3740,11 @@ exports[`Select default value clear 1`] = `
   width: 100%;
 }
 
-.c10:focus {
-  background-color: rgba(221,221,221,0.4);
-  color: #000000;
-}
-
 .c14 {
   background-color: #7D4CDB;
   color: #FFFFFF;
   display: block;
   width: 100%;
-}
-
-.c14:focus {
-  background-color: rgba(221,221,221,0.4);
-  color: #000000;
 }
 
 .c5:focus {
@@ -4990,11 +4955,6 @@ exports[`Select disabled key 2`] = `
   width: 100%;
 }
 
-.c6:focus {
-  background-color: rgba(221,221,221,0.4);
-  color: #000000;
-}
-
 @media only screen and (max-width:768px) {
 
 }
@@ -5290,11 +5250,6 @@ exports[`Select disabled option value 1`] = `
 .c6 {
   display: block;
   width: 100%;
-}
-
-.c6:focus {
-  background-color: rgba(221,221,221,0.4);
-  color: #000000;
 }
 
 @media only screen and (max-width:768px) {
@@ -5945,11 +5900,6 @@ exports[`Select large drop container height 1`] = `
   width: 100%;
 }
 
-.c6:focus {
-  background-color: rgba(221,221,221,0.4);
-  color: #000000;
-}
-
 @media only screen and (max-width:768px) {
 
 }
@@ -6194,11 +6144,6 @@ exports[`Select medium drop container height 1`] = `
 .c6 {
   display: block;
   width: 100%;
-}
-
-.c6:focus {
-  background-color: rgba(221,221,221,0.4);
-  color: #000000;
 }
 
 @media only screen and (max-width:768px) {
@@ -7013,11 +6958,6 @@ exports[`Select onChange with valueKey string 2`] = `
   width: 100%;
 }
 
-.c6:focus {
-  background-color: rgba(221,221,221,0.4);
-  color: #000000;
-}
-
 @media only screen and (max-width:768px) {
 
 }
@@ -7500,11 +7440,6 @@ exports[`Select onChange with valueLabel 2`] = `
 .c6 {
   display: block;
   width: 100%;
-}
-
-.c6:focus {
-  background-color: rgba(221,221,221,0.4);
-  color: #000000;
 }
 
 @media only screen and (max-width:768px) {
@@ -8042,11 +7977,6 @@ exports[`Select onChange without valueKey 2`] = `
 .c6 {
   display: block;
   width: 100%;
-}
-
-.c6:focus {
-  background-color: rgba(221,221,221,0.4);
-  color: #000000;
 }
 
 @media only screen and (max-width:768px) {
@@ -9188,11 +9118,6 @@ exports[`Select prop: onOpen 3`] = `
   width: 100%;
 }
 
-.c6:focus {
-  background-color: rgba(221,221,221,0.4);
-  color: #000000;
-}
-
 @media only screen and (max-width:768px) {
 
 }
@@ -9303,7 +9228,7 @@ exports[`Select prop: onOpen 5`] = `
     aria-posinset="1"
     aria-selected="false"
     aria-setsize="2"
-    class="StyledButton-sc-323bzc-0 ghVuhX SelectContainer__SelectOption-sc-1wi0ul8-1 mhbs"
+    class="StyledButton-sc-323bzc-0 ghVuhX SelectContainer__SelectOption-sc-1wi0ul8-1 cJsyfs"
     role="option"
     tabindex="-1"
     type="button"
@@ -9322,7 +9247,7 @@ exports[`Select prop: onOpen 5`] = `
     aria-posinset="2"
     aria-selected="false"
     aria-setsize="2"
-    class="StyledButton-sc-323bzc-0 ghVuhX SelectContainer__SelectOption-sc-1wi0ul8-1 mhbs"
+    class="StyledButton-sc-323bzc-0 ghVuhX SelectContainer__SelectOption-sc-1wi0ul8-1 cJsyfs"
     role="option"
     tabindex="-1"
     type="button"
@@ -11850,21 +11775,11 @@ exports[`Select search 2`] = `
   width: 100%;
 }
 
-.c9:focus {
-  background-color: rgba(221,221,221,0.4);
-  color: #000000;
-}
-
 .c13 {
   background-color: #7D4CDB;
   color: #FFFFFF;
   display: block;
   width: 100%;
-}
-
-.c13:focus {
-  background-color: rgba(221,221,221,0.4);
-  color: #000000;
 }
 
 @media only screen and (max-width:768px) {
@@ -12513,11 +12428,6 @@ exports[`Select search and select 2`] = `
 .c9 {
   display: block;
   width: 100%;
-}
-
-.c9:focus {
-  background-color: rgba(221,221,221,0.4);
-  color: #000000;
 }
 
 @media only screen and (max-width:768px) {
@@ -15855,11 +15765,6 @@ exports[`Select small drop container height 1`] = `
 .c6 {
   display: block;
   width: 100%;
-}
-
-.c6:focus {
-  background-color: rgba(221,221,221,0.4);
-  color: #000000;
 }
 
 @media only screen and (max-width:768px) {

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -423,6 +423,11 @@ exports[`Select Clear option renders - bottom 1`] = `
   width: 100%;
 }
 
+.c6:focus {
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
+}
+
 @media only screen and (max-width:768px) {
 
 }
@@ -676,6 +681,11 @@ exports[`Select Clear option renders correct label when wrapped in FormField 1`]
 .c6 {
   display: block;
   width: 100%;
+}
+
+.c6:focus {
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
 }
 
 @media only screen and (max-width:768px) {
@@ -941,6 +951,11 @@ exports[`Select Clear option renders custom label 1`] = `
   width: 100%;
 }
 
+.c6:focus {
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
+}
+
 @media only screen and (max-width:768px) {
 
 }
@@ -1194,6 +1209,11 @@ exports[`Select Clear option renders- top 1`] = `
 .c6 {
   display: block;
   width: 100%;
+}
+
+.c6:focus {
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
 }
 
 @media only screen and (max-width:768px) {
@@ -2047,6 +2067,11 @@ exports[`Select applies custom global.hover theme to options 2`] = `
   width: 100%;
 }
 
+.c1:focus {
+  background-color: lightgreen;
+  color: #7D4CDB;
+}
+
 @media only screen and (max-width:768px) {
 
 }
@@ -2803,6 +2828,11 @@ exports[`Select complex options and children 3`] = `
   width: 100%;
 }
 
+.c6:focus {
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
+}
+
 @media only screen and (max-width:768px) {
 
 }
@@ -3528,7 +3558,7 @@ exports[`Select default value clear 1`] = `
   padding: 12px;
 }
 
-.c10 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3547,7 +3577,7 @@ exports[`Select default value clear 1`] = `
   padding: 12px;
 }
 
-.c14 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3595,13 +3625,13 @@ exports[`Select default value clear 1`] = `
   color: #555555;
 }
 
-.c11 {
+.c12 {
   margin: 0px;
   font-size: 18px;
   line-height: 24px;
 }
 
-.c5 {
+.c4 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -3620,27 +3650,27 @@ exports[`Select default value clear 1`] = `
   width: 100%;
 }
 
-.c5:focus:not(:focus-visible) {
+.c4:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c4:focus:not(:focus-visible) > circle,
+.c4:focus:not(:focus-visible) > ellipse,
+.c4:focus:not(:focus-visible) > line,
+.c4:focus:not(:focus-visible) > path,
+.c4:focus:not(:focus-visible) > polygon,
+.c4:focus:not(:focus-visible) > polyline,
+.c4:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c4:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c8 {
+.c9 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -3658,27 +3688,27 @@ exports[`Select default value clear 1`] = `
   text-align: inherit;
 }
 
-.c8:focus:not(:focus-visible) {
+.c9:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c8:focus:not(:focus-visible) > circle,
-.c8:focus:not(:focus-visible) > ellipse,
-.c8:focus:not(:focus-visible) > line,
-.c8:focus:not(:focus-visible) > path,
-.c8:focus:not(:focus-visible) > polygon,
-.c8:focus:not(:focus-visible) > polyline,
-.c8:focus:not(:focus-visible) > rect {
+.c9:focus:not(:focus-visible) > circle,
+.c9:focus:not(:focus-visible) > ellipse,
+.c9:focus:not(:focus-visible) > line,
+.c9:focus:not(:focus-visible) > path,
+.c9:focus:not(:focus-visible) > polygon,
+.c9:focus:not(:focus-visible) > polyline,
+.c9:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c8:focus:not(:focus-visible)::-moz-focus-inner {
+.c9:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c12 {
+.c13 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -3696,23 +3726,23 @@ exports[`Select default value clear 1`] = `
   text-align: inherit;
 }
 
-.c12:focus:not(:focus-visible) {
+.c13:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible) > circle,
-.c12:focus:not(:focus-visible) > ellipse,
-.c12:focus:not(:focus-visible) > line,
-.c12:focus:not(:focus-visible) > path,
-.c12:focus:not(:focus-visible) > polygon,
-.c12:focus:not(:focus-visible) > polyline,
-.c12:focus:not(:focus-visible) > rect {
+.c13:focus:not(:focus-visible) > circle,
+.c13:focus:not(:focus-visible) > ellipse,
+.c13:focus:not(:focus-visible) > line,
+.c13:focus:not(:focus-visible) > path,
+.c13:focus:not(:focus-visible) > polygon,
+.c13:focus:not(:focus-visible) > polyline,
+.c13:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible)::-moz-focus-inner {
+.c13:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
@@ -3720,7 +3750,7 @@ exports[`Select default value clear 1`] = `
   max-height: inherit;
 }
 
-.c4 {
+.c8 {
   position: relative;
   -webkit-scroll-behavior: smooth;
   -moz-scroll-behavior: smooth;
@@ -3730,16 +3760,31 @@ exports[`Select default value clear 1`] = `
   outline: none;
 }
 
-.c9 {
+.c10 {
   display: block;
   width: 100%;
 }
 
-.c13 {
+.c10:focus {
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
+}
+
+.c14 {
   background-color: #7D4CDB;
   color: #FFFFFF;
   display: block;
   width: 100%;
+}
+
+.c14:focus {
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
+}
+
+.c5:focus {
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
 }
 
 @media only screen and (max-width:768px) {
@@ -3753,7 +3798,7 @@ exports[`Select default value clear 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c10 {
+  .c11 {
     padding: 6px;
   }
 }
@@ -3788,39 +3833,40 @@ exports[`Select default value clear 1`] = `
     class="c2 c3"
     id="test-select__select-drop"
   >
+    <button
+      aria-label="Clear selection, press down arrow to move to select options"
+      class="c4 c5"
+      type="button"
+    >
+      <div
+        class="c6"
+      >
+        <span
+          class="c7"
+        >
+          Clear selection
+        </span>
+      </div>
+    </button>
     <div
-      class="c4"
+      class="c8"
       role="listbox"
       tabindex="-1"
     >
       <button
-        class="c5"
-        type="button"
-      >
-        <div
-          class="c6"
-        >
-          <span
-            class="c7"
-          >
-            Clear selection
-          </span>
-        </div>
-      </button>
-      <button
         aria-posinset="1"
         aria-selected="false"
         aria-setsize="2"
-        class="c8 c9"
+        class="c9 c10"
         role="option"
         tabindex="-1"
         type="button"
       >
         <div
-          class="c10"
+          class="c11"
         >
           <span
-            class="c11"
+            class="c12"
           >
             one
           </span>
@@ -3830,23 +3876,23 @@ exports[`Select default value clear 1`] = `
         aria-posinset="2"
         aria-selected="true"
         aria-setsize="2"
-        class="c12 c13"
+        class="c13 c14"
         role="option"
         tabindex="0"
         type="button"
       >
         <div
-          class="c10"
+          class="c11"
         >
           <span
-            class="c11"
+            class="c12"
           >
             two
           </span>
         </div>
       </button>
       <div
-        class="c14"
+        class="c15"
       />
     </div>
   </div>
@@ -4944,6 +4990,11 @@ exports[`Select disabled key 2`] = `
   width: 100%;
 }
 
+.c6:focus {
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
+}
+
 @media only screen and (max-width:768px) {
 
 }
@@ -5239,6 +5290,11 @@ exports[`Select disabled option value 1`] = `
 .c6 {
   display: block;
   width: 100%;
+}
+
+.c6:focus {
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
 }
 
 @media only screen and (max-width:768px) {
@@ -5889,6 +5945,11 @@ exports[`Select large drop container height 1`] = `
   width: 100%;
 }
 
+.c6:focus {
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
+}
+
 @media only screen and (max-width:768px) {
 
 }
@@ -6133,6 +6194,11 @@ exports[`Select medium drop container height 1`] = `
 .c6 {
   display: block;
   width: 100%;
+}
+
+.c6:focus {
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
 }
 
 @media only screen and (max-width:768px) {
@@ -6947,6 +7013,11 @@ exports[`Select onChange with valueKey string 2`] = `
   width: 100%;
 }
 
+.c6:focus {
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
+}
+
 @media only screen and (max-width:768px) {
 
 }
@@ -7429,6 +7500,11 @@ exports[`Select onChange with valueLabel 2`] = `
 .c6 {
   display: block;
   width: 100%;
+}
+
+.c6:focus {
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
 }
 
 @media only screen and (max-width:768px) {
@@ -7966,6 +8042,11 @@ exports[`Select onChange without valueKey 2`] = `
 .c6 {
   display: block;
   width: 100%;
+}
+
+.c6:focus {
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
 }
 
 @media only screen and (max-width:768px) {
@@ -9107,6 +9188,11 @@ exports[`Select prop: onOpen 3`] = `
   width: 100%;
 }
 
+.c6:focus {
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
+}
+
 @media only screen and (max-width:768px) {
 
 }
@@ -9217,7 +9303,7 @@ exports[`Select prop: onOpen 5`] = `
     aria-posinset="1"
     aria-selected="false"
     aria-setsize="2"
-    class="StyledButton-sc-323bzc-0 ghVuhX SelectContainer__SelectOption-sc-1wi0ul8-1 khNgJL"
+    class="StyledButton-sc-323bzc-0 ghVuhX SelectContainer__SelectOption-sc-1wi0ul8-1 mhbs"
     role="option"
     tabindex="-1"
     type="button"
@@ -9236,7 +9322,7 @@ exports[`Select prop: onOpen 5`] = `
     aria-posinset="2"
     aria-selected="false"
     aria-setsize="2"
-    class="StyledButton-sc-323bzc-0 ghVuhX SelectContainer__SelectOption-sc-1wi0ul8-1 khNgJL"
+    class="StyledButton-sc-323bzc-0 ghVuhX SelectContainer__SelectOption-sc-1wi0ul8-1 mhbs"
     role="option"
     tabindex="-1"
     type="button"
@@ -11764,11 +11850,21 @@ exports[`Select search 2`] = `
   width: 100%;
 }
 
+.c9:focus {
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
+}
+
 .c13 {
   background-color: #7D4CDB;
   color: #FFFFFF;
   display: block;
   width: 100%;
+}
+
+.c13:focus {
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
 }
 
 @media only screen and (max-width:768px) {
@@ -12417,6 +12513,11 @@ exports[`Select search and select 2`] = `
 .c9 {
   display: block;
   width: 100%;
+}
+
+.c9:focus {
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
 }
 
 @media only screen and (max-width:768px) {
@@ -15754,6 +15855,11 @@ exports[`Select small drop container height 1`] = `
 .c6 {
   display: block;
   width: 100%;
+}
+
+.c6:focus {
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
 }
 
 @media only screen and (max-width:768px) {

--- a/src/js/components/Select/__tests__/__snapshots__/SelectMultiple-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/SelectMultiple-test.js.snap
@@ -1012,9 +1012,19 @@ exports[`Select Controlled multiple onChange toggle with valueKey reduce 2`] = `
   width: 100%;
 }
 
+.c6:focus {
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
+}
+
 .c10 {
   display: block;
   width: 100%;
+}
+
+.c10:focus {
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
 }
 
 @media only screen and (max-width:768px) {
@@ -1555,6 +1565,11 @@ exports[`Select Controlled multiple onChange with valueKey reduce 2`] = `
   width: 100%;
 }
 
+.c6:focus {
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
+}
+
 @media only screen and (max-width:768px) {
 
 }
@@ -2091,6 +2106,11 @@ exports[`Select Controlled multiple onChange with valueKey string 2`] = `
 .c6 {
   display: block;
   width: 100%;
+}
+
+.c6:focus {
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
 }
 
 @media only screen and (max-width:768px) {
@@ -2631,6 +2651,11 @@ exports[`Select Controlled multiple onChange without valueKey 2`] = `
   width: 100%;
 }
 
+.c6:focus {
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
+}
+
 @media only screen and (max-width:768px) {
 
 }
@@ -2753,7 +2778,7 @@ exports[`Select Controlled multiple onChange without valueKey 4`] = `
       <button
         aria-posinset="1"
         aria-setsize="2"
-        class="StyledButton-sc-323bzc-0 ghVuhX SelectContainer__SelectOption-sc-1wi0ul8-1 khNgJL"
+        class="StyledButton-sc-323bzc-0 ghVuhX SelectContainer__SelectOption-sc-1wi0ul8-1 mhbs"
         role="option"
         tabindex="-1"
         type="button"
@@ -2771,7 +2796,7 @@ exports[`Select Controlled multiple onChange without valueKey 4`] = `
       <button
         aria-posinset="2"
         aria-setsize="2"
-        class="StyledButton-sc-323bzc-0 ghVuhX SelectContainer__SelectOption-sc-1wi0ul8-1 khNgJL"
+        class="StyledButton-sc-323bzc-0 ghVuhX SelectContainer__SelectOption-sc-1wi0ul8-1 mhbs"
         role="option"
         tabindex="-1"
         type="button"
@@ -3277,6 +3302,11 @@ exports[`Select Controlled multiple values 3`] = `
   color: #FFFFFF;
   display: block;
   width: 100%;
+}
+
+.c6:focus {
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
 }
 
 @media only screen and (max-width:768px) {
@@ -3815,6 +3845,11 @@ exports[`Select Controlled multiple with empty results 2`] = `
 .c6 {
   display: block;
   width: 100%;
+}
+
+.c6:focus {
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
 }
 
 @media only screen and (max-width:768px) {

--- a/src/js/components/Select/__tests__/__snapshots__/SelectMultiple-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/SelectMultiple-test.js.snap
@@ -1012,19 +1012,9 @@ exports[`Select Controlled multiple onChange toggle with valueKey reduce 2`] = `
   width: 100%;
 }
 
-.c6:focus {
-  background-color: rgba(221,221,221,0.4);
-  color: #000000;
-}
-
 .c10 {
   display: block;
   width: 100%;
-}
-
-.c10:focus {
-  background-color: rgba(221,221,221,0.4);
-  color: #000000;
 }
 
 @media only screen and (max-width:768px) {
@@ -1565,11 +1555,6 @@ exports[`Select Controlled multiple onChange with valueKey reduce 2`] = `
   width: 100%;
 }
 
-.c6:focus {
-  background-color: rgba(221,221,221,0.4);
-  color: #000000;
-}
-
 @media only screen and (max-width:768px) {
 
 }
@@ -2106,11 +2091,6 @@ exports[`Select Controlled multiple onChange with valueKey string 2`] = `
 .c6 {
   display: block;
   width: 100%;
-}
-
-.c6:focus {
-  background-color: rgba(221,221,221,0.4);
-  color: #000000;
 }
 
 @media only screen and (max-width:768px) {
@@ -2651,11 +2631,6 @@ exports[`Select Controlled multiple onChange without valueKey 2`] = `
   width: 100%;
 }
 
-.c6:focus {
-  background-color: rgba(221,221,221,0.4);
-  color: #000000;
-}
-
 @media only screen and (max-width:768px) {
 
 }
@@ -2778,7 +2753,7 @@ exports[`Select Controlled multiple onChange without valueKey 4`] = `
       <button
         aria-posinset="1"
         aria-setsize="2"
-        class="StyledButton-sc-323bzc-0 ghVuhX SelectContainer__SelectOption-sc-1wi0ul8-1 mhbs"
+        class="StyledButton-sc-323bzc-0 ghVuhX SelectContainer__SelectOption-sc-1wi0ul8-1 cJsyfs"
         role="option"
         tabindex="-1"
         type="button"
@@ -2796,7 +2771,7 @@ exports[`Select Controlled multiple onChange without valueKey 4`] = `
       <button
         aria-posinset="2"
         aria-setsize="2"
-        class="StyledButton-sc-323bzc-0 ghVuhX SelectContainer__SelectOption-sc-1wi0ul8-1 mhbs"
+        class="StyledButton-sc-323bzc-0 ghVuhX SelectContainer__SelectOption-sc-1wi0ul8-1 cJsyfs"
         role="option"
         tabindex="-1"
         type="button"
@@ -3302,11 +3277,6 @@ exports[`Select Controlled multiple values 3`] = `
   color: #FFFFFF;
   display: block;
   width: 100%;
-}
-
-.c6:focus {
-  background-color: rgba(221,221,221,0.4);
-  color: #000000;
 }
 
 @media only screen and (max-width:768px) {
@@ -3845,11 +3815,6 @@ exports[`Select Controlled multiple with empty results 2`] = `
 .c6 {
   display: block;
   width: 100%;
-}
-
-.c6:focus {
-  background-color: rgba(221,221,221,0.4);
-  color: #000000;
 }
 
 @media only screen and (max-width:768px) {

--- a/src/js/components/Select/stories/Clear.js
+++ b/src/js/components/Select/stories/Clear.js
@@ -2,7 +2,10 @@ import React, { useState } from 'react';
 
 import { Box, Select } from 'grommet';
 
-const options = ['one', 'two', 'three'];
+const options = [];
+for (let i = 0; i < 500; i += 1) {
+  options.push(`Number ${i}`);
+}
 
 const ClearTop = () => {
   const [value, setValue] = useState();

--- a/src/js/components/Select/stories/Clear.js
+++ b/src/js/components/Select/stories/Clear.js
@@ -17,6 +17,7 @@ const ClearTop = () => {
         multiple
         options={options}
         onChange={({ value: nextValue }) => setValue(nextValue)}
+        dropHeight="large"
         clear
       />
     </Box>
@@ -33,6 +34,7 @@ const ClearBottom = () => {
         multiple
         options={options}
         onChange={({ value: nextValue }) => setValue(nextValue)}
+        dropHeight="large"
         clear={{ position: 'bottom' }}
       />
     </Box>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

- Fixes Select so that when `clear` is used, all Select options still render (original issue filed)
- Improves accessibility behavior of clear button by:
   - Moving ClearButton outside of the options box (clear button is not an option)
   - Improving styling of focused element to apply hover treatment (since focusIndicator={false}) so that keyboard user can track where the active element is
   - Enhanced a11yTitle of Clear Button

To Do: 
- [x] Enhance testing suite to improve "Clear" tests (I have made some enhancements but commented them out due to a timeout error I was receiving)

User should be able to tab to the "Clear Selection" button if it is at the bottom.

In this video, I open the select with "space", use down arrow to move through the options, "enter" to select options", then "tab" to tab through the select options and get to "Clear Selection". I am using VoiceOver on Mac.

https://user-images.githubusercontent.com/12522275/185514749-a8aa33c5-790c-4ead-aca8-d253975a7b5d.mov

#### Where should the reviewer start?

SelectContainer

#### What testing has been done on this PR?

Using Clear story.

#### How should this be manually tested?

Use Clear story.

#### Do Jest tests follow these best practices?

- [x] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [x] `userEvent` is used in place of `fireEvent`. (userEvent was causing timeout, used fireEvent)
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #6267 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
Yes. Fixed `clear` bug where not all Select options would render.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.