### PR TITLE
add node type for message prop in notification widget

### DIFF
--- a/src/js/components/Notification/Notification.js
+++ b/src/js/components/Notification/Notification.js
@@ -47,8 +47,10 @@ const Notification = ({ message, onClose, status, title, toast }) => {
       >
         <Box>
           <Text {...theme.notification.title}>{title}</Text>
-          {message && (
+          {typeof message === 'string' ? (
             <Paragraph {...theme.notification.message}>{message}</Paragraph>
+          ) : (
+            message
           )}
         </Box>
         {onClose && (

--- a/src/js/components/Notification/index.d.ts
+++ b/src/js/components/Notification/index.d.ts
@@ -4,7 +4,7 @@ export type StatusType = 'critical' | 'warning' | 'normal' | 'unknown';
 
 export interface NotificationProps {
   title: string;
-  message?: string;
+  message?: string | React.ReactNode;
   status?: StatusType;
   toast?: boolean;
   onClose?: (...args: any[]) => any;

--- a/src/js/components/Notification/propTypes.js
+++ b/src/js/components/Notification/propTypes.js
@@ -4,7 +4,7 @@ let PropType = {};
 if (process.env.NODE_ENV !== 'production') {
   PropType = {
     title: PropTypes.string.isRequired,
-    message: PropTypes.string,
+    message: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
     status: PropTypes.oneOf(['critical', 'warning', 'normal', 'unknown']),
     toast: PropTypes.bool,
     onClose: PropTypes.func,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR adds `node` type for `message` prop in notification component to support custom template in notification message

#### Where should the reviewer start?
Reviewer should look into changes done on `NotificationProps` and then in main notification component.

#### What testing has been done on this PR?
I have tested the changes by passing sample node to message prop.

#### How should this be manually tested?
You can pass the different type of values (string or node only) to `message` prop manually to see if your template is being reflected on the UI properly or not.

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
[Issue - 6320](https://github.com/grommet/grommet/issues/6320)

#### Screenshots (if appropriate)
<img width="960" alt="Screenshot 2022-10-04 at 9 53 13 AM" src="https://user-images.githubusercontent.com/29942751/193765026-2671cfba-69c2-4ab8-9665-3e5d79768ec5.png">

#### Do the grommet docs need to be updated?
Yes 

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
Yes