### PR TITLE
(Select) fix: trigger a validation for multiple selection

### DIFF
--- a/src/js/components/Form/__tests__/Form-test-controlled.js
+++ b/src/js/components/Form/__tests__/Form-test-controlled.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import userEvent from '@testing-library/user-event';
 
 import 'jest-styled-components';
 
@@ -10,6 +11,7 @@ import { Button } from '../../Button';
 import { TextInput } from '../../TextInput';
 import { CheckBox } from '../../CheckBox';
 import { Box } from '../../Box';
+import { Select } from '../../Select';
 
 describe('Form controlled', () => {
   test('controlled', () => {
@@ -930,5 +932,85 @@ describe('Form controlled', () => {
     expect(screen.queryAllByText('invalid')).toHaveLength(2);
     // lastName should not trigger required validation onMount
     expect(screen.queryAllByText('required')).toHaveLength(0);
+  });
+
+  test('validate select with multiple selection', async () => {
+    global.scrollTo = jest.fn();
+    const Test = () => {
+      const options = ['foo', 'bar', 'baz'];
+      const [formValue, setFormValue] = useState({
+        firstName: '',
+        multiple: [],
+      });
+
+      return (
+        <Form
+          value={formValue}
+          validate="change"
+          onChange={(nextValue) => setFormValue(nextValue)}
+        >
+          <FormField
+            label="Multiple"
+            name="multiple"
+            htmlFor="multiple"
+            required
+            validate={[
+              (value) => {
+                if (value.length === 1) {
+                  return {
+                    message: 'multiple selection error',
+                    status: 'error',
+                  };
+                }
+                return undefined;
+              },
+            ]}
+          >
+            <Select
+              data-testid="multiple"
+              multiple
+              size="medium"
+              name="multiple"
+              id="multiple"
+              placeholder="multiple"
+              options={options}
+              closeOnChange={false}
+            />
+          </FormField>
+
+          <FormField
+            label="First Name"
+            htmlFor="first-name"
+            name="firstName"
+            required
+            validate={[
+              { regexp: /^[a-z]/i },
+              (firstName) => {
+                if (firstName && firstName.length === 1)
+                  return 'must be >1 character';
+                return undefined;
+              },
+            ]}
+          >
+            <TextInput
+              id="first-name"
+              name="firstName"
+              placeholder="firstName"
+            />
+          </FormField>
+        </Form>
+      );
+    };
+
+    render(
+      <Grommet>
+        <Test />
+      </Grommet>,
+    );
+
+    userEvent.click(screen.getByTestId('multiple'));
+    expect(await screen.findByRole('listbox')).toBeTruthy();
+    userEvent.click(screen.getByRole('option', { name: 'foo' }));
+    expect(await screen.findByText('multiple selection error')).toBeTruthy();
   });
 });

--- a/src/js/components/Select/Select.js
+++ b/src/js/components/Select/Select.js
@@ -181,7 +181,7 @@ const Select = forwardRef(
         // input. if it is an object, then the user has not provided necessary
         // props to reduce object option
         if (
-          typeof nextValue !== 'object' &&
+          (typeof nextValue !== 'object' || multiple) &&
           nextValue !== event.target.value &&
           inputRef.current
         ) {
@@ -214,7 +214,14 @@ const Select = forwardRef(
           onChange(adjustedEvent);
         }
       },
-      [closeOnChange, onChange, onRequestClose, setValue, triggerChangeEvent],
+      [
+        closeOnChange,
+        multiple,
+        onChange,
+        onRequestClose,
+        setValue,
+        triggerChangeEvent,
+      ],
     );
 
     const SelectIcon = getSelectIcon(icon, theme, open);


### PR DESCRIPTION
#### What does this PR do?
For Select component with multiple selection `nextValue` is an object (array) and we want to trigger change event in this situation to trigger a validation.

#### Where should the reviewer start?
Select.js

#### What testing has been done on this PR?
Manual and unit tests

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
https://github.com/grommet/grommet/issues/6303

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?