### PR TITLE
SelectMultiple - adjust padding on selection summary

### DIFF
--- a/src/js/components/SelectMultiple/SelectMultipleContainer.js
+++ b/src/js/components/SelectMultiple/SelectMultipleContainer.js
@@ -342,12 +342,7 @@ const SelectMultipleContainer = forwardRef(
 
     if (showSelectedInline)
       summaryContent = (
-        <Box
-          direction="row"
-          justify="between"
-          flex={false}
-          pad={{ left: 'small' }}
-        >
+        <Box direction="row" justify="between" flex={false}>
           {summaryContent}
           <Button onClick={onClose} a11yTitle="Close Select">
             <Box fill alignSelf="start" pad={{ right: 'small', top: 'small' }}>

--- a/src/js/components/SelectMultiple/SelectionSummary.js
+++ b/src/js/components/SelectMultiple/SelectionSummary.js
@@ -45,7 +45,9 @@ const SelectionSummary = ({
   if (search === '' || search === undefined)
     return (
       <Box
-        pad={showSelectedInline ? { vertical: 'xsmall' } : 'small'}
+        pad={
+          showSelectedInline ? { left: 'xsmall', vertical: 'xsmall' } : 'xsmall'
+        }
         direction="row"
         justify="between"
         gap="small"
@@ -53,7 +55,7 @@ const SelectionSummary = ({
         flex={showSelectedInline}
       >
         <Box pad={{ vertical: 'xsmall' }} alignSelf="center">
-          <Text margin={{ vertical: 'xsmall' }} size="small">
+          <Text size="small">
             {value.length === 0 || onMore
               ? `${value.length} selected`
               : `${value.length} selected of ${options.length}`}
@@ -99,7 +101,11 @@ const SelectionSummary = ({
           )}
       </Box>
     );
-  return <Text size="small">{`${value.length} selected`}</Text>;
+  return (
+    <Box pad="xsmall">
+      <Text size="small">{`${value.length} selected`}</Text>
+    </Box>
+  );
 };
 
 export { SelectionSummary };


### PR DESCRIPTION
#### What does this PR do?
Fixes issues with the padding in the selection summary area of the SelectMultiple

Before:
<img width="300" alt="Screen Shot 2022-09-21 at 1 24 02 PM" src="https://user-images.githubusercontent.com/54560994/191592640-5a5da5e7-7962-414b-8bbc-4bac90e4facd.png">

<img width="328" alt="Screen Shot 2022-09-21 at 1 25 30 PM" src="https://user-images.githubusercontent.com/54560994/191592909-ece9a996-79a2-421c-ac60-476c810b991a.png">

After:
<img width="313" alt="Screen Shot 2022-09-21 at 1 24 34 PM" src="https://user-images.githubusercontent.com/54560994/191592749-f66ee8b6-76f6-4161-83bc-078970fa278c.png">

<img width="307" alt="Screen Shot 2022-09-21 at 1 25 44 PM" src="https://user-images.githubusercontent.com/54560994/191592954-497dd165-7361-4507-83b8-cab3f6733b36.png">

#### Where should the reviewer start?

#### What testing has been done on this PR?
existing storybook stories
#### How should this be manually tested?
storybook
#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No
#### Should this PR be mentioned in the release notes?
No, component not released yet
#### Is this change backwards compatible or is it a breaking change?
Backwards compatible