### PR TITLE
make aria-label readable for Select

### DIFF
--- a/src/js/components/Select/Select.js
+++ b/src/js/components/Select/Select.js
@@ -278,19 +278,35 @@ const Select = forwardRef(
 
     const iconColor = getIconColor(theme);
 
+    let ariaLabelGenerated = '';
+    if (value) {
+      if (Array.isArray(value)) {
+        ariaLabelGenerated = `; ${value.length || 0} selected`;
+      } else if (typeof value === 'object' && value !== null) {
+        ariaLabelGenerated = `; Selected: ${inputValue}`;
+      } else {
+        ariaLabelGenerated = format({
+          id: 'select.selected',
+          messages,
+          values: {
+            // eslint-disable-next-line no-nested-ternary
+            currentSelectedValue: valueKey?.reduce
+              ? inputValue
+              : displayLabelKey
+              ? value[displayLabelKey]
+              : value,
+          },
+        });
+      }
+    }
+
     return (
       <Keyboard onDown={onRequestOpen} onUp={onRequestOpen}>
         <StyledSelectDropButton
           ref={ref}
-          a11yTitle={`${ariaLabel || a11yTitle || placeholder || 'Open Drop'}${
-            value
-              ? format({
-                  id: 'select.selected',
-                  messages,
-                  values: { currentSelectedValue: value },
-                })
-              : ''
-          }`}
+          a11yTitle={`${
+            ariaLabel || a11yTitle || placeholder || 'Open Drop'
+          }${ariaLabelGenerated}`}
           aria-expanded={Boolean(open)}
           aria-haspopup="listbox"
           id={id}

--- a/src/js/components/Select/Select.js
+++ b/src/js/components/Select/Select.js
@@ -281,7 +281,9 @@ const Select = forwardRef(
     let ariaLabelGenerated = '';
     if (value) {
       if (Array.isArray(value)) {
-        ariaLabelGenerated = `; ${value.length || 0} selected`;
+        ariaLabelGenerated = `; ${value.length || 0} ${
+          value.length === 1 ? 'option' : 'options'
+        } selected`;
       } else if (typeof value === 'object' && value !== null) {
         ariaLabelGenerated = `; Selected: ${inputValue}`;
       } else {

--- a/src/js/components/Select/__tests__/__snapshots__/Select-multiple-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-multiple-test.js.snap
@@ -221,7 +221,7 @@ exports[`Select Controlled deselect an option 1`] = `
 <button
   aria-expanded="false"
   aria-haspopup="listbox"
-  aria-label="test select; Selected: one"
+  aria-label="test select; 1 selected"
   class="c0 c1"
   id="test-select"
   type="button"
@@ -489,7 +489,7 @@ exports[`Select Controlled multiple 1`] = `
 <button
   aria-expanded="false"
   aria-haspopup="listbox"
-  aria-label="Open Drop; Selected: "
+  aria-label="Open Drop; 0 selected"
   class="c0 c1"
   id="test-select"
   type="button"
@@ -769,7 +769,7 @@ exports[`Select Controlled multiple onChange toggle with valueKey reduce 1`] = `
   <button
     aria-expanded="false"
     aria-haspopup="listbox"
-    aria-label="test select; Selected: 1"
+    aria-label="test select; 1 selected"
     class="c1 c2"
     id="test-select"
     type="button"
@@ -3127,7 +3127,7 @@ exports[`Select Controlled multiple onChange without labelKey 8`] = `
     <button
       aria-expanded="true"
       aria-haspopup="listbox"
-      aria-label="test select; Selected: [object Object],[object Object]"
+      aria-label="test select; 2 selected"
       class="c1 c2"
       id="test-select"
       type="button"
@@ -4107,7 +4107,7 @@ exports[`Select Controlled multiple onChange without valueKey 8`] = `
     <button
       aria-expanded="true"
       aria-haspopup="listbox"
-      aria-label="test select; Selected: [object Object],[object Object]"
+      aria-label="test select; 2 selected"
       class="c1 c2"
       id="test-select"
       type="button"
@@ -5085,7 +5085,7 @@ exports[`Select Controlled multiple onChange without valueKey or labelKey 8`] = 
     <button
       aria-expanded="true"
       aria-haspopup="listbox"
-      aria-label="test select; Selected: [object Object],[object Object]"
+      aria-label="test select; 2 selected"
       class="c1 c2"
       id="test-select"
       type="button"
@@ -5355,7 +5355,7 @@ exports[`Select Controlled multiple values 1`] = `
 <button
   aria-expanded="false"
   aria-haspopup="listbox"
-  aria-label="test select; Selected: one,two"
+  aria-label="test select; 2 selected"
   class="c0 c1"
   id="test-select"
   type="button"
@@ -5406,7 +5406,7 @@ exports[`Select Controlled multiple values 2`] = `
 <button
   aria-expanded="true"
   aria-haspopup="listbox"
-  aria-label="test select; Selected: one,two"
+  aria-label="test select; 2 selected"
   class="StyledButton-sc-323bzc-0 hIPuDF StyledSelect__StyledSelectDropButton-sc-znp66n-5 iCxWAc"
   id="test-select"
   type="button"
@@ -5945,7 +5945,7 @@ exports[`Select Controlled multiple with empty results 1`] = `
   <button
     aria-expanded="false"
     aria-haspopup="listbox"
-    aria-label="test select; Selected: "
+    aria-label="test select; 0 selected"
     class="c1 c2"
     id="test-select"
     type="button"
@@ -6470,7 +6470,7 @@ exports[`Select Controlled select another option 1`] = `
 <button
   aria-expanded="false"
   aria-haspopup="listbox"
-  aria-label="test select; Selected: two"
+  aria-label="test select; 1 selected"
   class="c0 c1"
   id="test-select"
   type="button"

--- a/src/js/components/Select/__tests__/__snapshots__/Select-multiple-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-multiple-test.js.snap
@@ -221,7 +221,7 @@ exports[`Select Controlled deselect an option 1`] = `
 <button
   aria-expanded="false"
   aria-haspopup="listbox"
-  aria-label="test select; 1 selected"
+  aria-label="test select; 1 option selected"
   class="c0 c1"
   id="test-select"
   type="button"
@@ -489,7 +489,7 @@ exports[`Select Controlled multiple 1`] = `
 <button
   aria-expanded="false"
   aria-haspopup="listbox"
-  aria-label="Open Drop; 0 selected"
+  aria-label="Open Drop; 0 options selected"
   class="c0 c1"
   id="test-select"
   type="button"
@@ -769,7 +769,7 @@ exports[`Select Controlled multiple onChange toggle with valueKey reduce 1`] = `
   <button
     aria-expanded="false"
     aria-haspopup="listbox"
-    aria-label="test select; 1 selected"
+    aria-label="test select; 1 option selected"
     class="c1 c2"
     id="test-select"
     type="button"
@@ -3127,7 +3127,7 @@ exports[`Select Controlled multiple onChange without labelKey 8`] = `
     <button
       aria-expanded="true"
       aria-haspopup="listbox"
-      aria-label="test select; 2 selected"
+      aria-label="test select; 2 options selected"
       class="c1 c2"
       id="test-select"
       type="button"
@@ -4107,7 +4107,7 @@ exports[`Select Controlled multiple onChange without valueKey 8`] = `
     <button
       aria-expanded="true"
       aria-haspopup="listbox"
-      aria-label="test select; 2 selected"
+      aria-label="test select; 2 options selected"
       class="c1 c2"
       id="test-select"
       type="button"
@@ -5085,7 +5085,7 @@ exports[`Select Controlled multiple onChange without valueKey or labelKey 8`] = 
     <button
       aria-expanded="true"
       aria-haspopup="listbox"
-      aria-label="test select; 2 selected"
+      aria-label="test select; 2 options selected"
       class="c1 c2"
       id="test-select"
       type="button"
@@ -5355,7 +5355,7 @@ exports[`Select Controlled multiple values 1`] = `
 <button
   aria-expanded="false"
   aria-haspopup="listbox"
-  aria-label="test select; 2 selected"
+  aria-label="test select; 2 options selected"
   class="c0 c1"
   id="test-select"
   type="button"
@@ -5406,7 +5406,7 @@ exports[`Select Controlled multiple values 2`] = `
 <button
   aria-expanded="true"
   aria-haspopup="listbox"
-  aria-label="test select; 2 selected"
+  aria-label="test select; 2 options selected"
   class="StyledButton-sc-323bzc-0 hIPuDF StyledSelect__StyledSelectDropButton-sc-znp66n-5 iCxWAc"
   id="test-select"
   type="button"
@@ -5945,7 +5945,7 @@ exports[`Select Controlled multiple with empty results 1`] = `
   <button
     aria-expanded="false"
     aria-haspopup="listbox"
-    aria-label="test select; 0 selected"
+    aria-label="test select; 0 options selected"
     class="c1 c2"
     id="test-select"
     type="button"
@@ -6470,7 +6470,7 @@ exports[`Select Controlled select another option 1`] = `
 <button
   aria-expanded="false"
   aria-haspopup="listbox"
-  aria-label="test select; 1 selected"
+  aria-label="test select; 1 option selected"
   class="c0 c1"
   id="test-select"
   type="button"

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -19217,7 +19217,7 @@ exports[`Select size 1`] = `
 <button
   aria-expanded="false"
   aria-haspopup="listbox"
-  aria-label="Open Drop; 0 selected"
+  aria-label="Open Drop; 0 options selected"
   class="c0 c1"
   id="test-select"
   type="button"

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -4381,7 +4381,7 @@ exports[`Select default value object options 1`] = `
   <button
     aria-expanded="false"
     aria-haspopup="listbox"
-    aria-label="test select; Selected: 2"
+    aria-label="test select; Selected: two"
     class="c1 c2"
     id="test-select"
     type="button"
@@ -7863,7 +7863,7 @@ exports[`Select onChange with valueKey object 4`] = `
     <button
       aria-expanded="false"
       aria-haspopup="listbox"
-      aria-label="test select; Selected: 1"
+      aria-label="test select; Selected: Value1"
       class="c1 c2"
       id="test-select"
       type="button"
@@ -8696,7 +8696,7 @@ exports[`Select onChange with valueKey string 4`] = `
     <button
       aria-expanded="false"
       aria-haspopup="listbox"
-      aria-label="test select; Selected: [object Object]"
+      aria-label="test select; Selected: Value1"
       class="c1 c2"
       id="test-select"
       type="button"
@@ -10015,7 +10015,7 @@ exports[`Select onChange without labelKey 4`] = `
     <button
       aria-expanded="false"
       aria-haspopup="listbox"
-      aria-label="test select; Selected: [object Object]"
+      aria-label="test select; Selected: 1"
       class="c1 c2"
       id="test-select"
       type="button"
@@ -10848,7 +10848,7 @@ exports[`Select onChange without labelKey or valueKey 4`] = `
     <button
       aria-expanded="false"
       aria-haspopup="listbox"
-      aria-label="test select; Selected: [object Object]"
+      aria-label="test select; Selected: 1"
       class="c1 c2"
       id="test-select"
       type="button"
@@ -11681,7 +11681,7 @@ exports[`Select onChange without valueKey 4`] = `
     <button
       aria-expanded="false"
       aria-haspopup="listbox"
-      aria-label="test select; Selected: [object Object]"
+      aria-label="test select; Selected: Value1"
       class="c1 c2"
       id="test-select"
       type="button"
@@ -16922,7 +16922,7 @@ exports[`Select select an option with complex options 1`] = `
 <button
   aria-expanded="false"
   aria-haspopup="listbox"
-  aria-label="Open Drop; Selected: [object Object]"
+  aria-label="Open Drop; Selected: undefined"
   class="c0 "
   id="test-select"
   type="button"
@@ -19217,7 +19217,7 @@ exports[`Select size 1`] = `
 <button
   aria-expanded="false"
   aria-haspopup="listbox"
-  aria-label="Open Drop; Selected: "
+  aria-label="Open Drop; 0 selected"
   class="c0 c1"
   id="test-select"
   type="button"


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

make aria-label readable for Select component

#### Where should the reviewer start?

Select component

#### What testing has been done on this PR?

#### How should this be manually tested?

Check the aria-labels for Select examples in the Storybook

#### Do Jest tests follow these best practices?

- [x] `screen` is used for querying.
- [x] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [x] `userEvent` is used in place of `fireEvent`.
- [x] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#6393 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
