### PR TITLE
Adjust notification theme

### DIFF
--- a/src/js/components/Notification/__tests__/__snapshots__/Notification-test.js.snap
+++ b/src/js/components/Notification/__tests__/__snapshots__/Notification-test.js.snap
@@ -252,6 +252,7 @@ exports[`Notification global 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  border-radius: 6px;
 }
 
 .c2 {
@@ -269,10 +270,10 @@ exports[`Notification global 1`] = `
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
-  padding-left: 48px;
-  padding-right: 48px;
-  padding-top: 6px;
-  padding-bottom: 6px;
+  padding-left: 24px;
+  padding-right: 24px;
+  padding-top: 12px;
+  padding-bottom: 12px;
 }
 
 .c3 {
@@ -341,16 +342,22 @@ exports[`Notification global 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c2 {
-    padding-left: 24px;
-    padding-right: 24px;
+  .c1 {
+    border-radius: 3px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c2 {
-    padding-top: 3px;
-    padding-bottom: 3px;
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    padding-top: 6px;
+    padding-bottom: 6px;
   }
 }
 
@@ -4249,6 +4256,7 @@ exports[`Notification status 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  border-radius: 6px;
 }
 
 .c2 {
@@ -4266,10 +4274,10 @@ exports[`Notification status 1`] = `
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
-  padding-left: 48px;
-  padding-right: 48px;
-  padding-top: 6px;
-  padding-bottom: 6px;
+  padding-left: 24px;
+  padding-right: 24px;
+  padding-top: 12px;
+  padding-bottom: 12px;
 }
 
 .c3 {
@@ -4317,6 +4325,7 @@ exports[`Notification status 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  border-radius: 6px;
 }
 
 .c12 {
@@ -4332,6 +4341,7 @@ exports[`Notification status 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  border-radius: 6px;
 }
 
 .c6 {
@@ -4368,22 +4378,40 @@ exports[`Notification status 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c2 {
-    padding-left: 24px;
-    padding-right: 24px;
+  .c1 {
+    border-radius: 3px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c2 {
-    padding-top: 3px;
-    padding-bottom: 3px;
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    padding-top: 6px;
+    padding-bottom: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c3 {
     padding-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c10 {
+    border-radius: 3px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c12 {
+    border-radius: 3px;
   }
 }
 

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -1796,9 +1796,10 @@ Object {
           "global": Object {
             "container": Object {
               "pad": Object {
-                "horizontal": "large",
-                "vertical": "xsmall",
+                "horizontal": "medium",
+                "vertical": "small",
               },
+              "round": "xsmall",
             },
             "direction": "row",
           },
@@ -3708,9 +3709,10 @@ Object {
           "global": Object {
             "container": Object {
               "pad": Object {
-                "horizontal": "large",
-                "vertical": "xsmall",
+                "horizontal": "medium",
+                "vertical": "small",
               },
+              "round": "xsmall",
             },
             "direction": "row",
           },

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1143,9 +1143,10 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         direction: 'row',
         container: {
           // any box props
+          round: 'xsmall',
           pad: {
-            horizontal: 'large',
-            vertical: 'xsmall',
+            horizontal: 'medium',
+            vertical: 'small',
           },
         },
       },


### PR DESCRIPTION
#### What does this PR do?
Adjusts the notification theme based on comments in https://github.com/grommet/grommet-site/pull/416

One thing I was considering... on the grommet site PR the notification felt more like a page level notification. Right now we only have the option to have global notifications or toast notifications. Would these styling changes make sense to have for page level notifications one we have that option? Or should this styling change be applied to both global and page level notifications?

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No
#### Should this PR be mentioned in the release notes?
Yes
#### Is this change backwards compatible or is it a breaking change?
Backwards compatible