### PR TITLE
Update DataTable groupBy parameters to optional

### DIFF
--- a/src/js/components/DataTable/index.d.ts
+++ b/src/js/components/DataTable/index.d.ts
@@ -91,12 +91,12 @@ export interface DataTableProps<TRowType = any> {
   groupBy?:
     | string
     | {
-        property: string;
-        expand: Array<string>;
-        expandable: Array<string>;
-        select: { [key: string]: 'all' | 'some' | 'none' };
-        onExpand: (expandedKeys: string[]) => void;
-        onSelect: (select: (string | number)[], datum: TRowType) => void;
+        property?: string;
+        expand?: Array<string>;
+        expandable?: Array<string>;
+        select?: { [key: string]: 'all' | 'some' | 'none' };
+        onExpand?: (expandedKeys: string[]) => void;
+        onSelect?: (select: (string | number)[], datum: TRowType) => void;
       };
   primaryKey?: string | boolean;
   select?: (string | number)[];


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Errors were being caused for some TS users bc the `groupBy` object notation was requiring all parameters. However, our [storybook example](https://storybook.grommet.io/?path=/story/visualizations-datatable-spacex-grouped--space-x) that is just js doesn't use all the parameters. The TS should mirror the non-typed experience.

#### Where should the reviewer start?

src/js/components/DataTable/index.d.ts

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?
Yes. Updated `groupBy` typescript definition.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.