### PR TITLE
Fix accessiblity violations in Drop storybooks

### DIFF
--- a/src/js/components/Drop/stories/Inline.js
+++ b/src/js/components/Drop/stories/Inline.js
@@ -18,7 +18,7 @@ const InlineDrop = () => {
     // <Grommet theme={...}>
     <Box fill align="center" justify="center">
       <Box
-        background="dark-3"
+        background="dark-2"
         pad="medium"
         align="center"
         justify="start"

--- a/src/js/components/Drop/stories/Overflow.js
+++ b/src/js/components/Drop/stories/Overflow.js
@@ -24,7 +24,7 @@ const OverflowDrop = () => {
     // <Grommet theme={...}>
     <Box fill align="center" justify="center">
       <Box
-        background="dark-3"
+        background="dark-2"
         pad="medium"
         align="center"
         justify="start"

--- a/src/js/components/Drop/stories/Plain.js
+++ b/src/js/components/Drop/stories/Plain.js
@@ -14,7 +14,7 @@ const PlainDrop = () => {
     // <Grommet theme={...}>
     <Box background="light-3" fill align="center" justify="center">
       <Box
-        background="dark-3"
+        background="dark-2"
         pad="medium"
         align="center"
         justify="start"

--- a/src/js/components/Drop/stories/Simple.js
+++ b/src/js/components/Drop/stories/Simple.js
@@ -17,7 +17,7 @@ const SimpleDrop = () => {
     // <Grommet theme={...}>
     <Box fill align="center" justify="center">
       <Box
-        background="dark-3"
+        background="dark-2"
         pad="medium"
         align="center"
         justify="start"

--- a/src/js/components/Drop/stories/Styled.js
+++ b/src/js/components/Drop/stories/Styled.js
@@ -18,7 +18,7 @@ const StyledDrop = () => {
     // <Grommet theme={...}>
     <Box fill align="center" justify="center">
       <Box
-        background="dark-3"
+        background="dark-2"
         pad="medium"
         align="center"
         justify="start"


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Fixes color contrast accessibility violations in 5 `Drop` storybooks

#### Where should the reviewer start?

`Drop` component storybooks

#### What testing has been done on this PR?

Ran `yarn test` before commiting

#### How should this be manually tested?

Check the accessibility tabs for the following storybooks:
* `Drop/Inline`
* `Drop/Overflow`
* `Drop/Plain`
* `Drop/Simple`
* `Drop/Styled`

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#6124 

#### Screenshots (if appropriate)

<img width="869" alt="image" src="https://user-images.githubusercontent.com/43496356/193494473-10ee9ba4-bf12-4e52-8a42-ce3ba101b6c9.png">

#### Do the grommet docs need to be updated?

No

#### Should this PR be mentioned in the release notes?

No

#### Is this change backwards compatible or is it a breaking change?

No
