### PR TITLE
Fix aria-label violation for Labels story

### DIFF
--- a/src/js/components/Sidebar/stories/Labels.js
+++ b/src/js/components/Sidebar/stories/Labels.js
@@ -41,14 +41,14 @@ const SidebarButton = ({ icon, label, ...rest }) => (
 );
 
 const SidebarFooter = () => (
-  <Nav>
+  <Nav aria-label="sidebar footer">
     <SidebarButton icon={<Chat />} />
     <SidebarButton icon={<Help />} />
   </Nav>
 );
 
 const MainNavigation = () => (
-  <Nav gap="large" responsive={false}>
+  <Nav aria-label="main navigation" gap="large" responsive={false}>
     <SidebarButton icon={<StatusInfoSmall />} label="Focus" />
     <SidebarButton icon={<Projects />} label="Services" />
     <SidebarButton icon={<Clock />} label="Glances" />


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adding aria-labels into Nav components to fix a11y violation in Labels story

#### Where should the reviewer start?
Check Sidebar/Labels story in Storybook

#### What testing has been done on this PR?
yarn test + Storybook manual testing

#### How should this be manually tested?
Through Storybook

#### Do Jest tests follow these best practices?
Changes don't affect tests

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
[#6124](https://github.com/grommet/grommet/issues/6124)

#### Screenshots (if appropriate)
<img width="976" alt="Screenshot 2022-10-01 at 19 44 50" src="https://user-images.githubusercontent.com/75381317/193421660-32b988d3-0a1b-46f1-a885-28c13d15ff8f.png">

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
No
