### PR TITLE
Fix conditional in normalizeBackgroundImage

### DIFF
--- a/src/js/components/Box/__tests__/Box-test.tsx
+++ b/src/js/components/Box/__tests__/Box-test.tsx
@@ -241,6 +241,13 @@ describe('Box', () => {
         <Box background={{ image: 'image-2', color: 'red', opacity: true }}>
           <Text>background image from theme</Text>
         </Box>
+        <Box
+          background={{
+            image:
+              'url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAMAAAADCAYAAABWKLW/AAAABGdBTUEAALGPC/xhBQAAAA9JREFUCB1jYMAC/mOIAQASFQEAlwuUYwAAAABJRU5ErkJggg==)',
+            dark: true,
+          }}
+        />
       </Grommet>,
     );
 

--- a/src/js/components/Box/__tests__/__snapshots__/Box-test.tsx.snap
+++ b/src/js/components/Box/__tests__/__snapshots__/Box-test.tsx.snap
@@ -1758,6 +1758,25 @@ exports[`Box background from theme 1`] = `
   opacity: 0.4;
 }
 
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  color: #f8f8f8;
+  background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAMAAAADCAYAAABWKLW/AAAABGdBTUEAALGPC/xhBQAAAA9JREFUCB1jYMAC/mOIAQASFQEAlwuUYwAAAABJRU5ErkJggg==);
+  background-repeat: no-repeat;
+  background-position: center center;
+  background-size: cover;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
 .c2 {
   font-size: 18px;
   line-height: 24px;
@@ -1784,6 +1803,9 @@ exports[`Box background from theme 1`] = `
         background image from theme
       </span>
     </div>
+    <div
+      class="c4"
+    />
   </div>
 </DocumentFragment>
 `;

--- a/src/js/utils/background.js
+++ b/src/js/utils/background.js
@@ -47,7 +47,7 @@ const normalizeBackgroundImage = (background, theme) => {
     result =
       normalizeBackground(
         background.dark
-          ? theme.global.backgrounds?.[background.image].dark
+          ? theme.global.backgrounds?.[background.image]?.dark
           : theme.global.backgrounds?.[background.image],
         theme,
       ) || background.image;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Fixes type error when `global.backgrounds` is defined but Box's `background.image` does not exist in the theme.

#### Where should the reviewer start?
src/js/utils/background.js

#### What testing has been done on this PR?
In storybook and added unit test.

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

Before, this error would occur:

<img width="644" alt="Screen Shot 2022-10-07 at 10 01 55 AM" src="https://user-images.githubusercontent.com/12522275/194612515-04373957-1256-4f00-9651-25b9b4db1b26.png">

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?
No. -- `global.backgrounds` is new and I don't believe many themes had leveraged it yet.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.