### PR TITLE
Change notification theme to have background and rounding for non-global and non-toast notifications

### DIFF
--- a/src/js/components/Notification/__tests__/__snapshots__/Notification-test.js.snap
+++ b/src/js/components/Notification/__tests__/__snapshots__/Notification-test.js.snap
@@ -49,6 +49,7 @@ exports[`Notification custom theme 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  border-radius: 6px;
 }
 
 .c2 {
@@ -132,6 +133,12 @@ exports[`Notification custom theme 1`] = `
   -ms-text-size-adjust: 100%;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    border-radius: 3px;
+  }
 }
 
 @media only screen and (max-width:768px) {
@@ -252,7 +259,7 @@ exports[`Notification global 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  border-radius: 6px;
+  border-radius: 0px;
 }
 
 .c2 {
@@ -270,10 +277,10 @@ exports[`Notification global 1`] = `
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
-  padding-left: 24px;
-  padding-right: 24px;
-  padding-top: 12px;
-  padding-bottom: 12px;
+  padding-left: 48px;
+  padding-right: 48px;
+  padding-top: 6px;
+  padding-bottom: 6px;
 }
 
 .c3 {
@@ -343,21 +350,21 @@ exports[`Notification global 1`] = `
 
 @media only screen and (max-width:768px) {
   .c1 {
-    border-radius: 3px;
+    border-radius: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c2 {
-    padding-left: 12px;
-    padding-right: 12px;
+    padding-left: 24px;
+    padding-right: 24px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c2 {
-    padding-top: 6px;
-    padding-bottom: 6px;
+    padding-top: 3px;
+    padding-bottom: 3px;
   }
 }
 
@@ -467,13 +474,13 @@ exports[`Notification multi actions 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background-color: rgba(255,255,255,1);
-  color: #444444;
+  background-color: rgba(204,204,204,0.1);
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  border-radius: 6px;
 }
 
 .c2 {
@@ -577,6 +584,12 @@ exports[`Notification multi actions 1`] = `
 
 .c10 {
   white-space: nowrap;
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    border-radius: 3px;
+  }
 }
 
 @media only screen and (max-width:768px) {
@@ -707,7 +720,7 @@ exports[`Notification position bottom 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background-color: rgba(255,255,255,1);
+  background-color: #FFFFFF;
   color: #444444;
   min-width: 0;
   min-height: 0;
@@ -943,6 +956,11 @@ exports[`Notification position bottom 1`] = `
 
 exports[`Notification position bottom 2`] = `
 "@media only screen and (max-width: 768px) {
+  .fFAKuU {
+    border-radius: 3px;
+  }
+}
+@media only screen and (max-width: 768px) {
   .hyfhRJ {
     padding-left: 6px;
     padding-right: 6px;
@@ -1003,7 +1021,7 @@ exports[`Notification position bottom-left 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background-color: rgba(255,255,255,1);
+  background-color: #FFFFFF;
   color: #444444;
   min-width: 0;
   min-height: 0;
@@ -1239,6 +1257,11 @@ exports[`Notification position bottom-left 1`] = `
 
 exports[`Notification position bottom-left 2`] = `
 "@media only screen and (max-width: 768px) {
+  .fFAKuU {
+    border-radius: 3px;
+  }
+}
+@media only screen and (max-width: 768px) {
   .hyfhRJ {
     padding-left: 6px;
     padding-right: 6px;
@@ -1299,7 +1322,7 @@ exports[`Notification position bottom-right 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background-color: rgba(255,255,255,1);
+  background-color: #FFFFFF;
   color: #444444;
   min-width: 0;
   min-height: 0;
@@ -1535,6 +1558,11 @@ exports[`Notification position bottom-right 1`] = `
 
 exports[`Notification position bottom-right 2`] = `
 "@media only screen and (max-width: 768px) {
+  .fFAKuU {
+    border-radius: 3px;
+  }
+}
+@media only screen and (max-width: 768px) {
   .hyfhRJ {
     padding-left: 6px;
     padding-right: 6px;
@@ -1595,7 +1623,7 @@ exports[`Notification position center 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background-color: rgba(255,255,255,1);
+  background-color: #FFFFFF;
   color: #444444;
   min-width: 0;
   min-height: 0;
@@ -1831,6 +1859,11 @@ exports[`Notification position center 1`] = `
 
 exports[`Notification position center 2`] = `
 "@media only screen and (max-width: 768px) {
+  .fFAKuU {
+    border-radius: 3px;
+  }
+}
+@media only screen and (max-width: 768px) {
   .hyfhRJ {
     padding-left: 6px;
     padding-right: 6px;
@@ -1891,7 +1924,7 @@ exports[`Notification position end 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background-color: rgba(255,255,255,1);
+  background-color: #FFFFFF;
   color: #444444;
   min-width: 0;
   min-height: 0;
@@ -2127,6 +2160,11 @@ exports[`Notification position end 1`] = `
 
 exports[`Notification position end 2`] = `
 "@media only screen and (max-width: 768px) {
+  .fFAKuU {
+    border-radius: 3px;
+  }
+}
+@media only screen and (max-width: 768px) {
   .hyfhRJ {
     padding-left: 6px;
     padding-right: 6px;
@@ -2187,7 +2225,7 @@ exports[`Notification position left 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background-color: rgba(255,255,255,1);
+  background-color: #FFFFFF;
   color: #444444;
   min-width: 0;
   min-height: 0;
@@ -2423,6 +2461,11 @@ exports[`Notification position left 1`] = `
 
 exports[`Notification position left 2`] = `
 "@media only screen and (max-width: 768px) {
+  .fFAKuU {
+    border-radius: 3px;
+  }
+}
+@media only screen and (max-width: 768px) {
   .hyfhRJ {
     padding-left: 6px;
     padding-right: 6px;
@@ -2483,7 +2526,7 @@ exports[`Notification position right 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background-color: rgba(255,255,255,1);
+  background-color: #FFFFFF;
   color: #444444;
   min-width: 0;
   min-height: 0;
@@ -2719,6 +2762,11 @@ exports[`Notification position right 1`] = `
 
 exports[`Notification position right 2`] = `
 "@media only screen and (max-width: 768px) {
+  .fFAKuU {
+    border-radius: 3px;
+  }
+}
+@media only screen and (max-width: 768px) {
   .hyfhRJ {
     padding-left: 6px;
     padding-right: 6px;
@@ -2779,7 +2827,7 @@ exports[`Notification position start 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background-color: rgba(255,255,255,1);
+  background-color: #FFFFFF;
   color: #444444;
   min-width: 0;
   min-height: 0;
@@ -3015,6 +3063,11 @@ exports[`Notification position start 1`] = `
 
 exports[`Notification position start 2`] = `
 "@media only screen and (max-width: 768px) {
+  .fFAKuU {
+    border-radius: 3px;
+  }
+}
+@media only screen and (max-width: 768px) {
   .hyfhRJ {
     padding-left: 6px;
     padding-right: 6px;
@@ -3075,7 +3128,7 @@ exports[`Notification position top 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background-color: rgba(255,255,255,1);
+  background-color: #FFFFFF;
   color: #444444;
   min-width: 0;
   min-height: 0;
@@ -3311,6 +3364,11 @@ exports[`Notification position top 1`] = `
 
 exports[`Notification position top 2`] = `
 "@media only screen and (max-width: 768px) {
+  .fFAKuU {
+    border-radius: 3px;
+  }
+}
+@media only screen and (max-width: 768px) {
   .hyfhRJ {
     padding-left: 6px;
     padding-right: 6px;
@@ -3371,7 +3429,7 @@ exports[`Notification position top-left 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background-color: rgba(255,255,255,1);
+  background-color: #FFFFFF;
   color: #444444;
   min-width: 0;
   min-height: 0;
@@ -3607,6 +3665,11 @@ exports[`Notification position top-left 1`] = `
 
 exports[`Notification position top-left 2`] = `
 "@media only screen and (max-width: 768px) {
+  .fFAKuU {
+    border-radius: 3px;
+  }
+}
+@media only screen and (max-width: 768px) {
   .hyfhRJ {
     padding-left: 6px;
     padding-right: 6px;
@@ -3667,7 +3730,7 @@ exports[`Notification position top-right 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background-color: rgba(255,255,255,1);
+  background-color: #FFFFFF;
   color: #444444;
   min-width: 0;
   min-height: 0;
@@ -3903,6 +3966,11 @@ exports[`Notification position top-right 1`] = `
 
 exports[`Notification position top-right 2`] = `
 "@media only screen and (max-width: 768px) {
+  .fFAKuU {
+    border-radius: 3px;
+  }
+}
+@media only screen and (max-width: 768px) {
   .hyfhRJ {
     padding-left: 6px;
     padding-right: 6px;
@@ -3964,13 +4032,13 @@ exports[`Notification should have no accessibility violations 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background-color: rgba(255,255,255,1);
-  color: #444444;
+  background-color: rgba(204,204,204,0.1);
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  border-radius: 6px;
 }
 
 .c2 {
@@ -4040,6 +4108,12 @@ exports[`Notification should have no accessibility violations 1`] = `
   -ms-text-size-adjust: 100%;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    border-radius: 3px;
+  }
 }
 
 @media only screen and (max-width:768px) {
@@ -4256,7 +4330,7 @@ exports[`Notification status 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  border-radius: 6px;
+  border-radius: 0px;
 }
 
 .c2 {
@@ -4274,10 +4348,10 @@ exports[`Notification status 1`] = `
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
-  padding-left: 24px;
-  padding-right: 24px;
-  padding-top: 12px;
-  padding-bottom: 12px;
+  padding-left: 48px;
+  padding-right: 48px;
+  padding-top: 6px;
+  padding-bottom: 6px;
 }
 
 .c3 {
@@ -4325,7 +4399,7 @@ exports[`Notification status 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  border-radius: 6px;
+  border-radius: 0px;
 }
 
 .c12 {
@@ -4341,7 +4415,7 @@ exports[`Notification status 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  border-radius: 6px;
+  border-radius: 0px;
 }
 
 .c6 {
@@ -4379,21 +4453,21 @@ exports[`Notification status 1`] = `
 
 @media only screen and (max-width:768px) {
   .c1 {
-    border-radius: 3px;
+    border-radius: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c2 {
-    padding-left: 12px;
-    padding-right: 12px;
+    padding-left: 24px;
+    padding-right: 24px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c2 {
-    padding-top: 6px;
-    padding-bottom: 6px;
+    padding-top: 3px;
+    padding-bottom: 3px;
   }
 }
 
@@ -4405,13 +4479,13 @@ exports[`Notification status 1`] = `
 
 @media only screen and (max-width:768px) {
   .c10 {
-    border-radius: 3px;
+    border-radius: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c12 {
-    border-radius: 3px;
+    border-radius: 0px;
   }
 }
 

--- a/src/js/components/Notification/stories/CustomThemed/ThemedNotification.tsx
+++ b/src/js/components/Notification/stories/CustomThemed/ThemedNotification.tsx
@@ -4,7 +4,7 @@ import { Box, Grommet, Notification } from 'grommet';
 
 import { deepMerge } from 'grommet/utils';
 import { grommet, ThemeType } from 'grommet/themes';
-import { DisabledOutline, CircleQuestion } from 'grommet-icons';
+import { CircleQuestion } from 'grommet-icons';
 
 // Type annotations can only be used in TypeScript files.
 // Remove ': ThemeType' if you are not using Typescript.
@@ -18,7 +18,6 @@ const customTheme: ThemeType = deepMerge(grommet, {
     container: {
       // any BoxProps
       pad: { horizontal: 'large', vertical: '36px' },
-      background: '#87a200',
       border: { color: '#000000', size: 'large' },
     },
     iconContainer: {
@@ -46,6 +45,7 @@ const customTheme: ThemeType = deepMerge(grommet, {
     },
     unknown: {
       icon: CircleQuestion,
+      background: '#87a200',
     },
   },
 });

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -1779,28 +1779,30 @@ Object {
               "horizontal": "small",
               "vertical": "xsmall",
             },
+            "round": "xsmall",
           },
           "critical": Object {
-            "color": "status-critical",
-            "global": Object {
-              "background": Object {
-                "color": "status-critical",
-                "opacity": "weak",
-              },
+            "background": Object {
+              "color": "status-critical",
+              "opacity": "weak",
             },
+            "color": "status-critical",
             "icon": Object {
               "$$typeof": Symbol(react.forward_ref),
               "render": [Function],
+            },
+            "toast": Object {
+              "background": "background-front",
             },
           },
           "direction": "column",
           "global": Object {
             "container": Object {
               "pad": Object {
-                "horizontal": "medium",
-                "vertical": "small",
+                "horizontal": "large",
+                "vertical": "xsmall",
               },
-              "round": "xsmall",
+              "round": "none",
             },
             "direction": "row",
           },
@@ -1811,26 +1813,31 @@ Object {
             },
           },
           "info": Object {
+            "background": "background-contrast",
             "color": "text-strong",
             "icon": Object {
               "$$typeof": Symbol(react.forward_ref),
               "render": [Function],
+            },
+            "toast": Object {
+              "background": "background-front",
             },
           },
           "message": Object {
             "margin": "none",
           },
           "normal": Object {
-            "color": "status-ok",
-            "global": Object {
-              "background": Object {
-                "color": "status-ok",
-                "opacity": "weak",
-              },
+            "background": Object {
+              "color": "status-ok",
+              "opacity": "weak",
             },
+            "color": "status-ok",
             "icon": Object {
               "$$typeof": Symbol(react.forward_ref),
               "render": [Function],
+            },
+            "toast": Object {
+              "background": "background-front",
             },
           },
           "textContainer": Object {
@@ -1842,7 +1849,6 @@ Object {
           "toast": Object {
             "container": Object {
               "elevation": "medium",
-              "round": "xsmall",
               "width": "medium",
             },
             "layer": Object {
@@ -1859,29 +1865,31 @@ Object {
             },
           },
           "unknown": Object {
-            "color": "status-unknown",
-            "global": Object {
-              "background": Object {
-                "color": "status-unknown",
-                "opacity": "weak",
-              },
+            "background": Object {
+              "color": "status-unknown",
+              "opacity": "weak",
             },
+            "color": "status-unknown",
             "icon": Object {
               "$$typeof": Symbol(react.forward_ref),
               "render": [Function],
+            },
+            "toast": Object {
+              "background": "background-front",
             },
           },
           "warning": Object {
-            "color": "status-warning",
-            "global": Object {
-              "background": Object {
-                "color": "status-warning",
-                "opacity": "weak",
-              },
+            "background": Object {
+              "color": "status-warning",
+              "opacity": "weak",
             },
+            "color": "status-warning",
             "icon": Object {
               "$$typeof": Symbol(react.forward_ref),
               "render": [Function],
+            },
+            "toast": Object {
+              "background": "background-front",
             },
           },
         },
@@ -3692,28 +3700,30 @@ Object {
               "horizontal": "small",
               "vertical": "xsmall",
             },
+            "round": "xsmall",
           },
           "critical": Object {
-            "color": "status-critical",
-            "global": Object {
-              "background": Object {
-                "color": "status-critical",
-                "opacity": "weak",
-              },
+            "background": Object {
+              "color": "status-critical",
+              "opacity": "weak",
             },
+            "color": "status-critical",
             "icon": Object {
               "$$typeof": Symbol(react.forward_ref),
               "render": [Function],
+            },
+            "toast": Object {
+              "background": "background-front",
             },
           },
           "direction": "column",
           "global": Object {
             "container": Object {
               "pad": Object {
-                "horizontal": "medium",
-                "vertical": "small",
+                "horizontal": "large",
+                "vertical": "xsmall",
               },
-              "round": "xsmall",
+              "round": "none",
             },
             "direction": "row",
           },
@@ -3724,26 +3734,31 @@ Object {
             },
           },
           "info": Object {
+            "background": "background-contrast",
             "color": "text-strong",
             "icon": Object {
               "$$typeof": Symbol(react.forward_ref),
               "render": [Function],
+            },
+            "toast": Object {
+              "background": "background-front",
             },
           },
           "message": Object {
             "margin": "none",
           },
           "normal": Object {
-            "color": "status-ok",
-            "global": Object {
-              "background": Object {
-                "color": "status-ok",
-                "opacity": "weak",
-              },
+            "background": Object {
+              "color": "status-ok",
+              "opacity": "weak",
             },
+            "color": "status-ok",
             "icon": Object {
               "$$typeof": Symbol(react.forward_ref),
               "render": [Function],
+            },
+            "toast": Object {
+              "background": "background-front",
             },
           },
           "textContainer": Object {
@@ -3755,7 +3770,6 @@ Object {
           "toast": Object {
             "container": Object {
               "elevation": "medium",
-              "round": "xsmall",
               "width": "medium",
             },
             "layer": Object {
@@ -3772,29 +3786,31 @@ Object {
             },
           },
           "unknown": Object {
-            "color": "status-unknown",
-            "global": Object {
-              "background": Object {
-                "color": "status-unknown",
-                "opacity": "weak",
-              },
+            "background": Object {
+              "color": "status-unknown",
+              "opacity": "weak",
             },
+            "color": "status-unknown",
             "icon": Object {
               "$$typeof": Symbol(react.forward_ref),
               "render": [Function],
+            },
+            "toast": Object {
+              "background": "background-front",
             },
           },
           "warning": Object {
-            "color": "status-warning",
-            "global": Object {
-              "background": Object {
-                "color": "status-warning",
-                "opacity": "weak",
-              },
+            "background": Object {
+              "color": "status-warning",
+              "opacity": "weak",
             },
+            "color": "status-warning",
             "icon": Object {
               "$$typeof": Symbol(react.forward_ref),
               "render": [Function],
+            },
+            "toast": Object {
+              "background": "background-front",
             },
           },
         },

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1134,6 +1134,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       direction: 'column',
       container: {
         // any box props
+        round: 'xsmall',
         pad: { horizontal: 'small', vertical: 'xsmall' },
         background: {
           color: 'background-front',
@@ -1143,10 +1144,10 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         direction: 'row',
         container: {
           // any box props
-          round: 'xsmall',
+          round: 'none',
           pad: {
-            horizontal: 'medium',
-            vertical: 'small',
+            horizontal: 'large',
+            vertical: 'xsmall',
           },
         },
       },
@@ -1155,7 +1156,6 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         container: {
           // any box props
           elevation: 'medium',
-          round: 'xsmall',
           width: 'medium',
         },
         layer: {
@@ -1186,58 +1186,60 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       },
       critical: {
         icon: StatusCriticalSmall,
-        // background: undefined,
-        color: 'status-critical',
-        global: {
-          background: {
-            color: 'status-critical',
-            opacity: 'weak',
-          },
+        background: {
+          color: 'status-critical',
+          opacity: 'weak',
         },
-        // toast: {},
+        color: 'status-critical',
+        // global: {},
+        toast: {
+          background: 'background-front',
+        },
       },
       warning: {
         icon: StatusWarningSmall,
-        // background: undefined,
-        color: 'status-warning',
-        global: {
-          background: {
-            color: 'status-warning',
-            opacity: 'weak',
-          },
+        background: {
+          color: 'status-warning',
+          opacity: 'weak',
         },
-        // toast: {},
+        color: 'status-warning',
+        // global: {},
+        toast: {
+          background: 'background-front',
+        },
       },
       normal: {
         icon: StatusGoodSmall,
-        // background: undefined,
-        color: 'status-ok',
-        global: {
-          background: {
-            color: 'status-ok',
-            opacity: 'weak',
-          },
+        background: {
+          color: 'status-ok',
+          opacity: 'weak',
         },
-        // toast: {},
+        color: 'status-ok',
+        // global: {},
+        toast: {
+          background: 'background-front',
+        },
       },
       info: {
         icon: CircleInformation,
-        // background: undefined,
+        background: 'background-contrast',
         color: 'text-strong',
         // global: {},
-        // toast: {},
+        toast: {
+          background: 'background-front',
+        },
       },
       unknown: {
         icon: StatusUnknownSmall,
-        // background: undefined,
-        color: 'status-unknown',
-        global: {
-          background: {
-            color: 'status-unknown',
-            opacity: 'weak',
-          },
+        background: {
+          color: 'status-unknown',
+          opacity: 'weak',
         },
-        // toast: {},
+        color: 'status-unknown',
+        // global: {},
+        toast: {
+          background: 'background-front',
+        },
       },
       // deprecate "undefined" in v3
       // and if undefined, no icon


### PR DESCRIPTION
#### What does this PR do?
Any notification that is not `global` or `toast` should have both rounding and a background color.

This PR should not affect the appearance of global or toast notifications (besides reverting the changes to the global notification theme from this pr: https://github.com/grommet/grommet/pull/6330)

#### Where should the reviewer start?

#### What testing has been done on this PR?
Tested with existing storybook stories and changed the status of the notifications to confirm all are displaying as expected.

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No
#### Should this PR be mentioned in the release notes?
Yes
#### Is this change backwards compatible or is it a breaking change?
Backwards compatible