### PR TITLE
SelectMultiple - adjust behavior when lazy loading

### DIFF
--- a/src/js/components/SelectMultiple/SelectMultiple.js
+++ b/src/js/components/SelectMultiple/SelectMultiple.js
@@ -421,10 +421,12 @@ const SelectMultiple = forwardRef(
                         {...rest}
                         tabIndex="-1"
                         type="text"
-                        // eslint-disable-next-line max-len
                         placeholder={
+                          // eslint-disable-next-line no-nested-ternary
                           value.length === 0
                             ? placeholder || selectValue || displayLabelKey
+                            : onMore
+                            ? `${value.length} selected`
                             : `${value.length} selected of ${allOptions.length}`
                         }
                         plain

--- a/src/js/components/SelectMultiple/SelectMultipleContainer.js
+++ b/src/js/components/SelectMultiple/SelectMultipleContainer.js
@@ -330,6 +330,7 @@ const SelectMultipleContainer = forwardRef(
         labelKey={labelKey}
         limit={limit}
         onChange={onChange}
+        onMore={onMore}
         options={options}
         search={search}
         setActiveIndex={setActiveIndex}
@@ -349,7 +350,7 @@ const SelectMultipleContainer = forwardRef(
         >
           {summaryContent}
           <Button onClick={onClose} a11yTitle="Close Select">
-            <Box pad={{ right: 'small' }}>
+            <Box fill alignSelf="start" pad={{ right: 'small', top: 'small' }}>
               <FormUp />
             </Box>
           </Button>

--- a/src/js/components/SelectMultiple/SelectionSummary.js
+++ b/src/js/components/SelectMultiple/SelectionSummary.js
@@ -14,6 +14,7 @@ const SelectionSummary = ({
   labelKey,
   limit,
   onChange,
+  onMore,
   options,
   search,
   setActiveIndex,
@@ -51,50 +52,51 @@ const SelectionSummary = ({
         fill="horizontal"
         flex={showSelectedInline}
       >
-        <Box alignSelf="center">
-          <Text size="small">
-            {value.length === 0
-              ? `0 selected`
+        <Box pad={{ vertical: 'xsmall' }} alignSelf="center">
+          <Text margin={{ vertical: 'xsmall' }} size="small">
+            {value.length === 0 || onMore
+              ? `${value.length} selected`
               : `${value.length} selected of ${options.length}`}
           </Text>
         </Box>
         {(options.length &&
-          (!limit || !(value.length === 0 && selectedValuesDisabled()))) >
-          0 && (
-          <Button
-            a11yTitle={
-              value.length === 0 || selectedValuesDisabled()
-                ? `Select all ${options.length} options`
-                : `${value.length} options selected. Clear all?`
-            }
-            label={
-              value.length === 0 || selectedValuesDisabled()
-                ? 'Select All'
-                : 'Clear All'
-            }
-            onClick={(event) => {
-              const selectAll = value.length === 0 || selectedValuesDisabled();
-              if (onChange) {
-                const nextSelected = options.filter((i, index) =>
-                  selectAll
-                    ? !isDisabled(index) || isSelected(index)
-                    : isDisabled(index) && isSelected(index),
-                );
-                const nextValue = nextSelected.map((i) =>
-                  valueKey && valueKey.reduce ? applyKey(i, valueKey) : i,
-                );
-                onChange(event, {
-                  option: options,
-                  value: nextValue,
-                  selected: nextSelected,
-                });
+          (!limit || !(value.length === 0 && selectedValuesDisabled()))) > 0 &&
+          (!onMore || (onMore && value.length !== 0)) && (
+            <Button
+              a11yTitle={
+                value.length === 0 || selectedValuesDisabled()
+                  ? `Select all ${options.length} options`
+                  : `${value.length} options selected. Clear all?`
               }
-              if (limit && !selectAll) setActiveIndex(0);
-            }}
-            onFocus={() => setActiveIndex(-1)}
-            ref={clearRef}
-          />
-        )}
+              label={
+                value.length === 0 || selectedValuesDisabled()
+                  ? 'Select All'
+                  : 'Clear All'
+              }
+              onClick={(event) => {
+                const selectAll =
+                  value.length === 0 || selectedValuesDisabled();
+                if (onChange) {
+                  const nextSelected = options.filter((i, index) =>
+                    selectAll
+                      ? !isDisabled(index) || isSelected(index)
+                      : isDisabled(index) && isSelected(index),
+                  );
+                  const nextValue = nextSelected.map((i) =>
+                    valueKey && valueKey.reduce ? applyKey(i, valueKey) : i,
+                  );
+                  onChange(event, {
+                    option: options,
+                    value: nextValue,
+                    selected: nextSelected,
+                  });
+                }
+                if (limit && !selectAll) setActiveIndex(0);
+              }}
+              onFocus={() => setActiveIndex(-1)}
+              ref={clearRef}
+            />
+          )}
       </Box>
     );
   return <Text size="small">{`${value.length} selected`}</Text>;

--- a/src/js/components/SelectMultiple/__tests__/__snapshots__/SelectMultiple-test.tsx.snap
+++ b/src/js/components/SelectMultiple/__tests__/__snapshots__/SelectMultiple-test.tsx.snap
@@ -1137,6 +1137,10 @@ exports[`SelectMultiple disabled option 1`] = `
 
 }
 
+@media only screen and (max-width:768px) {
+
+}
+
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
 
 }
@@ -1523,6 +1527,10 @@ exports[`SelectMultiple keyboard interactions 1`] = `
 
 }
 
+@media only screen and (max-width:768px) {
+
+}
+
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
 
 }
@@ -1806,6 +1814,10 @@ exports[`SelectMultiple limit 1`] = `
     margin-left: 6px;
     margin-right: 6px;
   }
+}
+
+@media only screen and (max-width:768px) {
+
 }
 
 @media only screen and (max-width:768px) {
@@ -2467,6 +2479,10 @@ exports[`SelectMultiple select all and clear 1`] = `
     margin-left: 6px;
     margin-right: 6px;
   }
+}
+
+@media only screen and (max-width:768px) {
+
 }
 
 @media only screen and (max-width:768px) {
@@ -3476,6 +3492,14 @@ exports[`SelectMultiple showSelectionInline 1`] = `
 }
 
 @media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
   .c15 {
     margin-right: 6px;
   }
@@ -4052,6 +4076,14 @@ exports[`SelectMultiple showSelectionInline with children 1`] = `
 }
 
 @media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
   .c14 {
     padding: 6px;
   }
@@ -4260,6 +4292,14 @@ exports[`SelectMultiple showSelectionInline with children 2`] = `
 
 .c2 {
   cursor: pointer;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
 }
 
 @media only screen and (max-width:768px) {

--- a/src/js/components/SelectMultiple/stories/Default.js
+++ b/src/js/components/SelectMultiple/stories/Default.js
@@ -28,7 +28,6 @@ export const Default = () => {
       <SelectMultiple
         value={valueMultiple}
         placeholder="Select"
-        allOptions={defaultOptions}
         options={options}
         onSearch={(text) => {
           // The line below escapes regular expression special characters:

--- a/src/js/components/SelectMultiple/stories/LongList.js
+++ b/src/js/components/SelectMultiple/stories/LongList.js
@@ -1,0 +1,54 @@
+import React from 'react';
+
+import { Box, SelectMultiple } from 'grommet';
+
+const dummyOptions = Array(2000)
+  .fill()
+  .map((_, i) => `option ${i}`)
+  .sort((a, b) =>
+    a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' }),
+  );
+
+export const LongList = () => {
+  const [selected, setSelected] = React.useState([]);
+  const [options, setOptions] = React.useState(dummyOptions.slice(0, 200));
+
+  const onMore = () => {
+    setTimeout(() => {
+      setOptions(dummyOptions.slice(0, options.length + 200));
+    }, 1000);
+  };
+
+  const onChange = ({ value: nextSelected }) => setSelected(nextSelected);
+
+  return (
+    // Uncomment <Grommet> lines when using outside of storybook
+    // <Grommet theme={...}>
+    <Box fill align="center" justify="start" pad="large">
+      <SelectMultiple
+        showSelectedInline
+        placeholder="select an option..."
+        value={selected}
+        options={options}
+        dropHeight="medium"
+        onMore={onMore}
+        onChange={onChange}
+      />
+    </Box>
+    // </Grommet>
+  );
+};
+
+LongList.storyName = 'Long list';
+
+LongList.parameters = {
+  chromatic: { disable: true },
+};
+
+LongList.args = {
+  full: true,
+};
+
+export default {
+  title: 'Input/SelectMultiple/Long list',
+};


### PR DESCRIPTION
#### What does this PR do?
When using the `onMore` prop with SelectMultiple we shouldn't show the 'Select All' button, because without all the options loaded we don't have a good way to select all of them. In addition we shouldn't show the total number of options when lazy loading because the total is unknown.

This PR also adjusts the alignment of the close arrow when using `showSelectedInline`.

#### Where should the reviewer start?

#### What testing has been done on this PR?
Added storybook story SelectMultiple/Long list

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
no, component hasn't been released yet
#### Is this change backwards compatible or is it a breaking change?
backwards compatible