### PR TITLE
Fix SkipLinks filters out undefined children

### DIFF
--- a/src/js/components/SkipLinks/SkipLinks.js
+++ b/src/js/components/SkipLinks/SkipLinks.js
@@ -59,12 +59,15 @@ const SkipLinks = ({ children, id, messages }) => {
           {format({ id: 'skipLinks.skipTo', messages })}
         </Text>
         <Box align="center" gap="medium">
-          {Children.map(children, (child, index) =>
-            cloneElement(child, {
-              // eslint-disable-next-line react/no-array-index-key
-              key: `skip-link-${index}`,
-              onClick: removeLayer,
-            }),
+          {Children.map(
+            children,
+            (child, index) =>
+              child &&
+              cloneElement(child, {
+                // eslint-disable-next-line react/no-array-index-key
+                key: `skip-link-${index}`,
+                onClick: removeLayer,
+              }),
           )}
         </Box>
       </Box>

--- a/src/js/components/SkipLinks/__tests__/SkipLink-test.js
+++ b/src/js/components/SkipLinks/__tests__/SkipLink-test.js
@@ -72,4 +72,16 @@ describe('SkipLink', () => {
     });
     expect(container.firstChild).toMatchSnapshot();
   });
+
+  test('should automatically filter out undefined children', () => {
+    const showSecondLink = false;
+    const result = render(
+      <SkipLinks>
+        {showSecondLink && <SkipLink id="nav" label="Table of Contents" />}
+        <SkipLink id="main" label="Main Content" />
+      </SkipLinks>,
+    );
+
+    expect(result).toBeDefined();
+  });
 });


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fix SkipLinks should automatically filter out undefined children

#### Where should the reviewer start?
From this issue #6266 

#### What testing has been done on this PR?
[SkipLinks/__tests__/SkipLink-test.js](https://github.com/grommet/grommet/compare/master...nidble:grommet:fix_skiplinks_filter_undefined_children?expand=1#diff-556d87db273d0732b0d8eef79133f8a2e0b028c03f76ead8858e45eb6a8fc0a8)

#### How should this be manually tested?
Reproducing https://codesandbox.io/s/grommet-v2-template-forked-dwsdu5?file=/index.js:343-411

#### Do Jest tests follow these best practices?

- [x] `screen` is used for querying.
- [x] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [x] `userEvent` is used in place of `fireEvent`.
- [x] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
No
#### What are the relevant issues?
#6266
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No
#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
Yes