### PR TITLE
fix/radio-button-focus-indicator

### DIFF
--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
@@ -2663,7 +2663,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 1`] =
   flex: 0 0 auto;
 }
 
-.c23 {
+.c24 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2715,7 +2715,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 1`] =
   border-radius: 4px;
 }
 
-.c25 {
+.c28 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2741,7 +2741,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 1`] =
   border-radius: 100%;
 }
 
-.c24 {
+.c27 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -2833,7 +2833,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 1`] =
   border-color: #000000;
 }
 
-.c22 {
+.c23 {
   opacity: 0;
   -moz-appearance: none;
   width: 0;
@@ -2842,11 +2842,31 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 1`] =
   cursor: pointer;
 }
 
-.c26 {
+.c29 {
   box-sizing: border-box;
   width: 24px;
   height: 24px;
   fill: #7D4CDB;
+}
+
+.c22:focus + .c25 {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c22:focus + .c25 > circle,
+.c22:focus + .c26 > ellipse,
+.c22:focus + .c26 > line,
+.c22:focus + .c26 > path,
+.c22:focus + .c26 > polygon,
+.c22:focus + .c26 > polyline,
+.c22:focus + .c26 > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c22:focus + .c25::-moz-focus-inner {
+  border: 0;
 }
 
 .c2 {
@@ -2896,7 +2916,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 1`] =
   border: 0;
 }
 
-.c27 {
+.c30 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -2924,47 +2944,47 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 1`] =
   transition-timing-function: ease-in-out;
 }
 
-.c27:hover {
+.c30:hover {
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c27:focus {
+.c30:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c27:focus > circle,
-.c27:focus > ellipse,
-.c27:focus > line,
-.c27:focus > path,
-.c27:focus > polygon,
-.c27:focus > polyline,
-.c27:focus > rect {
+.c30:focus > circle,
+.c30:focus > ellipse,
+.c30:focus > line,
+.c30:focus > path,
+.c30:focus > polygon,
+.c30:focus > polyline,
+.c30:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c27:focus::-moz-focus-inner {
+.c30:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c27:focus:not(:focus-visible) {
+.c30:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c27:focus:not(:focus-visible) > circle,
-.c27:focus:not(:focus-visible) > ellipse,
-.c27:focus:not(:focus-visible) > line,
-.c27:focus:not(:focus-visible) > path,
-.c27:focus:not(:focus-visible) > polygon,
-.c27:focus:not(:focus-visible) > polyline,
-.c27:focus:not(:focus-visible) > rect {
+.c30:focus:not(:focus-visible) > circle,
+.c30:focus:not(:focus-visible) > ellipse,
+.c30:focus:not(:focus-visible) > line,
+.c30:focus:not(:focus-visible) > path,
+.c30:focus:not(:focus-visible) > polygon,
+.c30:focus:not(:focus-visible) > polyline,
+.c30:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c27:focus:not(:focus-visible)::-moz-focus-inner {
+.c30:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
@@ -3069,7 +3089,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 1`] =
 }
 
 @media only screen and (max-width:768px) {
-  .c23 {
+  .c24 {
     border: solid 2px rgba(0,0,0,0.15);
   }
 }
@@ -3085,13 +3105,13 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 1`] =
 }
 
 @media only screen and (max-width:768px) {
-  .c25 {
+  .c28 {
     border: solid 2px #7D4CDB;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c24 {
+  .c27 {
     height: 6px;
   }
 }
@@ -3243,7 +3263,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 1`] =
               class="c21 "
             >
               <input
-                class="c22"
+                class="c22 c23"
                 id="test-radiobuttongroup-one"
                 name="test-radiobuttongroup"
                 tabindex="-1"
@@ -3251,7 +3271,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 1`] =
                 value="one"
               />
               <div
-                class="c23 "
+                class="c24 c25 c26"
               />
             </div>
             <span
@@ -3261,7 +3281,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 1`] =
             </span>
           </label>
           <div
-            class="c24"
+            class="c27"
           />
           <label
             class="c20"
@@ -3271,7 +3291,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 1`] =
               class="c21 "
             >
               <input
-                class="c22"
+                class="c22 c23"
                 id="test-radiobuttongroup-two"
                 name="test-radiobuttongroup"
                 tabindex="0"
@@ -3279,10 +3299,10 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 1`] =
                 value="two"
               />
               <div
-                class="c25 "
+                class="c28 c25 c26"
               >
                 <svg
-                  class="c26"
+                  class="c29"
                   preserveAspectRatio="xMidYMid meet"
                   viewBox="0 0 24 24"
                 >
@@ -3301,7 +3321,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 1`] =
             </span>
           </label>
           <div
-            class="c24"
+            class="c27"
           />
           <label
             class="c20"
@@ -3311,7 +3331,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 1`] =
               class="c21 "
             >
               <input
-                class="c22"
+                class="c22 c23"
                 id="test-radiobuttongroup-three"
                 name="test-radiobuttongroup"
                 tabindex="-1"
@@ -3319,7 +3339,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 1`] =
                 value="three"
               />
               <div
-                class="c23 "
+                class="c24 c25 c26"
               />
             </div>
             <span
@@ -3332,7 +3352,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 1`] =
       </div>
     </div>
     <button
-      class="c27"
+      class="c30"
       type="reset"
     >
       Reset
@@ -3463,7 +3483,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
           role="radiogroup"
         >
           <label
-            class="StyledRadioButton__StyledRadioButtonContainer-sc-g1f6ld-0 drCFDy"
+            class="StyledRadioButton__StyledRadioButtonContainer-sc-g1f6ld-0 hlxOha"
             for="test-radiobuttongroup-one"
           >
             <div
@@ -3478,7 +3498,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
                 value="one"
               />
               <div
-                class="StyledBox-sc-13pk1d4-0 jDrtOq StyledRadioButton__StyledRadioButtonBox-sc-g1f6ld-4 iA-dCYh"
+                class="StyledBox-sc-13pk1d4-0 jDrtOq StyledRadioButton__StyledRadioButtonBox-sc-g1f6ld-4 imvMLc"
               />
             </div>
             <span
@@ -3491,7 +3511,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
             class="StyledBox__StyledBoxGap-sc-13pk1d4-1 drdMXk"
           />
           <label
-            class="StyledRadioButton__StyledRadioButtonContainer-sc-g1f6ld-0 drCFDy"
+            class="StyledRadioButton__StyledRadioButtonContainer-sc-g1f6ld-0 hlxOha"
             for="test-radiobuttongroup-two"
           >
             <div
@@ -3506,7 +3526,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
                 value="two"
               />
               <div
-                class="StyledBox-sc-13pk1d4-0 jDrtOq StyledRadioButton__StyledRadioButtonBox-sc-g1f6ld-4 iA-dCYh"
+                class="StyledBox-sc-13pk1d4-0 jDrtOq StyledRadioButton__StyledRadioButtonBox-sc-g1f6ld-4 imvMLc"
               />
             </div>
             <span
@@ -3519,7 +3539,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
             class="StyledBox__StyledBoxGap-sc-13pk1d4-1 drdMXk"
           />
           <label
-            class="StyledRadioButton__StyledRadioButtonContainer-sc-g1f6ld-0 drCFDy"
+            class="StyledRadioButton__StyledRadioButtonContainer-sc-g1f6ld-0 hlxOha"
             for="test-radiobuttongroup-three"
           >
             <div
@@ -3534,7 +3554,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
                 value="three"
               />
               <div
-                class="StyledBox-sc-13pk1d4-0 jDrtOq StyledRadioButton__StyledRadioButtonBox-sc-g1f6ld-4 iA-dCYh"
+                class="StyledBox-sc-13pk1d4-0 jDrtOq StyledRadioButton__StyledRadioButtonBox-sc-g1f6ld-4 imvMLc"
               />
             </div>
             <span

--- a/src/js/components/RadioButton/StyledRadioButton.js
+++ b/src/js/components/RadioButton/StyledRadioButton.js
@@ -14,8 +14,9 @@ const StyledRadioButtonContainer = styled.label`
   align-items: center;
   user-select: none;
   width: fit-content;
-  ${(props) => props.disabled && disabledStyle} ${(props) =>
-    !props.disabled && 'cursor: pointer;'}
+
+  ${(props) => props.disabled && disabledStyle};
+  ${(props) => !props.disabled && 'cursor: pointer;'};
 
   :hover input:not([disabled]) + div,
   :hover input:not([disabled]) + span {
@@ -108,6 +109,10 @@ const StyledRadioButtonBox = styled.div`
     )};
   ${(props) => props.focus && focusStyle()};
   ${(props) => props.theme.radioButton.check.extend};
+
+  ${StyledRadioButtonInput}:focus + & {
+    ${focusStyle()}
+  }
 `;
 
 StyledRadioButtonBox.defaultProps = {};

--- a/src/js/components/RadioButton/__tests__/__snapshots__/RadioButton-test.tsx.snap
+++ b/src/js/components/RadioButton/__tests__/__snapshots__/RadioButton-test.tsx.snap
@@ -28,7 +28,7 @@ exports[`RadioButton background-color themed 1`] = `
   flex: 0 0 auto;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -81,7 +81,7 @@ exports[`RadioButton background-color themed 1`] = `
   border-color: #000000;
 }
 
-.c3 {
+.c4 {
   opacity: 0;
   -moz-appearance: none;
   width: 0;
@@ -90,12 +90,32 @@ exports[`RadioButton background-color themed 1`] = `
   cursor: pointer;
 }
 
-.c5 {
+.c7 {
   background-color: red;
 }
 
+.c3:focus + .c6 {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus + .c6 > circle,
+.c3:focus + .c7 > ellipse,
+.c3:focus + .c7 > line,
+.c3:focus + .c7 > path,
+.c3:focus + .c7 > polygon,
+.c3:focus + .c7 > polyline,
+.c3:focus + .c7 > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus + .c6::-moz-focus-inner {
+  border: 0;
+}
+
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c5 {
     border: solid 2px rgba(0,0,0,0.15);
   }
 }
@@ -110,12 +130,12 @@ exports[`RadioButton background-color themed 1`] = `
       class="c2 "
     >
       <input
-        class="c3"
+        class="c3 c4"
         name="test"
         type="radio"
       />
       <div
-        class="c4 c5"
+        class="c5 c6 c7"
       />
     </div>
   </label>
@@ -150,7 +170,7 @@ exports[`RadioButton background-color themed symbolic 1`] = `
   flex: 0 0 auto;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -203,7 +223,7 @@ exports[`RadioButton background-color themed symbolic 1`] = `
   border-color: #000000;
 }
 
-.c3 {
+.c4 {
   opacity: 0;
   -moz-appearance: none;
   width: 0;
@@ -212,12 +232,32 @@ exports[`RadioButton background-color themed symbolic 1`] = `
   cursor: pointer;
 }
 
-.c5 {
+.c7 {
   background-color: #7D4CDB;
 }
 
+.c3:focus + .c6 {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus + .c6 > circle,
+.c3:focus + .c7 > ellipse,
+.c3:focus + .c7 > line,
+.c3:focus + .c7 > path,
+.c3:focus + .c7 > polygon,
+.c3:focus + .c7 > polyline,
+.c3:focus + .c7 > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus + .c6::-moz-focus-inner {
+  border: 0;
+}
+
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c5 {
     border: solid 2px rgba(0,0,0,0.15);
   }
 }
@@ -232,12 +272,12 @@ exports[`RadioButton background-color themed symbolic 1`] = `
       class="c2 "
     >
       <input
-        class="c3"
+        class="c3 c4"
         name="test"
         type="radio"
       />
       <div
-        class="c4 c5"
+        class="c5 c6 c7"
       />
     </div>
   </label>
@@ -272,7 +312,7 @@ exports[`RadioButton basic 1`] = `
   flex: 0 0 auto;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -325,7 +365,7 @@ exports[`RadioButton basic 1`] = `
   border-color: #000000;
 }
 
-.c3 {
+.c4 {
   opacity: 0;
   -moz-appearance: none;
   width: 0;
@@ -334,8 +374,28 @@ exports[`RadioButton basic 1`] = `
   cursor: pointer;
 }
 
+.c3:focus + .c6 {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus + .c6 > circle,
+.c3:focus + .c7 > ellipse,
+.c3:focus + .c7 > line,
+.c3:focus + .c7 > path,
+.c3:focus + .c7 > polygon,
+.c3:focus + .c7 > polyline,
+.c3:focus + .c7 > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus + .c6::-moz-focus-inner {
+  border: 0;
+}
+
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c5 {
     border: solid 2px rgba(0,0,0,0.15);
   }
 }
@@ -350,13 +410,13 @@ exports[`RadioButton basic 1`] = `
       class="c2 "
     >
       <input
-        class="c3"
+        class="c3 c4"
         name="test"
         type="radio"
         value="1"
       />
       <div
-        class="c4 "
+        class="c5 c6 c7"
       />
     </div>
   </label>
@@ -368,14 +428,14 @@ exports[`RadioButton basic 1`] = `
       class="c2 "
     >
       <input
-        class="c3"
+        class="c3 c4"
         id="test id"
         name="test"
         type="radio"
         value="2"
       />
       <div
-        class="c4 "
+        class="c5 c6 c7"
       />
     </div>
   </label>
@@ -410,7 +470,7 @@ exports[`RadioButton checked 1`] = `
   flex: 0 0 auto;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -463,7 +523,7 @@ exports[`RadioButton checked 1`] = `
   border-color: #000000;
 }
 
-.c3 {
+.c4 {
   opacity: 0;
   -moz-appearance: none;
   width: 0;
@@ -472,15 +532,35 @@ exports[`RadioButton checked 1`] = `
   cursor: pointer;
 }
 
-.c5 {
+.c8 {
   box-sizing: border-box;
   width: 24px;
   height: 24px;
   fill: #7D4CDB;
 }
 
+.c3:focus + .c6 {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus + .c6 > circle,
+.c3:focus + .c7 > ellipse,
+.c3:focus + .c7 > line,
+.c3:focus + .c7 > path,
+.c3:focus + .c7 > polygon,
+.c3:focus + .c7 > polyline,
+.c3:focus + .c7 > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus + .c6::-moz-focus-inner {
+  border: 0;
+}
+
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c5 {
     border: solid 2px #7D4CDB;
   }
 }
@@ -496,16 +576,16 @@ exports[`RadioButton checked 1`] = `
     >
       <input
         checked=""
-        class="c3"
+        class="c3 c4"
         name="test"
         type="radio"
         value="1"
       />
       <div
-        class="c4 "
+        class="c5 c6 c7"
       >
         <svg
-          class="c5"
+          class="c8"
           preserveAspectRatio="xMidYMid meet"
           viewBox="0 0 24 24"
         >
@@ -700,7 +780,7 @@ exports[`RadioButton disabled 1`] = `
   flex: 0 0 auto;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -726,7 +806,7 @@ exports[`RadioButton disabled 1`] = `
   border-radius: 100%;
 }
 
-.c5 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -780,7 +860,7 @@ exports[`RadioButton disabled 1`] = `
   border-color: #000000;
 }
 
-.c3 {
+.c4 {
   opacity: 0;
   -moz-appearance: none;
   width: 0;
@@ -788,21 +868,41 @@ exports[`RadioButton disabled 1`] = `
   margin: 0;
 }
 
-.c6 {
+.c9 {
   box-sizing: border-box;
   width: 24px;
   height: 24px;
   fill: #7D4CDB;
 }
 
+.c3:focus + .c6 {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus + .c6 > circle,
+.c3:focus + .c7 > ellipse,
+.c3:focus + .c7 > line,
+.c3:focus + .c7 > path,
+.c3:focus + .c7 > polygon,
+.c3:focus + .c7 > polyline,
+.c3:focus + .c7 > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus + .c6::-moz-focus-inner {
+  border: 0;
+}
+
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c5 {
     border: solid 2px rgba(0,0,0,0.15);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c8 {
     border: solid 2px #7D4CDB;
   }
 }
@@ -818,14 +918,14 @@ exports[`RadioButton disabled 1`] = `
       class="c2 "
     >
       <input
-        class="c3"
+        class="c3 c4"
         disabled=""
         name="test"
         type="radio"
         value="1"
       />
       <div
-        class="c4 "
+        class="c5 c6 c7"
       />
     </div>
   </label>
@@ -838,17 +938,17 @@ exports[`RadioButton disabled 1`] = `
     >
       <input
         checked=""
-        class="c3"
+        class="c3 c4"
         disabled=""
         name="test"
         type="radio"
         value="2"
       />
       <div
-        class="c5 "
+        class="c8 c6 c7"
       >
         <svg
-          class="c6"
+          class="c9"
           preserveAspectRatio="xMidYMid meet"
           viewBox="0 0 24 24"
         >
@@ -893,7 +993,7 @@ exports[`RadioButton label 1`] = `
   flex: 0 0 auto;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -946,13 +1046,33 @@ exports[`RadioButton label 1`] = `
   border-color: #000000;
 }
 
-.c3 {
+.c4 {
   opacity: 0;
   -moz-appearance: none;
   width: 0;
   height: 0;
   margin: 0;
   cursor: pointer;
+}
+
+.c3:focus + .c6 {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus + .c6 > circle,
+.c3:focus + .c7 > ellipse,
+.c3:focus + .c7 > line,
+.c3:focus + .c7 > path,
+.c3:focus + .c7 > polygon,
+.c3:focus + .c7 > polyline,
+.c3:focus + .c7 > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus + .c6::-moz-focus-inner {
+  border: 0;
 }
 
 @media only screen and (max-width:768px) {
@@ -962,7 +1082,7 @@ exports[`RadioButton label 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c5 {
     border: solid 2px rgba(0,0,0,0.15);
   }
 }
@@ -977,13 +1097,13 @@ exports[`RadioButton label 1`] = `
       class="c2 "
     >
       <input
-        class="c3"
+        class="c3 c4"
         name="test"
         type="radio"
         value="1"
       />
       <div
-        class="c4 "
+        class="c5 c6 c7"
       />
     </div>
     <span
@@ -999,13 +1119,13 @@ exports[`RadioButton label 1`] = `
       class="c2 "
     >
       <input
-        class="c3"
+        class="c3 c4"
         name="test"
         type="radio"
         value="2"
       />
       <div
-        class="c4 "
+        class="c5 c6 c7"
       />
     </div>
     <div>
@@ -1044,7 +1164,7 @@ exports[`RadioButton label themed 1`] = `
   flex: 0 0 auto;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1097,7 +1217,7 @@ exports[`RadioButton label themed 1`] = `
   border-color: #000000;
 }
 
-.c3 {
+.c4 {
   opacity: 0;
   -moz-appearance: none;
   width: 0;
@@ -1106,8 +1226,28 @@ exports[`RadioButton label themed 1`] = `
   cursor: pointer;
 }
 
-.c5 {
+.c8 {
   font-weight: 500;
+}
+
+.c3:focus + .c6 {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus + .c6 > circle,
+.c3:focus + .c7 > ellipse,
+.c3:focus + .c7 > line,
+.c3:focus + .c7 > path,
+.c3:focus + .c7 > polygon,
+.c3:focus + .c7 > polyline,
+.c3:focus + .c7 > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus + .c6::-moz-focus-inner {
+  border: 0;
 }
 
 @media only screen and (max-width:768px) {
@@ -1117,7 +1257,7 @@ exports[`RadioButton label themed 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c5 {
     border: solid 2px rgba(0,0,0,0.15);
   }
 }
@@ -1132,16 +1272,16 @@ exports[`RadioButton label themed 1`] = `
       class="c2 "
     >
       <input
-        class="c3"
+        class="c3 c4"
         name="test"
         type="radio"
       />
       <div
-        class="c4 "
+        class="c5 c6 c7"
       />
     </div>
     <span
-      class="c5"
+      class="c8"
     >
       test
     </span>
@@ -1177,7 +1317,7 @@ exports[`RadioButton renders custom circle icon 1`] = `
   flex: 0 0 auto;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1230,7 +1370,7 @@ exports[`RadioButton renders custom circle icon 1`] = `
   border-color: #000000;
 }
 
-.c3 {
+.c4 {
   opacity: 0;
   -moz-appearance: none;
   width: 0;
@@ -1239,8 +1379,28 @@ exports[`RadioButton renders custom circle icon 1`] = `
   cursor: pointer;
 }
 
+.c3:focus + .c6 {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus + .c6 > circle,
+.c3:focus + .c7 > ellipse,
+.c3:focus + .c7 > line,
+.c3:focus + .c7 > path,
+.c3:focus + .c7 > polygon,
+.c3:focus + .c7 > polyline,
+.c3:focus + .c7 > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus + .c6::-moz-focus-inner {
+  border: 0;
+}
+
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c5 {
     border: solid 2px #7D4CDB;
   }
 }
@@ -1256,12 +1416,12 @@ exports[`RadioButton renders custom circle icon 1`] = `
     >
       <input
         checked=""
-        class="c3"
+        class="c3 c4"
         name="test"
         type="radio"
       />
       <div
-        class="c4 "
+        class="c5 c6 c7"
       >
         <svg
           as=".StyledRadioButton__StyledRadioButtonIcon-sc-g1f6ld-3"
@@ -1302,7 +1462,7 @@ exports[`RadioButton should apply a11yTitle or aria-label 1`] = `
   flex: 0 0 auto;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1355,7 +1515,7 @@ exports[`RadioButton should apply a11yTitle or aria-label 1`] = `
   border-color: #000000;
 }
 
-.c3 {
+.c4 {
   opacity: 0;
   -moz-appearance: none;
   width: 0;
@@ -1364,8 +1524,28 @@ exports[`RadioButton should apply a11yTitle or aria-label 1`] = `
   cursor: pointer;
 }
 
+.c3:focus + .c6 {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus + .c6 > circle,
+.c3:focus + .c7 > ellipse,
+.c3:focus + .c7 > line,
+.c3:focus + .c7 > path,
+.c3:focus + .c7 > polygon,
+.c3:focus + .c7 > polyline,
+.c3:focus + .c7 > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus + .c6::-moz-focus-inner {
+  border: 0;
+}
+
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c5 {
     border: solid 2px rgba(0,0,0,0.15);
   }
 }
@@ -1381,12 +1561,12 @@ exports[`RadioButton should apply a11yTitle or aria-label 1`] = `
     >
       <input
         aria-label="test"
-        class="c3"
+        class="c3 c4"
         name="test"
         type="radio"
       />
       <div
-        class="c4 "
+        class="c5 c6 c7"
       />
     </div>
   </label>
@@ -1398,12 +1578,12 @@ exports[`RadioButton should apply a11yTitle or aria-label 1`] = `
     >
       <input
         aria-label="test-2"
-        class="c3"
+        class="c3 c4"
         name="test"
         type="radio"
       />
       <div
-        class="c4 "
+        class="c5 c6 c7"
       />
     </div>
   </label>
@@ -1438,7 +1618,7 @@ exports[`RadioButton should have no accessibility violations 1`] = `
   flex: 0 0 auto;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1491,7 +1671,7 @@ exports[`RadioButton should have no accessibility violations 1`] = `
   border-color: #000000;
 }
 
-.c3 {
+.c4 {
   opacity: 0;
   -moz-appearance: none;
   width: 0;
@@ -1500,8 +1680,28 @@ exports[`RadioButton should have no accessibility violations 1`] = `
   cursor: pointer;
 }
 
+.c3:focus + .c6 {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus + .c6 > circle,
+.c3:focus + .c7 > ellipse,
+.c3:focus + .c7 > line,
+.c3:focus + .c7 > path,
+.c3:focus + .c7 > polygon,
+.c3:focus + .c7 > polyline,
+.c3:focus + .c7 > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus + .c6::-moz-focus-inner {
+  border: 0;
+}
+
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c5 {
     border: solid 2px rgba(0,0,0,0.15);
   }
 }
@@ -1517,12 +1717,12 @@ exports[`RadioButton should have no accessibility violations 1`] = `
     >
       <input
         aria-label="test"
-        class="c3"
+        class="c3 c4"
         name="test"
         type="radio"
       />
       <div
-        class="c4 "
+        class="c5 c6 c7"
       />
     </div>
   </label>

--- a/src/js/components/RadioButtonGroup/__tests__/__snapshots__/RadioButtonGroup-test.js.snap
+++ b/src/js/components/RadioButtonGroup/__tests__/__snapshots__/RadioButtonGroup-test.js.snap
@@ -42,7 +42,7 @@ exports[`RadioButtonGroup adding additional props 1`] = `
   flex: 0 0 auto;
 }
 
-.c5 {
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -68,7 +68,7 @@ exports[`RadioButtonGroup adding additional props 1`] = `
   border-radius: 100%;
 }
 
-.c6 {
+.c9 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -105,7 +105,7 @@ exports[`RadioButtonGroup adding additional props 1`] = `
   border-color: #000000;
 }
 
-.c4 {
+.c5 {
   opacity: 0;
   -moz-appearance: none;
   width: 0;
@@ -114,14 +114,34 @@ exports[`RadioButtonGroup adding additional props 1`] = `
   cursor: pointer;
 }
 
+.c4:focus + .c7 {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus + .c7 > circle,
+.c4:focus + .c8 > ellipse,
+.c4:focus + .c8 > line,
+.c4:focus + .c8 > path,
+.c4:focus + .c8 > polygon,
+.c4:focus + .c8 > polyline,
+.c4:focus + .c8 > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus + .c7::-moz-focus-inner {
+  border: 0;
+}
+
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c6 {
     border: solid 2px rgba(0,0,0,0.15);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c6 {
+  .c9 {
     height: 6px;
   }
 }
@@ -141,7 +161,7 @@ exports[`RadioButtonGroup adding additional props 1`] = `
         class="c3 "
       >
         <input
-          class="c4"
+          class="c4 c5"
           data-testid="testid-1"
           id="ONE"
           name="test"
@@ -150,12 +170,12 @@ exports[`RadioButtonGroup adding additional props 1`] = `
           value="1"
         />
         <div
-          class="c5 "
+          class="c6 c7 c8"
         />
       </div>
     </label>
     <div
-      class="c6"
+      class="c9"
     />
     <label
       class="c2"
@@ -165,7 +185,7 @@ exports[`RadioButtonGroup adding additional props 1`] = `
         class="c3 "
       >
         <input
-          class="c4"
+          class="c4 c5"
           data-testid="testid-2"
           id="TWO"
           name="test"
@@ -174,7 +194,7 @@ exports[`RadioButtonGroup adding additional props 1`] = `
           value="2"
         />
         <div
-          class="c5 "
+          class="c6 c7 c8"
         />
       </div>
     </label>
@@ -225,7 +245,7 @@ exports[`RadioButtonGroup boolean options 1`] = `
   flex: 0 0 auto;
 }
 
-.c5 {
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -251,7 +271,7 @@ exports[`RadioButtonGroup boolean options 1`] = `
   border-radius: 100%;
 }
 
-.c8 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -277,7 +297,7 @@ exports[`RadioButtonGroup boolean options 1`] = `
   border-radius: 100%;
 }
 
-.c7 {
+.c10 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -314,7 +334,7 @@ exports[`RadioButtonGroup boolean options 1`] = `
   border-color: #000000;
 }
 
-.c4 {
+.c5 {
   opacity: 0;
   -moz-appearance: none;
   width: 0;
@@ -323,11 +343,31 @@ exports[`RadioButtonGroup boolean options 1`] = `
   cursor: pointer;
 }
 
-.c6 {
+.c9 {
   box-sizing: border-box;
   width: 24px;
   height: 24px;
   fill: #7D4CDB;
+}
+
+.c4:focus + .c7 {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus + .c7 > circle,
+.c4:focus + .c8 > ellipse,
+.c4:focus + .c8 > line,
+.c4:focus + .c8 > path,
+.c4:focus + .c8 > polygon,
+.c4:focus + .c8 > polyline,
+.c4:focus + .c8 > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus + .c7::-moz-focus-inner {
+  border: 0;
 }
 
 @media only screen and (max-width:768px) {
@@ -337,19 +377,19 @@ exports[`RadioButtonGroup boolean options 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c6 {
     border: solid 2px #7D4CDB;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c11 {
     border: solid 2px rgba(0,0,0,0.15);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c7 {
+  .c10 {
     height: 6px;
   }
 }
@@ -370,7 +410,7 @@ exports[`RadioButtonGroup boolean options 1`] = `
       >
         <input
           checked=""
-          class="c4"
+          class="c4 c5"
           id="true"
           name="test"
           tabindex="0"
@@ -378,10 +418,10 @@ exports[`RadioButtonGroup boolean options 1`] = `
           value="true"
         />
         <div
-          class="c5 "
+          class="c6 c7 c8"
         >
           <svg
-            class="c6"
+            class="c9"
             preserveAspectRatio="xMidYMid meet"
             viewBox="0 0 24 24"
           >
@@ -400,7 +440,7 @@ exports[`RadioButtonGroup boolean options 1`] = `
       </span>
     </label>
     <div
-      class="c7"
+      class="c10"
     />
     <label
       class="c2"
@@ -410,7 +450,7 @@ exports[`RadioButtonGroup boolean options 1`] = `
         class="c3 "
       >
         <input
-          class="c4"
+          class="c4 c5"
           id="false"
           name="test"
           tabindex="-1"
@@ -418,7 +458,7 @@ exports[`RadioButtonGroup boolean options 1`] = `
           value="false"
         />
         <div
-          class="c8 "
+          class="c11 c7 c8"
         />
       </div>
       <span
@@ -646,7 +686,7 @@ exports[`RadioButtonGroup defaultValue 1`] = `
   flex: 0 0 auto;
 }
 
-.c5 {
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -672,7 +712,7 @@ exports[`RadioButtonGroup defaultValue 1`] = `
   border-radius: 100%;
 }
 
-.c8 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -698,7 +738,7 @@ exports[`RadioButtonGroup defaultValue 1`] = `
   border-radius: 100%;
 }
 
-.c7 {
+.c10 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -735,7 +775,7 @@ exports[`RadioButtonGroup defaultValue 1`] = `
   border-color: #000000;
 }
 
-.c4 {
+.c5 {
   opacity: 0;
   -moz-appearance: none;
   width: 0;
@@ -744,11 +784,31 @@ exports[`RadioButtonGroup defaultValue 1`] = `
   cursor: pointer;
 }
 
-.c6 {
+.c9 {
   box-sizing: border-box;
   width: 24px;
   height: 24px;
   fill: #7D4CDB;
+}
+
+.c4:focus + .c7 {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus + .c7 > circle,
+.c4:focus + .c8 > ellipse,
+.c4:focus + .c8 > line,
+.c4:focus + .c8 > path,
+.c4:focus + .c8 > polygon,
+.c4:focus + .c8 > polyline,
+.c4:focus + .c8 > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus + .c7::-moz-focus-inner {
+  border: 0;
 }
 
 @media only screen and (max-width:768px) {
@@ -758,19 +818,19 @@ exports[`RadioButtonGroup defaultValue 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c6 {
     border: solid 2px #7D4CDB;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c11 {
     border: solid 2px rgba(0,0,0,0.15);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c7 {
+  .c10 {
     height: 6px;
   }
 }
@@ -792,7 +852,7 @@ exports[`RadioButtonGroup defaultValue 1`] = `
         >
           <input
             checked=""
-            class="c4"
+            class="c4 c5"
             id="one"
             name="test"
             tabindex="0"
@@ -800,10 +860,10 @@ exports[`RadioButtonGroup defaultValue 1`] = `
             value="one"
           />
           <div
-            class="c5 "
+            class="c6 c7 c8"
           >
             <svg
-              class="c6"
+              class="c9"
               preserveAspectRatio="xMidYMid meet"
               viewBox="0 0 24 24"
             >
@@ -822,7 +882,7 @@ exports[`RadioButtonGroup defaultValue 1`] = `
         </span>
       </label>
       <div
-        class="c7"
+        class="c10"
       />
       <label
         class="c2"
@@ -832,7 +892,7 @@ exports[`RadioButtonGroup defaultValue 1`] = `
           class="c3 "
         >
           <input
-            class="c4"
+            class="c4 c5"
             id="two"
             name="test"
             tabindex="-1"
@@ -840,7 +900,7 @@ exports[`RadioButtonGroup defaultValue 1`] = `
             value="two"
           />
           <div
-            class="c8 "
+            class="c11 c7 c8"
           />
         </div>
         <span
@@ -897,7 +957,7 @@ exports[`RadioButtonGroup number options 1`] = `
   flex: 0 0 auto;
 }
 
-.c5 {
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -923,7 +983,7 @@ exports[`RadioButtonGroup number options 1`] = `
   border-radius: 100%;
 }
 
-.c8 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -949,7 +1009,7 @@ exports[`RadioButtonGroup number options 1`] = `
   border-radius: 100%;
 }
 
-.c7 {
+.c10 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -986,7 +1046,7 @@ exports[`RadioButtonGroup number options 1`] = `
   border-color: #000000;
 }
 
-.c4 {
+.c5 {
   opacity: 0;
   -moz-appearance: none;
   width: 0;
@@ -995,11 +1055,31 @@ exports[`RadioButtonGroup number options 1`] = `
   cursor: pointer;
 }
 
-.c6 {
+.c9 {
   box-sizing: border-box;
   width: 24px;
   height: 24px;
   fill: #7D4CDB;
+}
+
+.c4:focus + .c7 {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus + .c7 > circle,
+.c4:focus + .c8 > ellipse,
+.c4:focus + .c8 > line,
+.c4:focus + .c8 > path,
+.c4:focus + .c8 > polygon,
+.c4:focus + .c8 > polyline,
+.c4:focus + .c8 > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus + .c7::-moz-focus-inner {
+  border: 0;
 }
 
 @media only screen and (max-width:768px) {
@@ -1009,19 +1089,19 @@ exports[`RadioButtonGroup number options 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c6 {
     border: solid 2px #7D4CDB;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c11 {
     border: solid 2px rgba(0,0,0,0.15);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c7 {
+  .c10 {
     height: 6px;
   }
 }
@@ -1042,7 +1122,7 @@ exports[`RadioButtonGroup number options 1`] = `
       >
         <input
           checked=""
-          class="c4"
+          class="c4 c5"
           id="1"
           name="test"
           tabindex="0"
@@ -1050,10 +1130,10 @@ exports[`RadioButtonGroup number options 1`] = `
           value="1"
         />
         <div
-          class="c5 "
+          class="c6 c7 c8"
         >
           <svg
-            class="c6"
+            class="c9"
             preserveAspectRatio="xMidYMid meet"
             viewBox="0 0 24 24"
           >
@@ -1072,7 +1152,7 @@ exports[`RadioButtonGroup number options 1`] = `
       </span>
     </label>
     <div
-      class="c7"
+      class="c10"
     />
     <label
       class="c2"
@@ -1082,7 +1162,7 @@ exports[`RadioButtonGroup number options 1`] = `
         class="c3 "
       >
         <input
-          class="c4"
+          class="c4 c5"
           id="2"
           name="test"
           tabindex="-1"
@@ -1090,7 +1170,7 @@ exports[`RadioButtonGroup number options 1`] = `
           value="2"
         />
         <div
-          class="c8 "
+          class="c11 c7 c8"
         />
       </div>
       <span
@@ -1146,7 +1226,7 @@ exports[`RadioButtonGroup object options 1`] = `
   flex: 0 0 auto;
 }
 
-.c5 {
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1172,7 +1252,7 @@ exports[`RadioButtonGroup object options 1`] = `
   border-radius: 100%;
 }
 
-.c6 {
+.c9 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -1209,13 +1289,33 @@ exports[`RadioButtonGroup object options 1`] = `
   border-color: #000000;
 }
 
-.c4 {
+.c5 {
   opacity: 0;
   -moz-appearance: none;
   width: 0;
   height: 0;
   margin: 0;
   cursor: pointer;
+}
+
+.c4:focus + .c7 {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus + .c7 > circle,
+.c4:focus + .c8 > ellipse,
+.c4:focus + .c8 > line,
+.c4:focus + .c8 > path,
+.c4:focus + .c8 > polygon,
+.c4:focus + .c8 > polyline,
+.c4:focus + .c8 > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus + .c7::-moz-focus-inner {
+  border: 0;
 }
 
 @media only screen and (max-width:768px) {
@@ -1225,13 +1325,13 @@ exports[`RadioButtonGroup object options 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c6 {
     border: solid 2px rgba(0,0,0,0.15);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c6 {
+  .c9 {
     height: 6px;
   }
 }
@@ -1251,7 +1351,7 @@ exports[`RadioButtonGroup object options 1`] = `
         class="c3 "
       >
         <input
-          class="c4"
+          class="c4 c5"
           id="onE"
           name="test"
           tabindex="0"
@@ -1259,7 +1359,7 @@ exports[`RadioButtonGroup object options 1`] = `
           value="one"
         />
         <div
-          class="c5 "
+          class="c6 c7 c8"
         />
       </div>
       <span
@@ -1269,7 +1369,7 @@ exports[`RadioButtonGroup object options 1`] = `
       </span>
     </label>
     <div
-      class="c6"
+      class="c9"
     />
     <label
       class="c2"
@@ -1279,7 +1379,7 @@ exports[`RadioButtonGroup object options 1`] = `
         class="c3 "
       >
         <input
-          class="c4"
+          class="c4 c5"
           id="twO"
           name="test"
           tabindex="-1"
@@ -1287,7 +1387,7 @@ exports[`RadioButtonGroup object options 1`] = `
           value="two"
         />
         <div
-          class="c5 "
+          class="c6 c7 c8"
         />
       </div>
       <span
@@ -1342,7 +1442,7 @@ exports[`RadioButtonGroup object options disabled 1`] = `
   flex: 0 0 auto;
 }
 
-.c5 {
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1368,7 +1468,7 @@ exports[`RadioButtonGroup object options disabled 1`] = `
   border-radius: 100%;
 }
 
-.c6 {
+.c9 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -1406,7 +1506,7 @@ exports[`RadioButtonGroup object options disabled 1`] = `
   border-color: #000000;
 }
 
-.c7 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1428,12 +1528,12 @@ exports[`RadioButtonGroup object options disabled 1`] = `
   cursor: pointer;
 }
 
-.c7:hover input:not([disabled]) + div,
-.c7:hover input:not([disabled]) + span {
+.c10:hover input:not([disabled]) + div,
+.c10:hover input:not([disabled]) + span {
   border-color: #000000;
 }
 
-.c4 {
+.c5 {
   opacity: 0;
   -moz-appearance: none;
   width: 0;
@@ -1441,7 +1541,7 @@ exports[`RadioButtonGroup object options disabled 1`] = `
   margin: 0;
 }
 
-.c8 {
+.c11 {
   opacity: 0;
   -moz-appearance: none;
   width: 0;
@@ -1450,14 +1550,34 @@ exports[`RadioButtonGroup object options disabled 1`] = `
   cursor: pointer;
 }
 
+.c4:focus + .c7 {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus + .c7 > circle,
+.c4:focus + .c8 > ellipse,
+.c4:focus + .c8 > line,
+.c4:focus + .c8 > path,
+.c4:focus + .c8 > polygon,
+.c4:focus + .c8 > polyline,
+.c4:focus + .c8 > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus + .c7::-moz-focus-inner {
+  border: 0;
+}
+
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c6 {
     border: solid 2px rgba(0,0,0,0.15);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c6 {
+  .c9 {
     height: 6px;
   }
 }
@@ -1477,7 +1597,7 @@ exports[`RadioButtonGroup object options disabled 1`] = `
         class="c3 "
       >
         <input
-          class="c4"
+          class="c4 c5"
           disabled=""
           name="test"
           tabindex="0"
@@ -1485,28 +1605,28 @@ exports[`RadioButtonGroup object options disabled 1`] = `
           value="one"
         />
         <div
-          class="c5 "
+          class="c6 c7 c8"
         />
       </div>
     </label>
     <div
-      class="c6"
+      class="c9"
     />
     <label
-      class="c7"
+      class="c10"
     >
       <div
         class="c3 "
       >
         <input
-          class="c8"
+          class="c4 c11"
           name="test"
           tabindex="-1"
           type="radio"
           value="two"
         />
         <div
-          class="c5 "
+          class="c6 c7 c8"
         />
       </div>
     </label>
@@ -1556,7 +1676,7 @@ exports[`RadioButtonGroup object options just value 1`] = `
   flex: 0 0 auto;
 }
 
-.c5 {
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1582,7 +1702,7 @@ exports[`RadioButtonGroup object options just value 1`] = `
   border-radius: 100%;
 }
 
-.c7 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1608,7 +1728,7 @@ exports[`RadioButtonGroup object options just value 1`] = `
   border-radius: 100%;
 }
 
-.c6 {
+.c9 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -1645,7 +1765,7 @@ exports[`RadioButtonGroup object options just value 1`] = `
   border-color: #000000;
 }
 
-.c4 {
+.c5 {
   opacity: 0;
   -moz-appearance: none;
   width: 0;
@@ -1654,27 +1774,47 @@ exports[`RadioButtonGroup object options just value 1`] = `
   cursor: pointer;
 }
 
-.c8 {
+.c11 {
   box-sizing: border-box;
   width: 24px;
   height: 24px;
   fill: #7D4CDB;
 }
 
+.c4:focus + .c7 {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus + .c7 > circle,
+.c4:focus + .c8 > ellipse,
+.c4:focus + .c8 > line,
+.c4:focus + .c8 > path,
+.c4:focus + .c8 > polygon,
+.c4:focus + .c8 > polyline,
+.c4:focus + .c8 > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus + .c7::-moz-focus-inner {
+  border: 0;
+}
+
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c6 {
     border: solid 2px rgba(0,0,0,0.15);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c7 {
+  .c10 {
     border: solid 2px #7D4CDB;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c6 {
+  .c9 {
     height: 6px;
   }
 }
@@ -1693,19 +1833,19 @@ exports[`RadioButtonGroup object options just value 1`] = `
         class="c3 "
       >
         <input
-          class="c4"
+          class="c4 c5"
           name="test"
           tabindex="-1"
           type="radio"
           value="one"
         />
         <div
-          class="c5 "
+          class="c6 c7 c8"
         />
       </div>
     </label>
     <div
-      class="c6"
+      class="c9"
     />
     <label
       class="c2"
@@ -1715,17 +1855,17 @@ exports[`RadioButtonGroup object options just value 1`] = `
       >
         <input
           checked=""
-          class="c4"
+          class="c4 c5"
           name="test"
           tabindex="0"
           type="radio"
           value="two"
         />
         <div
-          class="c7 "
+          class="c10 c7 c8"
         >
           <svg
-            class="c8"
+            class="c11"
             preserveAspectRatio="xMidYMid meet"
             viewBox="0 0 24 24"
           >
@@ -1785,7 +1925,7 @@ exports[`RadioButtonGroup should have no accessibility violations 1`] = `
   flex: 0 0 auto;
 }
 
-.c5 {
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1838,13 +1978,33 @@ exports[`RadioButtonGroup should have no accessibility violations 1`] = `
   border-color: #000000;
 }
 
-.c4 {
+.c5 {
   opacity: 0;
   -moz-appearance: none;
   width: 0;
   height: 0;
   margin: 0;
   cursor: pointer;
+}
+
+.c4:focus + .c7 {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus + .c7 > circle,
+.c4:focus + .c8 > ellipse,
+.c4:focus + .c8 > line,
+.c4:focus + .c8 > path,
+.c4:focus + .c8 > polygon,
+.c4:focus + .c8 > polyline,
+.c4:focus + .c8 > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus + .c7::-moz-focus-inner {
+  border: 0;
 }
 
 @media only screen and (max-width:768px) {
@@ -1854,7 +2014,7 @@ exports[`RadioButtonGroup should have no accessibility violations 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c6 {
     border: solid 2px rgba(0,0,0,0.15);
   }
 }
@@ -1875,7 +2035,7 @@ exports[`RadioButtonGroup should have no accessibility violations 1`] = `
           class="c3 "
         >
           <input
-            class="c4"
+            class="c4 c5"
             id="option1"
             name="test"
             tabindex="0"
@@ -1883,7 +2043,7 @@ exports[`RadioButtonGroup should have no accessibility violations 1`] = `
             value="option1"
           />
           <div
-            class="c5 "
+            class="c6 c7 c8"
           />
         </div>
         <span
@@ -1940,7 +2100,7 @@ exports[`RadioButtonGroup string options 1`] = `
   flex: 0 0 auto;
 }
 
-.c5 {
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1966,7 +2126,7 @@ exports[`RadioButtonGroup string options 1`] = `
   border-radius: 100%;
 }
 
-.c8 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1992,7 +2152,7 @@ exports[`RadioButtonGroup string options 1`] = `
   border-radius: 100%;
 }
 
-.c7 {
+.c10 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -2029,7 +2189,7 @@ exports[`RadioButtonGroup string options 1`] = `
   border-color: #000000;
 }
 
-.c4 {
+.c5 {
   opacity: 0;
   -moz-appearance: none;
   width: 0;
@@ -2038,11 +2198,31 @@ exports[`RadioButtonGroup string options 1`] = `
   cursor: pointer;
 }
 
-.c6 {
+.c9 {
   box-sizing: border-box;
   width: 24px;
   height: 24px;
   fill: #7D4CDB;
+}
+
+.c4:focus + .c7 {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus + .c7 > circle,
+.c4:focus + .c8 > ellipse,
+.c4:focus + .c8 > line,
+.c4:focus + .c8 > path,
+.c4:focus + .c8 > polygon,
+.c4:focus + .c8 > polyline,
+.c4:focus + .c8 > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus + .c7::-moz-focus-inner {
+  border: 0;
 }
 
 @media only screen and (max-width:768px) {
@@ -2052,19 +2232,19 @@ exports[`RadioButtonGroup string options 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c6 {
     border: solid 2px #7D4CDB;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c11 {
     border: solid 2px rgba(0,0,0,0.15);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c7 {
+  .c10 {
     height: 6px;
   }
 }
@@ -2085,7 +2265,7 @@ exports[`RadioButtonGroup string options 1`] = `
       >
         <input
           checked=""
-          class="c4"
+          class="c4 c5"
           id="one"
           name="test"
           tabindex="0"
@@ -2093,10 +2273,10 @@ exports[`RadioButtonGroup string options 1`] = `
           value="one"
         />
         <div
-          class="c5 "
+          class="c6 c7 c8"
         >
           <svg
-            class="c6"
+            class="c9"
             preserveAspectRatio="xMidYMid meet"
             viewBox="0 0 24 24"
           >
@@ -2115,7 +2295,7 @@ exports[`RadioButtonGroup string options 1`] = `
       </span>
     </label>
     <div
-      class="c7"
+      class="c10"
     />
     <label
       class="c2"
@@ -2125,7 +2305,7 @@ exports[`RadioButtonGroup string options 1`] = `
         class="c3 "
       >
         <input
-          class="c4"
+          class="c4 c5"
           id="two"
           name="test"
           tabindex="-1"
@@ -2133,7 +2313,7 @@ exports[`RadioButtonGroup string options 1`] = `
           value="two"
         />
         <div
-          class="c8 "
+          class="c11 c7 c8"
         />
       </div>
       <span


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds style to input when using `tab` and Closes (hopefully 😅) issue #6328 

The issue was that there was no focus style being applied to the radio button when navigating with the keyboard.

#### Where should the reviewer start?
On the StyledRadioButton file. Also, related snapshot test were updated.

#### What testing has been done on this PR?
Snapshot was fixed and all tests are passing. 

#### How should this be manually tested?
`yarn test`

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
#6328

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Should be backwards compatible.