### PR TITLE
Notification - revert title type to be optional

### DIFF
--- a/src/js/components/Notification/index.d.ts
+++ b/src/js/components/Notification/index.d.ts
@@ -6,7 +6,7 @@ export type StatusType = 'critical' | 'warning' | 'normal' | 'info' | 'unknown';
 export interface NotificationProps {
   actions?: AnchorType[];
   global?: boolean;
-  title: string;
+  title?: string;
   message?: string | React.ReactNode;
   status?: StatusType;
   toast?:


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Notification - Revert `title`'s type to be optional. [Related](https://github.com/grommet/grommet/pull/6390#discussion_r989163678)

#### Where should the reviewer start?

/Notification/index.d.ts

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No

#### Should this PR be mentioned in the release notes?

No

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible