### PR TITLE
add formField.checkBox.pad as an option to be handeled in formField

### DIFF
--- a/src/js/components/FormField/FormField.js
+++ b/src/js/components/FormField/FormField.js
@@ -220,6 +220,7 @@ const FormField = forwardRef(
           if (
             child &&
             child.type &&
+            'CheckBox'.indexOf(child.type.displayName) === -1 &&
             grommetInputNames.indexOf(child.type.displayName) !== -1 &&
             child.props.plain === undefined &&
             child.props.focusIndicator === undefined
@@ -227,6 +228,19 @@ const FormField = forwardRef(
             return cloneElement(child, {
               plain: true,
               focusIndicator: false,
+            });
+          }
+          if (
+            child &&
+            child.type &&
+            'CheckBox'.indexOf(child.type.displayName) !== -1 &&
+            child.props.plain === undefined &&
+            child.props.focusIndicator === undefined
+          ) {
+            return cloneElement(child, {
+              plain: true,
+              focusIndicator: false,
+              pad: formFieldTheme?.checkBox?.pad,
             });
           }
           return child;

--- a/src/js/components/FormField/FormField.js
+++ b/src/js/components/FormField/FormField.js
@@ -220,7 +220,6 @@ const FormField = forwardRef(
           if (
             child &&
             child.type &&
-            'CheckBox'.indexOf(child.type.displayName) === -1 &&
             grommetInputNames.indexOf(child.type.displayName) !== -1 &&
             child.props.plain === undefined &&
             child.props.focusIndicator === undefined
@@ -228,19 +227,10 @@ const FormField = forwardRef(
             return cloneElement(child, {
               plain: true,
               focusIndicator: false,
-            });
-          }
-          if (
-            child &&
-            child.type &&
-            'CheckBox'.indexOf(child.type.displayName) !== -1 &&
-            child.props.plain === undefined &&
-            child.props.focusIndicator === undefined
-          ) {
-            return cloneElement(child, {
-              plain: true,
-              focusIndicator: false,
-              pad: formFieldTheme?.checkBox?.pad,
+              pad:
+                'CheckBox'.indexOf(child.type.displayName) !== -1
+                  ? formFieldTheme?.checkBox?.pad
+                  : undefined,
             });
           }
           return child;

--- a/src/js/components/FormField/__tests__/FormField-test.js
+++ b/src/js/components/FormField/__tests__/FormField-test.js
@@ -9,6 +9,7 @@ import 'regenerator-runtime/runtime';
 import { Alert, New, StatusInfo } from 'grommet-icons';
 import { Grommet } from '../../Grommet';
 import { Form } from '../../Form';
+import { CheckBox } from '../../CheckBox';
 import { FormField } from '..';
 import { TextInput } from '../../TextInput';
 
@@ -414,6 +415,32 @@ describe('FormField', () => {
       >
         <Form>
           <FormField label="label" required={{ indicator: false }} />
+        </Form>
+      </Grommet>,
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test('checkbox pad is defined in formfield', () => {
+    const { container } = render(
+      <Grommet
+        theme={{
+          formField: {
+            checkBox: {
+              pad: {
+                horizontal: 'small',
+                vertical: 'xsmall',
+              },
+            },
+          },
+        }}
+      >
+        <Form>
+          <FormField label="label">
+            <CheckBox label="checkbox with pad" />
+          </FormField>
+          <CheckBox label="checkbox without pad" />
         </Form>
       </Grommet>,
     );

--- a/src/js/components/FormField/__tests__/__snapshots__/FormField-test.js.snap
+++ b/src/js/components/FormField/__tests__/__snapshots__/FormField-test.js.snap
@@ -132,6 +132,273 @@ exports[`FormField abut with margin 1`] = `
 </div>
 `;
 
+exports[`FormField checkbox pad is defined in formfield 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-bottom: 12px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 12px;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-right: 12px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: solid 2px rgba(0,0,0,0.15);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 24px;
+  width: 24px;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  border-radius: 4px;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+  cursor: pointer;
+}
+
+.c4:hover input:not([disabled]) + div,
+.c4:hover input:not([disabled]) + span {
+  border-color: #000000;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  cursor: pointer;
+}
+
+.c9:hover input:not([disabled]) + div,
+.c9:hover input:not([disabled]) + span {
+  border-color: #000000;
+}
+
+.c7 {
+  opacity: 0;
+  -moz-appearance: none;
+  width: 0;
+  height: 0;
+  margin: 0;
+  cursor: pointer;
+}
+
+.c7:checked + span > span {
+  left: calc( 48px - 24px );
+  background: #7D4CDB;
+}
+
+.c6 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c2 {
+  margin-left: 12px;
+  margin-right: 12px;
+  margin-top: 6px;
+  margin-bottom: 6px;
+  font-size: 18px;
+  line-height: 24px;
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    margin-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c3 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c3 {
+    padding: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c5 {
+    margin-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c8 {
+    border: solid 2px rgba(0,0,0,0.15);
+  }
+}
+
+<div
+  class="c0"
+>
+  <form>
+    <div
+      class="c1 "
+    >
+      <label
+        class="c2"
+      >
+        label
+      </label>
+      <div
+        class="c3 FormField__FormFieldContentBox-sc-m9hood-1"
+      >
+        <label
+          class="c4"
+          label="checkbox with pad"
+        >
+          <div
+            class="c5 c6"
+          >
+            <input
+              class="c7"
+              type="checkbox"
+            />
+            <div
+              class="c8 "
+            />
+          </div>
+          <span>
+            checkbox with pad
+          </span>
+        </label>
+      </div>
+    </div>
+    <label
+      class="c9"
+      label="checkbox without pad"
+    >
+      <div
+        class="c5 c6"
+      >
+        <input
+          class="c7"
+          type="checkbox"
+        />
+        <div
+          class="c8 "
+        />
+      </div>
+      <span>
+        checkbox without pad
+      </span>
+    </label>
+  </form>
+</div>
+`;
+
 exports[`FormField contentProps 1`] = `
 .c0 {
   font-size: 18px;

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -773,6 +773,9 @@ export interface ThemeType {
       margin?: MarginType;
       pad?: PadType;
     };
+    checkBox: {
+      pad: PadType;
+    };
     disabled?: {
       background?: BackgroundType;
       border?: {

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -867,6 +867,9 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         position: 'inner',
         side: 'bottom',
       },
+      // checkBox: {
+      //   pad: undefined,
+      // },
       content: {
         // margin: undefined,
         pad: 'small',


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
adds `formField.checkBox.pad` this will add `pad` to checkbox from theme.
#### Where should the reviewer start?
FormField
#### What testing has been done on this PR?
set pad value to formField.checkBox.pad
#### How should this be manually tested?
set pad value to formField.checkBox.pad
Custom story
#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
needed for theme
https://github.com/grommet/grommet-theme-hpe/pull/269
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
yes I will add a PR if this is the direction we go
#### Should this PR be mentioned in the release notes?
sure
#### Is this change backwards compatible or is it a breaking change?
backwards compatible