### PR TITLE
Fix List layout when it has action and onOrder defined

### DIFF
--- a/src/js/components/List/List.js
+++ b/src/js/components/List/List.js
@@ -637,6 +637,11 @@ const List = React.forwardRef(
                     </Box>
                   );
 
+                  // wrap the main content and use
+                  // the boxProps defined for the content
+                  content = <Box flex {...boxProps}>{content}</Box>;
+
+                  // Adjust the boxProps to account for the order controls
                   boxProps = {
                     direction: 'row',
                     align:
@@ -644,7 +649,6 @@ const List = React.forwardRef(
                     gap: 'medium',
                   };
 
-                  content = <Box flex>{content}</Box>;
                 }
 
                 let itemAriaProps;

--- a/src/js/components/List/__tests__/List-test.js
+++ b/src/js/components/List/__tests__/List-test.js
@@ -11,6 +11,7 @@ import { Grommet } from '../../Grommet';
 import { List } from '..';
 import { Box } from '../../Box';
 import { Text } from '../../Text';
+import { Button } from '../../Button';
 
 const data = [];
 for (let i = 0; i < 95; i += 1) {
@@ -548,6 +549,39 @@ describe('List onOrder', () => {
       which: 13,
     });
     expect(onOrder).toHaveBeenCalled();
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});
+
+describe('List onOrder with action', () => {
+  let onOrder;
+  let App;
+
+  beforeEach(() => {
+    onOrder = jest.fn();
+    App = () => {
+      const [ordered, setOrdered] = useState([{ a: 'alpha' }, { a: 'beta' }]);
+      return (
+        <Grommet>
+          <List
+            data={ordered}
+            primaryKey="a"
+            onOrder={(newData) => {
+              setOrdered(newData);
+              onOrder(newData);
+            }}
+            // eslint-disable-next-line react/no-unstable-nested-components
+            action={(item, index) =>
+              <Button key={`action${index}`} label="Action"/>}
+          />
+        </Grommet>
+      );
+    };
+  });
+
+  test('Render', () => {
+    const { container } = render(<App />);
+
     expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/js/components/List/__tests__/List-test.js
+++ b/src/js/components/List/__tests__/List-test.js
@@ -580,9 +580,9 @@ describe('List onOrder with action', () => {
   });
 
   test('Render', () => {
-    const { container } = render(<App />);
+    const { asFragment } = render(<App />);
 
-    expect(container.firstChild).toMatchSnapshot();
+    expect(asFragment()).toMatchSnapshot();
   });
 });
 

--- a/src/js/components/List/__tests__/__snapshots__/List-test.js.snap
+++ b/src/js/components/List/__tests__/__snapshots__/List-test.js.snap
@@ -16567,7 +16567,8 @@ exports[`List onOrder Mouse move down 2`] = `
 `;
 
 exports[`List onOrder with action Render 1`] = `
-.c12 {
+<DocumentFragment>
+  .c12 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -16972,181 +16973,182 @@ exports[`List onOrder with action Render 1`] = `
 }
 
 <div
-  class="c0"
->
-  <ul
-    class="c1"
-    role="listbox"
-    tabindex="0"
+    class="c0"
   >
-    <li
-      class="c2 c3"
-      draggable="true"
+    <ul
+      class="c1"
+      role="listbox"
+      tabindex="0"
     >
-      <span
-        class="c4"
+      <li
+        class="c2 c3"
+        draggable="true"
       >
-        1
-      </span>
-      <div
-        class="c5"
-      />
-      <div
-        class="c6"
-      >
-        <div
-          class="c7"
+        <span
+          class="c4"
         >
-          <span
-            class="c8"
+          1
+        </span>
+        <div
+          class="c5"
+        />
+        <div
+          class="c6"
+        >
+          <div
+            class="c7"
           >
-            alpha
-          </span>
+            <span
+              class="c8"
+            >
+              alpha
+            </span>
+          </div>
+          <div
+            class="c5"
+          />
+          <button
+            class="c9"
+            type="button"
+          >
+            Action
+          </button>
         </div>
         <div
           class="c5"
         />
-        <button
-          class="c9"
-          type="button"
-        >
-          Action
-        </button>
-      </div>
-      <div
-        class="c5"
-      />
-      <div
-        class="c10"
-      >
-        <button
-          aria-label="1 alpha move up"
-          class="c11"
-          disabled=""
-          id="alphaMoveUp"
-          tabindex="-1"
-          type="button"
-        >
-          <svg
-            aria-label="FormUp"
-            class="c12"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="m18 15-6-6-6 6"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-        <button
-          aria-label="1 alpha move down"
-          class="c13"
-          id="alphaMoveDown"
-          tabindex="-1"
-          type="button"
-        >
-          <svg
-            aria-label="FormDown"
-            class="c12"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="m18 9-6 6-6-6"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-      </div>
-    </li>
-    <li
-      class="c14 c3"
-      draggable="true"
-    >
-      <span
-        class="c4"
-      >
-        2
-      </span>
-      <div
-        class="c5"
-      />
-      <div
-        class="c6"
-      >
         <div
-          class="c7"
+          class="c10"
         >
-          <span
-            class="c8"
+          <button
+            aria-label="1 alpha move up"
+            class="c11"
+            disabled=""
+            id="alphaMoveUp"
+            tabindex="-1"
+            type="button"
           >
-            beta
-          </span>
+            <svg
+              aria-label="FormUp"
+              class="c12"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 15-6-6-6 6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+          <button
+            aria-label="1 alpha move down"
+            class="c13"
+            id="alphaMoveDown"
+            tabindex="-1"
+            type="button"
+          >
+            <svg
+              aria-label="FormDown"
+              class="c12"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 9-6 6-6-6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </div>
+      </li>
+      <li
+        class="c14 c3"
+        draggable="true"
+      >
+        <span
+          class="c4"
+        >
+          2
+        </span>
+        <div
+          class="c5"
+        />
+        <div
+          class="c6"
+        >
+          <div
+            class="c7"
+          >
+            <span
+              class="c8"
+            >
+              beta
+            </span>
+          </div>
+          <div
+            class="c5"
+          />
+          <button
+            class="c9"
+            type="button"
+          >
+            Action
+          </button>
         </div>
         <div
           class="c5"
         />
-        <button
-          class="c9"
-          type="button"
+        <div
+          class="c10"
         >
-          Action
-        </button>
-      </div>
-      <div
-        class="c5"
-      />
-      <div
-        class="c10"
-      >
-        <button
-          aria-label="2 beta move up"
-          class="c13"
-          id="betaMoveUp"
-          tabindex="-1"
-          type="button"
-        >
-          <svg
-            aria-label="FormUp"
-            class="c12"
-            viewBox="0 0 24 24"
+          <button
+            aria-label="2 beta move up"
+            class="c13"
+            id="betaMoveUp"
+            tabindex="-1"
+            type="button"
           >
-            <path
-              d="m18 15-6-6-6 6"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-        <button
-          aria-label="2 beta move down"
-          class="c11"
-          disabled=""
-          id="betaMoveDown"
-          tabindex="-1"
-          type="button"
-        >
-          <svg
-            aria-label="FormDown"
-            class="c12"
-            viewBox="0 0 24 24"
+            <svg
+              aria-label="FormUp"
+              class="c12"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 15-6-6-6 6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+          <button
+            aria-label="2 beta move down"
+            class="c11"
+            disabled=""
+            id="betaMoveDown"
+            tabindex="-1"
+            type="button"
           >
-            <path
-              d="m18 9-6 6-6-6"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-      </div>
-    </li>
-  </ul>
-</div>
+            <svg
+              aria-label="FormDown"
+              class="c12"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 9-6 6-6-6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </div>
+      </li>
+    </ul>
+  </div>
+</DocumentFragment>
 `;
 
 exports[`List pad object 1`] = `

--- a/src/js/components/List/__tests__/__snapshots__/List-test.js.snap
+++ b/src/js/components/List/__tests__/__snapshots__/List-test.js.snap
@@ -16566,6 +16566,589 @@ exports[`List onOrder Mouse move down 2`] = `
 </div>
 `;
 
+exports[`List onOrder with action Render 1`] = `
+.c12 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #666666;
+  stroke: #666666;
+}
+
+.c12 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c12 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c12 *[stroke*="#"],
+.c12 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c12 *[fill-rule],
+.c12 *[FILL-RULE],
+.c12 *[fill*="#"],
+.c12 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-top: solid 1px rgba(0,0,0,0.33);
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  padding-left: 24px;
+  padding-right: 24px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.c14 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  padding-left: 24px;
+  padding-right: 24px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+
+.c5 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  width: 24px;
+}
+
+.c4 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c8 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c9 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: 2px solid #7D4CDB;
+  border-radius: 18px;
+  color: #444444;
+  padding: 4px 22px;
+  font-size: 18px;
+  line-height: 24px;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+}
+
+.c9:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c9:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9:focus > circle,
+.c9:focus > ellipse,
+.c9:focus > line,
+.c9:focus > path,
+.c9:focus > polygon,
+.c9:focus > polyline,
+.c9:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c9:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c9:focus:not(:focus-visible) > circle,
+.c9:focus:not(:focus-visible) > ellipse,
+.c9:focus:not(:focus-visible) > line,
+.c9:focus:not(:focus-visible) > path,
+.c9:focus:not(:focus-visible) > polygon,
+.c9:focus:not(:focus-visible) > polyline,
+.c9:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c9:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c11 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  opacity: 0.3;
+  cursor: default;
+  line-height: 0;
+  padding: 12px;
+}
+
+.c11:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c11:focus:not(:focus-visible) > circle,
+.c11:focus:not(:focus-visible) > ellipse,
+.c11:focus:not(:focus-visible) > line,
+.c11:focus:not(:focus-visible) > path,
+.c11:focus:not(:focus-visible) > polygon,
+.c11:focus:not(:focus-visible) > polyline,
+.c11:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c11:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c13 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  line-height: 0;
+  padding: 12px;
+}
+
+.c13:hover {
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
+}
+
+.c13:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c13:focus:not(:focus-visible) > circle,
+.c13:focus:not(:focus-visible) > ellipse,
+.c13:focus:not(:focus-visible) > line,
+.c13:focus:not(:focus-visible) > path,
+.c13:focus:not(:focus-visible) > polygon,
+.c13:focus:not(:focus-visible) > polyline,
+.c13:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c13:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c1 {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.c1:focus {
+  outline: 2px solid #6FFFB0;
+}
+
+.c3 {
+  cursor: move;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    border-top: solid 1px rgba(0,0,0,0.33);
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c14 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c14 {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c14 {
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c5 {
+    width: 12px;
+  }
+}
+
+<div
+  class="c0"
+>
+  <ul
+    class="c1"
+    role="listbox"
+    tabindex="0"
+  >
+    <li
+      class="c2 c3"
+      draggable="true"
+    >
+      <span
+        class="c4"
+      >
+        1
+      </span>
+      <div
+        class="c5"
+      />
+      <div
+        class="c6"
+      >
+        <div
+          class="c7"
+        >
+          <span
+            class="c8"
+          >
+            alpha
+          </span>
+        </div>
+        <div
+          class="c5"
+        />
+        <button
+          class="c9"
+          type="button"
+        >
+          Action
+        </button>
+      </div>
+      <div
+        class="c5"
+      />
+      <div
+        class="c10"
+      >
+        <button
+          aria-label="1 alpha move up"
+          class="c11"
+          disabled=""
+          id="alphaMoveUp"
+          tabindex="-1"
+          type="button"
+        >
+          <svg
+            aria-label="FormUp"
+            class="c12"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="m18 15-6-6-6 6"
+              fill="none"
+              stroke="#000"
+              stroke-width="2"
+            />
+          </svg>
+        </button>
+        <button
+          aria-label="1 alpha move down"
+          class="c13"
+          id="alphaMoveDown"
+          tabindex="-1"
+          type="button"
+        >
+          <svg
+            aria-label="FormDown"
+            class="c12"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="m18 9-6 6-6-6"
+              fill="none"
+              stroke="#000"
+              stroke-width="2"
+            />
+          </svg>
+        </button>
+      </div>
+    </li>
+    <li
+      class="c14 c3"
+      draggable="true"
+    >
+      <span
+        class="c4"
+      >
+        2
+      </span>
+      <div
+        class="c5"
+      />
+      <div
+        class="c6"
+      >
+        <div
+          class="c7"
+        >
+          <span
+            class="c8"
+          >
+            beta
+          </span>
+        </div>
+        <div
+          class="c5"
+        />
+        <button
+          class="c9"
+          type="button"
+        >
+          Action
+        </button>
+      </div>
+      <div
+        class="c5"
+      />
+      <div
+        class="c10"
+      >
+        <button
+          aria-label="2 beta move up"
+          class="c13"
+          id="betaMoveUp"
+          tabindex="-1"
+          type="button"
+        >
+          <svg
+            aria-label="FormUp"
+            class="c12"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="m18 15-6-6-6 6"
+              fill="none"
+              stroke="#000"
+              stroke-width="2"
+            />
+          </svg>
+        </button>
+        <button
+          aria-label="2 beta move down"
+          class="c11"
+          disabled=""
+          id="betaMoveDown"
+          tabindex="-1"
+          type="button"
+        >
+          <svg
+            aria-label="FormDown"
+            class="c12"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="m18 9-6 6-6-6"
+              fill="none"
+              stroke="#000"
+              stroke-width="2"
+            />
+          </svg>
+        </button>
+      </div>
+    </li>
+  </ul>
+</div>
+`;
+
 exports[`List pad object 1`] = `
 .c0 {
   font-size: 18px;


### PR DESCRIPTION
When you have a List with both `action` and `onOrder` specified the action and primary/secondary labels end up in a container that is column layout rather than the typical row layout you have with `action` when `onOrder` isn't used.

#### What does this PR do?
This change uses the same layout for the non onOrder-related elements as it would have used without `onOrder`. In the case of `action`, this puts the action next to the onOrder controls more like you'd expect.

#### Where should the reviewer start?
List.js

#### What testing has been done on this PR?
Manual, storybook and Jest

#### How should this be manually tested?
Manualy add an action to an onOrder example.

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Fixes #6341 

#### Screenshots (if appropriate)
Before:
![image](https://user-images.githubusercontent.com/12054362/192029726-2b149d29-be39-4f30-9ef8-9663ff025f5b.png)

After:
![image](https://user-images.githubusercontent.com/12054362/192029597-2bdbac0a-ec84-49ea-b1a6-78baa0bcf82e.png)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Yes

#### Is this change backwards compatible or is it a breaking change?
Backwards Compatible