### PR TITLE
fix console error in storybook story

### DIFF
--- a/src/js/components/DataTable/stories/SpaceX.js
+++ b/src/js/components/DataTable/stories/SpaceX.js
@@ -23,7 +23,7 @@ const columns = [
         const content = (
           <Box width={{ max: 'medium' }}>
             {datum.failures?.map(({ reason }) => (
-              <Text>{reason}</Text>
+              <Text key={reason}>{reason}</Text>
             ))}
           </Box>
         );

--- a/src/js/components/DataTable/stories/SpaceXUngrouped.js
+++ b/src/js/components/DataTable/stories/SpaceXUngrouped.js
@@ -80,7 +80,6 @@ export const SpaceXUngrouped = () => {
       })
         .then((response) => response.json())
         .then(({ docs }) => {
-          console.log(docs);
           setData(docs || []);
         })
         .catch((error) => console.error('Unable to get data:', error));

--- a/src/js/components/DataTable/stories/SpaceXUngrouped.js
+++ b/src/js/components/DataTable/stories/SpaceXUngrouped.js
@@ -13,7 +13,7 @@ const columns = [
     property: 'rocket',
     header: 'Rocket',
     size: 'small',
-    render: (datum) => <Text>{datum.rocket.name}</Text>,
+    render: (datum) => <Text key={datum.rocket.name}>{datum.rocket.name}</Text>,
   },
   {
     property: 'success',
@@ -24,7 +24,7 @@ const columns = [
         const content = (
           <Box width={{ max: 'medium' }}>
             {datum.failures?.map(({ reason }) => (
-              <Text>{reason}</Text>
+              <Text key={reason}>{reason}</Text>
             ))}
           </Box>
         );
@@ -80,6 +80,7 @@ export const SpaceXUngrouped = () => {
       })
         .then((response) => response.json())
         .then(({ docs }) => {
+          console.log(docs);
           setData(docs || []);
         })
         .catch((error) => console.error('Unable to get data:', error));


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
adds a `key` to text
#### Where should the reviewer start?
[DataTable/stories/SpaceXUngrouped.js](https://github.com/grommet/grommet/compare/master...britt6612:clean-console-error-storybook?expand=1#diff-bfe6bcf159bf6f25e0fc779f35ec3bf90001be6ad3cec007d72ed6d344d353df)
#### What testing has been done on this PR?
locally 
#### How should this be manually tested?
locally 
#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
saw error while going through storybook for release thought it would be nice to clean up 
#### What are the relevant issues?
none
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
backwards compatible 