### PR TITLE
Changed DataChart to not show detail for missing values

### DIFF
--- a/src/js/components/DataChart/Detail.js
+++ b/src/js/components/DataChart/Detail.js
@@ -143,8 +143,8 @@ const Detail = ({
               {series
                 .filter(
                   ({ property }) =>
-                    !activeProperty ||
-                    activeProperty === property ||
+                    ((!activeProperty || activeProperty === property) &&
+                      data?.[detailIndex]?.[property] !== undefined) ||
                     (axis && axis.x && axis.x.property === property),
                 )
                 .map((serie) => {


### PR DESCRIPTION
#### What does this PR do?

Changed DataChart to not show detail for missing values.
When data objects are sparsely populated, the `detail` was including properties with no associated values. This would result in either blank content or showing "undefined" when there is a prefix.
This change omits including properties for which the value at the current detail index isn't provided.

#### What testing has been done on this PR?

DataChart Prediction story detail

#### How should this be manually tested?

^^^

#### Do Jest tests follow these best practices?

no test changes, hard to test detail interaction in jest tests

#### Any background context you want to provide?

This was uncovered via grommet-designer creating designs with sparse data.

#### Screenshots (if appropriate)

Previously:
<img width="233" alt="Screen Shot 2022-10-06 at 10 01 09 PM" src="https://user-images.githubusercontent.com/11637956/194471332-a0d5c952-ec2e-48d3-b952-08e9aba87bb0.png">

Subsequently:
<img width="224" alt="Screen Shot 2022-10-06 at 10 01 27 PM" src="https://user-images.githubusercontent.com/11637956/194471365-a639573d-8174-4386-b606-825e94422305.png">

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
