### PR TITLE
Add weight prop to Heading

### DIFF
--- a/src/js/components/Heading/Heading.js
+++ b/src/js/components/Heading/Heading.js
@@ -5,7 +5,7 @@ import { HeadingPropTypes } from './propTypes';
 
 const Heading = forwardRef(
   (
-    { color, fill, level, ...rest },
+    { color, fill, level, weight, ...rest },
     ref, // munged to avoid styled-components putting it in the DOM
   ) => (
     // enforce level to be a number
@@ -14,6 +14,7 @@ const Heading = forwardRef(
       colorProp={color}
       fillProp={fill}
       level={+level}
+      weight={weight}
       {...rest}
       ref={ref}
     />

--- a/src/js/components/Heading/StyledHeading.js
+++ b/src/js/components/Heading/StyledHeading.js
@@ -8,7 +8,7 @@ import {
 } from '../../utils';
 import { defaultProps } from '../../default-props';
 
-const sizeStyle = props => {
+const sizeStyle = (props) => {
   // size is a combination of the level and size properties
   const size = props.size || 'medium';
   const headingTheme = props.theme.heading;
@@ -20,9 +20,11 @@ const sizeStyle = props => {
         font-size: ${data ? data.size : size};
         line-height: ${data ? data.height : 'normal'};
         max-width: ${(props.fillProp && 'none') ||
-          (data && data.maxWidth) ||
-          levelStyle.medium.maxWidth};
-        font-weight: ${levelStyle.font.weight || headingTheme.weight};
+        (data && data.maxWidth) ||
+        levelStyle.medium.maxWidth};
+        font-weight: ${props.weight ||
+        levelStyle.font.weight ||
+        headingTheme.weight};
       `,
     ];
     if (props.responsive && headingTheme.responsiveBreakpoint) {
@@ -53,7 +55,7 @@ const sizeStyle = props => {
   return '';
 };
 
-const fontFamily = props => {
+const fontFamily = (props) => {
   const { font } = props.theme.heading.level[props.level] || {};
   if (font && font.family) {
     return css`
@@ -74,18 +76,18 @@ const truncateStyle = `
 `;
 
 const colorStyle = css`
-  color: ${props =>
+  color: ${(props) =>
     normalizeColor(props.colorProp || props.theme.heading.color, props.theme)};
 `;
 
 const StyledHeading = styled.h1`
   ${genericStyles}
-  ${props => fontFamily(props)}
-  ${props => sizeStyle(props)}
-  ${props => props.textAlign && textAlignStyle}
-  ${props => props.truncate && truncateStyle}
-  ${props => (props.colorProp || props.theme.heading.color) && colorStyle}
-  ${props => props.theme.heading && props.theme.heading.extend}
+  ${(props) => fontFamily(props)}
+  ${(props) => sizeStyle(props)}
+  ${(props) => props.textAlign && textAlignStyle}
+  ${(props) => props.truncate && truncateStyle}
+  ${(props) => (props.colorProp || props.theme.heading.color) && colorStyle}
+  ${(props) => props.theme.heading && props.theme.heading.extend}
 `;
 
 StyledHeading.defaultProps = {};

--- a/src/js/components/Heading/__tests__/Heading-test.tsx
+++ b/src/js/components/Heading/__tests__/Heading-test.tsx
@@ -134,6 +134,19 @@ test('responsive renders', () => {
   expect(container.firstChild).toMatchSnapshot();
 });
 
+test('weight renders', () => {
+  const { asFragment } = render(
+    <Grommet>
+      <Heading>My heading</Heading>
+      <Heading weight="normal">My heading</Heading>
+      <Heading weight="bold">My heading</Heading>
+      <Heading weight={700}>My heading</Heading>
+    </Grommet>,
+  );
+
+  expect(asFragment()).toMatchSnapshot();
+});
+
 test('Theme based font family renders', () => {
   const customTheme = {
     heading: {

--- a/src/js/components/Heading/__tests__/__snapshots__/Heading-test.tsx.snap
+++ b/src/js/components/Heading/__tests__/__snapshots__/Heading-test.tsx.snap
@@ -1171,3 +1171,102 @@ exports[`responsive renders 1`] = `
   />
 </div>
 `;
+
+exports[`weight renders 1`] = `
+<DocumentFragment>
+  .c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  font-size: 50px;
+  line-height: 56px;
+  max-width: 1200px;
+  font-weight: 600;
+}
+
+.c2 {
+  font-size: 50px;
+  line-height: 56px;
+  max-width: 1200px;
+  font-weight: normal;
+}
+
+.c3 {
+  font-size: 50px;
+  line-height: 56px;
+  max-width: 1200px;
+  font-weight: bold;
+}
+
+.c4 {
+  font-size: 50px;
+  line-height: 56px;
+  max-width: 1200px;
+  font-weight: 700;
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    font-size: 34px;
+    line-height: 40px;
+    max-width: 816px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    font-size: 34px;
+    line-height: 40px;
+    max-width: 816px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c3 {
+    font-size: 34px;
+    line-height: 40px;
+    max-width: 816px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c4 {
+    font-size: 34px;
+    line-height: 40px;
+    max-width: 816px;
+  }
+}
+
+<div
+    class="c0"
+  >
+    <h1
+      class="c1"
+    >
+      My heading
+    </h1>
+    <h1
+      class="c2"
+    >
+      My heading
+    </h1>
+    <h1
+      class="c3"
+    >
+      My heading
+    </h1>
+    <h1
+      class="c4"
+    >
+      My heading
+    </h1>
+  </div>
+</DocumentFragment>
+`;

--- a/src/js/components/Heading/index.d.ts
+++ b/src/js/components/Heading/index.d.ts
@@ -23,6 +23,7 @@ export interface HeadingProps {
   size?: 'small' | 'medium' | 'large' | 'xlarge' | string;
   textAlign?: TextAlignType;
   truncate?: boolean;
+  weight?: 'normal' | 'bold' | 'lighter' | 'bolder' | number | string;
 }
 
 type hProps =

--- a/src/js/components/Heading/propTypes.js
+++ b/src/js/components/Heading/propTypes.js
@@ -15,6 +15,11 @@ if (process.env.NODE_ENV !== 'production') {
     ]),
     textAlign: PropTypes.oneOf(['start', 'center', 'end', 'justify']),
     truncate: PropTypes.bool,
+    weight: PropTypes.oneOfType([
+      PropTypes.oneOf(['normal', 'bold', 'lighter', 'bolder']),
+      PropTypes.number,
+      PropTypes.string,
+    ]),
   };
 }
 export const HeadingPropTypes = PropType;

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -472,6 +472,7 @@ Object {
       "size": [Function],
       "textAlign": [Function],
       "truncate": [Function],
+      "weight": [Function],
     },
     "render": [Function],
   },


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Closes #6276 by adding `weight` to `<Heading />`

#### Where should the reviewer start?

Heading.js

#### What testing has been done on this PR?

Jest test suite, Storybook, plus new snapshot.

#### How should this be manually tested?

```
<Heading weight="normal">My Heading</Heading>
<Heading weight="bold">My Heading</Heading>
<Heading weight={700}>My Heading</Heading>
```

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [x] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#6276

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

Yes.

#### Should this PR be mentioned in the release notes?

Yes.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.