### PR TITLE
SelectMultiple - fix object options search

### DIFF
--- a/src/js/components/SelectMultiple/SelectMultiple.js
+++ b/src/js/components/SelectMultiple/SelectMultiple.js
@@ -167,9 +167,9 @@ const SelectMultiple = forwardRef(
     }, [onOpen, open]);
 
     useEffect(() => {
-      if (sortSelectedOnClose && value && ((open && search) || !open)) {
+      if (sortSelectedOnClose && ((open && search) || !open)) {
         const selectedOptions = optionsProp.filter((option) =>
-          value.includes(
+          value?.includes(
             valueKey && valueKey.reduce ? applyKey(option, valueKey) : option,
           ),
         );

--- a/src/js/components/SelectMultiple/SelectMultipleContainer.js
+++ b/src/js/components/SelectMultiple/SelectMultipleContainer.js
@@ -466,7 +466,7 @@ const SelectMultipleContainer = forwardRef(
                   }
 
                   if (!children && search) {
-                    let searchText = search.toLowerCase();
+                    const searchText = search.toLowerCase();
                     if (
                       typeof optionLabel === 'string' &&
                       optionLabel.toLowerCase().indexOf(searchText) >= 0

--- a/src/js/components/SelectMultiple/SelectMultipleContainer.js
+++ b/src/js/components/SelectMultiple/SelectMultipleContainer.js
@@ -466,25 +466,26 @@ const SelectMultipleContainer = forwardRef(
                   }
 
                   if (!children && search) {
+                    let searchText = search.toLowerCase();
                     if (
                       typeof optionLabel === 'string' &&
-                      optionLabel.toLowerCase().indexOf(search) >= 0
+                      optionLabel.toLowerCase().indexOf(searchText) >= 0
                     ) {
                       // code to bold search term in matching options
                       const boldIndex = optionLabel
                         .toLowerCase()
-                        .indexOf(search);
+                        .indexOf(searchText);
                       const childBeginning = optionLabel.substring(
                         0,
                         boldIndex,
                       );
                       let childBold = optionLabel.substring(
                         boldIndex,
-                        boldIndex + search.length,
+                        boldIndex + searchText.length,
                       );
                       childBold = <b>{childBold}</b>;
                       const childEnd = optionLabel.substring(
-                        boldIndex + search.length,
+                        boldIndex + searchText.length,
                       );
                       child = (
                         <CheckBox

--- a/src/js/components/SelectMultiple/stories/Default.js
+++ b/src/js/components/SelectMultiple/stories/Default.js
@@ -18,7 +18,7 @@ const defaultOptions = [
 
 export const Default = () => {
   const [options, setOptions] = useState(defaultOptions);
-  const [valueMultiple, setValueMultiple] = useState();
+  const [valueMultiple, setValueMultiple] = useState([]);
 
   return (
     // Uncomment <Grommet> lines when using outside of storybook

--- a/src/js/components/SelectMultiple/stories/Default.js
+++ b/src/js/components/SelectMultiple/stories/Default.js
@@ -18,7 +18,7 @@ const defaultOptions = [
 
 export const Default = () => {
   const [options, setOptions] = useState(defaultOptions);
-  const [valueMultiple, setValueMultiple] = useState([]);
+  const [valueMultiple, setValueMultiple] = useState();
 
   return (
     // Uncomment <Grommet> lines when using outside of storybook

--- a/src/js/components/SelectMultiple/stories/ObjectOptions.js
+++ b/src/js/components/SelectMultiple/stories/ObjectOptions.js
@@ -47,6 +47,9 @@ export const ObjectOptions = () => {
         labelKey="label"
         valueKey={{ key: 'value' }}
         options={options}
+        onClose={() => {
+          setOptions(objectOptions);
+        }}
       />
     </Box>
     // </Grommet>


### PR DESCRIPTION
#### What does this PR do?
Fixes an issue when `options` are objects search doesn't behave as expected.
Also fixes an issue where capital letters in the search were not bolding the matches found. (When searching matching letters should be bolded)

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?
Storybook object options story

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)
Before:

https://user-images.githubusercontent.com/54560994/192879097-a8ca740f-d755-40af-896d-f9e2c1146613.mp4

After:

https://user-images.githubusercontent.com/54560994/192879147-8c66657f-d364-4f57-a588-77011ebb3239.mp4

#### Do the grommet docs need to be updated?
No
#### Should this PR be mentioned in the release notes?
Yes
#### Is this change backwards compatible or is it a breaking change?
Backwards compatible