### PR TITLE
SelectMultiple - Improve alignment of open/close icon

### DIFF
--- a/src/js/components/SelectMultiple/SelectMultipleContainer.js
+++ b/src/js/components/SelectMultiple/SelectMultipleContainer.js
@@ -345,15 +345,14 @@ const SelectMultipleContainer = forwardRef(
           direction="row"
           justify="between"
           flex={false}
-          pad={{ horizontal: 'small' }}
+          pad={{ left: 'small' }}
         >
           {summaryContent}
-          <Button
-            icon={<FormUp />}
-            onClick={onClose}
-            a11yTitle="Close Select"
-            plain
-          />
+          <Button onClick={onClose} a11yTitle="Close Select">
+            <Box pad={{ right: 'small' }}>
+              <FormUp />
+            </Box>
+          </Button>
         </Box>
       );
 

--- a/src/js/components/SelectMultiple/SelectMultipleContainer.js
+++ b/src/js/components/SelectMultiple/SelectMultipleContainer.js
@@ -345,7 +345,7 @@ const SelectMultipleContainer = forwardRef(
           direction="row"
           justify="between"
           flex={false}
-          pad={{ horizontal: 'small', top: 'xsmall' }}
+          pad={{ horizontal: 'small' }}
         >
           {summaryContent}
           <Button

--- a/src/js/components/SelectMultiple/SelectionSummary.js
+++ b/src/js/components/SelectMultiple/SelectionSummary.js
@@ -49,7 +49,7 @@ const SelectionSummary = ({
         justify="between"
         gap="small"
         fill="horizontal"
-        flex
+        flex={showSelectedInline}
       >
         <Box alignSelf="center">
           <Text size="small">

--- a/src/js/components/SelectMultiple/__tests__/__snapshots__/SelectMultiple-test.tsx.snap
+++ b/src/js/components/SelectMultiple/__tests__/__snapshots__/SelectMultiple-test.tsx.snap
@@ -3472,6 +3472,10 @@ exports[`SelectMultiple showSelectionInline 1`] = `
 }
 
 @media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
   .c15 {
     margin-right: 6px;
   }
@@ -4044,6 +4048,10 @@ exports[`SelectMultiple showSelectionInline with children 1`] = `
 }
 
 @media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
   .c14 {
     padding: 6px;
   }
@@ -4252,6 +4260,10 @@ exports[`SelectMultiple showSelectionInline with children 2`] = `
 
 .c2 {
   cursor: pointer;
+}
+
+@media only screen and (max-width:768px) {
+
 }
 
 @media only screen and (max-width:768px) {

--- a/src/js/components/SelectMultiple/__tests__/__snapshots__/SelectMultiple-test.tsx.snap
+++ b/src/js/components/SelectMultiple/__tests__/__snapshots__/SelectMultiple-test.tsx.snap
@@ -3472,10 +3472,6 @@ exports[`SelectMultiple showSelectionInline 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
   .c15 {
     margin-right: 6px;
   }
@@ -4048,10 +4044,6 @@ exports[`SelectMultiple showSelectionInline with children 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
   .c14 {
     padding: 6px;
   }
@@ -4260,10 +4252,6 @@ exports[`SelectMultiple showSelectionInline with children 2`] = `
 
 .c2 {
   cursor: pointer;
-}
-
-@media only screen and (max-width:768px) {
-
 }
 
 @media only screen and (max-width:768px) {


### PR DESCRIPTION
#### What does this PR do?
Fixes an issue in the `showSelectedInline` version of SelectMultiple the open/close arrow isn't in the same location when the drop is open vs closed.

Current behavior:

https://user-images.githubusercontent.com/54560994/190019309-0e101e74-5078-48d2-af34-2a9e0052e5bf.mp4

Fixed behavior:

https://user-images.githubusercontent.com/54560994/190019436-3faae639-ea79-42e3-859b-15cdb872a6a2.mp4

Note: this PR also fixes an issue where the summary selection content was getting vertically squished when the screen has limited vertical space.

current:
<img width="358" alt="Screen Shot 2022-09-13 at 4 21 48 PM" src="https://user-images.githubusercontent.com/54560994/190019673-adabebcc-60cd-4dde-8600-37777ebde165.png">

fixed:
<img width="361" alt="Screen Shot 2022-09-13 at 4 21 26 PM" src="https://user-images.githubusercontent.com/54560994/190019631-03f28900-e43d-466e-b408-969b88de05d9.png">


#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No
#### Should this PR be mentioned in the release notes?
No, SelectMultiple component has not been released yet
#### Is this change backwards compatible or is it a breaking change?
backwards compatible