### PR TITLE
fix/button dark mode color

### DIFF
--- a/src/js/components/Button/StyledButtonKind.js
+++ b/src/js/components/Button/StyledButtonKind.js
@@ -76,6 +76,7 @@ const padStyle = ({ sizeProp: size, theme, kind }) => {
 
 const basicStyle = (props) => css`
   border: none;
+  color: inherit;
   ${radiusStyle(props)};
   ${padStyle(props)}
   ${fontStyle(props)}

--- a/src/js/components/Button/__tests__/__snapshots__/Button-kind-test.js.snap
+++ b/src/js/components/Button/__tests__/__snapshots__/Button-kind-test.js.snap
@@ -65,6 +65,7 @@ exports[`Button kind badge should apply background 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 18px;
   padding: 4px 22px;
   font-size: 18px;
@@ -231,6 +232,7 @@ exports[`Button kind badge should be offset from top-right corner 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 18px;
   padding: 4px 22px;
   font-size: 18px;
@@ -398,6 +400,7 @@ exports[`Button kind badge should display "+" when number is greater than max 1`
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 18px;
   padding: 4px 22px;
   font-size: 18px;
@@ -571,6 +574,7 @@ exports[`Button kind badge should display number content 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 18px;
   padding: 4px 22px;
   font-size: 18px;
@@ -755,6 +759,7 @@ exports[`Button kind badge should render custom element 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 18px;
   padding: 4px 22px;
   font-size: 18px;
@@ -957,6 +962,7 @@ exports[`Button kind badge should render relative to contents when button has no
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 18px;
   padding: 4px 22px;
   font-size: 18px;
@@ -1090,6 +1096,7 @@ exports[`Button kind border on default button 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 18px;
   padding: 4px 22px;
   font-size: 18px;
@@ -1216,6 +1223,7 @@ exports[`Button kind button icon colors 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 18px;
   padding: 4px 22px;
   font-size: 18px;
@@ -1362,6 +1370,7 @@ exports[`Button kind button with icon and align 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 18px;
   padding: 4px 22px;
   font-size: 18px;
@@ -1472,6 +1481,7 @@ exports[`Button kind default button 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 10px;
   font-size: 18px;
@@ -1565,6 +1575,7 @@ exports[`Button kind disabled with hoverIndicator should not hover 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 18px;
   padding: 4px 22px;
   font-size: 18px;
@@ -1649,7 +1660,7 @@ exports[`Button kind disabled with hoverIndicator should not hover 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
 >
   <button
-    class="StyledButtonKind-sc-1vhfpnt-0 jmrTmz"
+    class="StyledButtonKind-sc-1vhfpnt-0 bguLGq"
     disabled=""
     type="button"
   >
@@ -1671,6 +1682,7 @@ exports[`Button kind extend on default button 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 18px;
   padding: 4px 22px;
   font-size: 18px;
@@ -1760,6 +1772,7 @@ exports[`Button kind fill 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 18px;
   padding: 4px 22px;
   font-size: 18px;
@@ -1831,6 +1844,7 @@ exports[`Button kind fill 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 18px;
   padding: 4px 22px;
   font-size: 18px;
@@ -1897,6 +1911,7 @@ exports[`Button kind fill 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 18px;
   padding: 4px 22px;
   font-size: 18px;
@@ -1998,6 +2013,7 @@ exports[`Button kind font on button default 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 18px;
   padding: 4px 22px;
   font-size: 18px;
@@ -2088,6 +2104,7 @@ exports[`Button kind font undefined 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 18px;
   padding: 4px 22px;
   font-size: 18px;
@@ -2262,6 +2279,7 @@ exports[`Button kind hover secondary with color and background 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 18px;
   padding: 4px 22px;
   font-size: 18px;
@@ -2349,7 +2367,7 @@ exports[`Button kind hover secondary with color and background 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
 >
   <button
-    class="StyledButtonKind-sc-1vhfpnt-0 dePmIQ"
+    class="StyledButtonKind-sc-1vhfpnt-0 gnQBRF"
     type="button"
   >
     Button
@@ -2370,6 +2388,7 @@ exports[`Button kind hoverIndicator with color and background 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 18px;
   padding: 4px 22px;
   font-size: 18px;
@@ -2455,7 +2474,7 @@ exports[`Button kind hoverIndicator with color and background 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
 >
   <button
-    class="StyledButtonKind-sc-1vhfpnt-0 gIFSMH"
+    class="StyledButtonKind-sc-1vhfpnt-0 iKLOOa"
     type="button"
   >
     Button
@@ -2542,6 +2561,7 @@ exports[`Button kind mouseOver and mouseOut events 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 18px;
   padding: 4px 22px;
   font-size: 18px;
@@ -2654,7 +2674,7 @@ exports[`Button kind mouseOver and mouseOut events 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
 >
   <button
-    class="StyledButtonKind-sc-1vhfpnt-0 cdUjho"
+    class="StyledButtonKind-sc-1vhfpnt-0 efsBvF"
     type="button"
   >
     <div
@@ -2694,6 +2714,7 @@ exports[`Button kind no border on default button 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 18px;
   padding: 4px 22px;
   font-size: 18px;
@@ -2783,6 +2804,7 @@ exports[`Button kind no padding on default button 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 18px;
   padding: 4px 22px;
   font-size: 18px;
@@ -2873,6 +2895,7 @@ exports[`Button kind opacity on default button 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 18px;
   padding: 4px 22px;
   font-size: 18px;
@@ -2962,6 +2985,7 @@ exports[`Button kind padding on default button 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 18px;
   padding: 4px 22px;
   font-size: 18px;
@@ -3260,6 +3284,7 @@ exports[`Button kind primary button 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 10px;
   font-size: 18px;
@@ -3328,6 +3353,7 @@ exports[`Button kind primary button 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 10px;
   font-size: 18px;
@@ -3538,6 +3564,7 @@ exports[`Button kind secondary button 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 10px;
   font-size: 18px;
@@ -3635,6 +3662,7 @@ exports[`Button kind should apply styling according to theme size definitions 1`
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 8px;
   font-size: 14px;
@@ -3700,6 +3728,7 @@ exports[`Button kind should apply styling according to theme size definitions 1`
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 18px;
   padding: 6px 12px;
   font-size: 18px;
@@ -3765,6 +3794,7 @@ exports[`Button kind should apply styling according to theme size definitions 1`
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 6px 12px;
   font-size: 18px;
@@ -3830,6 +3860,7 @@ exports[`Button kind should apply styling according to theme size definitions 1`
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 6px;
   padding: 6px 16px;
   font-size: 22px;
@@ -3936,6 +3967,7 @@ exports[`Button kind size of default button 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 8px;
   font-size: 14px;

--- a/src/js/components/Button/stories/DarkMode.js
+++ b/src/js/components/Button/stories/DarkMode.js
@@ -1,0 +1,41 @@
+import React from 'react';
+
+import { Box, Button, Grommet } from 'grommet';
+import { deepMerge } from 'grommet/utils';
+import { hpe } from 'grommet-theme-hpe';
+
+const myTheme = deepMerge(hpe, {
+  button: {
+    'background-contrast': {
+      background: 'background-contrast',
+      color: 'text-strong',
+    },
+    active: {
+      'background-contrast': {
+        color: 'text-strong',
+      },
+    },
+  },
+});
+
+export const DarkMode = () => (
+  <Grommet theme={myTheme}>
+    <Box
+      background={{ dark: true, color: 'background' }}
+      pad="large"
+      gap="medium"
+      align="start"
+    >
+      <Button label="Test button" kind="background-contrast" />
+      <Button label="Active Test button" kind="background-contrast" active />
+    </Box>
+    <Box pad="large" gap="medium" align="start">
+      <Button label="Test button" kind="background-contrast" />
+      <Button label="Active Test button" kind="background-contrast" active />
+    </Box>
+  </Grommet>
+);
+
+export default {
+  title: 'Controls/Button/DarkMode',
+};

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -21488,6 +21488,7 @@ exports[`DataTable should apply pagination styling 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -21574,6 +21575,7 @@ exports[`DataTable should apply pagination styling 1`] = `
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -21651,6 +21653,7 @@ exports[`DataTable should apply pagination styling 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -21727,6 +21730,7 @@ exports[`DataTable should apply pagination styling 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -24256,6 +24260,7 @@ exports[`DataTable should paginate 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -24342,6 +24347,7 @@ exports[`DataTable should paginate 1`] = `
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -24419,6 +24425,7 @@ exports[`DataTable should paginate 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -24495,6 +24502,7 @@ exports[`DataTable should paginate 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -26594,6 +26602,7 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -26680,6 +26689,7 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -26757,6 +26767,7 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -26833,6 +26844,7 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -27886,6 +27898,7 @@ exports[`DataTable should render new data when page changes 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -27972,6 +27985,7 @@ exports[`DataTable should render new data when page changes 1`] = `
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -28049,6 +28063,7 @@ exports[`DataTable should render new data when page changes 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -28125,6 +28140,7 @@ exports[`DataTable should render new data when page changes 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -31467,7 +31483,7 @@ exports[`DataTable should render new data when page changes 2`] = `
           >
             <button
               aria-label="Go to previous page"
-              class="StyledButtonKind-sc-1vhfpnt-0 keNLVa StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKQztq"
+              class="StyledButtonKind-sc-1vhfpnt-0 haokZj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKQztq"
               type="button"
             >
               <svg
@@ -31492,7 +31508,7 @@ exports[`DataTable should render new data when page changes 2`] = `
           >
             <button
               aria-label="Go to page 1"
-              class="StyledButtonKind-sc-1vhfpnt-0 mwqRM StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKQztq"
+              class="StyledButtonKind-sc-1vhfpnt-0 bpJYGB StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKQztq"
               type="button"
             >
               1
@@ -31507,7 +31523,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             <button
               aria-current="page"
               aria-label="Go to page 2"
-              class="StyledButtonKind-sc-1vhfpnt-0 iMAkpG StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKQztq"
+              class="StyledButtonKind-sc-1vhfpnt-0 keYDKv StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKQztq"
               type="button"
             >
               2
@@ -31522,7 +31538,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             <button
               aria-disabled="true"
               aria-label="Go to next page"
-              class="StyledButtonKind-sc-1vhfpnt-0 jfPneK StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKQztq"
+              class="StyledButtonKind-sc-1vhfpnt-0 bIsOjP StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKQztq"
               disabled=""
               type="button"
             >
@@ -31772,6 +31788,7 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -31858,6 +31875,7 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -31935,6 +31953,7 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -32011,6 +32030,7 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -34110,6 +34130,7 @@ exports[`DataTable should show correct page when "show" is { page: # } 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -34197,6 +34218,7 @@ exports[`DataTable should show correct page when "show" is { page: # } 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -34275,6 +34297,7 @@ exports[`DataTable should show correct page when "show" is { page: # } 1`] = `
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -34352,6 +34375,7 @@ exports[`DataTable should show correct page when "show" is { page: # } 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;

--- a/src/js/components/List/__tests__/__snapshots__/List-test.js.snap
+++ b/src/js/components/List/__tests__/__snapshots__/List-test.js.snap
@@ -4404,6 +4404,7 @@ exports[`List events should apply pagination styling 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -4490,6 +4491,7 @@ exports[`List events should apply pagination styling 1`] = `
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -4567,6 +4569,7 @@ exports[`List events should apply pagination styling 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -4643,6 +4646,7 @@ exports[`List events should apply pagination styling 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -5560,6 +5564,7 @@ exports[`List events should paginate 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -5646,6 +5651,7 @@ exports[`List events should paginate 1`] = `
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -5723,6 +5729,7 @@ exports[`List events should paginate 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -5799,6 +5806,7 @@ exports[`List events should paginate 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -6559,6 +6567,7 @@ exports[`List events should render correct num items per page (step) 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -6645,6 +6654,7 @@ exports[`List events should render correct num items per page (step) 1`] = `
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -6722,6 +6732,7 @@ exports[`List events should render correct num items per page (step) 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -6798,6 +6809,7 @@ exports[`List events should render correct num items per page (step) 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -7448,6 +7460,7 @@ exports[`List events should render new data when page changes 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -7534,6 +7547,7 @@ exports[`List events should render new data when page changes 1`] = `
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -7611,6 +7625,7 @@ exports[`List events should render new data when page changes 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -7687,6 +7702,7 @@ exports[`List events should render new data when page changes 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -11810,7 +11826,7 @@ exports[`List events should render new data when page changes 2`] = `
           >
             <button
               aria-label="Go to previous page"
-              class="StyledButtonKind-sc-1vhfpnt-0 keNLVa StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKQztq"
+              class="StyledButtonKind-sc-1vhfpnt-0 haokZj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKQztq"
               type="button"
             >
               <svg
@@ -11835,7 +11851,7 @@ exports[`List events should render new data when page changes 2`] = `
           >
             <button
               aria-label="Go to page 1"
-              class="StyledButtonKind-sc-1vhfpnt-0 mwqRM StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKQztq"
+              class="StyledButtonKind-sc-1vhfpnt-0 bpJYGB StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKQztq"
               type="button"
             >
               1
@@ -11850,7 +11866,7 @@ exports[`List events should render new data when page changes 2`] = `
             <button
               aria-current="page"
               aria-label="Go to page 2"
-              class="StyledButtonKind-sc-1vhfpnt-0 iMAkpG StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKQztq"
+              class="StyledButtonKind-sc-1vhfpnt-0 keYDKv StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKQztq"
               type="button"
             >
               2
@@ -11865,7 +11881,7 @@ exports[`List events should render new data when page changes 2`] = `
             <button
               aria-disabled="true"
               aria-label="Go to next page"
-              class="StyledButtonKind-sc-1vhfpnt-0 jfPneK StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKQztq"
+              class="StyledButtonKind-sc-1vhfpnt-0 bIsOjP StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKQztq"
               disabled=""
               type="button"
             >
@@ -12114,6 +12130,7 @@ exports[`List events should show correct item index when "show" is a number 1`] 
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -12200,6 +12217,7 @@ exports[`List events should show correct item index when "show" is a number 1`] 
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -12277,6 +12295,7 @@ exports[`List events should show correct item index when "show" is a number 1`] 
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -12353,6 +12372,7 @@ exports[`List events should show correct item index when "show" is a number 1`] 
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -13113,6 +13133,7 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -13200,6 +13221,7 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -13278,6 +13300,7 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -13355,6 +13378,7 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;

--- a/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
+++ b/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
@@ -1578,6 +1578,7 @@ exports[`Menu custom theme with default button 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 18px;
   padding: 4px 22px;
   font-size: 18px;
@@ -2597,6 +2598,7 @@ exports[`Menu menu with children when custom theme has default button 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 18px;
   padding: 4px 22px;
   font-size: 18px;

--- a/src/js/components/Pagination/__tests__/__snapshots__/Pagination-test.tsx.snap
+++ b/src/js/components/Pagination/__tests__/__snapshots__/Pagination-test.tsx.snap
@@ -126,6 +126,7 @@ exports[`Pagination should allow user to control page via state with page +
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -203,6 +204,7 @@ exports[`Pagination should allow user to control page via state with page +
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -279,6 +281,7 @@ exports[`Pagination should allow user to control page via state with page +
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -725,6 +728,7 @@ exports[`Pagination should apply a11yTitle and aria-label 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -811,6 +815,7 @@ exports[`Pagination should apply a11yTitle and aria-label 1`] = `
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -888,6 +893,7 @@ exports[`Pagination should apply a11yTitle and aria-label 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -964,6 +970,7 @@ exports[`Pagination should apply a11yTitle and aria-label 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -1537,6 +1544,7 @@ exports[`Pagination should apply button kind style when referenced by a string 1
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 18px;
   padding: 4px 22px;
   font-size: 18px;
@@ -1629,6 +1637,7 @@ exports[`Pagination should apply button kind style when referenced by a string 1
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
+  color: inherit;
   border-radius: 18px;
   padding: 4px 22px;
   font-size: 18px;
@@ -1709,6 +1718,7 @@ exports[`Pagination should apply button kind style when referenced by a string 1
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 18px;
   padding: 4px 22px;
   font-size: 18px;
@@ -1785,6 +1795,7 @@ exports[`Pagination should apply button kind style when referenced by a string 1
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 18px;
   padding: 4px 22px;
   font-size: 18px;
@@ -2226,6 +2237,7 @@ exports[`Pagination should apply custom theme 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -2312,6 +2324,7 @@ exports[`Pagination should apply custom theme 1`] = `
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -2389,6 +2402,7 @@ exports[`Pagination should apply custom theme 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -2465,6 +2479,7 @@ exports[`Pagination should apply custom theme 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -2927,6 +2942,7 @@ exports[`Pagination should apply size 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -3013,6 +3029,7 @@ exports[`Pagination should apply size 1`] = `
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -3090,6 +3107,7 @@ exports[`Pagination should apply size 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -3166,6 +3184,7 @@ exports[`Pagination should apply size 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -3253,6 +3272,7 @@ exports[`Pagination should apply size 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 3px;
   padding: 4px 4px;
   font-size: 14px;
@@ -3339,6 +3359,7 @@ exports[`Pagination should apply size 1`] = `
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
+  color: inherit;
   border-radius: 3px;
   padding: 4px 4px;
   font-size: 14px;
@@ -3416,6 +3437,7 @@ exports[`Pagination should apply size 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 3px;
   padding: 4px 4px;
   font-size: 14px;
@@ -3492,6 +3514,7 @@ exports[`Pagination should apply size 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 3px;
   padding: 4px 4px;
   font-size: 14px;
@@ -3579,6 +3602,7 @@ exports[`Pagination should apply size 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 6px;
   padding: 4px 4px;
   font-size: 22px;
@@ -3665,6 +3689,7 @@ exports[`Pagination should apply size 1`] = `
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
+  color: inherit;
   border-radius: 6px;
   padding: 4px 4px;
   font-size: 22px;
@@ -3742,6 +3767,7 @@ exports[`Pagination should apply size 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 6px;
   padding: 4px 4px;
   font-size: 22px;
@@ -3818,6 +3844,7 @@ exports[`Pagination should apply size 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 6px;
   padding: 4px 4px;
   font-size: 22px;
@@ -4618,6 +4645,7 @@ exports[`Pagination should change the page on prop change 1`] = `
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -4695,6 +4723,7 @@ exports[`Pagination should change the page on prop change 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -4771,6 +4800,7 @@ exports[`Pagination should change the page on prop change 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -5217,6 +5247,7 @@ exports[`Pagination should disable next button if on last page 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -5304,6 +5335,7 @@ exports[`Pagination should disable next button if on last page 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -5382,6 +5414,7 @@ exports[`Pagination should disable next button if on last page 1`] = `
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -5459,6 +5492,7 @@ exports[`Pagination should disable next button if on last page 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -5866,6 +5900,7 @@ exports[`Pagination should disable previous and next controls when numberItems
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -5952,6 +5987,7 @@ exports[`Pagination should disable previous and next controls when numberItems
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -6266,6 +6302,7 @@ exports[`Pagination should disable previous and next controls when numberItems
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -6571,6 +6608,7 @@ exports[`Pagination should disable previous and next controls when numberItems
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -6657,6 +6695,7 @@ exports[`Pagination should disable previous and next controls when numberItems
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -7009,6 +7048,7 @@ exports[`Pagination should disable previous button if on first page 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -7095,6 +7135,7 @@ exports[`Pagination should disable previous button if on first page 1`] = `
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -7172,6 +7213,7 @@ exports[`Pagination should disable previous button if on first page 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -7248,6 +7290,7 @@ exports[`Pagination should disable previous button if on first page 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -7665,6 +7708,7 @@ exports[`Pagination should display next page of results when "next" is
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -7742,6 +7786,7 @@ exports[`Pagination should display next page of results when "next" is
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -7818,6 +7863,7 @@ exports[`Pagination should display next page of results when "next" is
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -8127,7 +8173,7 @@ exports[`Pagination should display next page of results when "next" is
         >
           <button
             aria-label="Go to previous page"
-            class="StyledButtonKind-sc-1vhfpnt-0 keNLVa StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKQztq"
+            class="StyledButtonKind-sc-1vhfpnt-0 haokZj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKQztq"
             type="button"
           >
             <svg
@@ -8152,7 +8198,7 @@ exports[`Pagination should display next page of results when "next" is
         >
           <button
             aria-label="Go to page 1"
-            class="StyledButtonKind-sc-1vhfpnt-0 mwqRM StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKQztq"
+            class="StyledButtonKind-sc-1vhfpnt-0 bpJYGB StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKQztq"
             type="button"
           >
             1
@@ -8167,7 +8213,7 @@ exports[`Pagination should display next page of results when "next" is
           <button
             aria-current="page"
             aria-label="Go to page 2"
-            class="StyledButtonKind-sc-1vhfpnt-0 iMAkpG StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKQztq"
+            class="StyledButtonKind-sc-1vhfpnt-0 keYDKv StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKQztq"
             type="button"
           >
             2
@@ -8181,7 +8227,7 @@ exports[`Pagination should display next page of results when "next" is
         >
           <button
             aria-label="Go to page 3"
-            class="StyledButtonKind-sc-1vhfpnt-0 mwqRM StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKQztq"
+            class="StyledButtonKind-sc-1vhfpnt-0 bpJYGB StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKQztq"
             type="button"
           >
             3
@@ -8195,7 +8241,7 @@ exports[`Pagination should display next page of results when "next" is
         >
           <button
             aria-label="Go to page 4"
-            class="StyledButtonKind-sc-1vhfpnt-0 mwqRM StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKQztq"
+            class="StyledButtonKind-sc-1vhfpnt-0 bpJYGB StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKQztq"
             type="button"
           >
             4
@@ -8209,7 +8255,7 @@ exports[`Pagination should display next page of results when "next" is
         >
           <button
             aria-label="Go to page 5"
-            class="StyledButtonKind-sc-1vhfpnt-0 mwqRM StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKQztq"
+            class="StyledButtonKind-sc-1vhfpnt-0 bpJYGB StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKQztq"
             type="button"
           >
             5
@@ -8235,7 +8281,7 @@ exports[`Pagination should display next page of results when "next" is
         >
           <button
             aria-label="Go to page 24"
-            class="StyledButtonKind-sc-1vhfpnt-0 mwqRM StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKQztq"
+            class="StyledButtonKind-sc-1vhfpnt-0 bpJYGB StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKQztq"
             type="button"
           >
             24
@@ -8249,7 +8295,7 @@ exports[`Pagination should display next page of results when "next" is
         >
           <button
             aria-label="Go to next page"
-            class="StyledButtonKind-sc-1vhfpnt-0 keNLVa StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKQztq"
+            class="StyledButtonKind-sc-1vhfpnt-0 haokZj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKQztq"
             type="button"
           >
             <svg
@@ -8398,6 +8444,7 @@ exports[`Pagination should display page 'n' of results when "page n" is
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -8475,6 +8522,7 @@ exports[`Pagination should display page 'n' of results when "page n" is
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -8551,6 +8599,7 @@ exports[`Pagination should display page 'n' of results when "page n" is
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -8964,6 +9013,7 @@ exports[`Pagination should display previous page of results when "previous" is
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -9051,6 +9101,7 @@ exports[`Pagination should display previous page of results when "previous" is
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -9129,6 +9180,7 @@ exports[`Pagination should display previous page of results when "previous" is
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -9428,7 +9480,7 @@ exports[`Pagination should display previous page of results when "previous" is
         >
           <button
             aria-label="Go to previous page"
-            class="StyledButtonKind-sc-1vhfpnt-0 keNLVa StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKQztq"
+            class="StyledButtonKind-sc-1vhfpnt-0 haokZj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKQztq"
             type="button"
           >
             <svg
@@ -9453,7 +9505,7 @@ exports[`Pagination should display previous page of results when "previous" is
         >
           <button
             aria-label="Go to page 1"
-            class="StyledButtonKind-sc-1vhfpnt-0 mwqRM StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKQztq"
+            class="StyledButtonKind-sc-1vhfpnt-0 bpJYGB StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKQztq"
             type="button"
           >
             1
@@ -9468,7 +9520,7 @@ exports[`Pagination should display previous page of results when "previous" is
           <button
             aria-current="page"
             aria-label="Go to page 2"
-            class="StyledButtonKind-sc-1vhfpnt-0 iMAkpG StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKQztq"
+            class="StyledButtonKind-sc-1vhfpnt-0 keYDKv StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKQztq"
             type="button"
           >
             2
@@ -9482,7 +9534,7 @@ exports[`Pagination should display previous page of results when "previous" is
         >
           <button
             aria-label="Go to page 3"
-            class="StyledButtonKind-sc-1vhfpnt-0 mwqRM StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKQztq"
+            class="StyledButtonKind-sc-1vhfpnt-0 bpJYGB StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKQztq"
             type="button"
           >
             3
@@ -9496,7 +9548,7 @@ exports[`Pagination should display previous page of results when "previous" is
         >
           <button
             aria-label="Go to page 4"
-            class="StyledButtonKind-sc-1vhfpnt-0 mwqRM StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKQztq"
+            class="StyledButtonKind-sc-1vhfpnt-0 bpJYGB StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKQztq"
             type="button"
           >
             4
@@ -9510,7 +9562,7 @@ exports[`Pagination should display previous page of results when "previous" is
         >
           <button
             aria-label="Go to page 5"
-            class="StyledButtonKind-sc-1vhfpnt-0 mwqRM StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKQztq"
+            class="StyledButtonKind-sc-1vhfpnt-0 bpJYGB StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKQztq"
             type="button"
           >
             5
@@ -9536,7 +9588,7 @@ exports[`Pagination should display previous page of results when "previous" is
         >
           <button
             aria-label="Go to page 24"
-            class="StyledButtonKind-sc-1vhfpnt-0 mwqRM StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKQztq"
+            class="StyledButtonKind-sc-1vhfpnt-0 bpJYGB StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKQztq"
             type="button"
           >
             24
@@ -9550,7 +9602,7 @@ exports[`Pagination should display previous page of results when "previous" is
         >
           <button
             aria-label="Go to next page"
-            class="StyledButtonKind-sc-1vhfpnt-0 keNLVa StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKQztq"
+            class="StyledButtonKind-sc-1vhfpnt-0 haokZj StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iKQztq"
             type="button"
           >
             <svg
@@ -9731,6 +9783,7 @@ exports[`Pagination should display the correct last page based on items length
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -9817,6 +9870,7 @@ exports[`Pagination should display the correct last page based on items length
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -9894,6 +9948,7 @@ exports[`Pagination should display the correct last page based on items length
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -9970,6 +10025,7 @@ exports[`Pagination should display the correct last page based on items length
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -10384,6 +10440,7 @@ exports[`Pagination should render correct numberEdgePages 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -10471,6 +10528,7 @@ exports[`Pagination should render correct numberEdgePages 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -10549,6 +10607,7 @@ exports[`Pagination should render correct numberEdgePages 1`] = `
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -11005,6 +11064,7 @@ exports[`Pagination should render correct numberMiddlePages when even 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -11092,6 +11152,7 @@ exports[`Pagination should render correct numberMiddlePages when even 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -11170,6 +11231,7 @@ exports[`Pagination should render correct numberMiddlePages when even 1`] = `
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -11584,6 +11646,7 @@ exports[`Pagination should render correct numberMiddlePages when odd 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -11671,6 +11734,7 @@ exports[`Pagination should render correct numberMiddlePages when odd 1`] = `
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -11749,6 +11813,7 @@ exports[`Pagination should render correct numberMiddlePages when odd 1`] = `
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -12211,6 +12276,7 @@ exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -12297,6 +12363,7 @@ exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -12374,6 +12441,7 @@ exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -12450,6 +12518,7 @@ exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -12871,6 +12940,7 @@ exports[`Pagination should set page to last page if page prop > total possible
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -12958,6 +13028,7 @@ exports[`Pagination should set page to last page if page prop > total possible
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -13036,6 +13107,7 @@ exports[`Pagination should set page to last page if page prop > total possible
   background-color: rgba(221,221,221,0.4);
   color: #000000;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
@@ -13113,6 +13185,7 @@ exports[`Pagination should set page to last page if page prop > total possible
   overflow: visible;
   text-transform: none;
   border: none;
+  color: inherit;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Closes #6301 - "If the theme doesn't specify a label color for a specific button state (e.g., active), then the active button should have the same label color as the default state."

#### Where should the reviewer start?
On the Button component. `DarkMode.js` was added to the storybook for visual testing, and the file `StyledButtonKind.js` was modified, as well as the related snapshots.

#### What testing has been done on this PR?
Snapshot was fixed and all tests are passing. Also used Storybook.

#### How should this be manually tested?
`yarn test`

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
#6301

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible
