### PR TITLE
added font-variant to global font type

### DIFF
--- a/src/js/components/Button/__tests__/__snapshots__/Button-kind-test.js.snap
+++ b/src/js/components/Button/__tests__/__snapshots__/Button-kind-test.js.snap
@@ -1646,7 +1646,7 @@ exports[`Button kind disabled with hoverIndicator should not hover 1`] = `
 
 exports[`Button kind disabled with hoverIndicator should not hover 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <button
     class="StyledButtonKind-sc-1vhfpnt-0 jmrTmz"
@@ -2346,7 +2346,7 @@ exports[`Button kind hover secondary with color and background 1`] = `
 
 exports[`Button kind hover secondary with color and background 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <button
     class="StyledButtonKind-sc-1vhfpnt-0 dePmIQ"
@@ -2452,7 +2452,7 @@ exports[`Button kind hoverIndicator with color and background 1`] = `
 
 exports[`Button kind hoverIndicator with color and background 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <button
     class="StyledButtonKind-sc-1vhfpnt-0 gIFSMH"
@@ -2651,7 +2651,7 @@ exports[`Button kind mouseOver and mouseOut events 1`] = `
 
 exports[`Button kind mouseOver and mouseOut events 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <button
     class="StyledButtonKind-sc-1vhfpnt-0 cdUjho"

--- a/src/js/components/Button/__tests__/__snapshots__/Button-kind-test.js.snap
+++ b/src/js/components/Button/__tests__/__snapshots__/Button-kind-test.js.snap
@@ -1646,7 +1646,7 @@ exports[`Button kind disabled with hoverIndicator should not hover 1`] = `
 
 exports[`Button kind disabled with hoverIndicator should not hover 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <button
     class="StyledButtonKind-sc-1vhfpnt-0 jmrTmz"
@@ -2346,7 +2346,7 @@ exports[`Button kind hover secondary with color and background 1`] = `
 
 exports[`Button kind hover secondary with color and background 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <button
     class="StyledButtonKind-sc-1vhfpnt-0 dePmIQ"
@@ -2452,7 +2452,7 @@ exports[`Button kind hoverIndicator with color and background 1`] = `
 
 exports[`Button kind hoverIndicator with color and background 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <button
     class="StyledButtonKind-sc-1vhfpnt-0 gIFSMH"
@@ -2651,7 +2651,7 @@ exports[`Button kind mouseOver and mouseOut events 1`] = `
 
 exports[`Button kind mouseOver and mouseOut events 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <button
     class="StyledButtonKind-sc-1vhfpnt-0 cdUjho"

--- a/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.tsx.snap
+++ b/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.tsx.snap
@@ -1160,7 +1160,7 @@ exports[`Calendar change months 1`] = `
 
 exports[`Calendar change months 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <div
     class="StyledCalendar-sc-1y4xhmp-0 eRFLFF"
@@ -15986,7 +15986,7 @@ exports[`Calendar select date 1`] = `
 
 exports[`Calendar select date 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <div
     class="StyledCalendar-sc-1y4xhmp-0 eRFLFF"
@@ -18005,7 +18005,7 @@ exports[`Calendar select dates 1`] = `
 
 exports[`Calendar select dates 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <div
     class="StyledCalendar-sc-1y4xhmp-0 eRFLFF"

--- a/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.tsx.snap
+++ b/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.tsx.snap
@@ -1160,7 +1160,7 @@ exports[`Calendar change months 1`] = `
 
 exports[`Calendar change months 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <div
     class="StyledCalendar-sc-1y4xhmp-0 eRFLFF"
@@ -15986,7 +15986,7 @@ exports[`Calendar select date 1`] = `
 
 exports[`Calendar select date 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <div
     class="StyledCalendar-sc-1y4xhmp-0 eRFLFF"
@@ -18005,7 +18005,7 @@ exports[`Calendar select dates 1`] = `
 
 exports[`Calendar select dates 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <div
     class="StyledCalendar-sc-1y4xhmp-0 eRFLFF"

--- a/src/js/components/CheckBox/__tests__/__snapshots__/CheckBox-test.tsx.snap
+++ b/src/js/components/CheckBox/__tests__/__snapshots__/CheckBox-test.tsx.snap
@@ -315,7 +315,7 @@ exports[`CheckBox controlled 1`] = `
 
 exports[`CheckBox controlled 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <label
     class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 jUgUBs"

--- a/src/js/components/CheckBox/__tests__/__snapshots__/CheckBox-test.tsx.snap
+++ b/src/js/components/CheckBox/__tests__/__snapshots__/CheckBox-test.tsx.snap
@@ -315,7 +315,7 @@ exports[`CheckBox controlled 1`] = `
 
 exports[`CheckBox controlled 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <label
     class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 jUgUBs"

--- a/src/js/components/CheckBoxGroup/__tests__/__snapshots__/CheckBoxGroup-test.tsx.snap
+++ b/src/js/components/CheckBoxGroup/__tests__/__snapshots__/CheckBoxGroup-test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`CheckBoxGroup custom theme 1`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 bRUjod StyledCheckBoxGroup-sc-2nhc5d-0"
@@ -56,7 +56,7 @@ exports[`CheckBoxGroup custom theme 1`] = `
 exports[`CheckBoxGroup defaultValue renders 1`] = `
 <DocumentFragment>
   <div
-    class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+    class="StyledGrommet-sc-19lkkz7-0 eANINY"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 iNDmPr StyledCheckBoxGroup-sc-2nhc5d-0"
@@ -122,7 +122,7 @@ exports[`CheckBoxGroup defaultValue renders 1`] = `
 
 exports[`CheckBoxGroup disabled renders 1`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 iNDmPr StyledCheckBoxGroup-sc-2nhc5d-0"
@@ -239,7 +239,7 @@ exports[`CheckBoxGroup disabled renders 1`] = `
 
 exports[`CheckBoxGroup initial value renders 1`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 iNDmPr StyledCheckBoxGroup-sc-2nhc5d-0"
@@ -338,7 +338,7 @@ exports[`CheckBoxGroup initial value renders 1`] = `
 
 exports[`CheckBoxGroup labelKey 1`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 iNDmPr StyledCheckBoxGroup-sc-2nhc5d-0"
@@ -391,7 +391,7 @@ exports[`CheckBoxGroup labelKey 1`] = `
 
 exports[`CheckBoxGroup onChange 1`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 iNDmPr StyledCheckBoxGroup-sc-2nhc5d-0"
@@ -455,7 +455,7 @@ exports[`CheckBoxGroup onChange 1`] = `
 
 exports[`CheckBoxGroup onClick for check and uncheck a CheckBox 1`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 hHdQrv StyledCheckBoxGroup-sc-2nhc5d-0"
@@ -520,7 +520,7 @@ exports[`CheckBoxGroup onClick for check and uncheck a CheckBox 1`] = `
 
 exports[`CheckBoxGroup onClick for check and uncheck a CheckBox 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 hHdQrv StyledCheckBoxGroup-sc-2nhc5d-0"
@@ -574,7 +574,7 @@ exports[`CheckBoxGroup onClick for check and uncheck a CheckBox 2`] = `
 
 exports[`CheckBoxGroup options renders 1`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 iNDmPr StyledCheckBoxGroup-sc-2nhc5d-0"
@@ -627,7 +627,7 @@ exports[`CheckBoxGroup options renders 1`] = `
 
 exports[`CheckBoxGroup value renders 1`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 iNDmPr StyledCheckBoxGroup-sc-2nhc5d-0"
@@ -692,7 +692,7 @@ exports[`CheckBoxGroup value renders 1`] = `
 
 exports[`CheckBoxGroup valueKey 1`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 iNDmPr StyledCheckBoxGroup-sc-2nhc5d-0"

--- a/src/js/components/CheckBoxGroup/__tests__/__snapshots__/CheckBoxGroup-test.tsx.snap
+++ b/src/js/components/CheckBoxGroup/__tests__/__snapshots__/CheckBoxGroup-test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`CheckBoxGroup custom theme 1`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 bRUjod StyledCheckBoxGroup-sc-2nhc5d-0"
@@ -55,7 +55,7 @@ exports[`CheckBoxGroup custom theme 1`] = `
 
 exports[`CheckBoxGroup disabled renders 1`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 iNDmPr StyledCheckBoxGroup-sc-2nhc5d-0"
@@ -172,7 +172,7 @@ exports[`CheckBoxGroup disabled renders 1`] = `
 
 exports[`CheckBoxGroup initial value renders 1`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 iNDmPr StyledCheckBoxGroup-sc-2nhc5d-0"
@@ -271,7 +271,7 @@ exports[`CheckBoxGroup initial value renders 1`] = `
 
 exports[`CheckBoxGroup labelKey 1`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 iNDmPr StyledCheckBoxGroup-sc-2nhc5d-0"
@@ -324,7 +324,7 @@ exports[`CheckBoxGroup labelKey 1`] = `
 
 exports[`CheckBoxGroup onChange 1`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 iNDmPr StyledCheckBoxGroup-sc-2nhc5d-0"
@@ -388,7 +388,7 @@ exports[`CheckBoxGroup onChange 1`] = `
 
 exports[`CheckBoxGroup onClick for check and uncheck a CheckBox 1`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 hHdQrv StyledCheckBoxGroup-sc-2nhc5d-0"
@@ -453,7 +453,7 @@ exports[`CheckBoxGroup onClick for check and uncheck a CheckBox 1`] = `
 
 exports[`CheckBoxGroup onClick for check and uncheck a CheckBox 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 hHdQrv StyledCheckBoxGroup-sc-2nhc5d-0"
@@ -507,7 +507,7 @@ exports[`CheckBoxGroup onClick for check and uncheck a CheckBox 2`] = `
 
 exports[`CheckBoxGroup options renders 1`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 iNDmPr StyledCheckBoxGroup-sc-2nhc5d-0"
@@ -560,7 +560,7 @@ exports[`CheckBoxGroup options renders 1`] = `
 
 exports[`CheckBoxGroup value renders 1`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 iNDmPr StyledCheckBoxGroup-sc-2nhc5d-0"
@@ -625,7 +625,7 @@ exports[`CheckBoxGroup value renders 1`] = `
 
 exports[`CheckBoxGroup valueKey 1`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 iNDmPr StyledCheckBoxGroup-sc-2nhc5d-0"

--- a/src/js/components/Clock/__tests__/__snapshots__/Clock-test.tsx.snap
+++ b/src/js/components/Clock/__tests__/__snapshots__/Clock-test.tsx.snap
@@ -362,7 +362,7 @@ exports[`Clock run 1`] = `
 
 exports[`Clock run 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <svg
     class="StyledClock__StyledAnalog-sc-y4xw8s-3 jLVvXU"

--- a/src/js/components/Clock/__tests__/__snapshots__/Clock-test.tsx.snap
+++ b/src/js/components/Clock/__tests__/__snapshots__/Clock-test.tsx.snap
@@ -362,7 +362,7 @@ exports[`Clock run 1`] = `
 
 exports[`Clock run 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <svg
     class="StyledClock__StyledAnalog-sc-y4xw8s-3 jLVvXU"

--- a/src/js/components/Collapsible/__tests__/__snapshots__/Collapsible-test.tsx.snap
+++ b/src/js/components/Collapsible/__tests__/__snapshots__/Collapsible-test.tsx.snap
@@ -56,7 +56,7 @@ exports[`Collapsible onClick open default 1`] = `
 
 exports[`Collapsible onClick open default 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <div
     aria-hidden="true"

--- a/src/js/components/Collapsible/__tests__/__snapshots__/Collapsible-test.tsx.snap
+++ b/src/js/components/Collapsible/__tests__/__snapshots__/Collapsible-test.tsx.snap
@@ -56,7 +56,7 @@ exports[`Collapsible onClick open default 1`] = `
 
 exports[`Collapsible onClick open default 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <div
     aria-hidden="true"

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -2627,7 +2627,7 @@ exports[`DataTable click 1`] = `
 
 exports[`DataTable click 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <table
     class="StyledTable-sc-1m3u5g-6 YPHTu StyledDataTable-sc-xrlyjm-0 hmFzTO"
@@ -3371,7 +3371,7 @@ exports[`DataTable custom theme 1`] = `
 
 exports[`DataTable custom theme 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <table
     class="StyledTable-sc-1m3u5g-6 YPHTu StyledDataTable-sc-xrlyjm-0 hmFzTO"
@@ -3738,7 +3738,7 @@ exports[`DataTable disabled click 1`] = `
 
 exports[`DataTable disabled click 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <table
     class="StyledTable-sc-1m3u5g-6 YPHTu StyledDataTable-sc-xrlyjm-0 hmFzTO"
@@ -5621,7 +5621,7 @@ exports[`DataTable groupBy 1`] = `
 
 exports[`DataTable groupBy 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <table
     class="StyledTable-sc-1m3u5g-6 YPHTu StyledDataTable-sc-xrlyjm-0 hmFzTO"
@@ -6921,7 +6921,7 @@ exports[`DataTable groupBy property 1`] = `
 
 exports[`DataTable groupBy property 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <table
     class="StyledTable-sc-1m3u5g-6 YPHTu StyledDataTable-sc-xrlyjm-0 hmFzTO"
@@ -7393,7 +7393,7 @@ exports[`DataTable groupBy toggle 1`] = `
 
 exports[`DataTable groupBy toggle 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <button
     type="button"
@@ -7974,7 +7974,7 @@ exports[`DataTable groupBy toggle 2`] = `
 
 exports[`DataTable groupBy toggle 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <button
     type="button"
@@ -11330,7 +11330,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 1`
 
 exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <table
     class="StyledTable-sc-1m3u5g-6 YPHTu StyledDataTable-sc-xrlyjm-0 hmFzTO"
@@ -11705,7 +11705,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
 
 exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <table
     class="StyledTable-sc-1m3u5g-6 YPHTu StyledDataTable-sc-xrlyjm-0 hmFzTO"
@@ -12514,7 +12514,7 @@ exports[`DataTable onSelect select/unselect all 1`] = `
 
 exports[`DataTable onSelect select/unselect all 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <table
     class="StyledTable-sc-1m3u5g-6 YPHTu StyledDataTable-sc-xrlyjm-0 hmFzTO"
@@ -12950,7 +12950,7 @@ exports[`DataTable onSelect select/unselect all 2`] = `
 
 exports[`DataTable onSelect select/unselect all 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <table
     class="StyledTable-sc-1m3u5g-6 YPHTu StyledDataTable-sc-xrlyjm-0 hmFzTO"
@@ -13589,7 +13589,7 @@ exports[`DataTable onSort 1`] = `
 
 exports[`DataTable onSort 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <table
     class="StyledTable-sc-1m3u5g-6 YPHTu StyledDataTable-sc-xrlyjm-0 hmFzTO"
@@ -14223,7 +14223,7 @@ exports[`DataTable onSort external 1`] = `
 
 exports[`DataTable onSort external 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <table
     class="StyledTable-sc-1m3u5g-6 YPHTu StyledDataTable-sc-xrlyjm-0 hmFzTO"
@@ -20423,7 +20423,7 @@ exports[`DataTable search 1`] = `
 
 exports[`DataTable search 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <table
     class="StyledTable-sc-1m3u5g-6 YPHTu StyledDataTable-sc-xrlyjm-0 hmFzTO"
@@ -21048,7 +21048,7 @@ exports[`DataTable select 1`] = `
 
 exports[`DataTable select 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <table
     class="StyledTable-sc-1m3u5g-6 YPHTu StyledDataTable-sc-xrlyjm-0 hmFzTO"
@@ -30001,7 +30001,7 @@ exports[`DataTable should render new data when page changes 1`] = `
 
 exports[`DataTable should render new data when page changes 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 iNDmPr StyledDataTable__StyledContainer-sc-xrlyjm-1 cmJcZv"
@@ -39125,7 +39125,7 @@ exports[`DataTable sort null data 1`] = `
 
 exports[`DataTable sort null data 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <table
     class="StyledTable-sc-1m3u5g-6 YPHTu StyledDataTable-sc-xrlyjm-0 hmFzTO"
@@ -39529,7 +39529,7 @@ exports[`DataTable sort null data 2`] = `
 
 exports[`DataTable sort null data 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <table
     class="StyledTable-sc-1m3u5g-6 YPHTu StyledDataTable-sc-xrlyjm-0 hmFzTO"
@@ -39933,7 +39933,7 @@ exports[`DataTable sort null data 3`] = `
 
 exports[`DataTable sort null data 4`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <table
     class="StyledTable-sc-1m3u5g-6 YPHTu StyledDataTable-sc-xrlyjm-0 hmFzTO"
@@ -40675,7 +40675,7 @@ exports[`DataTable sortable 1`] = `
 
 exports[`DataTable sortable 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <table
     class="StyledTable-sc-1m3u5g-6 YPHTu StyledDataTable-sc-xrlyjm-0 hmFzTO"

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -2627,7 +2627,7 @@ exports[`DataTable click 1`] = `
 
 exports[`DataTable click 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <table
     class="StyledTable-sc-1m3u5g-6 YPHTu StyledDataTable-sc-xrlyjm-0 hmFzTO"
@@ -3371,7 +3371,7 @@ exports[`DataTable custom theme 1`] = `
 
 exports[`DataTable custom theme 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <table
     class="StyledTable-sc-1m3u5g-6 YPHTu StyledDataTable-sc-xrlyjm-0 hmFzTO"
@@ -3738,7 +3738,7 @@ exports[`DataTable disabled click 1`] = `
 
 exports[`DataTable disabled click 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <table
     class="StyledTable-sc-1m3u5g-6 YPHTu StyledDataTable-sc-xrlyjm-0 hmFzTO"
@@ -5621,7 +5621,7 @@ exports[`DataTable groupBy 1`] = `
 
 exports[`DataTable groupBy 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <table
     class="StyledTable-sc-1m3u5g-6 YPHTu StyledDataTable-sc-xrlyjm-0 hmFzTO"
@@ -6921,7 +6921,7 @@ exports[`DataTable groupBy property 1`] = `
 
 exports[`DataTable groupBy property 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <table
     class="StyledTable-sc-1m3u5g-6 YPHTu StyledDataTable-sc-xrlyjm-0 hmFzTO"
@@ -7393,7 +7393,7 @@ exports[`DataTable groupBy toggle 1`] = `
 
 exports[`DataTable groupBy toggle 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <button
     type="button"
@@ -7974,7 +7974,7 @@ exports[`DataTable groupBy toggle 2`] = `
 
 exports[`DataTable groupBy toggle 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <button
     type="button"
@@ -11330,7 +11330,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 1`
 
 exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <table
     class="StyledTable-sc-1m3u5g-6 YPHTu StyledDataTable-sc-xrlyjm-0 hmFzTO"
@@ -11705,7 +11705,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
 
 exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <table
     class="StyledTable-sc-1m3u5g-6 YPHTu StyledDataTable-sc-xrlyjm-0 hmFzTO"
@@ -12514,7 +12514,7 @@ exports[`DataTable onSelect select/unselect all 1`] = `
 
 exports[`DataTable onSelect select/unselect all 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <table
     class="StyledTable-sc-1m3u5g-6 YPHTu StyledDataTable-sc-xrlyjm-0 hmFzTO"
@@ -12950,7 +12950,7 @@ exports[`DataTable onSelect select/unselect all 2`] = `
 
 exports[`DataTable onSelect select/unselect all 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <table
     class="StyledTable-sc-1m3u5g-6 YPHTu StyledDataTable-sc-xrlyjm-0 hmFzTO"
@@ -13589,7 +13589,7 @@ exports[`DataTable onSort 1`] = `
 
 exports[`DataTable onSort 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <table
     class="StyledTable-sc-1m3u5g-6 YPHTu StyledDataTable-sc-xrlyjm-0 hmFzTO"
@@ -14223,7 +14223,7 @@ exports[`DataTable onSort external 1`] = `
 
 exports[`DataTable onSort external 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <table
     class="StyledTable-sc-1m3u5g-6 YPHTu StyledDataTable-sc-xrlyjm-0 hmFzTO"
@@ -20423,7 +20423,7 @@ exports[`DataTable search 1`] = `
 
 exports[`DataTable search 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <table
     class="StyledTable-sc-1m3u5g-6 YPHTu StyledDataTable-sc-xrlyjm-0 hmFzTO"
@@ -21048,7 +21048,7 @@ exports[`DataTable select 1`] = `
 
 exports[`DataTable select 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <table
     class="StyledTable-sc-1m3u5g-6 YPHTu StyledDataTable-sc-xrlyjm-0 hmFzTO"
@@ -30001,7 +30001,7 @@ exports[`DataTable should render new data when page changes 1`] = `
 
 exports[`DataTable should render new data when page changes 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 iNDmPr StyledDataTable__StyledContainer-sc-xrlyjm-1 cmJcZv"
@@ -39125,7 +39125,7 @@ exports[`DataTable sort null data 1`] = `
 
 exports[`DataTable sort null data 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <table
     class="StyledTable-sc-1m3u5g-6 YPHTu StyledDataTable-sc-xrlyjm-0 hmFzTO"
@@ -39529,7 +39529,7 @@ exports[`DataTable sort null data 2`] = `
 
 exports[`DataTable sort null data 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <table
     class="StyledTable-sc-1m3u5g-6 YPHTu StyledDataTable-sc-xrlyjm-0 hmFzTO"
@@ -39933,7 +39933,7 @@ exports[`DataTable sort null data 3`] = `
 
 exports[`DataTable sort null data 4`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <table
     class="StyledTable-sc-1m3u5g-6 YPHTu StyledDataTable-sc-xrlyjm-0 hmFzTO"
@@ -40675,7 +40675,7 @@ exports[`DataTable sortable 1`] = `
 
 exports[`DataTable sortable 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <table
     class="StyledTable-sc-1m3u5g-6 YPHTu StyledDataTable-sc-xrlyjm-0 hmFzTO"

--- a/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.tsx.snap
+++ b/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.tsx.snap
@@ -1714,7 +1714,7 @@ exports[`DateInput controlled format inline 1`] = `
 
 exports[`DateInput controlled format inline 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 iNDmPr"
@@ -14602,7 +14602,7 @@ exports[`DateInput select format 1`] = `
 
 exports[`DateInput select format 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 lhOJod"
@@ -17357,7 +17357,7 @@ exports[`DateInput select format inline 1`] = `
 
 exports[`DateInput select format inline 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 iNDmPr"
@@ -22438,7 +22438,7 @@ exports[`DateInput select format inline range 1`] = `
 
 exports[`DateInput select format inline range 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 iNDmPr"
@@ -31708,7 +31708,7 @@ exports[`DateInput type format inline 1`] = `
 
 exports[`DateInput type format inline 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 iNDmPr"
@@ -36710,7 +36710,7 @@ exports[`DateInput type format inline range 1`] = `
 
 exports[`DateInput type format inline range 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 iNDmPr"
@@ -38962,7 +38962,7 @@ exports[`DateInput type format inline range partial 1`] = `
 
 exports[`DateInput type format inline range partial 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 iNDmPr"
@@ -39822,7 +39822,7 @@ exports[`DateInput type format inline range partial 2`] = `
 
 exports[`DateInput type format inline range partial 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 iNDmPr"
@@ -48990,7 +48990,7 @@ exports[`DateInput type format inline short 1`] = `
 
 exports[`DateInput type format inline short 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 iNDmPr"

--- a/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.tsx.snap
+++ b/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.tsx.snap
@@ -1714,7 +1714,7 @@ exports[`DateInput controlled format inline 1`] = `
 
 exports[`DateInput controlled format inline 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 iNDmPr"
@@ -3039,6 +3039,9 @@ exports[`DateInput controlled format inline without timezone 1`] = `
   align-items: center;
   width: 54.857142857142854px;
   height: 54.857142857142854px;
+  background-color: #7D4CDB;
+  color: #f8f8f8;
+  font-weight: bold;
 }
 
 .c20 {
@@ -3056,9 +3059,6 @@ exports[`DateInput controlled format inline without timezone 1`] = `
   align-items: center;
   width: 54.857142857142854px;
   height: 54.857142857142854px;
-  background-color: #7D4CDB;
-  color: #f8f8f8;
-  font-weight: bold;
 }
 
 .c4 {
@@ -3181,7 +3181,7 @@ exports[`DateInput controlled format inline without timezone 1`] = `
             id="item"
             name="item"
             placeholder="mm/dd/yyyy"
-            value="07/02/2020"
+            value="07/01/2020"
           />
         </div>
         <button
@@ -3262,7 +3262,7 @@ exports[`DateInput controlled format inline without timezone 1`] = `
             </div>
           </div>
           <div
-            aria-label="July 2020; Currently selected July 2, 2020;"
+            aria-label="July 2020; Currently selected July 1, 2020;"
             class="c13"
             role="grid"
             tabindex="0"
@@ -3370,7 +3370,7 @@ exports[`DateInput controlled format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       3
                     </div>
@@ -3387,7 +3387,7 @@ exports[`DateInput controlled format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       4
                     </div>
@@ -3409,7 +3409,7 @@ exports[`DateInput controlled format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       5
                     </div>
@@ -3426,7 +3426,7 @@ exports[`DateInput controlled format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       6
                     </div>
@@ -3443,7 +3443,7 @@ exports[`DateInput controlled format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       7
                     </div>
@@ -3460,7 +3460,7 @@ exports[`DateInput controlled format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       8
                     </div>
@@ -3477,7 +3477,7 @@ exports[`DateInput controlled format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       9
                     </div>
@@ -3494,7 +3494,7 @@ exports[`DateInput controlled format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       10
                     </div>
@@ -3511,7 +3511,7 @@ exports[`DateInput controlled format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       11
                     </div>
@@ -3533,7 +3533,7 @@ exports[`DateInput controlled format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       12
                     </div>
@@ -3550,7 +3550,7 @@ exports[`DateInput controlled format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       13
                     </div>
@@ -3567,7 +3567,7 @@ exports[`DateInput controlled format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       14
                     </div>
@@ -3584,7 +3584,7 @@ exports[`DateInput controlled format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       15
                     </div>
@@ -3601,7 +3601,7 @@ exports[`DateInput controlled format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       16
                     </div>
@@ -3618,7 +3618,7 @@ exports[`DateInput controlled format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       17
                     </div>
@@ -3635,7 +3635,7 @@ exports[`DateInput controlled format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       18
                     </div>
@@ -3657,7 +3657,7 @@ exports[`DateInput controlled format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       19
                     </div>
@@ -3674,7 +3674,7 @@ exports[`DateInput controlled format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       20
                     </div>
@@ -3691,7 +3691,7 @@ exports[`DateInput controlled format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       21
                     </div>
@@ -3708,7 +3708,7 @@ exports[`DateInput controlled format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       22
                     </div>
@@ -3725,7 +3725,7 @@ exports[`DateInput controlled format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       23
                     </div>
@@ -3742,7 +3742,7 @@ exports[`DateInput controlled format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       24
                     </div>
@@ -3759,7 +3759,7 @@ exports[`DateInput controlled format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       25
                     </div>
@@ -3781,7 +3781,7 @@ exports[`DateInput controlled format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       26
                     </div>
@@ -3798,7 +3798,7 @@ exports[`DateInput controlled format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       27
                     </div>
@@ -3815,7 +3815,7 @@ exports[`DateInput controlled format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       28
                     </div>
@@ -3832,7 +3832,7 @@ exports[`DateInput controlled format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       29
                     </div>
@@ -3849,7 +3849,7 @@ exports[`DateInput controlled format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       30
                     </div>
@@ -3866,7 +3866,7 @@ exports[`DateInput controlled format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       31
                     </div>
@@ -4475,23 +4475,6 @@ exports[`DateInput controlled format inline without timezone 2`] = `
   opacity: 0.5;
 }
 
-.c20 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  width: 54.857142857142854px;
-  height: 54.857142857142854px;
-}
-
 .c19 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -4510,6 +4493,23 @@ exports[`DateInput controlled format inline without timezone 2`] = `
   background-color: #7D4CDB;
   color: #f8f8f8;
   font-weight: bold;
+}
+
+.c20 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  width: 54.857142857142854px;
+  height: 54.857142857142854px;
 }
 
 .c4 {
@@ -14602,7 +14602,7 @@ exports[`DateInput select format 1`] = `
 
 exports[`DateInput select format 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 lhOJod"
@@ -17357,7 +17357,7 @@ exports[`DateInput select format inline 1`] = `
 
 exports[`DateInput select format inline 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 iNDmPr"
@@ -18607,6 +18607,9 @@ exports[`DateInput select format inline 3`] = `
   align-items: center;
   width: 54.857142857142854px;
   height: 54.857142857142854px;
+  background-color: #7D4CDB;
+  color: #f8f8f8;
+  font-weight: bold;
 }
 
 .c20 {
@@ -18624,9 +18627,6 @@ exports[`DateInput select format inline 3`] = `
   align-items: center;
   width: 54.857142857142854px;
   height: 54.857142857142854px;
-  background-color: #7D4CDB;
-  color: #f8f8f8;
-  font-weight: bold;
 }
 
 .c4 {
@@ -18749,7 +18749,7 @@ exports[`DateInput select format inline 3`] = `
             id="item"
             name="item"
             placeholder="mm/dd/yyyy"
-            value="07/02/2020"
+            value="07/01/2020"
           />
         </div>
         <button
@@ -18830,7 +18830,7 @@ exports[`DateInput select format inline 3`] = `
             </div>
           </div>
           <div
-            aria-label="July 2020; Currently selected July 2, 2020;"
+            aria-label="July 2020; Currently selected July 1, 2020;"
             class="c13"
             role="grid"
             tabindex="0"
@@ -18938,7 +18938,7 @@ exports[`DateInput select format inline 3`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       3
                     </div>
@@ -18955,7 +18955,7 @@ exports[`DateInput select format inline 3`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       4
                     </div>
@@ -18977,7 +18977,7 @@ exports[`DateInput select format inline 3`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       5
                     </div>
@@ -18994,7 +18994,7 @@ exports[`DateInput select format inline 3`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       6
                     </div>
@@ -19011,7 +19011,7 @@ exports[`DateInput select format inline 3`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       7
                     </div>
@@ -19028,7 +19028,7 @@ exports[`DateInput select format inline 3`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       8
                     </div>
@@ -19045,7 +19045,7 @@ exports[`DateInput select format inline 3`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       9
                     </div>
@@ -19062,7 +19062,7 @@ exports[`DateInput select format inline 3`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       10
                     </div>
@@ -19079,7 +19079,7 @@ exports[`DateInput select format inline 3`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       11
                     </div>
@@ -19101,7 +19101,7 @@ exports[`DateInput select format inline 3`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       12
                     </div>
@@ -19118,7 +19118,7 @@ exports[`DateInput select format inline 3`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       13
                     </div>
@@ -19135,7 +19135,7 @@ exports[`DateInput select format inline 3`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       14
                     </div>
@@ -19152,7 +19152,7 @@ exports[`DateInput select format inline 3`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       15
                     </div>
@@ -19169,7 +19169,7 @@ exports[`DateInput select format inline 3`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       16
                     </div>
@@ -19186,7 +19186,7 @@ exports[`DateInput select format inline 3`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       17
                     </div>
@@ -19203,7 +19203,7 @@ exports[`DateInput select format inline 3`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       18
                     </div>
@@ -19225,7 +19225,7 @@ exports[`DateInput select format inline 3`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       19
                     </div>
@@ -19242,7 +19242,7 @@ exports[`DateInput select format inline 3`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       20
                     </div>
@@ -19259,7 +19259,7 @@ exports[`DateInput select format inline 3`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       21
                     </div>
@@ -19276,7 +19276,7 @@ exports[`DateInput select format inline 3`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       22
                     </div>
@@ -19293,7 +19293,7 @@ exports[`DateInput select format inline 3`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       23
                     </div>
@@ -19310,7 +19310,7 @@ exports[`DateInput select format inline 3`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       24
                     </div>
@@ -19327,7 +19327,7 @@ exports[`DateInput select format inline 3`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       25
                     </div>
@@ -19349,7 +19349,7 @@ exports[`DateInput select format inline 3`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       26
                     </div>
@@ -19366,7 +19366,7 @@ exports[`DateInput select format inline 3`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       27
                     </div>
@@ -19383,7 +19383,7 @@ exports[`DateInput select format inline 3`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       28
                     </div>
@@ -19400,7 +19400,7 @@ exports[`DateInput select format inline 3`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       29
                     </div>
@@ -19417,7 +19417,7 @@ exports[`DateInput select format inline 3`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       30
                     </div>
@@ -19434,7 +19434,7 @@ exports[`DateInput select format inline 3`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       31
                     </div>
@@ -19909,7 +19909,7 @@ exports[`DateInput select format inline 4`] = `
   border: 0;
 }
 
-.c20 {
+.c21 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -19929,43 +19929,43 @@ exports[`DateInput select format inline 4`] = `
   color: #000000;
 }
 
-.c20:focus {
+.c21:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c20:focus > circle,
-.c20:focus > ellipse,
-.c20:focus > line,
-.c20:focus > path,
-.c20:focus > polygon,
-.c20:focus > polyline,
-.c20:focus > rect {
+.c21:focus > circle,
+.c21:focus > ellipse,
+.c21:focus > line,
+.c21:focus > path,
+.c21:focus > polygon,
+.c21:focus > polyline,
+.c21:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c20:focus::-moz-focus-inner {
+.c21:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c20:focus:not(:focus-visible) {
+.c21:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c20:focus:not(:focus-visible) > circle,
-.c20:focus:not(:focus-visible) > ellipse,
-.c20:focus:not(:focus-visible) > line,
-.c20:focus:not(:focus-visible) > path,
-.c20:focus:not(:focus-visible) > polygon,
-.c20:focus:not(:focus-visible) > polyline,
-.c20:focus:not(:focus-visible) > rect {
+.c21:focus:not(:focus-visible) > circle,
+.c21:focus:not(:focus-visible) > ellipse,
+.c21:focus:not(:focus-visible) > line,
+.c21:focus:not(:focus-visible) > path,
+.c21:focus:not(:focus-visible) > polygon,
+.c21:focus:not(:focus-visible) > polyline,
+.c21:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c20:focus:not(:focus-visible)::-moz-focus-inner {
+.c21:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
@@ -20045,24 +20045,7 @@ exports[`DateInput select format inline 4`] = `
   opacity: 0.5;
 }
 
-.c19 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  width: 54.857142857142854px;
-  height: 54.857142857142854px;
-}
-
-.c21 {
+.c20 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -20080,6 +20063,23 @@ exports[`DateInput select format inline 4`] = `
   background-color: #7D4CDB;
   color: #f8f8f8;
   font-weight: bold;
+}
+
+.c19 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  width: 54.857142857142854px;
+  height: 54.857142857142854px;
 }
 
 .c4 {
@@ -20202,7 +20202,7 @@ exports[`DateInput select format inline 4`] = `
             id="item"
             name="item"
             placeholder="mm/dd/yyyy"
-            value="07/20/2020"
+            value="07/19/2020"
           />
         </div>
         <button
@@ -20283,7 +20283,7 @@ exports[`DateInput select format inline 4`] = `
             </div>
           </div>
           <div
-            aria-label="July 2020; Currently selected July 20, 2020;"
+            aria-label="July 2020; Currently selected July 19, 2020;"
             class="c13"
             role="grid"
             tabindex="0"
@@ -20678,7 +20678,7 @@ exports[`DateInput select format inline 4`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       19
                     </div>
@@ -20690,12 +20690,12 @@ exports[`DateInput select format inline 4`] = `
                 >
                   <button
                     aria-label="Mon Jul 20 2020"
-                    class="c20"
+                    class="c21"
                     tabindex="-1"
                     type="button"
                   >
                     <div
-                      class="c21"
+                      class="c19"
                     >
                       20
                     </div>
@@ -22438,7 +22438,7 @@ exports[`DateInput select format inline range 1`] = `
 
 exports[`DateInput select format inline range 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 iNDmPr"
@@ -23688,6 +23688,9 @@ exports[`DateInput select format inline range without timezone 1`] = `
   align-items: center;
   width: 54.857142857142854px;
   height: 54.857142857142854px;
+  background-color: #7D4CDB;
+  color: #f8f8f8;
+  font-weight: bold;
 }
 
 .c20 {
@@ -23705,9 +23708,7 @@ exports[`DateInput select format inline range without timezone 1`] = `
   align-items: center;
   width: 54.857142857142854px;
   height: 54.857142857142854px;
-  background-color: #7D4CDB;
-  color: #f8f8f8;
-  font-weight: bold;
+  background-color: rgba(125,76,219,0.1);
 }
 
 .c21 {
@@ -23725,7 +23726,6 @@ exports[`DateInput select format inline range without timezone 1`] = `
   align-items: center;
   width: 54.857142857142854px;
   height: 54.857142857142854px;
-  background-color: rgba(125,76,219,0.1);
 }
 
 .c4 {
@@ -23848,7 +23848,7 @@ exports[`DateInput select format inline range without timezone 1`] = `
             id="item"
             name="item"
             placeholder="mm/dd/yyyy-mm/dd/yyyy"
-            value="07/02/2020-07/07/2020"
+            value="07/01/2020-07/06/2020"
           />
         </div>
         <button
@@ -23929,7 +23929,7 @@ exports[`DateInput select format inline range without timezone 1`] = `
             </div>
           </div>
           <div
-            aria-label="July 2020; Currently selected July 2, 2020 through July 7, 2020"
+            aria-label="July 2020; Currently selected July 1, 2020 through July 6, 2020"
             class="c13"
             role="grid"
             tabindex="0"
@@ -24037,7 +24037,7 @@ exports[`DateInput select format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c21"
+                      class="c20"
                     >
                       3
                     </div>
@@ -24054,7 +24054,7 @@ exports[`DateInput select format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c21"
+                      class="c20"
                     >
                       4
                     </div>
@@ -24076,7 +24076,7 @@ exports[`DateInput select format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c21"
+                      class="c20"
                     >
                       5
                     </div>
@@ -24093,7 +24093,7 @@ exports[`DateInput select format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c21"
+                      class="c19"
                     >
                       6
                     </div>
@@ -24110,7 +24110,7 @@ exports[`DateInput select format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c20"
+                      class="c21"
                     >
                       7
                     </div>
@@ -24127,7 +24127,7 @@ exports[`DateInput select format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       8
                     </div>
@@ -24144,7 +24144,7 @@ exports[`DateInput select format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       9
                     </div>
@@ -24161,7 +24161,7 @@ exports[`DateInput select format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       10
                     </div>
@@ -24178,7 +24178,7 @@ exports[`DateInput select format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       11
                     </div>
@@ -24200,7 +24200,7 @@ exports[`DateInput select format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       12
                     </div>
@@ -24217,7 +24217,7 @@ exports[`DateInput select format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       13
                     </div>
@@ -24234,7 +24234,7 @@ exports[`DateInput select format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       14
                     </div>
@@ -24251,7 +24251,7 @@ exports[`DateInput select format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       15
                     </div>
@@ -24268,7 +24268,7 @@ exports[`DateInput select format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       16
                     </div>
@@ -24285,7 +24285,7 @@ exports[`DateInput select format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       17
                     </div>
@@ -24302,7 +24302,7 @@ exports[`DateInput select format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       18
                     </div>
@@ -24324,7 +24324,7 @@ exports[`DateInput select format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       19
                     </div>
@@ -24341,7 +24341,7 @@ exports[`DateInput select format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       20
                     </div>
@@ -24358,7 +24358,7 @@ exports[`DateInput select format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       21
                     </div>
@@ -24375,7 +24375,7 @@ exports[`DateInput select format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       22
                     </div>
@@ -24392,7 +24392,7 @@ exports[`DateInput select format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       23
                     </div>
@@ -24409,7 +24409,7 @@ exports[`DateInput select format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       24
                     </div>
@@ -24426,7 +24426,7 @@ exports[`DateInput select format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       25
                     </div>
@@ -24448,7 +24448,7 @@ exports[`DateInput select format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       26
                     </div>
@@ -24465,7 +24465,7 @@ exports[`DateInput select format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       27
                     </div>
@@ -24482,7 +24482,7 @@ exports[`DateInput select format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       28
                     </div>
@@ -24499,7 +24499,7 @@ exports[`DateInput select format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       29
                     </div>
@@ -24516,7 +24516,7 @@ exports[`DateInput select format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       30
                     </div>
@@ -24533,7 +24533,7 @@ exports[`DateInput select format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       31
                     </div>
@@ -25008,7 +25008,7 @@ exports[`DateInput select format inline range without timezone 2`] = `
   border: 0;
 }
 
-.c20 {
+.c21 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -25028,43 +25028,43 @@ exports[`DateInput select format inline range without timezone 2`] = `
   color: #000000;
 }
 
-.c20:focus {
+.c21:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c20:focus > circle,
-.c20:focus > ellipse,
-.c20:focus > line,
-.c20:focus > path,
-.c20:focus > polygon,
-.c20:focus > polyline,
-.c20:focus > rect {
+.c21:focus > circle,
+.c21:focus > ellipse,
+.c21:focus > line,
+.c21:focus > path,
+.c21:focus > polygon,
+.c21:focus > polyline,
+.c21:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c20:focus::-moz-focus-inner {
+.c21:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c20:focus:not(:focus-visible) {
+.c21:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c20:focus:not(:focus-visible) > circle,
-.c20:focus:not(:focus-visible) > ellipse,
-.c20:focus:not(:focus-visible) > line,
-.c20:focus:not(:focus-visible) > path,
-.c20:focus:not(:focus-visible) > polygon,
-.c20:focus:not(:focus-visible) > polyline,
-.c20:focus:not(:focus-visible) > rect {
+.c21:focus:not(:focus-visible) > circle,
+.c21:focus:not(:focus-visible) > ellipse,
+.c21:focus:not(:focus-visible) > line,
+.c21:focus:not(:focus-visible) > path,
+.c21:focus:not(:focus-visible) > polygon,
+.c21:focus:not(:focus-visible) > polyline,
+.c21:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c20:focus:not(:focus-visible)::-moz-focus-inner {
+.c21:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
@@ -25144,24 +25144,7 @@ exports[`DateInput select format inline range without timezone 2`] = `
   opacity: 0.5;
 }
 
-.c19 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  width: 54.857142857142854px;
-  height: 54.857142857142854px;
-}
-
-.c21 {
+.c20 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -25179,6 +25162,23 @@ exports[`DateInput select format inline range without timezone 2`] = `
   background-color: #7D4CDB;
   color: #f8f8f8;
   font-weight: bold;
+}
+
+.c19 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  width: 54.857142857142854px;
+  height: 54.857142857142854px;
 }
 
 .c4 {
@@ -25301,7 +25301,7 @@ exports[`DateInput select format inline range without timezone 2`] = `
             id="item"
             name="item"
             placeholder="mm/dd/yyyy-mm/dd/yyyy"
-            value="07/10/2020-07/10/2020"
+            value="07/09/2020-07/09/2020"
           />
         </div>
         <button
@@ -25382,7 +25382,7 @@ exports[`DateInput select format inline range without timezone 2`] = `
             </div>
           </div>
           <div
-            aria-label="July 2020; Currently selected July 10, 2020 through July 10, 2020"
+            aria-label="July 2020; Currently selected July 9, 2020 through July 9, 2020"
             class="c13"
             role="grid"
             tabindex="0"
@@ -25597,7 +25597,7 @@ exports[`DateInput select format inline range without timezone 2`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       9
                     </div>
@@ -25609,12 +25609,12 @@ exports[`DateInput select format inline range without timezone 2`] = `
                 >
                   <button
                     aria-label="Fri Jul 10 2020"
-                    class="c20"
+                    class="c21"
                     tabindex="-1"
                     type="button"
                   >
                     <div
-                      class="c21"
+                      class="c19"
                     >
                       10
                     </div>
@@ -26363,7 +26363,7 @@ exports[`DateInput select format no timezone 1`] = `
           id="item"
           name="item"
           placeholder="mm/dd/yyyy"
-          value="07/02/2020"
+          value="07/01/2020"
         />
       </div>
       <button
@@ -26608,7 +26608,7 @@ exports[`DateInput select format no timezone 2`] = `
           id="item"
           name="item"
           placeholder="mm/dd/yyyy"
-          value="07/02/2020"
+          value="07/01/2020"
         />
       </div>
       <button
@@ -27053,6 +27053,9 @@ exports[`DateInput select format no timezone 3`] = `
   align-items: center;
   width: 54.857142857142854px;
   height: 54.857142857142854px;
+  background-color: #7D4CDB;
+  color: #f8f8f8;
+  font-weight: bold;
 }
 
 .c18 {
@@ -27070,9 +27073,6 @@ exports[`DateInput select format no timezone 3`] = `
   align-items: center;
   width: 54.857142857142854px;
   height: 54.857142857142854px;
-  background-color: #7D4CDB;
-  color: #f8f8f8;
-  font-weight: bold;
 }
 
 @media only screen and (max-width:768px) {
@@ -27184,7 +27184,7 @@ exports[`DateInput select format no timezone 3`] = `
         </div>
       </div>
       <div
-        aria-label="July 2020; Currently selected July 2, 2020;"
+        aria-label="July 2020; Currently selected July 1, 2020;"
         class="c10"
         role="grid"
         tabindex="0"
@@ -27292,7 +27292,7 @@ exports[`DateInput select format no timezone 3`] = `
                 type="button"
               >
                 <div
-                  class="c17"
+                  class="c18"
                 >
                   3
                 </div>
@@ -27309,7 +27309,7 @@ exports[`DateInput select format no timezone 3`] = `
                 type="button"
               >
                 <div
-                  class="c17"
+                  class="c18"
                 >
                   4
                 </div>
@@ -27331,7 +27331,7 @@ exports[`DateInput select format no timezone 3`] = `
                 type="button"
               >
                 <div
-                  class="c17"
+                  class="c18"
                 >
                   5
                 </div>
@@ -27348,7 +27348,7 @@ exports[`DateInput select format no timezone 3`] = `
                 type="button"
               >
                 <div
-                  class="c17"
+                  class="c18"
                 >
                   6
                 </div>
@@ -27365,7 +27365,7 @@ exports[`DateInput select format no timezone 3`] = `
                 type="button"
               >
                 <div
-                  class="c17"
+                  class="c18"
                 >
                   7
                 </div>
@@ -27382,7 +27382,7 @@ exports[`DateInput select format no timezone 3`] = `
                 type="button"
               >
                 <div
-                  class="c17"
+                  class="c18"
                 >
                   8
                 </div>
@@ -27399,7 +27399,7 @@ exports[`DateInput select format no timezone 3`] = `
                 type="button"
               >
                 <div
-                  class="c17"
+                  class="c18"
                 >
                   9
                 </div>
@@ -27416,7 +27416,7 @@ exports[`DateInput select format no timezone 3`] = `
                 type="button"
               >
                 <div
-                  class="c17"
+                  class="c18"
                 >
                   10
                 </div>
@@ -27433,7 +27433,7 @@ exports[`DateInput select format no timezone 3`] = `
                 type="button"
               >
                 <div
-                  class="c17"
+                  class="c18"
                 >
                   11
                 </div>
@@ -27455,7 +27455,7 @@ exports[`DateInput select format no timezone 3`] = `
                 type="button"
               >
                 <div
-                  class="c17"
+                  class="c18"
                 >
                   12
                 </div>
@@ -27472,7 +27472,7 @@ exports[`DateInput select format no timezone 3`] = `
                 type="button"
               >
                 <div
-                  class="c17"
+                  class="c18"
                 >
                   13
                 </div>
@@ -27489,7 +27489,7 @@ exports[`DateInput select format no timezone 3`] = `
                 type="button"
               >
                 <div
-                  class="c17"
+                  class="c18"
                 >
                   14
                 </div>
@@ -27506,7 +27506,7 @@ exports[`DateInput select format no timezone 3`] = `
                 type="button"
               >
                 <div
-                  class="c17"
+                  class="c18"
                 >
                   15
                 </div>
@@ -27523,7 +27523,7 @@ exports[`DateInput select format no timezone 3`] = `
                 type="button"
               >
                 <div
-                  class="c17"
+                  class="c18"
                 >
                   16
                 </div>
@@ -27540,7 +27540,7 @@ exports[`DateInput select format no timezone 3`] = `
                 type="button"
               >
                 <div
-                  class="c17"
+                  class="c18"
                 >
                   17
                 </div>
@@ -27557,7 +27557,7 @@ exports[`DateInput select format no timezone 3`] = `
                 type="button"
               >
                 <div
-                  class="c17"
+                  class="c18"
                 >
                   18
                 </div>
@@ -27579,7 +27579,7 @@ exports[`DateInput select format no timezone 3`] = `
                 type="button"
               >
                 <div
-                  class="c17"
+                  class="c18"
                 >
                   19
                 </div>
@@ -27596,7 +27596,7 @@ exports[`DateInput select format no timezone 3`] = `
                 type="button"
               >
                 <div
-                  class="c17"
+                  class="c18"
                 >
                   20
                 </div>
@@ -27613,7 +27613,7 @@ exports[`DateInput select format no timezone 3`] = `
                 type="button"
               >
                 <div
-                  class="c17"
+                  class="c18"
                 >
                   21
                 </div>
@@ -27630,7 +27630,7 @@ exports[`DateInput select format no timezone 3`] = `
                 type="button"
               >
                 <div
-                  class="c17"
+                  class="c18"
                 >
                   22
                 </div>
@@ -27647,7 +27647,7 @@ exports[`DateInput select format no timezone 3`] = `
                 type="button"
               >
                 <div
-                  class="c17"
+                  class="c18"
                 >
                   23
                 </div>
@@ -27664,7 +27664,7 @@ exports[`DateInput select format no timezone 3`] = `
                 type="button"
               >
                 <div
-                  class="c17"
+                  class="c18"
                 >
                   24
                 </div>
@@ -27681,7 +27681,7 @@ exports[`DateInput select format no timezone 3`] = `
                 type="button"
               >
                 <div
-                  class="c17"
+                  class="c18"
                 >
                   25
                 </div>
@@ -27703,7 +27703,7 @@ exports[`DateInput select format no timezone 3`] = `
                 type="button"
               >
                 <div
-                  class="c17"
+                  class="c18"
                 >
                   26
                 </div>
@@ -27720,7 +27720,7 @@ exports[`DateInput select format no timezone 3`] = `
                 type="button"
               >
                 <div
-                  class="c17"
+                  class="c18"
                 >
                   27
                 </div>
@@ -27737,7 +27737,7 @@ exports[`DateInput select format no timezone 3`] = `
                 type="button"
               >
                 <div
-                  class="c17"
+                  class="c18"
                 >
                   28
                 </div>
@@ -27754,7 +27754,7 @@ exports[`DateInput select format no timezone 3`] = `
                 type="button"
               >
                 <div
-                  class="c17"
+                  class="c18"
                 >
                   29
                 </div>
@@ -27771,7 +27771,7 @@ exports[`DateInput select format no timezone 3`] = `
                 type="button"
               >
                 <div
-                  class="c17"
+                  class="c18"
                 >
                   30
                 </div>
@@ -27788,7 +27788,7 @@ exports[`DateInput select format no timezone 3`] = `
                 type="button"
               >
                 <div
-                  class="c17"
+                  class="c18"
                 >
                   31
                 </div>
@@ -29466,6 +29466,9 @@ exports[`DateInput select inline without timezone 1`] = `
   align-items: center;
   width: 54.857142857142854px;
   height: 54.857142857142854px;
+  background-color: #7D4CDB;
+  color: #f8f8f8;
+  font-weight: bold;
 }
 
 .c16 {
@@ -29483,9 +29486,6 @@ exports[`DateInput select inline without timezone 1`] = `
   align-items: center;
   width: 54.857142857142854px;
   height: 54.857142857142854px;
-  background-color: #7D4CDB;
-  color: #f8f8f8;
-  font-weight: bold;
 }
 
 @media only screen and (max-width:768px) {
@@ -29573,7 +29573,7 @@ exports[`DateInput select inline without timezone 1`] = `
         </div>
       </div>
       <div
-        aria-label="July 2020; Currently selected July 2, 2020;"
+        aria-label="July 2020; Currently selected July 1, 2020;"
         class="c9"
         role="grid"
         tabindex="0"
@@ -29681,7 +29681,7 @@ exports[`DateInput select inline without timezone 1`] = `
                 type="button"
               >
                 <div
-                  class="c15"
+                  class="c16"
                 >
                   3
                 </div>
@@ -29698,7 +29698,7 @@ exports[`DateInput select inline without timezone 1`] = `
                 type="button"
               >
                 <div
-                  class="c15"
+                  class="c16"
                 >
                   4
                 </div>
@@ -29720,7 +29720,7 @@ exports[`DateInput select inline without timezone 1`] = `
                 type="button"
               >
                 <div
-                  class="c15"
+                  class="c16"
                 >
                   5
                 </div>
@@ -29737,7 +29737,7 @@ exports[`DateInput select inline without timezone 1`] = `
                 type="button"
               >
                 <div
-                  class="c15"
+                  class="c16"
                 >
                   6
                 </div>
@@ -29754,7 +29754,7 @@ exports[`DateInput select inline without timezone 1`] = `
                 type="button"
               >
                 <div
-                  class="c15"
+                  class="c16"
                 >
                   7
                 </div>
@@ -29771,7 +29771,7 @@ exports[`DateInput select inline without timezone 1`] = `
                 type="button"
               >
                 <div
-                  class="c15"
+                  class="c16"
                 >
                   8
                 </div>
@@ -29788,7 +29788,7 @@ exports[`DateInput select inline without timezone 1`] = `
                 type="button"
               >
                 <div
-                  class="c15"
+                  class="c16"
                 >
                   9
                 </div>
@@ -29805,7 +29805,7 @@ exports[`DateInput select inline without timezone 1`] = `
                 type="button"
               >
                 <div
-                  class="c15"
+                  class="c16"
                 >
                   10
                 </div>
@@ -29822,7 +29822,7 @@ exports[`DateInput select inline without timezone 1`] = `
                 type="button"
               >
                 <div
-                  class="c15"
+                  class="c16"
                 >
                   11
                 </div>
@@ -29844,7 +29844,7 @@ exports[`DateInput select inline without timezone 1`] = `
                 type="button"
               >
                 <div
-                  class="c15"
+                  class="c16"
                 >
                   12
                 </div>
@@ -29861,7 +29861,7 @@ exports[`DateInput select inline without timezone 1`] = `
                 type="button"
               >
                 <div
-                  class="c15"
+                  class="c16"
                 >
                   13
                 </div>
@@ -29878,7 +29878,7 @@ exports[`DateInput select inline without timezone 1`] = `
                 type="button"
               >
                 <div
-                  class="c15"
+                  class="c16"
                 >
                   14
                 </div>
@@ -29895,7 +29895,7 @@ exports[`DateInput select inline without timezone 1`] = `
                 type="button"
               >
                 <div
-                  class="c15"
+                  class="c16"
                 >
                   15
                 </div>
@@ -29912,7 +29912,7 @@ exports[`DateInput select inline without timezone 1`] = `
                 type="button"
               >
                 <div
-                  class="c15"
+                  class="c16"
                 >
                   16
                 </div>
@@ -29929,7 +29929,7 @@ exports[`DateInput select inline without timezone 1`] = `
                 type="button"
               >
                 <div
-                  class="c15"
+                  class="c16"
                 >
                   17
                 </div>
@@ -29946,7 +29946,7 @@ exports[`DateInput select inline without timezone 1`] = `
                 type="button"
               >
                 <div
-                  class="c15"
+                  class="c16"
                 >
                   18
                 </div>
@@ -29968,7 +29968,7 @@ exports[`DateInput select inline without timezone 1`] = `
                 type="button"
               >
                 <div
-                  class="c15"
+                  class="c16"
                 >
                   19
                 </div>
@@ -29985,7 +29985,7 @@ exports[`DateInput select inline without timezone 1`] = `
                 type="button"
               >
                 <div
-                  class="c15"
+                  class="c16"
                 >
                   20
                 </div>
@@ -30002,7 +30002,7 @@ exports[`DateInput select inline without timezone 1`] = `
                 type="button"
               >
                 <div
-                  class="c15"
+                  class="c16"
                 >
                   21
                 </div>
@@ -30019,7 +30019,7 @@ exports[`DateInput select inline without timezone 1`] = `
                 type="button"
               >
                 <div
-                  class="c15"
+                  class="c16"
                 >
                   22
                 </div>
@@ -30036,7 +30036,7 @@ exports[`DateInput select inline without timezone 1`] = `
                 type="button"
               >
                 <div
-                  class="c15"
+                  class="c16"
                 >
                   23
                 </div>
@@ -30053,7 +30053,7 @@ exports[`DateInput select inline without timezone 1`] = `
                 type="button"
               >
                 <div
-                  class="c15"
+                  class="c16"
                 >
                   24
                 </div>
@@ -30070,7 +30070,7 @@ exports[`DateInput select inline without timezone 1`] = `
                 type="button"
               >
                 <div
-                  class="c15"
+                  class="c16"
                 >
                   25
                 </div>
@@ -30092,7 +30092,7 @@ exports[`DateInput select inline without timezone 1`] = `
                 type="button"
               >
                 <div
-                  class="c15"
+                  class="c16"
                 >
                   26
                 </div>
@@ -30109,7 +30109,7 @@ exports[`DateInput select inline without timezone 1`] = `
                 type="button"
               >
                 <div
-                  class="c15"
+                  class="c16"
                 >
                   27
                 </div>
@@ -30126,7 +30126,7 @@ exports[`DateInput select inline without timezone 1`] = `
                 type="button"
               >
                 <div
-                  class="c15"
+                  class="c16"
                 >
                   28
                 </div>
@@ -30143,7 +30143,7 @@ exports[`DateInput select inline without timezone 1`] = `
                 type="button"
               >
                 <div
-                  class="c15"
+                  class="c16"
                 >
                   29
                 </div>
@@ -30160,7 +30160,7 @@ exports[`DateInput select inline without timezone 1`] = `
                 type="button"
               >
                 <div
-                  class="c15"
+                  class="c16"
                 >
                   30
                 </div>
@@ -30177,7 +30177,7 @@ exports[`DateInput select inline without timezone 1`] = `
                 type="button"
               >
                 <div
-                  class="c15"
+                  class="c16"
                 >
                   31
                 </div>
@@ -31708,7 +31708,7 @@ exports[`DateInput type format inline 1`] = `
 
 exports[`DateInput type format inline 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 iNDmPr"
@@ -34332,6 +34332,9 @@ exports[`DateInput type format inline partial without timezone 1`] = `
   align-items: center;
   width: 54.857142857142854px;
   height: 54.857142857142854px;
+  background-color: #7D4CDB;
+  color: #f8f8f8;
+  font-weight: bold;
 }
 
 .c20 {
@@ -34349,9 +34352,6 @@ exports[`DateInput type format inline partial without timezone 1`] = `
   align-items: center;
   width: 54.857142857142854px;
   height: 54.857142857142854px;
-  background-color: #7D4CDB;
-  color: #f8f8f8;
-  font-weight: bold;
 }
 
 .c4 {
@@ -34474,7 +34474,7 @@ exports[`DateInput type format inline partial without timezone 1`] = `
             id="item"
             name="item"
             placeholder="mm/dd/yyyy"
-            value="07/02/2020"
+            value="07/01/2020"
           />
         </div>
         <button
@@ -34555,7 +34555,7 @@ exports[`DateInput type format inline partial without timezone 1`] = `
             </div>
           </div>
           <div
-            aria-label="July 2020; Currently selected July 2, 2020;"
+            aria-label="July 2020; Currently selected July 1, 2020;"
             class="c13"
             role="grid"
             tabindex="0"
@@ -34663,7 +34663,7 @@ exports[`DateInput type format inline partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       3
                     </div>
@@ -34680,7 +34680,7 @@ exports[`DateInput type format inline partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       4
                     </div>
@@ -34702,7 +34702,7 @@ exports[`DateInput type format inline partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       5
                     </div>
@@ -34719,7 +34719,7 @@ exports[`DateInput type format inline partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       6
                     </div>
@@ -34736,7 +34736,7 @@ exports[`DateInput type format inline partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       7
                     </div>
@@ -34753,7 +34753,7 @@ exports[`DateInput type format inline partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       8
                     </div>
@@ -34770,7 +34770,7 @@ exports[`DateInput type format inline partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       9
                     </div>
@@ -34787,7 +34787,7 @@ exports[`DateInput type format inline partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       10
                     </div>
@@ -34804,7 +34804,7 @@ exports[`DateInput type format inline partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       11
                     </div>
@@ -34826,7 +34826,7 @@ exports[`DateInput type format inline partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       12
                     </div>
@@ -34843,7 +34843,7 @@ exports[`DateInput type format inline partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       13
                     </div>
@@ -34860,7 +34860,7 @@ exports[`DateInput type format inline partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       14
                     </div>
@@ -34877,7 +34877,7 @@ exports[`DateInput type format inline partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       15
                     </div>
@@ -34894,7 +34894,7 @@ exports[`DateInput type format inline partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       16
                     </div>
@@ -34911,7 +34911,7 @@ exports[`DateInput type format inline partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       17
                     </div>
@@ -34928,7 +34928,7 @@ exports[`DateInput type format inline partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       18
                     </div>
@@ -34950,7 +34950,7 @@ exports[`DateInput type format inline partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       19
                     </div>
@@ -34967,7 +34967,7 @@ exports[`DateInput type format inline partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       20
                     </div>
@@ -34984,7 +34984,7 @@ exports[`DateInput type format inline partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       21
                     </div>
@@ -35001,7 +35001,7 @@ exports[`DateInput type format inline partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       22
                     </div>
@@ -35018,7 +35018,7 @@ exports[`DateInput type format inline partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       23
                     </div>
@@ -35035,7 +35035,7 @@ exports[`DateInput type format inline partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       24
                     </div>
@@ -35052,7 +35052,7 @@ exports[`DateInput type format inline partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       25
                     </div>
@@ -35074,7 +35074,7 @@ exports[`DateInput type format inline partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       26
                     </div>
@@ -35091,7 +35091,7 @@ exports[`DateInput type format inline partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       27
                     </div>
@@ -35108,7 +35108,7 @@ exports[`DateInput type format inline partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       28
                     </div>
@@ -35125,7 +35125,7 @@ exports[`DateInput type format inline partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       29
                     </div>
@@ -35142,7 +35142,7 @@ exports[`DateInput type format inline partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       30
                     </div>
@@ -35159,7 +35159,7 @@ exports[`DateInput type format inline partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       31
                     </div>
@@ -36710,7 +36710,7 @@ exports[`DateInput type format inline range 1`] = `
 
 exports[`DateInput type format inline range 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 iNDmPr"
@@ -38962,7 +38962,7 @@ exports[`DateInput type format inline range partial 1`] = `
 
 exports[`DateInput type format inline range partial 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 iNDmPr"
@@ -39822,7 +39822,7 @@ exports[`DateInput type format inline range partial 2`] = `
 
 exports[`DateInput type format inline range partial 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 iNDmPr"
@@ -41072,6 +41072,9 @@ exports[`DateInput type format inline range partial without timezone 1`] = `
   align-items: center;
   width: 54.857142857142854px;
   height: 54.857142857142854px;
+  background-color: #7D4CDB;
+  color: #f8f8f8;
+  font-weight: bold;
 }
 
 .c20 {
@@ -41089,9 +41092,7 @@ exports[`DateInput type format inline range partial without timezone 1`] = `
   align-items: center;
   width: 54.857142857142854px;
   height: 54.857142857142854px;
-  background-color: #7D4CDB;
-  color: #f8f8f8;
-  font-weight: bold;
+  background-color: rgba(125,76,219,0.1);
 }
 
 .c21 {
@@ -41109,7 +41110,6 @@ exports[`DateInput type format inline range partial without timezone 1`] = `
   align-items: center;
   width: 54.857142857142854px;
   height: 54.857142857142854px;
-  background-color: rgba(125,76,219,0.1);
 }
 
 .c4 {
@@ -41232,7 +41232,7 @@ exports[`DateInput type format inline range partial without timezone 1`] = `
             id="item"
             name="item"
             placeholder="mm/dd/yyyy-mm/dd/yyyy"
-            value="07/02/2020-07/07/2020"
+            value="07/01/2020-07/06/2020"
           />
         </div>
         <button
@@ -41313,7 +41313,7 @@ exports[`DateInput type format inline range partial without timezone 1`] = `
             </div>
           </div>
           <div
-            aria-label="July 2020; Currently selected July 2, 2020 through July 7, 2020"
+            aria-label="July 2020; Currently selected July 1, 2020 through July 6, 2020"
             class="c13"
             role="grid"
             tabindex="0"
@@ -41421,7 +41421,7 @@ exports[`DateInput type format inline range partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c21"
+                      class="c20"
                     >
                       3
                     </div>
@@ -41438,7 +41438,7 @@ exports[`DateInput type format inline range partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c21"
+                      class="c20"
                     >
                       4
                     </div>
@@ -41460,7 +41460,7 @@ exports[`DateInput type format inline range partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c21"
+                      class="c20"
                     >
                       5
                     </div>
@@ -41477,7 +41477,7 @@ exports[`DateInput type format inline range partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c21"
+                      class="c19"
                     >
                       6
                     </div>
@@ -41494,7 +41494,7 @@ exports[`DateInput type format inline range partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c20"
+                      class="c21"
                     >
                       7
                     </div>
@@ -41511,7 +41511,7 @@ exports[`DateInput type format inline range partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       8
                     </div>
@@ -41528,7 +41528,7 @@ exports[`DateInput type format inline range partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       9
                     </div>
@@ -41545,7 +41545,7 @@ exports[`DateInput type format inline range partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       10
                     </div>
@@ -41562,7 +41562,7 @@ exports[`DateInput type format inline range partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       11
                     </div>
@@ -41584,7 +41584,7 @@ exports[`DateInput type format inline range partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       12
                     </div>
@@ -41601,7 +41601,7 @@ exports[`DateInput type format inline range partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       13
                     </div>
@@ -41618,7 +41618,7 @@ exports[`DateInput type format inline range partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       14
                     </div>
@@ -41635,7 +41635,7 @@ exports[`DateInput type format inline range partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       15
                     </div>
@@ -41652,7 +41652,7 @@ exports[`DateInput type format inline range partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       16
                     </div>
@@ -41669,7 +41669,7 @@ exports[`DateInput type format inline range partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       17
                     </div>
@@ -41686,7 +41686,7 @@ exports[`DateInput type format inline range partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       18
                     </div>
@@ -41708,7 +41708,7 @@ exports[`DateInput type format inline range partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       19
                     </div>
@@ -41725,7 +41725,7 @@ exports[`DateInput type format inline range partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       20
                     </div>
@@ -41742,7 +41742,7 @@ exports[`DateInput type format inline range partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       21
                     </div>
@@ -41759,7 +41759,7 @@ exports[`DateInput type format inline range partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       22
                     </div>
@@ -41776,7 +41776,7 @@ exports[`DateInput type format inline range partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       23
                     </div>
@@ -41793,7 +41793,7 @@ exports[`DateInput type format inline range partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       24
                     </div>
@@ -41810,7 +41810,7 @@ exports[`DateInput type format inline range partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       25
                     </div>
@@ -41832,7 +41832,7 @@ exports[`DateInput type format inline range partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       26
                     </div>
@@ -41849,7 +41849,7 @@ exports[`DateInput type format inline range partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       27
                     </div>
@@ -41866,7 +41866,7 @@ exports[`DateInput type format inline range partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       28
                     </div>
@@ -41883,7 +41883,7 @@ exports[`DateInput type format inline range partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       29
                     </div>
@@ -41900,7 +41900,7 @@ exports[`DateInput type format inline range partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       30
                     </div>
@@ -41917,7 +41917,7 @@ exports[`DateInput type format inline range partial without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       31
                     </div>
@@ -42451,23 +42451,6 @@ exports[`DateInput type format inline range partial without timezone 2`] = `
   opacity: 0.5;
 }
 
-.c19 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  width: 54.857142857142854px;
-  height: 54.857142857142854px;
-}
-
 .c20 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -42486,6 +42469,23 @@ exports[`DateInput type format inline range partial without timezone 2`] = `
   background-color: #7D4CDB;
   color: #f8f8f8;
   font-weight: bold;
+}
+
+.c19 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  width: 54.857142857142854px;
+  height: 54.857142857142854px;
 }
 
 .c4 {
@@ -42608,7 +42608,7 @@ exports[`DateInput type format inline range partial without timezone 2`] = `
             id="item"
             name="item"
             placeholder="mm/dd/yyyy-mm/dd/yyyy"
-            value="07/21/2020-07"
+            value="07/20/2020-"
           />
         </div>
         <button
@@ -42689,7 +42689,7 @@ exports[`DateInput type format inline range partial without timezone 2`] = `
             </div>
           </div>
           <div
-            aria-label="July 2020; Currently selected July 21, 2020 through none"
+            aria-label="July 2020; Currently selected July 20, 2020 through none"
             class="c13"
             role="grid"
             tabindex="0"
@@ -43101,7 +43101,7 @@ exports[`DateInput type format inline range partial without timezone 2`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       20
                     </div>
@@ -43118,7 +43118,7 @@ exports[`DateInput type format inline range partial without timezone 2`] = `
                     type="button"
                   >
                     <div
-                      class="c20"
+                      class="c19"
                     >
                       21
                     </div>
@@ -43827,23 +43827,6 @@ exports[`DateInput type format inline range partial without timezone 3`] = `
   opacity: 0.5;
 }
 
-.c19 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  width: 54.857142857142854px;
-  height: 54.857142857142854px;
-}
-
 .c20 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -43862,6 +43845,23 @@ exports[`DateInput type format inline range partial without timezone 3`] = `
   background-color: #7D4CDB;
   color: #f8f8f8;
   font-weight: bold;
+}
+
+.c19 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  width: 54.857142857142854px;
+  height: 54.857142857142854px;
 }
 
 .c4 {
@@ -43984,7 +43984,7 @@ exports[`DateInput type format inline range partial without timezone 3`] = `
             id="item"
             name="item"
             placeholder="mm/dd/yyyy-mm/dd/yyyy"
-            value="07/21/2020-"
+            value="07/20/2020-"
           />
         </div>
         <button
@@ -44065,7 +44065,7 @@ exports[`DateInput type format inline range partial without timezone 3`] = `
             </div>
           </div>
           <div
-            aria-label="July 2020; Currently selected July 21, 2020 through none"
+            aria-label="July 2020; Currently selected July 20, 2020 through none"
             class="c13"
             role="grid"
             tabindex="0"
@@ -44477,7 +44477,7 @@ exports[`DateInput type format inline range partial without timezone 3`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       20
                     </div>
@@ -44494,7 +44494,7 @@ exports[`DateInput type format inline range partial without timezone 3`] = `
                     type="button"
                   >
                     <div
-                      class="c20"
+                      class="c19"
                     >
                       21
                     </div>
@@ -45218,6 +45218,9 @@ exports[`DateInput type format inline range without timezone 1`] = `
   align-items: center;
   width: 54.857142857142854px;
   height: 54.857142857142854px;
+  background-color: #7D4CDB;
+  color: #f8f8f8;
+  font-weight: bold;
 }
 
 .c20 {
@@ -45235,9 +45238,7 @@ exports[`DateInput type format inline range without timezone 1`] = `
   align-items: center;
   width: 54.857142857142854px;
   height: 54.857142857142854px;
-  background-color: #7D4CDB;
-  color: #f8f8f8;
-  font-weight: bold;
+  background-color: rgba(125,76,219,0.1);
 }
 
 .c21 {
@@ -45255,7 +45256,6 @@ exports[`DateInput type format inline range without timezone 1`] = `
   align-items: center;
   width: 54.857142857142854px;
   height: 54.857142857142854px;
-  background-color: rgba(125,76,219,0.1);
 }
 
 .c4 {
@@ -45378,7 +45378,7 @@ exports[`DateInput type format inline range without timezone 1`] = `
             id="item"
             name="item"
             placeholder="mm/dd/yyyy-mm/dd/yyyy"
-            value="07/02/2020-07/07/2020"
+            value="07/01/2020-07/06/2020"
           />
         </div>
         <button
@@ -45459,7 +45459,7 @@ exports[`DateInput type format inline range without timezone 1`] = `
             </div>
           </div>
           <div
-            aria-label="July 2020; Currently selected July 2, 2020 through July 7, 2020"
+            aria-label="July 2020; Currently selected July 1, 2020 through July 6, 2020"
             class="c13"
             role="grid"
             tabindex="0"
@@ -45567,7 +45567,7 @@ exports[`DateInput type format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c21"
+                      class="c20"
                     >
                       3
                     </div>
@@ -45584,7 +45584,7 @@ exports[`DateInput type format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c21"
+                      class="c20"
                     >
                       4
                     </div>
@@ -45606,7 +45606,7 @@ exports[`DateInput type format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c21"
+                      class="c20"
                     >
                       5
                     </div>
@@ -45623,7 +45623,7 @@ exports[`DateInput type format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c21"
+                      class="c19"
                     >
                       6
                     </div>
@@ -45640,7 +45640,7 @@ exports[`DateInput type format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c20"
+                      class="c21"
                     >
                       7
                     </div>
@@ -45657,7 +45657,7 @@ exports[`DateInput type format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       8
                     </div>
@@ -45674,7 +45674,7 @@ exports[`DateInput type format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       9
                     </div>
@@ -45691,7 +45691,7 @@ exports[`DateInput type format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       10
                     </div>
@@ -45708,7 +45708,7 @@ exports[`DateInput type format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       11
                     </div>
@@ -45730,7 +45730,7 @@ exports[`DateInput type format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       12
                     </div>
@@ -45747,7 +45747,7 @@ exports[`DateInput type format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       13
                     </div>
@@ -45764,7 +45764,7 @@ exports[`DateInput type format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       14
                     </div>
@@ -45781,7 +45781,7 @@ exports[`DateInput type format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       15
                     </div>
@@ -45798,7 +45798,7 @@ exports[`DateInput type format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       16
                     </div>
@@ -45815,7 +45815,7 @@ exports[`DateInput type format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       17
                     </div>
@@ -45832,7 +45832,7 @@ exports[`DateInput type format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       18
                     </div>
@@ -45854,7 +45854,7 @@ exports[`DateInput type format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       19
                     </div>
@@ -45871,7 +45871,7 @@ exports[`DateInput type format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       20
                     </div>
@@ -45888,7 +45888,7 @@ exports[`DateInput type format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       21
                     </div>
@@ -45905,7 +45905,7 @@ exports[`DateInput type format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       22
                     </div>
@@ -45922,7 +45922,7 @@ exports[`DateInput type format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       23
                     </div>
@@ -45939,7 +45939,7 @@ exports[`DateInput type format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       24
                     </div>
@@ -45956,7 +45956,7 @@ exports[`DateInput type format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       25
                     </div>
@@ -45978,7 +45978,7 @@ exports[`DateInput type format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       26
                     </div>
@@ -45995,7 +45995,7 @@ exports[`DateInput type format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       27
                     </div>
@@ -46012,7 +46012,7 @@ exports[`DateInput type format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       28
                     </div>
@@ -46029,7 +46029,7 @@ exports[`DateInput type format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       29
                     </div>
@@ -46046,7 +46046,7 @@ exports[`DateInput type format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       30
                     </div>
@@ -46063,7 +46063,7 @@ exports[`DateInput type format inline range without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c21"
                     >
                       31
                     </div>
@@ -46597,23 +46597,6 @@ exports[`DateInput type format inline range without timezone 2`] = `
   opacity: 0.5;
 }
 
-.c19 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  width: 54.857142857142854px;
-  height: 54.857142857142854px;
-}
-
 .c20 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -46650,6 +46633,23 @@ exports[`DateInput type format inline range without timezone 2`] = `
   width: 54.857142857142854px;
   height: 54.857142857142854px;
   background-color: rgba(125,76,219,0.1);
+}
+
+.c19 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  width: 54.857142857142854px;
+  height: 54.857142857142854px;
 }
 
 .c4 {
@@ -46772,7 +46772,7 @@ exports[`DateInput type format inline range without timezone 2`] = `
             id="item"
             name="item"
             placeholder="mm/dd/yyyy-mm/dd/yyyy"
-            value="07/21/2020-07/23/2020"
+            value="07/20/2020-07/22/2020"
           />
         </div>
         <button
@@ -46853,7 +46853,7 @@ exports[`DateInput type format inline range without timezone 2`] = `
             </div>
           </div>
           <div
-            aria-label="July 2020; Currently selected July 21, 2020 through July 23, 2020"
+            aria-label="July 2020; Currently selected July 20, 2020 through July 22, 2020"
             class="c13"
             role="grid"
             tabindex="0"
@@ -47265,7 +47265,7 @@ exports[`DateInput type format inline range without timezone 2`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       20
                     </div>
@@ -47282,7 +47282,7 @@ exports[`DateInput type format inline range without timezone 2`] = `
                     type="button"
                   >
                     <div
-                      class="c20"
+                      class="c21"
                     >
                       21
                     </div>
@@ -47299,7 +47299,7 @@ exports[`DateInput type format inline range without timezone 2`] = `
                     type="button"
                   >
                     <div
-                      class="c21"
+                      class="c20"
                     >
                       22
                     </div>
@@ -47316,7 +47316,7 @@ exports[`DateInput type format inline range without timezone 2`] = `
                     type="button"
                   >
                     <div
-                      class="c20"
+                      class="c19"
                     >
                       23
                     </div>
@@ -48990,7 +48990,7 @@ exports[`DateInput type format inline short 1`] = `
 
 exports[`DateInput type format inline short 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 iNDmPr"
@@ -50240,6 +50240,9 @@ exports[`DateInput type format inline short without timezone 1`] = `
   align-items: center;
   width: 54.857142857142854px;
   height: 54.857142857142854px;
+  background-color: #7D4CDB;
+  color: #f8f8f8;
+  font-weight: bold;
 }
 
 .c20 {
@@ -50257,9 +50260,6 @@ exports[`DateInput type format inline short without timezone 1`] = `
   align-items: center;
   width: 54.857142857142854px;
   height: 54.857142857142854px;
-  background-color: #7D4CDB;
-  color: #f8f8f8;
-  font-weight: bold;
 }
 
 .c4 {
@@ -50382,7 +50382,7 @@ exports[`DateInput type format inline short without timezone 1`] = `
             id="item"
             name="item"
             placeholder="m/d/yy"
-            value="7/2/20"
+            value="7/1/20"
           />
         </div>
         <button
@@ -50463,7 +50463,7 @@ exports[`DateInput type format inline short without timezone 1`] = `
             </div>
           </div>
           <div
-            aria-label="July 2020; Currently selected July 2, 2020;"
+            aria-label="July 2020; Currently selected July 1, 2020;"
             class="c13"
             role="grid"
             tabindex="0"
@@ -50571,7 +50571,7 @@ exports[`DateInput type format inline short without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       3
                     </div>
@@ -50588,7 +50588,7 @@ exports[`DateInput type format inline short without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       4
                     </div>
@@ -50610,7 +50610,7 @@ exports[`DateInput type format inline short without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       5
                     </div>
@@ -50627,7 +50627,7 @@ exports[`DateInput type format inline short without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       6
                     </div>
@@ -50644,7 +50644,7 @@ exports[`DateInput type format inline short without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       7
                     </div>
@@ -50661,7 +50661,7 @@ exports[`DateInput type format inline short without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       8
                     </div>
@@ -50678,7 +50678,7 @@ exports[`DateInput type format inline short without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       9
                     </div>
@@ -50695,7 +50695,7 @@ exports[`DateInput type format inline short without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       10
                     </div>
@@ -50712,7 +50712,7 @@ exports[`DateInput type format inline short without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       11
                     </div>
@@ -50734,7 +50734,7 @@ exports[`DateInput type format inline short without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       12
                     </div>
@@ -50751,7 +50751,7 @@ exports[`DateInput type format inline short without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       13
                     </div>
@@ -50768,7 +50768,7 @@ exports[`DateInput type format inline short without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       14
                     </div>
@@ -50785,7 +50785,7 @@ exports[`DateInput type format inline short without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       15
                     </div>
@@ -50802,7 +50802,7 @@ exports[`DateInput type format inline short without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       16
                     </div>
@@ -50819,7 +50819,7 @@ exports[`DateInput type format inline short without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       17
                     </div>
@@ -50836,7 +50836,7 @@ exports[`DateInput type format inline short without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       18
                     </div>
@@ -50858,7 +50858,7 @@ exports[`DateInput type format inline short without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       19
                     </div>
@@ -50875,7 +50875,7 @@ exports[`DateInput type format inline short without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       20
                     </div>
@@ -50892,7 +50892,7 @@ exports[`DateInput type format inline short without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       21
                     </div>
@@ -50909,7 +50909,7 @@ exports[`DateInput type format inline short without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       22
                     </div>
@@ -50926,7 +50926,7 @@ exports[`DateInput type format inline short without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       23
                     </div>
@@ -50943,7 +50943,7 @@ exports[`DateInput type format inline short without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       24
                     </div>
@@ -50960,7 +50960,7 @@ exports[`DateInput type format inline short without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       25
                     </div>
@@ -50982,7 +50982,7 @@ exports[`DateInput type format inline short without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       26
                     </div>
@@ -50999,7 +50999,7 @@ exports[`DateInput type format inline short without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       27
                     </div>
@@ -51016,7 +51016,7 @@ exports[`DateInput type format inline short without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       28
                     </div>
@@ -51033,7 +51033,7 @@ exports[`DateInput type format inline short without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       29
                     </div>
@@ -51050,7 +51050,7 @@ exports[`DateInput type format inline short without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       30
                     </div>
@@ -51067,7 +51067,7 @@ exports[`DateInput type format inline short without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       31
                     </div>
@@ -51601,23 +51601,6 @@ exports[`DateInput type format inline short without timezone 2`] = `
   opacity: 0.5;
 }
 
-.c19 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  width: 54.857142857142854px;
-  height: 54.857142857142854px;
-}
-
 .c20 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -51636,6 +51619,23 @@ exports[`DateInput type format inline short without timezone 2`] = `
   background-color: #7D4CDB;
   color: #f8f8f8;
   font-weight: bold;
+}
+
+.c19 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  width: 54.857142857142854px;
+  height: 54.857142857142854px;
 }
 
 .c4 {
@@ -51758,7 +51758,7 @@ exports[`DateInput type format inline short without timezone 2`] = `
             id="item"
             name="item"
             placeholder="m/d/yy"
-            value="7/21/20"
+            value="7/20/20"
           />
         </div>
         <button
@@ -51839,7 +51839,7 @@ exports[`DateInput type format inline short without timezone 2`] = `
             </div>
           </div>
           <div
-            aria-label="July 2020; Currently selected July 21, 2020;"
+            aria-label="July 2020; Currently selected July 20, 2020;"
             class="c13"
             role="grid"
             tabindex="0"
@@ -52251,7 +52251,7 @@ exports[`DateInput type format inline short without timezone 2`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       20
                     </div>
@@ -52268,7 +52268,7 @@ exports[`DateInput type format inline short without timezone 2`] = `
                     type="button"
                   >
                     <div
-                      class="c20"
+                      class="c19"
                     >
                       21
                     </div>
@@ -52992,6 +52992,9 @@ exports[`DateInput type format inline without timezone 1`] = `
   align-items: center;
   width: 54.857142857142854px;
   height: 54.857142857142854px;
+  background-color: #7D4CDB;
+  color: #f8f8f8;
+  font-weight: bold;
 }
 
 .c20 {
@@ -53009,9 +53012,6 @@ exports[`DateInput type format inline without timezone 1`] = `
   align-items: center;
   width: 54.857142857142854px;
   height: 54.857142857142854px;
-  background-color: #7D4CDB;
-  color: #f8f8f8;
-  font-weight: bold;
 }
 
 .c4 {
@@ -53134,7 +53134,7 @@ exports[`DateInput type format inline without timezone 1`] = `
             id="item"
             name="item"
             placeholder="mm/dd/yyyy"
-            value="07/02/2020"
+            value="07/01/2020"
           />
         </div>
         <button
@@ -53215,7 +53215,7 @@ exports[`DateInput type format inline without timezone 1`] = `
             </div>
           </div>
           <div
-            aria-label="July 2020; Currently selected July 2, 2020;"
+            aria-label="July 2020; Currently selected July 1, 2020;"
             class="c13"
             role="grid"
             tabindex="0"
@@ -53323,7 +53323,7 @@ exports[`DateInput type format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       3
                     </div>
@@ -53340,7 +53340,7 @@ exports[`DateInput type format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       4
                     </div>
@@ -53362,7 +53362,7 @@ exports[`DateInput type format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       5
                     </div>
@@ -53379,7 +53379,7 @@ exports[`DateInput type format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       6
                     </div>
@@ -53396,7 +53396,7 @@ exports[`DateInput type format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       7
                     </div>
@@ -53413,7 +53413,7 @@ exports[`DateInput type format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       8
                     </div>
@@ -53430,7 +53430,7 @@ exports[`DateInput type format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       9
                     </div>
@@ -53447,7 +53447,7 @@ exports[`DateInput type format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       10
                     </div>
@@ -53464,7 +53464,7 @@ exports[`DateInput type format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       11
                     </div>
@@ -53486,7 +53486,7 @@ exports[`DateInput type format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       12
                     </div>
@@ -53503,7 +53503,7 @@ exports[`DateInput type format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       13
                     </div>
@@ -53520,7 +53520,7 @@ exports[`DateInput type format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       14
                     </div>
@@ -53537,7 +53537,7 @@ exports[`DateInput type format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       15
                     </div>
@@ -53554,7 +53554,7 @@ exports[`DateInput type format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       16
                     </div>
@@ -53571,7 +53571,7 @@ exports[`DateInput type format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       17
                     </div>
@@ -53588,7 +53588,7 @@ exports[`DateInput type format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       18
                     </div>
@@ -53610,7 +53610,7 @@ exports[`DateInput type format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       19
                     </div>
@@ -53627,7 +53627,7 @@ exports[`DateInput type format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       20
                     </div>
@@ -53644,7 +53644,7 @@ exports[`DateInput type format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       21
                     </div>
@@ -53661,7 +53661,7 @@ exports[`DateInput type format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       22
                     </div>
@@ -53678,7 +53678,7 @@ exports[`DateInput type format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       23
                     </div>
@@ -53695,7 +53695,7 @@ exports[`DateInput type format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       24
                     </div>
@@ -53712,7 +53712,7 @@ exports[`DateInput type format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       25
                     </div>
@@ -53734,7 +53734,7 @@ exports[`DateInput type format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       26
                     </div>
@@ -53751,7 +53751,7 @@ exports[`DateInput type format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       27
                     </div>
@@ -53768,7 +53768,7 @@ exports[`DateInput type format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       28
                     </div>
@@ -53785,7 +53785,7 @@ exports[`DateInput type format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       29
                     </div>
@@ -53802,7 +53802,7 @@ exports[`DateInput type format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       30
                     </div>
@@ -53819,7 +53819,7 @@ exports[`DateInput type format inline without timezone 1`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       31
                     </div>
@@ -54353,23 +54353,6 @@ exports[`DateInput type format inline without timezone 2`] = `
   opacity: 0.5;
 }
 
-.c19 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  width: 54.857142857142854px;
-  height: 54.857142857142854px;
-}
-
 .c20 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -54388,6 +54371,23 @@ exports[`DateInput type format inline without timezone 2`] = `
   background-color: #7D4CDB;
   color: #f8f8f8;
   font-weight: bold;
+}
+
+.c19 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  width: 54.857142857142854px;
+  height: 54.857142857142854px;
 }
 
 .c4 {
@@ -54510,7 +54510,7 @@ exports[`DateInput type format inline without timezone 2`] = `
             id="item"
             name="item"
             placeholder="mm/dd/yyyy"
-            value="07/21/2020"
+            value="07/20/2020"
           />
         </div>
         <button
@@ -54591,7 +54591,7 @@ exports[`DateInput type format inline without timezone 2`] = `
             </div>
           </div>
           <div
-            aria-label="July 2020; Currently selected July 21, 2020;"
+            aria-label="July 2020; Currently selected July 20, 2020;"
             class="c13"
             role="grid"
             tabindex="0"
@@ -55003,7 +55003,7 @@ exports[`DateInput type format inline without timezone 2`] = `
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20"
                     >
                       20
                     </div>
@@ -55020,7 +55020,7 @@ exports[`DateInput type format inline without timezone 2`] = `
                     type="button"
                   >
                     <div
-                      class="c20"
+                      class="c19"
                     >
                       21
                     </div>

--- a/src/js/components/Drop/__tests__/__snapshots__/Drop-test.tsx.snap
+++ b/src/js/components/Drop/__tests__/__snapshots__/Drop-test.tsx.snap
@@ -82,7 +82,7 @@ exports[`Drop align left left 2`] = `
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .iOcHVa {
+  .eaWCTq {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -176,7 +176,7 @@ exports[`Drop align left right top bottom 2`] = `
   overflow: auto;
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
-.iOcHVa {
+.eaWCTq {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -200,7 +200,7 @@ exports[`Drop align left right top bottom 2`] = `
   animation-delay: 0.01s;
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .iOcHVa {
+  .eaWCTq {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -295,7 +295,7 @@ exports[`Drop align right left top top 2`] = `
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .iOcHVa {
+  .eaWCTq {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -390,7 +390,7 @@ exports[`Drop align right right 2`] = `
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .iOcHVa {
+  .eaWCTq {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -485,7 +485,7 @@ exports[`Drop align right right bottom top 2`] = `
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .iOcHVa {
+  .eaWCTq {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -580,7 +580,7 @@ exports[`Drop align right right bottom top 4`] = `
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .iOcHVa {
+  .eaWCTq {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -660,7 +660,7 @@ exports[`Drop background 1`] = `
 
 exports[`Drop background 2`] = `
 "@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .iOcHVa {
+  .eaWCTq {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -754,7 +754,7 @@ exports[`Drop basic 2`] = `
   overflow: auto;
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
-.iOcHVa {
+.eaWCTq {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -778,7 +778,7 @@ exports[`Drop basic 2`] = `
   animation-delay: 0.01s;
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .iOcHVa {
+  .eaWCTq {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -872,7 +872,7 @@ exports[`Drop close 2`] = `
   overflow: auto;
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
-.iOcHVa {
+.eaWCTq {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -896,7 +896,7 @@ exports[`Drop close 2`] = `
   animation-delay: 0.01s;
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .iOcHVa {
+  .eaWCTq {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -990,7 +990,7 @@ exports[`Drop default elevation renders 2`] = `
   overflow: auto;
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
-.iOcHVa {
+.eaWCTq {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1014,7 +1014,7 @@ exports[`Drop default elevation renders 2`] = `
   animation-delay: 0.01s;
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .iOcHVa {
+  .eaWCTq {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1094,7 +1094,7 @@ exports[`Drop elevation 1`] = `
 
 exports[`Drop elevation 2`] = `
 "@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .iOcHVa {
+  .eaWCTq {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1188,7 +1188,7 @@ exports[`Drop invalid align 2`] = `
   overflow: auto;
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
-.iOcHVa {
+.eaWCTq {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1212,7 +1212,7 @@ exports[`Drop invalid align 2`] = `
   animation-delay: 0.01s;
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .iOcHVa {
+  .eaWCTq {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1306,7 +1306,7 @@ exports[`Drop invoke onClickOutside 2`] = `
   overflow: auto;
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
-.iOcHVa {
+.eaWCTq {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1330,7 +1330,7 @@ exports[`Drop invoke onClickOutside 2`] = `
   animation-delay: 0.01s;
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .iOcHVa {
+  .eaWCTq {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1418,7 +1418,7 @@ exports[`Drop margin 1`] = `
 
 exports[`Drop margin 2`] = `
 "@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .iOcHVa {
+  .eaWCTq {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1512,7 +1512,7 @@ exports[`Drop no stretch 2`] = `
   overflow: auto;
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
-.iOcHVa {
+.eaWCTq {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1536,7 +1536,7 @@ exports[`Drop no stretch 2`] = `
   animation-delay: 0.01s;
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .iOcHVa {
+  .eaWCTq {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1612,7 +1612,7 @@ exports[`Drop plain 1`] = `
 
 exports[`Drop plain 2`] = `
 "@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .iOcHVa {
+  .eaWCTq {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1706,7 +1706,7 @@ exports[`Drop resize 2`] = `
   overflow: auto;
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
-.iOcHVa {
+.eaWCTq {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1730,7 +1730,7 @@ exports[`Drop resize 2`] = `
   animation-delay: 0.01s;
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .iOcHVa {
+  .eaWCTq {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1810,7 +1810,7 @@ exports[`Drop restrict focus 1`] = `
 
 exports[`Drop restrict focus 2`] = `
 <div
-  class="StyledBox-sc-13pk1d4-0 kMTAEP StyledDrop-sc-16s5rx8-0 iOcHVa"
+  class="StyledBox-sc-13pk1d4-0 kMTAEP StyledDrop-sc-16s5rx8-0 eaWCTq"
   data-g-portal-id="0"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 1000px;"
@@ -1836,7 +1836,7 @@ exports[`Drop restrict focus 3`] = `
   overflow: auto;
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
-.iOcHVa {
+.eaWCTq {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1860,7 +1860,7 @@ exports[`Drop restrict focus 3`] = `
   animation-delay: 0.01s;
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .iOcHVa {
+  .eaWCTq {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1949,7 +1949,7 @@ exports[`Drop round 1`] = `
 
 exports[`Drop round 2`] = `
 "@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .iOcHVa {
+  .eaWCTq {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -2076,7 +2076,7 @@ exports[`Drop should render correct margin depending on value of align:
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .iOcHVa {
+  .eaWCTq {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -2174,7 +2174,7 @@ exports[`Drop should render correct margin depending on value of align:
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .iOcHVa {
+  .eaWCTq {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -2272,7 +2272,7 @@ exports[`Drop should render correct margin depending on value of align:
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .iOcHVa {
+  .eaWCTq {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -2371,7 +2371,7 @@ exports[`Drop should render correct margin depending on value of align:
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .iOcHVa {
+  .eaWCTq {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -2470,7 +2470,7 @@ exports[`Drop should render correct margin depending on value of align:
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .iOcHVa {
+  .eaWCTq {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -2569,7 +2569,7 @@ exports[`Drop should render correct margin depending on value of align:
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .iOcHVa {
+  .eaWCTq {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -2667,7 +2667,7 @@ exports[`Drop should render correct margin depending on value of align:
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .iOcHVa {
+  .eaWCTq {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -2765,7 +2765,7 @@ exports[`Drop should render correct margin depending on value of align:
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .iOcHVa {
+  .eaWCTq {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -2864,7 +2864,7 @@ exports[`Drop should render correct margin depending on value of align:
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .iOcHVa {
+  .eaWCTq {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -2963,7 +2963,7 @@ exports[`Drop should render correct margin depending on value of align:
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .iOcHVa {
+  .eaWCTq {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -3061,7 +3061,7 @@ exports[`Drop should render correct margin depending on value of align:
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .iOcHVa {
+  .eaWCTq {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -3159,7 +3159,7 @@ exports[`Drop should render correct margin depending on value of align:
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .iOcHVa {
+  .eaWCTq {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -3257,7 +3257,7 @@ exports[`Drop should render correct margin depending on value of align:
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .iOcHVa {
+  .eaWCTq {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -3355,7 +3355,7 @@ exports[`Drop should render correct margin depending on value of align:
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .iOcHVa {
+  .eaWCTq {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -3449,7 +3449,7 @@ exports[`Drop stretch = align 2`] = `
   overflow: auto;
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
-.iOcHVa {
+.eaWCTq {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -3473,7 +3473,7 @@ exports[`Drop stretch = align 2`] = `
   animation-delay: 0.01s;
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .iOcHVa {
+  .eaWCTq {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -3553,7 +3553,7 @@ exports[`Drop theme elevation renders 1`] = `
 
 exports[`Drop theme elevation renders 2`] = `
 "@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .iOcHVa {
+  .eaWCTq {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;

--- a/src/js/components/Drop/__tests__/__snapshots__/Drop-test.tsx.snap
+++ b/src/js/components/Drop/__tests__/__snapshots__/Drop-test.tsx.snap
@@ -82,7 +82,7 @@ exports[`Drop align left left 2`] = `
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .bFAyzd {
+  .iOcHVa {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -176,7 +176,7 @@ exports[`Drop align left right top bottom 2`] = `
   overflow: auto;
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
-.bFAyzd {
+.iOcHVa {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -200,7 +200,7 @@ exports[`Drop align left right top bottom 2`] = `
   animation-delay: 0.01s;
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .bFAyzd {
+  .iOcHVa {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -295,7 +295,7 @@ exports[`Drop align right left top top 2`] = `
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .bFAyzd {
+  .iOcHVa {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -390,7 +390,7 @@ exports[`Drop align right right 2`] = `
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .bFAyzd {
+  .iOcHVa {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -485,7 +485,7 @@ exports[`Drop align right right bottom top 2`] = `
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .bFAyzd {
+  .iOcHVa {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -580,7 +580,7 @@ exports[`Drop align right right bottom top 4`] = `
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .bFAyzd {
+  .iOcHVa {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -660,7 +660,7 @@ exports[`Drop background 1`] = `
 
 exports[`Drop background 2`] = `
 "@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .bFAyzd {
+  .iOcHVa {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -754,7 +754,7 @@ exports[`Drop basic 2`] = `
   overflow: auto;
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
-.bFAyzd {
+.iOcHVa {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -778,7 +778,7 @@ exports[`Drop basic 2`] = `
   animation-delay: 0.01s;
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .bFAyzd {
+  .iOcHVa {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -872,7 +872,7 @@ exports[`Drop close 2`] = `
   overflow: auto;
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
-.bFAyzd {
+.iOcHVa {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -896,7 +896,7 @@ exports[`Drop close 2`] = `
   animation-delay: 0.01s;
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .bFAyzd {
+  .iOcHVa {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -990,7 +990,7 @@ exports[`Drop default elevation renders 2`] = `
   overflow: auto;
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
-.bFAyzd {
+.iOcHVa {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1014,7 +1014,7 @@ exports[`Drop default elevation renders 2`] = `
   animation-delay: 0.01s;
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .bFAyzd {
+  .iOcHVa {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1094,7 +1094,7 @@ exports[`Drop elevation 1`] = `
 
 exports[`Drop elevation 2`] = `
 "@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .bFAyzd {
+  .iOcHVa {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1188,7 +1188,7 @@ exports[`Drop invalid align 2`] = `
   overflow: auto;
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
-.bFAyzd {
+.iOcHVa {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1212,7 +1212,7 @@ exports[`Drop invalid align 2`] = `
   animation-delay: 0.01s;
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .bFAyzd {
+  .iOcHVa {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1306,7 +1306,7 @@ exports[`Drop invoke onClickOutside 2`] = `
   overflow: auto;
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
-.bFAyzd {
+.iOcHVa {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1330,7 +1330,7 @@ exports[`Drop invoke onClickOutside 2`] = `
   animation-delay: 0.01s;
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .bFAyzd {
+  .iOcHVa {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1418,7 +1418,7 @@ exports[`Drop margin 1`] = `
 
 exports[`Drop margin 2`] = `
 "@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .bFAyzd {
+  .iOcHVa {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1512,7 +1512,7 @@ exports[`Drop no stretch 2`] = `
   overflow: auto;
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
-.bFAyzd {
+.iOcHVa {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1536,7 +1536,7 @@ exports[`Drop no stretch 2`] = `
   animation-delay: 0.01s;
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .bFAyzd {
+  .iOcHVa {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1612,7 +1612,7 @@ exports[`Drop plain 1`] = `
 
 exports[`Drop plain 2`] = `
 "@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .bFAyzd {
+  .iOcHVa {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1706,7 +1706,7 @@ exports[`Drop resize 2`] = `
   overflow: auto;
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
-.bFAyzd {
+.iOcHVa {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1730,7 +1730,7 @@ exports[`Drop resize 2`] = `
   animation-delay: 0.01s;
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .bFAyzd {
+  .iOcHVa {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1810,7 +1810,7 @@ exports[`Drop restrict focus 1`] = `
 
 exports[`Drop restrict focus 2`] = `
 <div
-  class="StyledBox-sc-13pk1d4-0 kMTAEP StyledDrop-sc-16s5rx8-0 bFAyzd"
+  class="StyledBox-sc-13pk1d4-0 kMTAEP StyledDrop-sc-16s5rx8-0 iOcHVa"
   data-g-portal-id="0"
   id="drop-node"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 1000px;"
@@ -1836,7 +1836,7 @@ exports[`Drop restrict focus 3`] = `
   overflow: auto;
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
-.bFAyzd {
+.iOcHVa {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1860,7 +1860,7 @@ exports[`Drop restrict focus 3`] = `
   animation-delay: 0.01s;
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .bFAyzd {
+  .iOcHVa {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1949,7 +1949,7 @@ exports[`Drop round 1`] = `
 
 exports[`Drop round 2`] = `
 "@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .bFAyzd {
+  .iOcHVa {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -2076,7 +2076,7 @@ exports[`Drop should render correct margin depending on value of align:
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .bFAyzd {
+  .iOcHVa {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -2174,7 +2174,7 @@ exports[`Drop should render correct margin depending on value of align:
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .bFAyzd {
+  .iOcHVa {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -2272,7 +2272,7 @@ exports[`Drop should render correct margin depending on value of align:
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .bFAyzd {
+  .iOcHVa {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -2371,7 +2371,7 @@ exports[`Drop should render correct margin depending on value of align:
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .bFAyzd {
+  .iOcHVa {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -2470,7 +2470,7 @@ exports[`Drop should render correct margin depending on value of align:
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .bFAyzd {
+  .iOcHVa {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -2569,7 +2569,7 @@ exports[`Drop should render correct margin depending on value of align:
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .bFAyzd {
+  .iOcHVa {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -2667,7 +2667,7 @@ exports[`Drop should render correct margin depending on value of align:
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .bFAyzd {
+  .iOcHVa {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -2765,7 +2765,7 @@ exports[`Drop should render correct margin depending on value of align:
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .bFAyzd {
+  .iOcHVa {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -2864,7 +2864,7 @@ exports[`Drop should render correct margin depending on value of align:
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .bFAyzd {
+  .iOcHVa {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -2963,7 +2963,7 @@ exports[`Drop should render correct margin depending on value of align:
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .bFAyzd {
+  .iOcHVa {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -3061,7 +3061,7 @@ exports[`Drop should render correct margin depending on value of align:
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .bFAyzd {
+  .iOcHVa {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -3159,7 +3159,7 @@ exports[`Drop should render correct margin depending on value of align:
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .bFAyzd {
+  .iOcHVa {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -3257,7 +3257,7 @@ exports[`Drop should render correct margin depending on value of align:
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .bFAyzd {
+  .iOcHVa {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -3355,7 +3355,7 @@ exports[`Drop should render correct margin depending on value of align:
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .bFAyzd {
+  .iOcHVa {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -3449,7 +3449,7 @@ exports[`Drop stretch = align 2`] = `
   overflow: auto;
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }
-.bFAyzd {
+.iOcHVa {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -3473,7 +3473,7 @@ exports[`Drop stretch = align 2`] = `
   animation-delay: 0.01s;
 }
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .bFAyzd {
+  .iOcHVa {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -3553,7 +3553,7 @@ exports[`Drop theme elevation renders 1`] = `
 
 exports[`Drop theme elevation renders 2`] = `
 "@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  .bFAyzd {
+  .iOcHVa {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-controlled.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-controlled.js.snap
@@ -209,7 +209,7 @@ exports[`Form controlled controlled 1`] = `
 
 exports[`Form controlled controlled 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <form>
     <div
@@ -243,7 +243,7 @@ exports[`Form controlled controlled 2`] = `
 
 exports[`Form controlled controlled 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <form>
     <div
@@ -613,7 +613,7 @@ exports[`Form controlled controlled Array of Form Fields 1`] = `
 
 exports[`Form controlled controlled Array of Form Fields 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <form>
     <div
@@ -754,7 +754,7 @@ exports[`Form controlled controlled Array of Form Fields 2`] = `
 
 exports[`Form controlled controlled Array of Form Fields 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <form>
     <div
@@ -1189,7 +1189,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate 1`] = `
 
 exports[`Form controlled controlled Array of Form Fields onValidate 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <form>
     <div
@@ -1636,7 +1636,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate custom error
 
 exports[`Form controlled controlled Array of Form Fields onValidate custom error 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <form>
     <div
@@ -1984,7 +1984,7 @@ exports[`Form controlled controlled FormField deprecated 1`] = `
 
 exports[`Form controlled controlled FormField deprecated 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <form>
     <div
@@ -2024,7 +2024,7 @@ exports[`Form controlled controlled FormField deprecated 2`] = `
 
 exports[`Form controlled controlled FormField deprecated 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <form>
     <div
@@ -2271,7 +2271,7 @@ exports[`Form controlled controlled input 1`] = `
 
 exports[`Form controlled controlled input 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <form>
     <div
@@ -2305,7 +2305,7 @@ exports[`Form controlled controlled input 2`] = `
 
 exports[`Form controlled controlled input 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <form>
     <div
@@ -2546,7 +2546,7 @@ exports[`Form controlled controlled input lazy 1`] = `
 
 exports[`Form controlled controlled input lazy 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <form>
     <div
@@ -2580,7 +2580,7 @@ exports[`Form controlled controlled input lazy 2`] = `
 
 exports[`Form controlled controlled input lazy 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <form>
     <div
@@ -2821,7 +2821,7 @@ exports[`Form controlled controlled lazy 1`] = `
 
 exports[`Form controlled controlled lazy 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <form>
     <div
@@ -2855,7 +2855,7 @@ exports[`Form controlled controlled lazy 2`] = `
 
 exports[`Form controlled controlled lazy 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <form>
     <div
@@ -3303,7 +3303,7 @@ exports[`Form controlled controlled onValidate 1`] = `
 
 exports[`Form controlled controlled onValidate 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <form>
     <div
@@ -3571,7 +3571,7 @@ exports[`Form controlled controlled onValidate custom error 1`] = `
 
 exports[`Form controlled controlled onValidate custom error 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <form>
     <div
@@ -3839,7 +3839,7 @@ exports[`Form controlled controlled onValidate custom info 1`] = `
 
 exports[`Form controlled controlled onValidate custom info 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <form>
     <div
@@ -4269,7 +4269,7 @@ exports[`Form controlled dynamicly removed fields using blur validation
 exports[`Form controlled dynamicly removed fields using blur validation
   don't keep validation errors 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <form>
     <div
@@ -4509,7 +4509,7 @@ exports[`Form controlled dynamicly removed fields using blur validation
 exports[`Form controlled dynamicly removed fields using blur validation
   don't keep validation errors 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <form>
     <div

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-controlled.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-controlled.js.snap
@@ -209,7 +209,7 @@ exports[`Form controlled controlled 1`] = `
 
 exports[`Form controlled controlled 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <form>
     <div
@@ -243,7 +243,7 @@ exports[`Form controlled controlled 2`] = `
 
 exports[`Form controlled controlled 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <form>
     <div
@@ -613,7 +613,7 @@ exports[`Form controlled controlled Array of Form Fields 1`] = `
 
 exports[`Form controlled controlled Array of Form Fields 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <form>
     <div
@@ -754,7 +754,7 @@ exports[`Form controlled controlled Array of Form Fields 2`] = `
 
 exports[`Form controlled controlled Array of Form Fields 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <form>
     <div
@@ -1189,7 +1189,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate 1`] = `
 
 exports[`Form controlled controlled Array of Form Fields onValidate 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <form>
     <div
@@ -1636,7 +1636,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate custom error
 
 exports[`Form controlled controlled Array of Form Fields onValidate custom error 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <form>
     <div
@@ -1984,7 +1984,7 @@ exports[`Form controlled controlled FormField deprecated 1`] = `
 
 exports[`Form controlled controlled FormField deprecated 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <form>
     <div
@@ -2024,7 +2024,7 @@ exports[`Form controlled controlled FormField deprecated 2`] = `
 
 exports[`Form controlled controlled FormField deprecated 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <form>
     <div
@@ -2271,7 +2271,7 @@ exports[`Form controlled controlled input 1`] = `
 
 exports[`Form controlled controlled input 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <form>
     <div
@@ -2305,7 +2305,7 @@ exports[`Form controlled controlled input 2`] = `
 
 exports[`Form controlled controlled input 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <form>
     <div
@@ -2546,7 +2546,7 @@ exports[`Form controlled controlled input lazy 1`] = `
 
 exports[`Form controlled controlled input lazy 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <form>
     <div
@@ -2580,7 +2580,7 @@ exports[`Form controlled controlled input lazy 2`] = `
 
 exports[`Form controlled controlled input lazy 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <form>
     <div
@@ -2821,7 +2821,7 @@ exports[`Form controlled controlled lazy 1`] = `
 
 exports[`Form controlled controlled lazy 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <form>
     <div
@@ -2855,7 +2855,7 @@ exports[`Form controlled controlled lazy 2`] = `
 
 exports[`Form controlled controlled lazy 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <form>
     <div
@@ -3303,7 +3303,7 @@ exports[`Form controlled controlled onValidate 1`] = `
 
 exports[`Form controlled controlled onValidate 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <form>
     <div
@@ -3571,7 +3571,7 @@ exports[`Form controlled controlled onValidate custom error 1`] = `
 
 exports[`Form controlled controlled onValidate custom error 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <form>
     <div
@@ -3839,7 +3839,7 @@ exports[`Form controlled controlled onValidate custom info 1`] = `
 
 exports[`Form controlled controlled onValidate custom info 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <form>
     <div
@@ -4269,7 +4269,7 @@ exports[`Form controlled dynamicly removed fields using blur validation
 exports[`Form controlled dynamicly removed fields using blur validation
   don't keep validation errors 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <form>
     <div
@@ -4509,7 +4509,7 @@ exports[`Form controlled dynamicly removed fields using blur validation
 exports[`Form controlled dynamicly removed fields using blur validation
   don't keep validation errors 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <form>
     <div

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
@@ -1306,7 +1306,7 @@ exports[`Form uncontrolled dynamicly removed fields should be removed from form 
 
 exports[`Form uncontrolled dynamicly removed fields should be removed from form value 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <form>
     <div
@@ -1741,7 +1741,7 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation
 exports[`Form uncontrolled dynamicly removed fields using blur validation
   don't keep validation errors 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <form>
     <div
@@ -1981,7 +1981,7 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation
 exports[`Form uncontrolled dynamicly removed fields using blur validation
   don't keep validation errors 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <form>
     <div
@@ -3343,7 +3343,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 1`] =
 
 exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <form>
     <div
@@ -3765,7 +3765,7 @@ exports[`Form uncontrolled uncontrolled 1`] = `
 
 exports[`Form uncontrolled uncontrolled 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <form>
     <div
@@ -3799,7 +3799,7 @@ exports[`Form uncontrolled uncontrolled 2`] = `
 
 exports[`Form uncontrolled uncontrolled 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <form>
     <div
@@ -4040,7 +4040,7 @@ exports[`Form uncontrolled uncontrolled onValidate 1`] = `
 
 exports[`Form uncontrolled uncontrolled onValidate 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <form>
     <div
@@ -4308,7 +4308,7 @@ exports[`Form uncontrolled uncontrolled onValidate custom error 1`] = `
 
 exports[`Form uncontrolled uncontrolled onValidate custom error 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <form>
     <div
@@ -4576,7 +4576,7 @@ exports[`Form uncontrolled uncontrolled onValidate custom info 1`] = `
 
 exports[`Form uncontrolled uncontrolled onValidate custom info 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <form>
     <div

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
@@ -1306,7 +1306,7 @@ exports[`Form uncontrolled dynamicly removed fields should be removed from form 
 
 exports[`Form uncontrolled dynamicly removed fields should be removed from form value 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <form>
     <div
@@ -1741,7 +1741,7 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation
 exports[`Form uncontrolled dynamicly removed fields using blur validation
   don't keep validation errors 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <form>
     <div
@@ -1981,7 +1981,7 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation
 exports[`Form uncontrolled dynamicly removed fields using blur validation
   don't keep validation errors 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <form>
     <div
@@ -3343,7 +3343,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 1`] =
 
 exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <form>
     <div
@@ -3765,7 +3765,7 @@ exports[`Form uncontrolled uncontrolled 1`] = `
 
 exports[`Form uncontrolled uncontrolled 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <form>
     <div
@@ -3799,7 +3799,7 @@ exports[`Form uncontrolled uncontrolled 2`] = `
 
 exports[`Form uncontrolled uncontrolled 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <form>
     <div
@@ -4040,7 +4040,7 @@ exports[`Form uncontrolled uncontrolled onValidate 1`] = `
 
 exports[`Form uncontrolled uncontrolled onValidate 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <form>
     <div
@@ -4308,7 +4308,7 @@ exports[`Form uncontrolled uncontrolled onValidate custom error 1`] = `
 
 exports[`Form uncontrolled uncontrolled onValidate custom error 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <form>
     <div
@@ -4576,7 +4576,7 @@ exports[`Form uncontrolled uncontrolled onValidate custom info 1`] = `
 
 exports[`Form uncontrolled uncontrolled onValidate custom info 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <form>
     <div

--- a/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
+++ b/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
@@ -117,7 +117,7 @@ exports[`Layer animation fadeIn 1`] = `
 `;
 
 exports[`Layer animation fadeIn 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -137,7 +137,7 @@ exports[`Layer animation fadeIn 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -276,7 +276,7 @@ exports[`Layer animation false 1`] = `
 `;
 
 exports[`Layer animation false 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -296,7 +296,7 @@ exports[`Layer animation false 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -437,7 +437,7 @@ exports[`Layer animation slide 1`] = `
 `;
 
 exports[`Layer animation slide 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -457,7 +457,7 @@ exports[`Layer animation slide 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -598,7 +598,7 @@ exports[`Layer animation true 1`] = `
 `;
 
 exports[`Layer animation true 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -618,7 +618,7 @@ exports[`Layer animation true 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -759,7 +759,7 @@ exports[`Layer custom margin 1`] = `
 `;
 
 exports[`Layer custom margin 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -779,7 +779,7 @@ exports[`Layer custom margin 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -919,7 +919,7 @@ exports[`Layer custom theme 1`] = `
 `;
 
 exports[`Layer custom theme 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -939,7 +939,7 @@ exports[`Layer custom theme 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -1066,7 +1066,7 @@ exports[`Layer dark context 1`] = `
 `;
 
 exports[`Layer dark context 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1086,7 +1086,7 @@ exports[`Layer dark context 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -1279,7 +1279,7 @@ exports[`Layer hidden 1`] = `
 
 exports[`Layer hidden 2`] = `
 "@media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -1305,7 +1305,7 @@ exports[`Layer hidden 2`] = `
 
 exports[`Layer hidden 3`] = `
 <div
-  class="StyledLayer-sc-rmtehz-0 kDaZhg"
+  class="StyledLayer-sc-rmtehz-0 dmyVLx"
   id="hidden-test"
   tabindex="-1"
 >
@@ -1328,7 +1328,7 @@ exports[`Layer hidden 3`] = `
 `;
 
 exports[`Layer hidden 4`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1348,7 +1348,7 @@ exports[`Layer hidden 4`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -1478,7 +1478,7 @@ exports[`Layer invoke onClickOutside when modal={false} 1`] = `
 `;
 
 exports[`Layer invoke onClickOutside when modal={false} 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1498,7 +1498,7 @@ exports[`Layer invoke onClickOutside when modal={false} 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -1616,7 +1616,7 @@ exports[`Layer invoke onClickOutside when modal={false} and layer has target 1`]
 
 exports[`Layer invoke onClickOutside when modal={false} and layer has target 2`] = `
 "@media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -1760,7 +1760,7 @@ exports[`Layer invoke onClickOutside when modal={true} 1`] = `
 `;
 
 exports[`Layer invoke onClickOutside when modal={true} 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1780,7 +1780,7 @@ exports[`Layer invoke onClickOutside when modal={true} 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -1912,7 +1912,7 @@ exports[`Layer invoke onClickOutside when modal={true} and layer has target 1`] 
 
 exports[`Layer invoke onClickOutside when modal={true} and layer has target 2`] = `
 "@media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -2311,7 +2311,7 @@ exports[`Layer invokes onEsc when modal={false} 1`] = `
 `;
 
 exports[`Layer invokes onEsc when modal={false} 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -2331,7 +2331,7 @@ exports[`Layer invokes onEsc when modal={false} 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -2529,7 +2529,7 @@ exports[`Layer margin large 1`] = `
 `;
 
 exports[`Layer margin large 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -2549,7 +2549,7 @@ exports[`Layer margin large 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -2690,7 +2690,7 @@ exports[`Layer margin medium 1`] = `
 `;
 
 exports[`Layer margin medium 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -2710,7 +2710,7 @@ exports[`Layer margin medium 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -2851,7 +2851,7 @@ exports[`Layer margin none 1`] = `
 `;
 
 exports[`Layer margin none 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -2871,7 +2871,7 @@ exports[`Layer margin none 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -3012,7 +3012,7 @@ exports[`Layer margin small 1`] = `
 `;
 
 exports[`Layer margin small 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -3032,7 +3032,7 @@ exports[`Layer margin small 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -3173,7 +3173,7 @@ exports[`Layer margin xsmall 1`] = `
 `;
 
 exports[`Layer margin xsmall 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -3193,7 +3193,7 @@ exports[`Layer margin xsmall 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -3320,7 +3320,7 @@ exports[`Layer non-modal 1`] = `
 `;
 
 exports[`Layer non-modal 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -3340,7 +3340,7 @@ exports[`Layer non-modal 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -3552,7 +3552,7 @@ exports[`Layer plain 1`] = `
 `;
 
 exports[`Layer plain 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -3572,7 +3572,7 @@ exports[`Layer plain 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -3713,7 +3713,7 @@ exports[`Layer position: bottom - full: false 1`] = `
 `;
 
 exports[`Layer position: bottom - full: false 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -3733,7 +3733,7 @@ exports[`Layer position: bottom - full: false 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -3875,7 +3875,7 @@ exports[`Layer position: bottom - full: horizontal 1`] = `
 `;
 
 exports[`Layer position: bottom - full: horizontal 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -3895,7 +3895,7 @@ exports[`Layer position: bottom - full: horizontal 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -4038,7 +4038,7 @@ exports[`Layer position: bottom - full: true 1`] = `
 `;
 
 exports[`Layer position: bottom - full: true 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -4058,7 +4058,7 @@ exports[`Layer position: bottom - full: true 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -4200,7 +4200,7 @@ exports[`Layer position: bottom - full: vertical 1`] = `
 `;
 
 exports[`Layer position: bottom - full: vertical 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -4220,7 +4220,7 @@ exports[`Layer position: bottom - full: vertical 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -4361,7 +4361,7 @@ exports[`Layer position: bottom-left - full: false 1`] = `
 `;
 
 exports[`Layer position: bottom-left - full: false 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -4381,7 +4381,7 @@ exports[`Layer position: bottom-left - full: false 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -4523,7 +4523,7 @@ exports[`Layer position: bottom-left - full: horizontal 1`] = `
 `;
 
 exports[`Layer position: bottom-left - full: horizontal 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -4543,7 +4543,7 @@ exports[`Layer position: bottom-left - full: horizontal 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -4686,7 +4686,7 @@ exports[`Layer position: bottom-left - full: true 1`] = `
 `;
 
 exports[`Layer position: bottom-left - full: true 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -4706,7 +4706,7 @@ exports[`Layer position: bottom-left - full: true 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -4848,7 +4848,7 @@ exports[`Layer position: bottom-left - full: vertical 1`] = `
 `;
 
 exports[`Layer position: bottom-left - full: vertical 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -4868,7 +4868,7 @@ exports[`Layer position: bottom-left - full: vertical 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -5009,7 +5009,7 @@ exports[`Layer position: bottom-right - full: false 1`] = `
 `;
 
 exports[`Layer position: bottom-right - full: false 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -5029,7 +5029,7 @@ exports[`Layer position: bottom-right - full: false 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -5171,7 +5171,7 @@ exports[`Layer position: bottom-right - full: horizontal 1`] = `
 `;
 
 exports[`Layer position: bottom-right - full: horizontal 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -5191,7 +5191,7 @@ exports[`Layer position: bottom-right - full: horizontal 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -5334,7 +5334,7 @@ exports[`Layer position: bottom-right - full: true 1`] = `
 `;
 
 exports[`Layer position: bottom-right - full: true 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -5354,7 +5354,7 @@ exports[`Layer position: bottom-right - full: true 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -5496,7 +5496,7 @@ exports[`Layer position: bottom-right - full: vertical 1`] = `
 `;
 
 exports[`Layer position: bottom-right - full: vertical 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -5516,7 +5516,7 @@ exports[`Layer position: bottom-right - full: vertical 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -5657,7 +5657,7 @@ exports[`Layer position: center - full: false 1`] = `
 `;
 
 exports[`Layer position: center - full: false 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -5677,7 +5677,7 @@ exports[`Layer position: center - full: false 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -5819,7 +5819,7 @@ exports[`Layer position: center - full: horizontal 1`] = `
 `;
 
 exports[`Layer position: center - full: horizontal 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -5839,7 +5839,7 @@ exports[`Layer position: center - full: horizontal 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -5979,7 +5979,7 @@ exports[`Layer position: center - full: true 1`] = `
 `;
 
 exports[`Layer position: center - full: true 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -5999,7 +5999,7 @@ exports[`Layer position: center - full: true 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -6141,7 +6141,7 @@ exports[`Layer position: center - full: vertical 1`] = `
 `;
 
 exports[`Layer position: center - full: vertical 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -6161,7 +6161,7 @@ exports[`Layer position: center - full: vertical 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -6302,7 +6302,7 @@ exports[`Layer position: end - full: false 1`] = `
 `;
 
 exports[`Layer position: end - full: false 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -6322,7 +6322,7 @@ exports[`Layer position: end - full: false 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -6464,7 +6464,7 @@ exports[`Layer position: end - full: horizontal 1`] = `
 `;
 
 exports[`Layer position: end - full: horizontal 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -6484,7 +6484,7 @@ exports[`Layer position: end - full: horizontal 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -6627,7 +6627,7 @@ exports[`Layer position: end - full: true 1`] = `
 `;
 
 exports[`Layer position: end - full: true 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -6647,7 +6647,7 @@ exports[`Layer position: end - full: true 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -6789,7 +6789,7 @@ exports[`Layer position: end - full: vertical 1`] = `
 `;
 
 exports[`Layer position: end - full: vertical 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -6809,7 +6809,7 @@ exports[`Layer position: end - full: vertical 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -6950,7 +6950,7 @@ exports[`Layer position: left - full: false 1`] = `
 `;
 
 exports[`Layer position: left - full: false 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -6970,7 +6970,7 @@ exports[`Layer position: left - full: false 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -7112,7 +7112,7 @@ exports[`Layer position: left - full: horizontal 1`] = `
 `;
 
 exports[`Layer position: left - full: horizontal 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -7132,7 +7132,7 @@ exports[`Layer position: left - full: horizontal 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -7275,7 +7275,7 @@ exports[`Layer position: left - full: true 1`] = `
 `;
 
 exports[`Layer position: left - full: true 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -7295,7 +7295,7 @@ exports[`Layer position: left - full: true 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -7437,7 +7437,7 @@ exports[`Layer position: left - full: vertical 1`] = `
 `;
 
 exports[`Layer position: left - full: vertical 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -7457,7 +7457,7 @@ exports[`Layer position: left - full: vertical 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -7598,7 +7598,7 @@ exports[`Layer position: right - full: false 1`] = `
 `;
 
 exports[`Layer position: right - full: false 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -7618,7 +7618,7 @@ exports[`Layer position: right - full: false 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -7760,7 +7760,7 @@ exports[`Layer position: right - full: horizontal 1`] = `
 `;
 
 exports[`Layer position: right - full: horizontal 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -7780,7 +7780,7 @@ exports[`Layer position: right - full: horizontal 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -7923,7 +7923,7 @@ exports[`Layer position: right - full: true 1`] = `
 `;
 
 exports[`Layer position: right - full: true 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -7943,7 +7943,7 @@ exports[`Layer position: right - full: true 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -8085,7 +8085,7 @@ exports[`Layer position: right - full: vertical 1`] = `
 `;
 
 exports[`Layer position: right - full: vertical 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -8105,7 +8105,7 @@ exports[`Layer position: right - full: vertical 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -8246,7 +8246,7 @@ exports[`Layer position: start - full: false 1`] = `
 `;
 
 exports[`Layer position: start - full: false 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -8266,7 +8266,7 @@ exports[`Layer position: start - full: false 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -8408,7 +8408,7 @@ exports[`Layer position: start - full: horizontal 1`] = `
 `;
 
 exports[`Layer position: start - full: horizontal 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -8428,7 +8428,7 @@ exports[`Layer position: start - full: horizontal 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -8571,7 +8571,7 @@ exports[`Layer position: start - full: true 1`] = `
 `;
 
 exports[`Layer position: start - full: true 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -8591,7 +8591,7 @@ exports[`Layer position: start - full: true 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -8733,7 +8733,7 @@ exports[`Layer position: start - full: vertical 1`] = `
 `;
 
 exports[`Layer position: start - full: vertical 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -8753,7 +8753,7 @@ exports[`Layer position: start - full: vertical 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -8894,7 +8894,7 @@ exports[`Layer position: top - full: false 1`] = `
 `;
 
 exports[`Layer position: top - full: false 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -8914,7 +8914,7 @@ exports[`Layer position: top - full: false 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -9056,7 +9056,7 @@ exports[`Layer position: top - full: horizontal 1`] = `
 `;
 
 exports[`Layer position: top - full: horizontal 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -9076,7 +9076,7 @@ exports[`Layer position: top - full: horizontal 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -9219,7 +9219,7 @@ exports[`Layer position: top - full: true 1`] = `
 `;
 
 exports[`Layer position: top - full: true 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -9239,7 +9239,7 @@ exports[`Layer position: top - full: true 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -9381,7 +9381,7 @@ exports[`Layer position: top - full: vertical 1`] = `
 `;
 
 exports[`Layer position: top - full: vertical 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -9401,7 +9401,7 @@ exports[`Layer position: top - full: vertical 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -9542,7 +9542,7 @@ exports[`Layer position: top-left - full: false 1`] = `
 `;
 
 exports[`Layer position: top-left - full: false 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -9562,7 +9562,7 @@ exports[`Layer position: top-left - full: false 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -9704,7 +9704,7 @@ exports[`Layer position: top-left - full: horizontal 1`] = `
 `;
 
 exports[`Layer position: top-left - full: horizontal 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -9724,7 +9724,7 @@ exports[`Layer position: top-left - full: horizontal 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -9867,7 +9867,7 @@ exports[`Layer position: top-left - full: true 1`] = `
 `;
 
 exports[`Layer position: top-left - full: true 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -9887,7 +9887,7 @@ exports[`Layer position: top-left - full: true 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -10029,7 +10029,7 @@ exports[`Layer position: top-left - full: vertical 1`] = `
 `;
 
 exports[`Layer position: top-left - full: vertical 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -10049,7 +10049,7 @@ exports[`Layer position: top-left - full: vertical 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -10190,7 +10190,7 @@ exports[`Layer position: top-right - full: false 1`] = `
 `;
 
 exports[`Layer position: top-right - full: false 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -10210,7 +10210,7 @@ exports[`Layer position: top-right - full: false 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -10352,7 +10352,7 @@ exports[`Layer position: top-right - full: horizontal 1`] = `
 `;
 
 exports[`Layer position: top-right - full: horizontal 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -10372,7 +10372,7 @@ exports[`Layer position: top-right - full: horizontal 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -10515,7 +10515,7 @@ exports[`Layer position: top-right - full: true 1`] = `
 `;
 
 exports[`Layer position: top-right - full: true 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -10535,7 +10535,7 @@ exports[`Layer position: top-right - full: true 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -10677,7 +10677,7 @@ exports[`Layer position: top-right - full: vertical 1`] = `
 `;
 
 exports[`Layer position: top-right - full: vertical 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -10697,7 +10697,7 @@ exports[`Layer position: top-right - full: vertical 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -10838,7 +10838,7 @@ exports[`Layer should apply background 1`] = `
 `;
 
 exports[`Layer should apply background 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -10858,7 +10858,7 @@ exports[`Layer should apply background 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -10997,7 +10997,7 @@ exports[`Layer should only place id on StyledLayer when singleId === true 1`] = 
 `;
 
 exports[`Layer should only place id on StyledLayer when singleId === true 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -11017,7 +11017,7 @@ exports[`Layer should only place id on StyledLayer when singleId === true 2`] = 
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -11160,7 +11160,7 @@ exports[`Layer should render correct border radius for position: bottom -
 
 exports[`Layer should render correct border radius for position: bottom - 
       full: false 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -11180,7 +11180,7 @@ exports[`Layer should render correct border radius for position: bottom -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -11324,7 +11324,7 @@ exports[`Layer should render correct border radius for position: bottom -
 
 exports[`Layer should render correct border radius for position: bottom - 
       full: horizontal 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -11344,7 +11344,7 @@ exports[`Layer should render correct border radius for position: bottom -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -11489,7 +11489,7 @@ exports[`Layer should render correct border radius for position: bottom -
 
 exports[`Layer should render correct border radius for position: bottom - 
       full: true 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -11509,7 +11509,7 @@ exports[`Layer should render correct border radius for position: bottom -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -11653,7 +11653,7 @@ exports[`Layer should render correct border radius for position: bottom -
 
 exports[`Layer should render correct border radius for position: bottom - 
       full: vertical 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -11673,7 +11673,7 @@ exports[`Layer should render correct border radius for position: bottom -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -11816,7 +11816,7 @@ exports[`Layer should render correct border radius for position: bottom-left -
 
 exports[`Layer should render correct border radius for position: bottom-left - 
       full: false 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -11836,7 +11836,7 @@ exports[`Layer should render correct border radius for position: bottom-left -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -11980,7 +11980,7 @@ exports[`Layer should render correct border radius for position: bottom-left -
 
 exports[`Layer should render correct border radius for position: bottom-left - 
       full: horizontal 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -12000,7 +12000,7 @@ exports[`Layer should render correct border radius for position: bottom-left -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -12145,7 +12145,7 @@ exports[`Layer should render correct border radius for position: bottom-left -
 
 exports[`Layer should render correct border radius for position: bottom-left - 
       full: true 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -12165,7 +12165,7 @@ exports[`Layer should render correct border radius for position: bottom-left -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -12309,7 +12309,7 @@ exports[`Layer should render correct border radius for position: bottom-left -
 
 exports[`Layer should render correct border radius for position: bottom-left - 
       full: vertical 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -12329,7 +12329,7 @@ exports[`Layer should render correct border radius for position: bottom-left -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -12472,7 +12472,7 @@ exports[`Layer should render correct border radius for position: bottom-right -
 
 exports[`Layer should render correct border radius for position: bottom-right - 
       full: false 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -12492,7 +12492,7 @@ exports[`Layer should render correct border radius for position: bottom-right -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -12636,7 +12636,7 @@ exports[`Layer should render correct border radius for position: bottom-right -
 
 exports[`Layer should render correct border radius for position: bottom-right - 
       full: horizontal 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -12656,7 +12656,7 @@ exports[`Layer should render correct border radius for position: bottom-right -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -12801,7 +12801,7 @@ exports[`Layer should render correct border radius for position: bottom-right -
 
 exports[`Layer should render correct border radius for position: bottom-right - 
       full: true 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -12821,7 +12821,7 @@ exports[`Layer should render correct border radius for position: bottom-right -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -12965,7 +12965,7 @@ exports[`Layer should render correct border radius for position: bottom-right -
 
 exports[`Layer should render correct border radius for position: bottom-right - 
       full: vertical 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -12985,7 +12985,7 @@ exports[`Layer should render correct border radius for position: bottom-right -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -13128,7 +13128,7 @@ exports[`Layer should render correct border radius for position: center -
 
 exports[`Layer should render correct border radius for position: center - 
       full: false 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -13148,7 +13148,7 @@ exports[`Layer should render correct border radius for position: center -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -13292,7 +13292,7 @@ exports[`Layer should render correct border radius for position: center -
 
 exports[`Layer should render correct border radius for position: center - 
       full: horizontal 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -13312,7 +13312,7 @@ exports[`Layer should render correct border radius for position: center -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -13454,7 +13454,7 @@ exports[`Layer should render correct border radius for position: center -
 
 exports[`Layer should render correct border radius for position: center - 
       full: true 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -13474,7 +13474,7 @@ exports[`Layer should render correct border radius for position: center -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -13618,7 +13618,7 @@ exports[`Layer should render correct border radius for position: center -
 
 exports[`Layer should render correct border radius for position: center - 
       full: vertical 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -13638,7 +13638,7 @@ exports[`Layer should render correct border radius for position: center -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -13782,7 +13782,7 @@ exports[`Layer should render correct border radius for position: end -
 
 exports[`Layer should render correct border radius for position: end - 
       full: false 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -13802,7 +13802,7 @@ exports[`Layer should render correct border radius for position: end -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -13946,7 +13946,7 @@ exports[`Layer should render correct border radius for position: end -
 
 exports[`Layer should render correct border radius for position: end - 
       full: horizontal 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -13966,7 +13966,7 @@ exports[`Layer should render correct border radius for position: end -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -14111,7 +14111,7 @@ exports[`Layer should render correct border radius for position: end -
 
 exports[`Layer should render correct border radius for position: end - 
       full: true 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -14131,7 +14131,7 @@ exports[`Layer should render correct border radius for position: end -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -14275,7 +14275,7 @@ exports[`Layer should render correct border radius for position: end -
 
 exports[`Layer should render correct border radius for position: end - 
       full: vertical 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -14295,7 +14295,7 @@ exports[`Layer should render correct border radius for position: end -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -14438,7 +14438,7 @@ exports[`Layer should render correct border radius for position: left -
 
 exports[`Layer should render correct border radius for position: left - 
       full: false 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -14458,7 +14458,7 @@ exports[`Layer should render correct border radius for position: left -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -14602,7 +14602,7 @@ exports[`Layer should render correct border radius for position: left -
 
 exports[`Layer should render correct border radius for position: left - 
       full: horizontal 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -14622,7 +14622,7 @@ exports[`Layer should render correct border radius for position: left -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -14767,7 +14767,7 @@ exports[`Layer should render correct border radius for position: left -
 
 exports[`Layer should render correct border radius for position: left - 
       full: true 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -14787,7 +14787,7 @@ exports[`Layer should render correct border radius for position: left -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -14931,7 +14931,7 @@ exports[`Layer should render correct border radius for position: left -
 
 exports[`Layer should render correct border radius for position: left - 
       full: vertical 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -14951,7 +14951,7 @@ exports[`Layer should render correct border radius for position: left -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -15094,7 +15094,7 @@ exports[`Layer should render correct border radius for position: right -
 
 exports[`Layer should render correct border radius for position: right - 
       full: false 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -15114,7 +15114,7 @@ exports[`Layer should render correct border radius for position: right -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -15258,7 +15258,7 @@ exports[`Layer should render correct border radius for position: right -
 
 exports[`Layer should render correct border radius for position: right - 
       full: horizontal 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -15278,7 +15278,7 @@ exports[`Layer should render correct border radius for position: right -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -15423,7 +15423,7 @@ exports[`Layer should render correct border radius for position: right -
 
 exports[`Layer should render correct border radius for position: right - 
       full: true 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -15443,7 +15443,7 @@ exports[`Layer should render correct border radius for position: right -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -15587,7 +15587,7 @@ exports[`Layer should render correct border radius for position: right -
 
 exports[`Layer should render correct border radius for position: right - 
       full: vertical 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -15607,7 +15607,7 @@ exports[`Layer should render correct border radius for position: right -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -15751,7 +15751,7 @@ exports[`Layer should render correct border radius for position: start -
 
 exports[`Layer should render correct border radius for position: start - 
       full: false 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -15771,7 +15771,7 @@ exports[`Layer should render correct border radius for position: start -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -15915,7 +15915,7 @@ exports[`Layer should render correct border radius for position: start -
 
 exports[`Layer should render correct border radius for position: start - 
       full: horizontal 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -15935,7 +15935,7 @@ exports[`Layer should render correct border radius for position: start -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -16080,7 +16080,7 @@ exports[`Layer should render correct border radius for position: start -
 
 exports[`Layer should render correct border radius for position: start - 
       full: true 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -16100,7 +16100,7 @@ exports[`Layer should render correct border radius for position: start -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -16244,7 +16244,7 @@ exports[`Layer should render correct border radius for position: start -
 
 exports[`Layer should render correct border radius for position: start - 
       full: vertical 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -16264,7 +16264,7 @@ exports[`Layer should render correct border radius for position: start -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -16407,7 +16407,7 @@ exports[`Layer should render correct border radius for position: top -
 
 exports[`Layer should render correct border radius for position: top - 
       full: false 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -16427,7 +16427,7 @@ exports[`Layer should render correct border radius for position: top -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -16571,7 +16571,7 @@ exports[`Layer should render correct border radius for position: top -
 
 exports[`Layer should render correct border radius for position: top - 
       full: horizontal 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -16591,7 +16591,7 @@ exports[`Layer should render correct border radius for position: top -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -16736,7 +16736,7 @@ exports[`Layer should render correct border radius for position: top -
 
 exports[`Layer should render correct border radius for position: top - 
       full: true 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -16756,7 +16756,7 @@ exports[`Layer should render correct border radius for position: top -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -16900,7 +16900,7 @@ exports[`Layer should render correct border radius for position: top -
 
 exports[`Layer should render correct border radius for position: top - 
       full: vertical 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -16920,7 +16920,7 @@ exports[`Layer should render correct border radius for position: top -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -17063,7 +17063,7 @@ exports[`Layer should render correct border radius for position: top-left -
 
 exports[`Layer should render correct border radius for position: top-left - 
       full: false 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -17083,7 +17083,7 @@ exports[`Layer should render correct border radius for position: top-left -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -17227,7 +17227,7 @@ exports[`Layer should render correct border radius for position: top-left -
 
 exports[`Layer should render correct border radius for position: top-left - 
       full: horizontal 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -17247,7 +17247,7 @@ exports[`Layer should render correct border radius for position: top-left -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -17392,7 +17392,7 @@ exports[`Layer should render correct border radius for position: top-left -
 
 exports[`Layer should render correct border radius for position: top-left - 
       full: true 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -17412,7 +17412,7 @@ exports[`Layer should render correct border radius for position: top-left -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -17556,7 +17556,7 @@ exports[`Layer should render correct border radius for position: top-left -
 
 exports[`Layer should render correct border radius for position: top-left - 
       full: vertical 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -17576,7 +17576,7 @@ exports[`Layer should render correct border radius for position: top-left -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -17719,7 +17719,7 @@ exports[`Layer should render correct border radius for position: top-right -
 
 exports[`Layer should render correct border radius for position: top-right - 
       full: false 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -17739,7 +17739,7 @@ exports[`Layer should render correct border radius for position: top-right -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -17883,7 +17883,7 @@ exports[`Layer should render correct border radius for position: top-right -
 
 exports[`Layer should render correct border radius for position: top-right - 
       full: horizontal 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -17903,7 +17903,7 @@ exports[`Layer should render correct border radius for position: top-right -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -18048,7 +18048,7 @@ exports[`Layer should render correct border radius for position: top-right -
 
 exports[`Layer should render correct border radius for position: top-right - 
       full: true 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -18068,7 +18068,7 @@ exports[`Layer should render correct border radius for position: top-right -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -18212,7 +18212,7 @@ exports[`Layer should render correct border radius for position: top-right -
 
 exports[`Layer should render correct border radius for position: top-right - 
       full: vertical 2`] = `
-".kDaZhg {
+".dmyVLx {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -18232,7 +18232,7 @@ exports[`Layer should render correct border radius for position: top-right -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -18366,7 +18366,7 @@ exports[`Layer target 1`] = `
 
 exports[`Layer target 2`] = `
 "@media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -18486,7 +18486,7 @@ exports[`Layer target not modal 1`] = `
 
 exports[`Layer target not modal 2`] = `
 "@media only screen and (max-width: 768px) {
-  .kDaZhg {
+  .dmyVLx {
     position: fixed;
     width: 100%;
     height: 100%;

--- a/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
+++ b/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
@@ -117,7 +117,7 @@ exports[`Layer animation fadeIn 1`] = `
 `;
 
 exports[`Layer animation fadeIn 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -137,7 +137,7 @@ exports[`Layer animation fadeIn 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -276,7 +276,7 @@ exports[`Layer animation false 1`] = `
 `;
 
 exports[`Layer animation false 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -296,7 +296,7 @@ exports[`Layer animation false 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -437,7 +437,7 @@ exports[`Layer animation slide 1`] = `
 `;
 
 exports[`Layer animation slide 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -457,7 +457,7 @@ exports[`Layer animation slide 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -598,7 +598,7 @@ exports[`Layer animation true 1`] = `
 `;
 
 exports[`Layer animation true 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -618,7 +618,7 @@ exports[`Layer animation true 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -759,7 +759,7 @@ exports[`Layer custom margin 1`] = `
 `;
 
 exports[`Layer custom margin 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -779,7 +779,7 @@ exports[`Layer custom margin 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -919,7 +919,7 @@ exports[`Layer custom theme 1`] = `
 `;
 
 exports[`Layer custom theme 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -939,7 +939,7 @@ exports[`Layer custom theme 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -1066,7 +1066,7 @@ exports[`Layer dark context 1`] = `
 `;
 
 exports[`Layer dark context 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1086,7 +1086,7 @@ exports[`Layer dark context 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -1279,7 +1279,7 @@ exports[`Layer hidden 1`] = `
 
 exports[`Layer hidden 2`] = `
 "@media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -1305,7 +1305,7 @@ exports[`Layer hidden 2`] = `
 
 exports[`Layer hidden 3`] = `
 <div
-  class="StyledLayer-sc-rmtehz-0 dmyVLx"
+  class="StyledLayer-sc-rmtehz-0 doeZDV"
   id="hidden-test"
   tabindex="-1"
 >
@@ -1328,7 +1328,7 @@ exports[`Layer hidden 3`] = `
 `;
 
 exports[`Layer hidden 4`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1348,7 +1348,7 @@ exports[`Layer hidden 4`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -1478,7 +1478,7 @@ exports[`Layer invoke onClickOutside when modal={false} 1`] = `
 `;
 
 exports[`Layer invoke onClickOutside when modal={false} 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1498,7 +1498,7 @@ exports[`Layer invoke onClickOutside when modal={false} 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -1616,7 +1616,7 @@ exports[`Layer invoke onClickOutside when modal={false} and layer has target 1`]
 
 exports[`Layer invoke onClickOutside when modal={false} and layer has target 2`] = `
 "@media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -1760,7 +1760,7 @@ exports[`Layer invoke onClickOutside when modal={true} 1`] = `
 `;
 
 exports[`Layer invoke onClickOutside when modal={true} 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -1780,7 +1780,7 @@ exports[`Layer invoke onClickOutside when modal={true} 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -1912,7 +1912,7 @@ exports[`Layer invoke onClickOutside when modal={true} and layer has target 1`] 
 
 exports[`Layer invoke onClickOutside when modal={true} and layer has target 2`] = `
 "@media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -2311,7 +2311,7 @@ exports[`Layer invokes onEsc when modal={false} 1`] = `
 `;
 
 exports[`Layer invokes onEsc when modal={false} 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -2331,7 +2331,7 @@ exports[`Layer invokes onEsc when modal={false} 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -2529,7 +2529,7 @@ exports[`Layer margin large 1`] = `
 `;
 
 exports[`Layer margin large 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -2549,7 +2549,7 @@ exports[`Layer margin large 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -2690,7 +2690,7 @@ exports[`Layer margin medium 1`] = `
 `;
 
 exports[`Layer margin medium 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -2710,7 +2710,7 @@ exports[`Layer margin medium 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -2851,7 +2851,7 @@ exports[`Layer margin none 1`] = `
 `;
 
 exports[`Layer margin none 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -2871,7 +2871,7 @@ exports[`Layer margin none 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -3012,7 +3012,7 @@ exports[`Layer margin small 1`] = `
 `;
 
 exports[`Layer margin small 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -3032,7 +3032,7 @@ exports[`Layer margin small 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -3173,7 +3173,7 @@ exports[`Layer margin xsmall 1`] = `
 `;
 
 exports[`Layer margin xsmall 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -3193,7 +3193,7 @@ exports[`Layer margin xsmall 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -3320,7 +3320,7 @@ exports[`Layer non-modal 1`] = `
 `;
 
 exports[`Layer non-modal 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -3340,7 +3340,7 @@ exports[`Layer non-modal 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -3552,7 +3552,7 @@ exports[`Layer plain 1`] = `
 `;
 
 exports[`Layer plain 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -3572,7 +3572,7 @@ exports[`Layer plain 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -3713,7 +3713,7 @@ exports[`Layer position: bottom - full: false 1`] = `
 `;
 
 exports[`Layer position: bottom - full: false 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -3733,7 +3733,7 @@ exports[`Layer position: bottom - full: false 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -3875,7 +3875,7 @@ exports[`Layer position: bottom - full: horizontal 1`] = `
 `;
 
 exports[`Layer position: bottom - full: horizontal 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -3895,7 +3895,7 @@ exports[`Layer position: bottom - full: horizontal 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -4038,7 +4038,7 @@ exports[`Layer position: bottom - full: true 1`] = `
 `;
 
 exports[`Layer position: bottom - full: true 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -4058,7 +4058,7 @@ exports[`Layer position: bottom - full: true 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -4200,7 +4200,7 @@ exports[`Layer position: bottom - full: vertical 1`] = `
 `;
 
 exports[`Layer position: bottom - full: vertical 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -4220,7 +4220,7 @@ exports[`Layer position: bottom - full: vertical 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -4361,7 +4361,7 @@ exports[`Layer position: bottom-left - full: false 1`] = `
 `;
 
 exports[`Layer position: bottom-left - full: false 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -4381,7 +4381,7 @@ exports[`Layer position: bottom-left - full: false 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -4523,7 +4523,7 @@ exports[`Layer position: bottom-left - full: horizontal 1`] = `
 `;
 
 exports[`Layer position: bottom-left - full: horizontal 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -4543,7 +4543,7 @@ exports[`Layer position: bottom-left - full: horizontal 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -4686,7 +4686,7 @@ exports[`Layer position: bottom-left - full: true 1`] = `
 `;
 
 exports[`Layer position: bottom-left - full: true 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -4706,7 +4706,7 @@ exports[`Layer position: bottom-left - full: true 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -4848,7 +4848,7 @@ exports[`Layer position: bottom-left - full: vertical 1`] = `
 `;
 
 exports[`Layer position: bottom-left - full: vertical 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -4868,7 +4868,7 @@ exports[`Layer position: bottom-left - full: vertical 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -5009,7 +5009,7 @@ exports[`Layer position: bottom-right - full: false 1`] = `
 `;
 
 exports[`Layer position: bottom-right - full: false 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -5029,7 +5029,7 @@ exports[`Layer position: bottom-right - full: false 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -5171,7 +5171,7 @@ exports[`Layer position: bottom-right - full: horizontal 1`] = `
 `;
 
 exports[`Layer position: bottom-right - full: horizontal 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -5191,7 +5191,7 @@ exports[`Layer position: bottom-right - full: horizontal 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -5334,7 +5334,7 @@ exports[`Layer position: bottom-right - full: true 1`] = `
 `;
 
 exports[`Layer position: bottom-right - full: true 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -5354,7 +5354,7 @@ exports[`Layer position: bottom-right - full: true 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -5496,7 +5496,7 @@ exports[`Layer position: bottom-right - full: vertical 1`] = `
 `;
 
 exports[`Layer position: bottom-right - full: vertical 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -5516,7 +5516,7 @@ exports[`Layer position: bottom-right - full: vertical 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -5657,7 +5657,7 @@ exports[`Layer position: center - full: false 1`] = `
 `;
 
 exports[`Layer position: center - full: false 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -5677,7 +5677,7 @@ exports[`Layer position: center - full: false 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -5819,7 +5819,7 @@ exports[`Layer position: center - full: horizontal 1`] = `
 `;
 
 exports[`Layer position: center - full: horizontal 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -5839,7 +5839,7 @@ exports[`Layer position: center - full: horizontal 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -5979,7 +5979,7 @@ exports[`Layer position: center - full: true 1`] = `
 `;
 
 exports[`Layer position: center - full: true 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -5999,7 +5999,7 @@ exports[`Layer position: center - full: true 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -6141,7 +6141,7 @@ exports[`Layer position: center - full: vertical 1`] = `
 `;
 
 exports[`Layer position: center - full: vertical 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -6161,7 +6161,7 @@ exports[`Layer position: center - full: vertical 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -6302,7 +6302,7 @@ exports[`Layer position: end - full: false 1`] = `
 `;
 
 exports[`Layer position: end - full: false 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -6322,7 +6322,7 @@ exports[`Layer position: end - full: false 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -6464,7 +6464,7 @@ exports[`Layer position: end - full: horizontal 1`] = `
 `;
 
 exports[`Layer position: end - full: horizontal 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -6484,7 +6484,7 @@ exports[`Layer position: end - full: horizontal 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -6627,7 +6627,7 @@ exports[`Layer position: end - full: true 1`] = `
 `;
 
 exports[`Layer position: end - full: true 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -6647,7 +6647,7 @@ exports[`Layer position: end - full: true 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -6789,7 +6789,7 @@ exports[`Layer position: end - full: vertical 1`] = `
 `;
 
 exports[`Layer position: end - full: vertical 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -6809,7 +6809,7 @@ exports[`Layer position: end - full: vertical 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -6950,7 +6950,7 @@ exports[`Layer position: left - full: false 1`] = `
 `;
 
 exports[`Layer position: left - full: false 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -6970,7 +6970,7 @@ exports[`Layer position: left - full: false 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -7112,7 +7112,7 @@ exports[`Layer position: left - full: horizontal 1`] = `
 `;
 
 exports[`Layer position: left - full: horizontal 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -7132,7 +7132,7 @@ exports[`Layer position: left - full: horizontal 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -7275,7 +7275,7 @@ exports[`Layer position: left - full: true 1`] = `
 `;
 
 exports[`Layer position: left - full: true 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -7295,7 +7295,7 @@ exports[`Layer position: left - full: true 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -7437,7 +7437,7 @@ exports[`Layer position: left - full: vertical 1`] = `
 `;
 
 exports[`Layer position: left - full: vertical 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -7457,7 +7457,7 @@ exports[`Layer position: left - full: vertical 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -7598,7 +7598,7 @@ exports[`Layer position: right - full: false 1`] = `
 `;
 
 exports[`Layer position: right - full: false 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -7618,7 +7618,7 @@ exports[`Layer position: right - full: false 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -7760,7 +7760,7 @@ exports[`Layer position: right - full: horizontal 1`] = `
 `;
 
 exports[`Layer position: right - full: horizontal 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -7780,7 +7780,7 @@ exports[`Layer position: right - full: horizontal 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -7923,7 +7923,7 @@ exports[`Layer position: right - full: true 1`] = `
 `;
 
 exports[`Layer position: right - full: true 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -7943,7 +7943,7 @@ exports[`Layer position: right - full: true 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -8085,7 +8085,7 @@ exports[`Layer position: right - full: vertical 1`] = `
 `;
 
 exports[`Layer position: right - full: vertical 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -8105,7 +8105,7 @@ exports[`Layer position: right - full: vertical 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -8246,7 +8246,7 @@ exports[`Layer position: start - full: false 1`] = `
 `;
 
 exports[`Layer position: start - full: false 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -8266,7 +8266,7 @@ exports[`Layer position: start - full: false 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -8408,7 +8408,7 @@ exports[`Layer position: start - full: horizontal 1`] = `
 `;
 
 exports[`Layer position: start - full: horizontal 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -8428,7 +8428,7 @@ exports[`Layer position: start - full: horizontal 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -8571,7 +8571,7 @@ exports[`Layer position: start - full: true 1`] = `
 `;
 
 exports[`Layer position: start - full: true 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -8591,7 +8591,7 @@ exports[`Layer position: start - full: true 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -8733,7 +8733,7 @@ exports[`Layer position: start - full: vertical 1`] = `
 `;
 
 exports[`Layer position: start - full: vertical 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -8753,7 +8753,7 @@ exports[`Layer position: start - full: vertical 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -8894,7 +8894,7 @@ exports[`Layer position: top - full: false 1`] = `
 `;
 
 exports[`Layer position: top - full: false 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -8914,7 +8914,7 @@ exports[`Layer position: top - full: false 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -9056,7 +9056,7 @@ exports[`Layer position: top - full: horizontal 1`] = `
 `;
 
 exports[`Layer position: top - full: horizontal 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -9076,7 +9076,7 @@ exports[`Layer position: top - full: horizontal 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -9219,7 +9219,7 @@ exports[`Layer position: top - full: true 1`] = `
 `;
 
 exports[`Layer position: top - full: true 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -9239,7 +9239,7 @@ exports[`Layer position: top - full: true 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -9381,7 +9381,7 @@ exports[`Layer position: top - full: vertical 1`] = `
 `;
 
 exports[`Layer position: top - full: vertical 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -9401,7 +9401,7 @@ exports[`Layer position: top - full: vertical 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -9542,7 +9542,7 @@ exports[`Layer position: top-left - full: false 1`] = `
 `;
 
 exports[`Layer position: top-left - full: false 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -9562,7 +9562,7 @@ exports[`Layer position: top-left - full: false 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -9704,7 +9704,7 @@ exports[`Layer position: top-left - full: horizontal 1`] = `
 `;
 
 exports[`Layer position: top-left - full: horizontal 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -9724,7 +9724,7 @@ exports[`Layer position: top-left - full: horizontal 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -9867,7 +9867,7 @@ exports[`Layer position: top-left - full: true 1`] = `
 `;
 
 exports[`Layer position: top-left - full: true 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -9887,7 +9887,7 @@ exports[`Layer position: top-left - full: true 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -10029,7 +10029,7 @@ exports[`Layer position: top-left - full: vertical 1`] = `
 `;
 
 exports[`Layer position: top-left - full: vertical 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -10049,7 +10049,7 @@ exports[`Layer position: top-left - full: vertical 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -10190,7 +10190,7 @@ exports[`Layer position: top-right - full: false 1`] = `
 `;
 
 exports[`Layer position: top-right - full: false 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -10210,7 +10210,7 @@ exports[`Layer position: top-right - full: false 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -10352,7 +10352,7 @@ exports[`Layer position: top-right - full: horizontal 1`] = `
 `;
 
 exports[`Layer position: top-right - full: horizontal 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -10372,7 +10372,7 @@ exports[`Layer position: top-right - full: horizontal 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -10515,7 +10515,7 @@ exports[`Layer position: top-right - full: true 1`] = `
 `;
 
 exports[`Layer position: top-right - full: true 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -10535,7 +10535,7 @@ exports[`Layer position: top-right - full: true 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -10677,7 +10677,7 @@ exports[`Layer position: top-right - full: vertical 1`] = `
 `;
 
 exports[`Layer position: top-right - full: vertical 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -10697,7 +10697,7 @@ exports[`Layer position: top-right - full: vertical 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -10838,7 +10838,7 @@ exports[`Layer should apply background 1`] = `
 `;
 
 exports[`Layer should apply background 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -10858,7 +10858,7 @@ exports[`Layer should apply background 2`] = `
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -10997,7 +10997,7 @@ exports[`Layer should only place id on StyledLayer when singleId === true 1`] = 
 `;
 
 exports[`Layer should only place id on StyledLayer when singleId === true 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -11017,7 +11017,7 @@ exports[`Layer should only place id on StyledLayer when singleId === true 2`] = 
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -11160,7 +11160,7 @@ exports[`Layer should render correct border radius for position: bottom -
 
 exports[`Layer should render correct border radius for position: bottom - 
       full: false 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -11180,7 +11180,7 @@ exports[`Layer should render correct border radius for position: bottom -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -11324,7 +11324,7 @@ exports[`Layer should render correct border radius for position: bottom -
 
 exports[`Layer should render correct border radius for position: bottom - 
       full: horizontal 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -11344,7 +11344,7 @@ exports[`Layer should render correct border radius for position: bottom -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -11489,7 +11489,7 @@ exports[`Layer should render correct border radius for position: bottom -
 
 exports[`Layer should render correct border radius for position: bottom - 
       full: true 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -11509,7 +11509,7 @@ exports[`Layer should render correct border radius for position: bottom -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -11653,7 +11653,7 @@ exports[`Layer should render correct border radius for position: bottom -
 
 exports[`Layer should render correct border radius for position: bottom - 
       full: vertical 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -11673,7 +11673,7 @@ exports[`Layer should render correct border radius for position: bottom -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -11816,7 +11816,7 @@ exports[`Layer should render correct border radius for position: bottom-left -
 
 exports[`Layer should render correct border radius for position: bottom-left - 
       full: false 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -11836,7 +11836,7 @@ exports[`Layer should render correct border radius for position: bottom-left -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -11980,7 +11980,7 @@ exports[`Layer should render correct border radius for position: bottom-left -
 
 exports[`Layer should render correct border radius for position: bottom-left - 
       full: horizontal 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -12000,7 +12000,7 @@ exports[`Layer should render correct border radius for position: bottom-left -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -12145,7 +12145,7 @@ exports[`Layer should render correct border radius for position: bottom-left -
 
 exports[`Layer should render correct border radius for position: bottom-left - 
       full: true 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -12165,7 +12165,7 @@ exports[`Layer should render correct border radius for position: bottom-left -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -12309,7 +12309,7 @@ exports[`Layer should render correct border radius for position: bottom-left -
 
 exports[`Layer should render correct border radius for position: bottom-left - 
       full: vertical 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -12329,7 +12329,7 @@ exports[`Layer should render correct border radius for position: bottom-left -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -12472,7 +12472,7 @@ exports[`Layer should render correct border radius for position: bottom-right -
 
 exports[`Layer should render correct border radius for position: bottom-right - 
       full: false 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -12492,7 +12492,7 @@ exports[`Layer should render correct border radius for position: bottom-right -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -12636,7 +12636,7 @@ exports[`Layer should render correct border radius for position: bottom-right -
 
 exports[`Layer should render correct border radius for position: bottom-right - 
       full: horizontal 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -12656,7 +12656,7 @@ exports[`Layer should render correct border radius for position: bottom-right -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -12801,7 +12801,7 @@ exports[`Layer should render correct border radius for position: bottom-right -
 
 exports[`Layer should render correct border radius for position: bottom-right - 
       full: true 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -12821,7 +12821,7 @@ exports[`Layer should render correct border radius for position: bottom-right -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -12965,7 +12965,7 @@ exports[`Layer should render correct border radius for position: bottom-right -
 
 exports[`Layer should render correct border radius for position: bottom-right - 
       full: vertical 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -12985,7 +12985,7 @@ exports[`Layer should render correct border radius for position: bottom-right -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -13128,7 +13128,7 @@ exports[`Layer should render correct border radius for position: center -
 
 exports[`Layer should render correct border radius for position: center - 
       full: false 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -13148,7 +13148,7 @@ exports[`Layer should render correct border radius for position: center -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -13292,7 +13292,7 @@ exports[`Layer should render correct border radius for position: center -
 
 exports[`Layer should render correct border radius for position: center - 
       full: horizontal 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -13312,7 +13312,7 @@ exports[`Layer should render correct border radius for position: center -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -13454,7 +13454,7 @@ exports[`Layer should render correct border radius for position: center -
 
 exports[`Layer should render correct border radius for position: center - 
       full: true 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -13474,7 +13474,7 @@ exports[`Layer should render correct border radius for position: center -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -13618,7 +13618,7 @@ exports[`Layer should render correct border radius for position: center -
 
 exports[`Layer should render correct border radius for position: center - 
       full: vertical 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -13638,7 +13638,7 @@ exports[`Layer should render correct border radius for position: center -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -13782,7 +13782,7 @@ exports[`Layer should render correct border radius for position: end -
 
 exports[`Layer should render correct border radius for position: end - 
       full: false 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -13802,7 +13802,7 @@ exports[`Layer should render correct border radius for position: end -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -13946,7 +13946,7 @@ exports[`Layer should render correct border radius for position: end -
 
 exports[`Layer should render correct border radius for position: end - 
       full: horizontal 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -13966,7 +13966,7 @@ exports[`Layer should render correct border radius for position: end -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -14111,7 +14111,7 @@ exports[`Layer should render correct border radius for position: end -
 
 exports[`Layer should render correct border radius for position: end - 
       full: true 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -14131,7 +14131,7 @@ exports[`Layer should render correct border radius for position: end -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -14275,7 +14275,7 @@ exports[`Layer should render correct border radius for position: end -
 
 exports[`Layer should render correct border radius for position: end - 
       full: vertical 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -14295,7 +14295,7 @@ exports[`Layer should render correct border radius for position: end -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -14438,7 +14438,7 @@ exports[`Layer should render correct border radius for position: left -
 
 exports[`Layer should render correct border radius for position: left - 
       full: false 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -14458,7 +14458,7 @@ exports[`Layer should render correct border radius for position: left -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -14602,7 +14602,7 @@ exports[`Layer should render correct border radius for position: left -
 
 exports[`Layer should render correct border radius for position: left - 
       full: horizontal 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -14622,7 +14622,7 @@ exports[`Layer should render correct border radius for position: left -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -14767,7 +14767,7 @@ exports[`Layer should render correct border radius for position: left -
 
 exports[`Layer should render correct border radius for position: left - 
       full: true 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -14787,7 +14787,7 @@ exports[`Layer should render correct border radius for position: left -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -14931,7 +14931,7 @@ exports[`Layer should render correct border radius for position: left -
 
 exports[`Layer should render correct border radius for position: left - 
       full: vertical 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -14951,7 +14951,7 @@ exports[`Layer should render correct border radius for position: left -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -15094,7 +15094,7 @@ exports[`Layer should render correct border radius for position: right -
 
 exports[`Layer should render correct border radius for position: right - 
       full: false 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -15114,7 +15114,7 @@ exports[`Layer should render correct border radius for position: right -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -15258,7 +15258,7 @@ exports[`Layer should render correct border radius for position: right -
 
 exports[`Layer should render correct border radius for position: right - 
       full: horizontal 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -15278,7 +15278,7 @@ exports[`Layer should render correct border radius for position: right -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -15423,7 +15423,7 @@ exports[`Layer should render correct border radius for position: right -
 
 exports[`Layer should render correct border radius for position: right - 
       full: true 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -15443,7 +15443,7 @@ exports[`Layer should render correct border radius for position: right -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -15587,7 +15587,7 @@ exports[`Layer should render correct border radius for position: right -
 
 exports[`Layer should render correct border radius for position: right - 
       full: vertical 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -15607,7 +15607,7 @@ exports[`Layer should render correct border radius for position: right -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -15751,7 +15751,7 @@ exports[`Layer should render correct border radius for position: start -
 
 exports[`Layer should render correct border radius for position: start - 
       full: false 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -15771,7 +15771,7 @@ exports[`Layer should render correct border radius for position: start -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -15915,7 +15915,7 @@ exports[`Layer should render correct border radius for position: start -
 
 exports[`Layer should render correct border radius for position: start - 
       full: horizontal 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -15935,7 +15935,7 @@ exports[`Layer should render correct border radius for position: start -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -16080,7 +16080,7 @@ exports[`Layer should render correct border radius for position: start -
 
 exports[`Layer should render correct border radius for position: start - 
       full: true 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -16100,7 +16100,7 @@ exports[`Layer should render correct border radius for position: start -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -16244,7 +16244,7 @@ exports[`Layer should render correct border radius for position: start -
 
 exports[`Layer should render correct border radius for position: start - 
       full: vertical 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -16264,7 +16264,7 @@ exports[`Layer should render correct border radius for position: start -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -16407,7 +16407,7 @@ exports[`Layer should render correct border radius for position: top -
 
 exports[`Layer should render correct border radius for position: top - 
       full: false 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -16427,7 +16427,7 @@ exports[`Layer should render correct border radius for position: top -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -16571,7 +16571,7 @@ exports[`Layer should render correct border radius for position: top -
 
 exports[`Layer should render correct border radius for position: top - 
       full: horizontal 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -16591,7 +16591,7 @@ exports[`Layer should render correct border radius for position: top -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -16736,7 +16736,7 @@ exports[`Layer should render correct border radius for position: top -
 
 exports[`Layer should render correct border radius for position: top - 
       full: true 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -16756,7 +16756,7 @@ exports[`Layer should render correct border radius for position: top -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -16900,7 +16900,7 @@ exports[`Layer should render correct border radius for position: top -
 
 exports[`Layer should render correct border radius for position: top - 
       full: vertical 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -16920,7 +16920,7 @@ exports[`Layer should render correct border radius for position: top -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -17063,7 +17063,7 @@ exports[`Layer should render correct border radius for position: top-left -
 
 exports[`Layer should render correct border radius for position: top-left - 
       full: false 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -17083,7 +17083,7 @@ exports[`Layer should render correct border radius for position: top-left -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -17227,7 +17227,7 @@ exports[`Layer should render correct border radius for position: top-left -
 
 exports[`Layer should render correct border radius for position: top-left - 
       full: horizontal 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -17247,7 +17247,7 @@ exports[`Layer should render correct border radius for position: top-left -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -17392,7 +17392,7 @@ exports[`Layer should render correct border radius for position: top-left -
 
 exports[`Layer should render correct border radius for position: top-left - 
       full: true 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -17412,7 +17412,7 @@ exports[`Layer should render correct border radius for position: top-left -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -17556,7 +17556,7 @@ exports[`Layer should render correct border radius for position: top-left -
 
 exports[`Layer should render correct border radius for position: top-left - 
       full: vertical 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -17576,7 +17576,7 @@ exports[`Layer should render correct border radius for position: top-left -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -17719,7 +17719,7 @@ exports[`Layer should render correct border radius for position: top-right -
 
 exports[`Layer should render correct border radius for position: top-right - 
       full: false 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -17739,7 +17739,7 @@ exports[`Layer should render correct border radius for position: top-right -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -17883,7 +17883,7 @@ exports[`Layer should render correct border radius for position: top-right -
 
 exports[`Layer should render correct border radius for position: top-right - 
       full: horizontal 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -17903,7 +17903,7 @@ exports[`Layer should render correct border radius for position: top-right -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -18048,7 +18048,7 @@ exports[`Layer should render correct border radius for position: top-right -
 
 exports[`Layer should render correct border radius for position: top-right - 
       full: true 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -18068,7 +18068,7 @@ exports[`Layer should render correct border radius for position: top-right -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -18212,7 +18212,7 @@ exports[`Layer should render correct border radius for position: top-right -
 
 exports[`Layer should render correct border radius for position: top-right - 
       full: vertical 2`] = `
-".dmyVLx {
+".doeZDV {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -18232,7 +18232,7 @@ exports[`Layer should render correct border radius for position: top-right -
   bottom: 0px;
 }
 @media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -18366,7 +18366,7 @@ exports[`Layer target 1`] = `
 
 exports[`Layer target 2`] = `
 "@media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -18486,7 +18486,7 @@ exports[`Layer target not modal 1`] = `
 
 exports[`Layer target not modal 2`] = `
 "@media only screen and (max-width: 768px) {
-  .dmyVLx {
+  .doeZDV {
     position: fixed;
     width: 100%;
     height: 100%;

--- a/src/js/components/List/__tests__/__snapshots__/List-test.js.snap
+++ b/src/js/components/List/__tests__/__snapshots__/List-test.js.snap
@@ -3796,7 +3796,7 @@ exports[`List events Enter key 1`] = `
 
 exports[`List events Enter key 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <ul
     aria-activedescendant="1"
@@ -3968,7 +3968,7 @@ exports[`List events focus and blur 1`] = `
 
 exports[`List events focus and blur 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <ul
     class="List__StyledList-sc-130gdqg-0 fLowDI"
@@ -4153,7 +4153,7 @@ exports[`List events mouse events 1`] = `
 
 exports[`List events mouse events 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <ul
     class="List__StyledList-sc-130gdqg-0 fLowDI"
@@ -8225,7 +8225,7 @@ exports[`List events should render new data when page changes 1`] = `
 
 exports[`List events should render new data when page changes 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 iNDmPr List__StyledContainer-sc-130gdqg-2 jLDXjU"
@@ -14386,7 +14386,7 @@ exports[`List onClickItem 1`] = `
 
 exports[`List onClickItem 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <ul
     class="List__StyledList-sc-130gdqg-0 fLowDI"
@@ -14875,7 +14875,7 @@ exports[`List onOrder Keyboard move down 1`] = `
 
 exports[`List onOrder Keyboard move down 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <ul
     aria-activedescendant="alphaMoveDown"
@@ -15029,7 +15029,7 @@ exports[`List onOrder Keyboard move down 2`] = `
 
 exports[`List onOrder Keyboard move down 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <ul
     aria-activedescendant="alphaMoveUp"
@@ -15645,7 +15645,7 @@ exports[`List onOrder Keyboard move up 1`] = `
 
 exports[`List onOrder Keyboard move up 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <ul
     aria-activedescendant="betaMoveUp"
@@ -15799,7 +15799,7 @@ exports[`List onOrder Keyboard move up 2`] = `
 
 exports[`List onOrder Keyboard move up 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <ul
     aria-activedescendant="betaMoveDown"
@@ -16415,7 +16415,7 @@ exports[`List onOrder Mouse move down 1`] = `
 
 exports[`List onOrder Mouse move down 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <ul
     class="List__StyledList-sc-130gdqg-0 fLowDI"

--- a/src/js/components/List/__tests__/__snapshots__/List-test.js.snap
+++ b/src/js/components/List/__tests__/__snapshots__/List-test.js.snap
@@ -3796,7 +3796,7 @@ exports[`List events Enter key 1`] = `
 
 exports[`List events Enter key 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <ul
     aria-activedescendant="1"
@@ -3968,7 +3968,7 @@ exports[`List events focus and blur 1`] = `
 
 exports[`List events focus and blur 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <ul
     class="List__StyledList-sc-130gdqg-0 fLowDI"
@@ -4153,7 +4153,7 @@ exports[`List events mouse events 1`] = `
 
 exports[`List events mouse events 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <ul
     class="List__StyledList-sc-130gdqg-0 fLowDI"
@@ -8225,7 +8225,7 @@ exports[`List events should render new data when page changes 1`] = `
 
 exports[`List events should render new data when page changes 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 iNDmPr List__StyledContainer-sc-130gdqg-2 jLDXjU"
@@ -14386,7 +14386,7 @@ exports[`List onClickItem 1`] = `
 
 exports[`List onClickItem 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <ul
     class="List__StyledList-sc-130gdqg-0 fLowDI"
@@ -14875,7 +14875,7 @@ exports[`List onOrder Keyboard move down 1`] = `
 
 exports[`List onOrder Keyboard move down 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <ul
     aria-activedescendant="alphaMoveDown"
@@ -15029,7 +15029,7 @@ exports[`List onOrder Keyboard move down 2`] = `
 
 exports[`List onOrder Keyboard move down 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <ul
     aria-activedescendant="alphaMoveUp"
@@ -15645,7 +15645,7 @@ exports[`List onOrder Keyboard move up 1`] = `
 
 exports[`List onOrder Keyboard move up 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <ul
     aria-activedescendant="betaMoveUp"
@@ -15799,7 +15799,7 @@ exports[`List onOrder Keyboard move up 2`] = `
 
 exports[`List onOrder Keyboard move up 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <ul
     aria-activedescendant="betaMoveDown"
@@ -16415,7 +16415,7 @@ exports[`List onOrder Mouse move down 1`] = `
 
 exports[`List onOrder Mouse move down 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <ul
     class="List__StyledList-sc-130gdqg-0 fLowDI"

--- a/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
+++ b/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
@@ -3063,7 +3063,7 @@ exports[`Menu open and close on click 1`] = `
 
 exports[`Menu open and close on click 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <button
     aria-expanded="true"

--- a/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
+++ b/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
@@ -3063,7 +3063,7 @@ exports[`Menu open and close on click 1`] = `
 
 exports[`Menu open and close on click 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <button
     aria-expanded="true"

--- a/src/js/components/Pagination/__tests__/__snapshots__/Pagination-test.tsx.snap
+++ b/src/js/components/Pagination/__tests__/__snapshots__/Pagination-test.tsx.snap
@@ -8110,7 +8110,7 @@ exports[`Pagination should display next page of results when "next" is
 exports[`Pagination should display next page of results when "next" is
   selected 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 iNDmPr Pagination__StyledPaginationContainer-sc-rnlw6m-0"
@@ -9411,7 +9411,7 @@ exports[`Pagination should display previous page of results when "previous" is
 exports[`Pagination should display previous page of results when "previous" is
   selected 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 iNDmPr Pagination__StyledPaginationContainer-sc-rnlw6m-0"

--- a/src/js/components/Pagination/__tests__/__snapshots__/Pagination-test.tsx.snap
+++ b/src/js/components/Pagination/__tests__/__snapshots__/Pagination-test.tsx.snap
@@ -8110,7 +8110,7 @@ exports[`Pagination should display next page of results when "next" is
 exports[`Pagination should display next page of results when "next" is
   selected 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 iNDmPr Pagination__StyledPaginationContainer-sc-rnlw6m-0"
@@ -9411,7 +9411,7 @@ exports[`Pagination should display previous page of results when "previous" is
 exports[`Pagination should display previous page of results when "previous" is
   selected 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 iNDmPr Pagination__StyledPaginationContainer-sc-rnlw6m-0"

--- a/src/js/components/Select/__tests__/__snapshots__/Select-multiple-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-multiple-test.js.snap
@@ -2734,7 +2734,7 @@ exports[`Select Controlled multiple onChange without valueKey 3`] = `
 
 exports[`Select Controlled multiple onChange without valueKey 4`] = `
 <div
-  class="StyledBox-sc-13pk1d4-0 kMTAEP StyledDrop-sc-16s5rx8-0 bFAyzd"
+  class="StyledBox-sc-13pk1d4-0 kMTAEP StyledDrop-sc-16s5rx8-0 iOcHVa"
   data-g-portal-id="0"
   id="test-select__drop"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"

--- a/src/js/components/Select/__tests__/__snapshots__/Select-multiple-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-multiple-test.js.snap
@@ -2734,7 +2734,7 @@ exports[`Select Controlled multiple onChange without valueKey 3`] = `
 
 exports[`Select Controlled multiple onChange without valueKey 4`] = `
 <div
-  class="StyledBox-sc-13pk1d4-0 kMTAEP StyledDrop-sc-16s5rx8-0 iOcHVa"
+  class="StyledBox-sc-13pk1d4-0 kMTAEP StyledDrop-sc-16s5rx8-0 eaWCTq"
   data-g-portal-id="0"
   id="test-select__drop"
   style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -10626,7 +10626,7 @@ exports[`Select renders custom up and down icons 1`] = `
 
 exports[`Select renders custom up and down icons 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <button
     aria-expanded="true"
@@ -15211,7 +15211,7 @@ exports[`Select select option by typing should not break if caller passes JSX 1`
 
 exports[`Select select option by typing should not break if caller passes JSX 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <button
     aria-expanded="false"

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -10626,7 +10626,7 @@ exports[`Select renders custom up and down icons 1`] = `
 
 exports[`Select renders custom up and down icons 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <button
     aria-expanded="true"
@@ -15211,7 +15211,7 @@ exports[`Select select option by typing should not break if caller passes JSX 1`
 
 exports[`Select select option by typing should not break if caller passes JSX 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <button
     aria-expanded="false"

--- a/src/js/components/SelectMultiple/__tests__/__snapshots__/SelectMultiple-test.tsx.snap
+++ b/src/js/components/SelectMultiple/__tests__/__snapshots__/SelectMultiple-test.tsx.snap
@@ -4191,7 +4191,7 @@ exports[`SelectMultiple showSelectionInline with children 1`] = `
 
 exports[`SelectMultiple showSelectionInline with children 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 lgkPHo SelectMultiple__StyledSelectBox-sc-18zwyth-0 gBOJlI"

--- a/src/js/components/SkipLinks/__tests__/__snapshots__/SkipLink-test.js.snap
+++ b/src/js/components/SkipLinks/__tests__/__snapshots__/SkipLink-test.js.snap
@@ -79,7 +79,7 @@ exports[`SkipLink basic 1`] = `
 
 exports[`SkipLink basic 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <div>
     <a
@@ -111,7 +111,7 @@ exports[`SkipLink basic 2`] = `
 
 exports[`SkipLink basic 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <div>
     <a
@@ -210,7 +210,7 @@ exports[`SkipLink should allow for single skip link 1`] = `
 
 exports[`SkipLink should allow for single skip link 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <div>
     <a
@@ -236,7 +236,7 @@ exports[`SkipLink should allow for single skip link 2`] = `
 
 exports[`SkipLink should allow for single skip link 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <div>
     <a

--- a/src/js/components/SkipLinks/__tests__/__snapshots__/SkipLink-test.js.snap
+++ b/src/js/components/SkipLinks/__tests__/__snapshots__/SkipLink-test.js.snap
@@ -79,7 +79,7 @@ exports[`SkipLink basic 1`] = `
 
 exports[`SkipLink basic 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <div>
     <a
@@ -111,7 +111,7 @@ exports[`SkipLink basic 2`] = `
 
 exports[`SkipLink basic 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <div>
     <a
@@ -210,7 +210,7 @@ exports[`SkipLink should allow for single skip link 1`] = `
 
 exports[`SkipLink should allow for single skip link 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <div>
     <a
@@ -236,7 +236,7 @@ exports[`SkipLink should allow for single skip link 2`] = `
 
 exports[`SkipLink should allow for single skip link 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <div>
     <a

--- a/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.tsx.snap
+++ b/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.tsx.snap
@@ -1232,7 +1232,7 @@ exports[`Tabs change to second tab 1`] = `
 
 exports[`Tabs change to second tab 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 iNDmPr StyledTabs-sc-a4fwxl-2 eCNyif"
@@ -2564,7 +2564,7 @@ exports[`Tabs set on hover 1`] = `
 
 exports[`Tabs set on hover 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 iNDmPr StyledTabs-sc-a4fwxl-2 eCNyif"
@@ -2625,7 +2625,7 @@ exports[`Tabs set on hover 2`] = `
 
 exports[`Tabs set on hover 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 iNDmPr StyledTabs-sc-a4fwxl-2 eCNyif"
@@ -2686,7 +2686,7 @@ exports[`Tabs set on hover 3`] = `
 
 exports[`Tabs set on hover 4`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 iNDmPr StyledTabs-sc-a4fwxl-2 eCNyif"
@@ -2747,7 +2747,7 @@ exports[`Tabs set on hover 4`] = `
 
 exports[`Tabs set on hover 5`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 iNDmPr StyledTabs-sc-a4fwxl-2 eCNyif"

--- a/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.tsx.snap
+++ b/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.tsx.snap
@@ -1232,7 +1232,7 @@ exports[`Tabs change to second tab 1`] = `
 
 exports[`Tabs change to second tab 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 iNDmPr StyledTabs-sc-a4fwxl-2 eCNyif"
@@ -2564,7 +2564,7 @@ exports[`Tabs set on hover 1`] = `
 
 exports[`Tabs set on hover 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 iNDmPr StyledTabs-sc-a4fwxl-2 eCNyif"
@@ -2625,7 +2625,7 @@ exports[`Tabs set on hover 2`] = `
 
 exports[`Tabs set on hover 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 iNDmPr StyledTabs-sc-a4fwxl-2 eCNyif"
@@ -2686,7 +2686,7 @@ exports[`Tabs set on hover 3`] = `
 
 exports[`Tabs set on hover 4`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 iNDmPr StyledTabs-sc-a4fwxl-2 eCNyif"
@@ -2747,7 +2747,7 @@ exports[`Tabs set on hover 4`] = `
 
 exports[`Tabs set on hover 5`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <div
     class="StyledBox-sc-13pk1d4-0 iNDmPr StyledTabs-sc-a4fwxl-2 eCNyif"

--- a/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.tsx.snap
+++ b/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.tsx.snap
@@ -510,7 +510,7 @@ exports[`TextInput calls onSuggestionsClose 3`] = `""`;
 
 exports[`TextInput calls onSuggestionsClose 4`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <div
     class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kZzThM"
@@ -1077,7 +1077,7 @@ exports[`TextInput close suggestion drop 3`] = `""`;
 
 exports[`TextInput close suggestion drop 4`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <div
     class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kZzThM"
@@ -1693,7 +1693,7 @@ exports[`TextInput handles next and previous without suggestion 1`] = `
 
 exports[`TextInput handles next and previous without suggestion 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <div
     class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kZzThM"
@@ -3959,7 +3959,7 @@ exports[`TextInput select suggestion 3`] = `""`;
 
 exports[`TextInput select suggestion 4`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <div
     class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kZzThM"
@@ -4565,7 +4565,7 @@ exports[`TextInput should only show default placeholder when placeholder is a
 exports[`TextInput should only show default placeholder when placeholder is a
   string 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <div
     class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kZzThM"

--- a/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.tsx.snap
+++ b/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.tsx.snap
@@ -510,7 +510,7 @@ exports[`TextInput calls onSuggestionsClose 3`] = `""`;
 
 exports[`TextInput calls onSuggestionsClose 4`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <div
     class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kZzThM"
@@ -1077,7 +1077,7 @@ exports[`TextInput close suggestion drop 3`] = `""`;
 
 exports[`TextInput close suggestion drop 4`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <div
     class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kZzThM"
@@ -1693,7 +1693,7 @@ exports[`TextInput handles next and previous without suggestion 1`] = `
 
 exports[`TextInput handles next and previous without suggestion 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <div
     class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kZzThM"
@@ -3959,7 +3959,7 @@ exports[`TextInput select suggestion 3`] = `""`;
 
 exports[`TextInput select suggestion 4`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <div
     class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kZzThM"
@@ -4565,7 +4565,7 @@ exports[`TextInput should only show default placeholder when placeholder is a
 exports[`TextInput should only show default placeholder when placeholder is a
   string 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <div
     class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kZzThM"

--- a/src/js/components/Tip/__tests__/__snapshots__/Tip-test.tsx.snap
+++ b/src/js/components/Tip/__tests__/__snapshots__/Tip-test.tsx.snap
@@ -218,7 +218,7 @@ exports[`Tip focus and blur events on the Tip's child 1`] = `
 
 exports[`Tip focus and blur events on the Tip's child 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <button
     class="StyledButton-sc-323bzc-0 dCFBao"

--- a/src/js/components/Tip/__tests__/__snapshots__/Tip-test.tsx.snap
+++ b/src/js/components/Tip/__tests__/__snapshots__/Tip-test.tsx.snap
@@ -218,7 +218,7 @@ exports[`Tip focus and blur events on the Tip's child 1`] = `
 
 exports[`Tip focus and blur events on the Tip's child 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <button
     class="StyledButton-sc-323bzc-0 dCFBao"

--- a/src/js/components/Video/__tests__/__snapshots__/Video-test.js.snap
+++ b/src/js/components/Video/__tests__/__snapshots__/Video-test.js.snap
@@ -1598,7 +1598,7 @@ exports[`Video Play and Pause event handlers 1`] = `
 
 exports[`Video Play and Pause event handlers 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <div
     class="StyledVideo__StyledVideoContainer-sc-w4v8h9-1 eKRKEJ"
@@ -5994,7 +5994,7 @@ exports[`Video mouse events handlers of controls 1`] = `
 
 exports[`Video mouse events handlers of controls 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <div
     class="StyledVideo__StyledVideoContainer-sc-w4v8h9-1 eKRKEJ"
@@ -6118,7 +6118,7 @@ exports[`Video mouse events handlers of controls 2`] = `
 
 exports[`Video mouse events handlers of controls 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <div
     class="StyledVideo__StyledVideoContainer-sc-w4v8h9-1 eKRKEJ"
@@ -8354,7 +8354,7 @@ exports[`Video scrubber 1`] = `
 
 exports[`Video scrubber 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <div
     class="StyledVideo__StyledVideoContainer-sc-w4v8h9-1 eKRKEJ"

--- a/src/js/components/Video/__tests__/__snapshots__/Video-test.js.snap
+++ b/src/js/components/Video/__tests__/__snapshots__/Video-test.js.snap
@@ -1598,7 +1598,7 @@ exports[`Video Play and Pause event handlers 1`] = `
 
 exports[`Video Play and Pause event handlers 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <div
     class="StyledVideo__StyledVideoContainer-sc-w4v8h9-1 eKRKEJ"
@@ -5994,7 +5994,7 @@ exports[`Video mouse events handlers of controls 1`] = `
 
 exports[`Video mouse events handlers of controls 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <div
     class="StyledVideo__StyledVideoContainer-sc-w4v8h9-1 eKRKEJ"
@@ -6118,7 +6118,7 @@ exports[`Video mouse events handlers of controls 2`] = `
 
 exports[`Video mouse events handlers of controls 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <div
     class="StyledVideo__StyledVideoContainer-sc-w4v8h9-1 eKRKEJ"
@@ -8354,7 +8354,7 @@ exports[`Video scrubber 1`] = `
 
 exports[`Video scrubber 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <div
     class="StyledVideo__StyledVideoContainer-sc-w4v8h9-1 eKRKEJ"

--- a/src/js/components/WorldMap/__tests__/__snapshots__/WorldMap-test.tsx.snap
+++ b/src/js/components/WorldMap/__tests__/__snapshots__/WorldMap-test.tsx.snap
@@ -488,7 +488,7 @@ exports[`WorldMap events on continents 1`] = `
 
 exports[`WorldMap events on continents 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <svg
     class="StyledWorldMap-sc-had4c3-0 HKnhA"
@@ -598,7 +598,7 @@ exports[`WorldMap events on continents 2`] = `
 
 exports[`WorldMap events on continents 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <svg
     class="StyledWorldMap-sc-had4c3-0 HKnhA"
@@ -1260,7 +1260,7 @@ exports[`WorldMap onSelectPlace and events of places 1`] = `
 
 exports[`WorldMap onSelectPlace and events of places 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <svg
     class="StyledWorldMap-sc-had4c3-0 HKnhA"
@@ -1374,7 +1374,7 @@ exports[`WorldMap onSelectPlace and events of places 2`] = `
 
 exports[`WorldMap onSelectPlace and events of places 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
+  class="StyledGrommet-sc-19lkkz7-0 eANINY"
 >
   <svg
     class="StyledWorldMap-sc-had4c3-0 HKnhA"

--- a/src/js/components/WorldMap/__tests__/__snapshots__/WorldMap-test.tsx.snap
+++ b/src/js/components/WorldMap/__tests__/__snapshots__/WorldMap-test.tsx.snap
@@ -488,7 +488,7 @@ exports[`WorldMap events on continents 1`] = `
 
 exports[`WorldMap events on continents 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <svg
     class="StyledWorldMap-sc-had4c3-0 HKnhA"
@@ -598,7 +598,7 @@ exports[`WorldMap events on continents 2`] = `
 
 exports[`WorldMap events on continents 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <svg
     class="StyledWorldMap-sc-had4c3-0 HKnhA"
@@ -1260,7 +1260,7 @@ exports[`WorldMap onSelectPlace and events of places 1`] = `
 
 exports[`WorldMap onSelectPlace and events of places 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <svg
     class="StyledWorldMap-sc-had4c3-0 HKnhA"
@@ -1374,7 +1374,7 @@ exports[`WorldMap onSelectPlace and events of places 2`] = `
 
 exports[`WorldMap onSelectPlace and events of places 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  class="StyledGrommet-sc-19lkkz7-0 gatMrI"
 >
   <svg
     class="StyledWorldMap-sc-had4c3-0 HKnhA"

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -395,6 +395,7 @@ export interface ThemeType {
       maxWidth?: string;
       size?: string;
       weight?: number | string;
+      variant?: string;
     };
     graph?: {
       colors?: GraphColorsType;

--- a/src/js/utils/styles.js
+++ b/src/js/utils/styles.js
@@ -9,6 +9,7 @@ export const baseStyle = css`
   font-size: ${(props) => props.theme.global.font.size};
   line-height: ${(props) => props.theme.global.font.height};
   font-weight: ${(props) => props.theme.global.font.weight};
+  font-variant: ${(props) => props.theme.global.font.variant};
   ${(props) =>
     !props.plain && backgroundStyle(props.theme.baseBackground, props.theme)}
   box-sizing: border-box;

--- a/src/js/utils/styles.js
+++ b/src/js/utils/styles.js
@@ -9,7 +9,10 @@ export const baseStyle = css`
   font-size: ${(props) => props.theme.global.font.size};
   line-height: ${(props) => props.theme.global.font.height};
   font-weight: ${(props) => props.theme.global.font.weight};
-  font-variant: ${(props) => props.theme.global.font.variant};
+  /* check if prop is defined in the theme*/
+  ${(props)=>props.theme.global.font.variant && `
+    font-variant:${props.theme.global.font.variant};
+  `}
   ${(props) =>
     !props.plain && backgroundStyle(props.theme.baseBackground, props.theme)}
   box-sizing: border-box;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds the ```font-variant``` option to the global font type
#### Where should the reviewer start?
```src/js/themes/base.d.ts```
#### What testing has been done on this PR?
```yarn test```, tests failing
#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
NA
#### What are the relevant issues?
https://github.com/grommet/grommet/issues/6289
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
