### PR TITLE
Harden Select against null value

### DIFF
--- a/src/js/components/Select/SelectContainer.js
+++ b/src/js/components/Select/SelectContainer.js
@@ -96,7 +96,7 @@ const SelectContainer = forwardRef(
     const theme = useContext(ThemeContext) || defaultProps.theme;
     const shouldShowClearButton = useCallback(
       (position) => {
-        const hasValue = Boolean(multiple ? value.length : value);
+        const hasValue = Boolean(multiple && value ? value.length : value);
         const showAtPosition =
           position === 'bottom'
             ? clear?.position === 'bottom'

--- a/src/js/components/Select/utils.js
+++ b/src/js/components/Select/utils.js
@@ -2,7 +2,7 @@ import { useCallback } from 'react';
 import { normalizeColor } from '../../utils';
 
 export const applyKey = (option, key) => {
-  if (option === undefined) return undefined;
+  if (option === undefined || option === null) return undefined;
   if (typeof key === 'object') return applyKey(option, key.key);
   if (typeof key === 'function') return key(option);
   if (key !== undefined) return option[key];


### PR DESCRIPTION
#### What does this PR do?
Fixes an issue where if a null value is passed to Select the following error appears:

![](https://user-images.githubusercontent.com/91684949/189983440-dade6aa3-d135-4bbd-a39d-8bcb22aeb795.png)


#### Where should the reviewer start?

#### What testing has been done on this PR?
Tested by setting value to null in select storybook stories

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes https://github.com/grommet/grommet/issues/6323

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No
#### Should this PR be mentioned in the release notes?
Maybe
#### Is this change backwards compatible or is it a breaking change?
Backwards compatible