### PR TITLE
SelectMultiple - Fix hover and cursor issue on disabled option

### DIFF
--- a/src/js/components/Select/StyledSelect.js
+++ b/src/js/components/Select/StyledSelect.js
@@ -61,6 +61,7 @@ export const SelectOption = styled(Button)`
   }
   display: block;
   width: 100%;
+  ${(props) => props[`aria-disabled`] && `cursor: default`};
 `;
 
 export const SelectTextInput = styled(TextInput)`

--- a/src/js/components/Select/__tests__/__snapshots__/Select-multiple-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-multiple-test.js.snap
@@ -2753,7 +2753,7 @@ exports[`Select Controlled multiple onChange without valueKey 4`] = `
       <button
         aria-posinset="1"
         aria-setsize="2"
-        class="StyledButton-sc-323bzc-0 ghVuhX StyledSelect__SelectOption-sc-znp66n-3 dlQohO"
+        class="StyledButton-sc-323bzc-0 ghVuhX StyledSelect__SelectOption-sc-znp66n-3 fkzPuo"
         role="option"
         tabindex="-1"
         type="button"
@@ -2771,7 +2771,7 @@ exports[`Select Controlled multiple onChange without valueKey 4`] = `
       <button
         aria-posinset="2"
         aria-setsize="2"
-        class="StyledButton-sc-323bzc-0 ghVuhX StyledSelect__SelectOption-sc-znp66n-3 dlQohO"
+        class="StyledButton-sc-323bzc-0 ghVuhX StyledSelect__SelectOption-sc-znp66n-3 fkzPuo"
         role="option"
         tabindex="-1"
         type="button"

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -5084,7 +5084,7 @@ exports[`Select disabled key 2`] = `
   padding: 12px;
 }
 
-.c10 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5225,6 +5225,12 @@ exports[`Select disabled key 2`] = `
 }
 
 .c6 {
+  display: block;
+  width: 100%;
+  cursor: default;
+}
+
+.c10 {
   display: block;
   width: 100%;
 }
@@ -5299,7 +5305,7 @@ exports[`Select disabled key 2`] = `
         aria-posinset="2"
         aria-selected="false"
         aria-setsize="2"
-        class="c9 c6"
+        class="c9 c10"
         role="option"
         tabindex="-1"
         type="button"
@@ -5315,7 +5321,7 @@ exports[`Select disabled key 2`] = `
         </div>
       </button>
       <div
-        class="c10"
+        class="c11"
       />
     </div>
   </div>
@@ -5381,7 +5387,7 @@ exports[`Select disabled option value 1`] = `
   padding: 12px;
 }
 
-.c10 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5524,6 +5530,12 @@ exports[`Select disabled option value 1`] = `
 .c6 {
   display: block;
   width: 100%;
+  cursor: default;
+}
+
+.c10 {
+  display: block;
+  width: 100%;
 }
 
 @media only screen and (max-width:768px) {
@@ -5596,7 +5608,7 @@ exports[`Select disabled option value 1`] = `
         aria-posinset="2"
         aria-selected="false"
         aria-setsize="2"
-        class="c9 c6"
+        class="c9 c10"
         role="option"
         tabindex="-1"
         type="button"
@@ -5612,7 +5624,7 @@ exports[`Select disabled option value 1`] = `
         </div>
       </button>
       <div
-        class="c10"
+        class="c11"
       />
     </div>
   </div>
@@ -10309,7 +10321,7 @@ exports[`Select prop: onOpen 5`] = `
     aria-posinset="1"
     aria-selected="false"
     aria-setsize="2"
-    class="StyledButton-sc-323bzc-0 ghVuhX StyledSelect__SelectOption-sc-znp66n-3 dlQohO"
+    class="StyledButton-sc-323bzc-0 ghVuhX StyledSelect__SelectOption-sc-znp66n-3 fkzPuo"
     role="option"
     tabindex="-1"
     type="button"
@@ -10328,7 +10340,7 @@ exports[`Select prop: onOpen 5`] = `
     aria-posinset="2"
     aria-selected="false"
     aria-setsize="2"
-    class="StyledButton-sc-323bzc-0 ghVuhX StyledSelect__SelectOption-sc-znp66n-3 dlQohO"
+    class="StyledButton-sc-323bzc-0 ghVuhX StyledSelect__SelectOption-sc-znp66n-3 fkzPuo"
     role="option"
     tabindex="-1"
     type="button"

--- a/src/js/components/SelectMultiple/SelectMultipleValue.js
+++ b/src/js/components/SelectMultiple/SelectMultipleValue.js
@@ -66,7 +66,7 @@ const SelectMultipleValue = ({
             aria-selected={value.includes(optionValue)}
             aria-disabled={optionDisabled}
             plain
-            hoverIndicator
+            hoverIndicator={!optionDisabled}
             fill="horizontal"
             tabIndex="0"
             onClick={(event) => {

--- a/src/js/components/SelectMultiple/__tests__/__snapshots__/SelectMultiple-test.tsx.snap
+++ b/src/js/components/SelectMultiple/__tests__/__snapshots__/SelectMultiple-test.tsx.snap
@@ -4624,11 +4624,6 @@ exports[`SelectMultiple showSelectionInline with disabled options 1`] = `
   width: 100%;
 }
 
-.c12:hover {
-  background-color: rgba(221,221,221,0.4);
-  color: #000000;
-}
-
 .c12:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
@@ -4787,6 +4782,7 @@ exports[`SelectMultiple showSelectionInline with disabled options 1`] = `
 .c13 {
   display: block;
   width: 100%;
+  cursor: default;
 }
 
 .c8 {


### PR DESCRIPTION
#### What does this PR do?
Fixes an issue in SelectMultiple where a disabled option has hover styling and the cursor is displayed as a pointer, incorrectly indicating that the option is clickable.

<img width="522" alt="Screen Shot 2022-09-22 at 1 03 51 PM" src="https://user-images.githubusercontent.com/54560994/191830446-5d601298-a741-4b30-abc7-468187fea7b2.png">

#### Where should the reviewer start?

#### What testing has been done on this PR?
Tested with SelectMultiple/Disabled story

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No
#### Should this PR be mentioned in the release notes?
No
#### Is this change backwards compatible or is it a breaking change?
Backwards compatible