### PR TITLE
Add defaultValue to CheckBoxGroup

### DIFF
--- a/src/js/components/CheckBoxGroup/CheckBoxGroup.js
+++ b/src/js/components/CheckBoxGroup/CheckBoxGroup.js
@@ -10,6 +10,7 @@ const CheckBoxGroup = forwardRef(
   (
     {
       children,
+      defaultValue,
       value: valueProp,
       disabled: disabledProp,
       focusIndicator = true,
@@ -41,7 +42,7 @@ const CheckBoxGroup = forwardRef(
     const [value, setValue] = formContext.useFormInput({
       name,
       value: valueProp,
-      initialValue: [],
+      initialValue: defaultValue || [],
     });
 
     // Logic is necessary to maintain a proper data structure for Form logic

--- a/src/js/components/CheckBoxGroup/__tests__/CheckBoxGroup-test.tsx
+++ b/src/js/components/CheckBoxGroup/__tests__/CheckBoxGroup-test.tsx
@@ -207,4 +207,14 @@ describe('CheckBoxGroup', () => {
     warnSpy.mockReset();
     warnSpy.mockRestore();
   });
+
+  test('defaultValue renders', () => {
+    const { asFragment } = render(
+      <Grommet>
+        <CheckBoxGroup options={['First', 'Second']} defaultValue={['First']} />
+      </Grommet>,
+    );
+
+    expect(asFragment()).toMatchSnapshot();
+  });
 });

--- a/src/js/components/CheckBoxGroup/__tests__/__snapshots__/CheckBoxGroup-test.tsx.snap
+++ b/src/js/components/CheckBoxGroup/__tests__/__snapshots__/CheckBoxGroup-test.tsx.snap
@@ -53,6 +53,73 @@ exports[`CheckBoxGroup custom theme 1`] = `
 </div>
 `;
 
+exports[`CheckBoxGroup defaultValue renders 1`] = `
+<DocumentFragment>
+  <div
+    class="StyledGrommet-sc-19lkkz7-0 bFgzgw"
+  >
+    <div
+      class="StyledBox-sc-13pk1d4-0 iNDmPr StyledCheckBoxGroup-sc-2nhc5d-0"
+      role="group"
+    >
+      <label
+        class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 jUgUBs"
+        label="First"
+      >
+        <div
+          class="StyledBox-sc-13pk1d4-0 gibDHu StyledCheckBox-sc-1dbk5ju-6 eJWclz"
+        >
+          <input
+            checked=""
+            class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
+            type="checkbox"
+          />
+          <div
+            class="StyledBox-sc-13pk1d4-0 bGhwjx StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 bNwZfh"
+          >
+            <svg
+              class="StyledCheckBox__StyledCheckBoxIcon-sc-1dbk5ju-0 frpnnl"
+              preserveAspectRatio="xMidYMid meet"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M6,11.3 L10.3,16 L18,6.2"
+                fill="none"
+              />
+            </svg>
+          </div>
+        </div>
+        <span>
+          First
+        </span>
+      </label>
+      <div
+        class="StyledBox__StyledBoxGap-sc-13pk1d4-1 qdAYv"
+      />
+      <label
+        class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 jUgUBs"
+        label="Second"
+      >
+        <div
+          class="StyledBox-sc-13pk1d4-0 gibDHu StyledCheckBox-sc-1dbk5ju-6 eJWclz"
+        >
+          <input
+            class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 cOPtKl"
+            type="checkbox"
+          />
+          <div
+            class="StyledBox-sc-13pk1d4-0 kibvml StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 bNwZfh"
+          />
+        </div>
+        <span>
+          Second
+        </span>
+      </label>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`CheckBoxGroup disabled renders 1`] = `
 <div
   class="StyledGrommet-sc-19lkkz7-0 bFgzgw"

--- a/src/js/components/CheckBoxGroup/index.d.ts
+++ b/src/js/components/CheckBoxGroup/index.d.ts
@@ -15,7 +15,7 @@ export interface CheckBoxType
 
 export interface CheckBoxGroupProps {
   value?: (number | string)[];
-  defaultValue?: (number | string | object)[];
+  defaultValue?: (number | string)[];
   disabled?: boolean;
   labelKey?: string;
   name?: string;

--- a/src/js/components/CheckBoxGroup/index.d.ts
+++ b/src/js/components/CheckBoxGroup/index.d.ts
@@ -15,6 +15,7 @@ export interface CheckBoxType
 
 export interface CheckBoxGroupProps {
   value?: (number | string)[];
+  defaultValue?: (number | string | object)[];
   disabled?: boolean;
   labelKey?: string;
   name?: string;
@@ -26,7 +27,7 @@ export interface CheckBoxGroupProps {
 export interface CheckBoxGroupExtendedProps
   extends CheckBoxGroupProps,
     BoxProps,
-    Omit<JSX.IntrinsicElements['div'], 'onClick' | 'onChange'> {}
+    Omit<JSX.IntrinsicElements['div'], 'onClick' | keyof CheckBoxGroupProps> {}
 
 declare const CheckBoxGroup: React.FC<CheckBoxGroupExtendedProps>;
 

--- a/src/js/components/CheckBoxGroup/propTypes.js
+++ b/src/js/components/CheckBoxGroup/propTypes.js
@@ -6,6 +6,13 @@ if (process.env.NODE_ENV !== 'production') {
     value: PropTypes.arrayOf(
       PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     ),
+    defaultValue: PropTypes.arrayOf(
+      PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.number,
+        PropTypes.shape({}),
+      ]),
+    ),
     disabled: PropTypes.bool,
     labelKey: PropTypes.string,
     name: PropTypes.string,

--- a/src/js/components/CheckBoxGroup/propTypes.js
+++ b/src/js/components/CheckBoxGroup/propTypes.js
@@ -7,11 +7,7 @@ if (process.env.NODE_ENV !== 'production') {
       PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     ),
     defaultValue: PropTypes.arrayOf(
-      PropTypes.oneOfType([
-        PropTypes.string,
-        PropTypes.number,
-        PropTypes.shape({}),
-      ]),
+      PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     ),
     disabled: PropTypes.bool,
     labelKey: PropTypes.string,

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -201,6 +201,7 @@ Object {
   "CheckBoxGroup": Object {
     "$$typeof": Symbol(react.forward_ref),
     "propTypes": Object {
+      "defaultValue": [Function],
       "disabled": [Function],
       "labelKey": [Function],
       "name": [Function],


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Adds `defaultValue` to CheckBoxGroup, similar to SelectMultiple.

#### Where should the reviewer start?
src/js/components/CheckBoxGroup/CheckBoxGroup.js

#### What testing has been done on this PR?
tested locally in storybook, added jest test.

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [x] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Yes.

#### Should this PR be mentioned in the release notes?
Yes. Added `defaultValue` to CheckBoxGroup.

#### Is this change backwards compatible or is it a breaking change?
backwards compatible.