### PR TITLE
onAnalytics improvements

### DIFF
--- a/src/js/components/Anchor/Anchor.js
+++ b/src/js/components/Anchor/Anchor.js
@@ -10,7 +10,7 @@ import React, {
 import { ThemeContext } from 'styled-components';
 import { defaultProps } from '../../default-props';
 
-import { normalizeColor } from '../../utils';
+import { findButtonParent, normalizeColor } from '../../utils';
 
 import { Box } from '../Box';
 
@@ -47,7 +47,7 @@ const Anchor = forwardRef(
       (event) => {
         sendAnalytics({
           type: 'anchorClick',
-          element: event.target,
+          element: findButtonParent(event.target),
           event,
           href,
           label: typeof label === 'string' ? label: undefined,

--- a/src/js/components/Button/Button.js
+++ b/src/js/components/Button/Button.js
@@ -210,12 +210,6 @@ const Button = forwardRef(
 
     const sendAnalytics = useAnalytics();
 
-/*    const findAncestor = (type, element) => {
-      if (element && element.nodeName !== type)
-        return findAncestor(type, element.parentElement);
-      return element;
-    };
-*/
     const onClick = useCallback(
       (event) => {
         sendAnalytics({

--- a/src/js/components/Button/Button.js
+++ b/src/js/components/Button/Button.js
@@ -12,6 +12,7 @@ import { ThemeContext } from 'styled-components';
 import {
   backgroundAndTextColors,
   colorIsDark,
+  findButtonParent,
   normalizeBackground,
   normalizeColor,
 } from '../../utils';
@@ -173,11 +174,17 @@ const Button = forwardRef(
 
     const sendAnalytics = useAnalytics();
 
+/*    const findAncestor = (type, element) => {
+      if (element && element.nodeName !== type)
+        return findAncestor(type, element.parentElement);
+      return element;
+    };
+*/
     const onClick = useCallback(
       (event) => {
         sendAnalytics({
           type: 'buttonClick',
-          element: event.target,
+          element: findButtonParent(event.target),
           event,
           href,
           label: typeof label === 'string' ? label: undefined,
@@ -393,7 +400,7 @@ const Button = forwardRef(
           href={href}
           kind={kind}
           themePaths={themePaths}
-          onClick={onClickProp ? onClick : undefined}
+          onClick={onClick}
           onFocus={(event) => {
             setFocus(true);
             if (onFocus) onFocus(event);

--- a/src/js/components/Layer/LayerContainer.js
+++ b/src/js/components/Layer/LayerContainer.js
@@ -72,18 +72,24 @@ const LayerContainer = forwardRef(
     useEffect(() => {
       const start = new Date();
       const element = layerRef.current;
-      sendAnalytics({
-        type: 'layerOpen',
-        element,
-      });
-      return () => {
+      const isHidden = position === 'hidden';
+      if (!isHidden) {
+
         sendAnalytics({
-          type: 'layerClose',
+          type: 'layerOpen',
           element,
-          elapsed: new Date().getTime() - start.getTime(),
         });
+      }
+      return () => {
+        if (!isHidden) {
+          sendAnalytics({
+            type: 'layerClose',
+            element,
+            elapsed: new Date().getTime() - start.getTime(),
+          });
+        }
       };
-    }, [sendAnalytics, layerRef]);
+    }, [sendAnalytics, layerRef, position]);
 
     useEffect(() => {
       if (position !== 'hidden') {

--- a/src/js/components/List/List.js
+++ b/src/js/components/List/List.js
@@ -16,6 +16,8 @@ import {
   useForwardedRef,
   usePagination,
 } from '../../utils';
+import { useAnalytics } from '../../contexts/AnalyticsContext';
+
 import { ListPropTypes } from './propTypes';
 
 const StyledList = styled.ul`
@@ -196,6 +198,8 @@ const List = React.forwardRef(
 
     const draggingRef = useRef();
 
+    const sendAnalytics = useAnalytics();
+
     const ariaProps = {
       role: onClickItem || onOrder ? 'listbox' : 'list',
     };
@@ -254,6 +258,13 @@ const List = React.forwardRef(
                     adjustedEvent.item = data[active];
                     adjustedEvent.index = active;
                     onClickItem(adjustedEvent);
+                    sendAnalytics({
+                      type: 'listItemClick',
+                      element: listRef.current,
+                      event: adjustedEvent,
+                      item: data[active],
+                      index: active,
+                    });
                   }
                 }
               : undefined
@@ -430,6 +441,13 @@ const List = React.forwardRef(
                         // put focus on the List container to meet WCAG
                         // accessibility guidelines that focus remains on `ul`
                         listRef.current.focus();
+                        sendAnalytics({
+                          type: 'listItemClick',
+                          element: listRef.current,
+                          event: adjustedEvent,
+                          item,
+                          index,
+                        });
                       }
                     },
                     onMouseOver: () => updateActive(index),

--- a/src/js/utils/DOM.js
+++ b/src/js/utils/DOM.js
@@ -197,3 +197,9 @@ export const isNodeBeforeScroll = (node, target) => {
     : { top: 0 };
   return top <= targetTop;
 };
+
+export const findButtonParent = (element) => {
+  if (element && (element.nodeName !== 'BUTTON') && (element.nodeName !== 'A'))
+    return findButtonParent(element.parentElement);
+  return element;
+};


### PR DESCRIPTION
Improve some of the analytics events.

#### What does this PR do?

- Makes Layer's with `position="hidden"` not generate open/close events.
- Adds support for events from List `onClickItem`.
- Makes the element returned in the event for Button and Anchor clicks always be the button or anchor element rather than one of it's children.

#### Where should the reviewer start?
Button.js

#### What testing has been done on this PR?
Manual, Jest and Storybook

#### How should this be manually tested?
Add a logging version of onAnalytics callback to `<Grommet>` usages. For example:
```jsx
const onAnalytics = (data) => console.log('onAnalytics', data);

<Grommet onAnalytics={onAnalytics}>
```
#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
#6302 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Not yet

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible
