### PR TITLE
Fix accessibility violation in Menu/Children storybook

### DIFF
--- a/src/js/components/Menu/stories/typescript/Children.tsx
+++ b/src/js/components/Menu/stories/typescript/Children.tsx
@@ -30,12 +30,7 @@ const MenuWithChildren = (props) => (
 );
 
 const Example = () => (
-  <Box
-    align="center"
-    pad="large"
-    gap="small"
-    background={{ color: 'dark-3', opacity: 0.6 }}
-  >
+  <Box align="center" pad="large" gap="small" background="dark-1">
     <MenuWithChildren disabled />
     <MenuWithChildren />
   </Box>

--- a/src/js/components/Menu/stories/typescript/Children.tsx
+++ b/src/js/components/Menu/stories/typescript/Children.tsx
@@ -30,7 +30,7 @@ const MenuWithChildren = (props) => (
 );
 
 const Example = () => (
-  <Box align="center" pad="large" gap="small" background="dark-1">
+  <Box align="center" pad="large" gap="small">
     <MenuWithChildren disabled />
     <MenuWithChildren />
   </Box>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Fixes accessibility violation by updating the background color of the menu in `Menu/Children` storybook

#### Where should the reviewer start?

`Menu/Children` storybook

#### What testing has been done on this PR?

`yarn test` was run before committing

#### How should this be manually tested?

Check the accessibility tab in the `Menu/Children` storybook

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#6124

#### Screenshots (if appropriate)

~https://user-images.githubusercontent.com/43496356/194731855-20d0ba78-5fb0-4063-80bf-34de3939a0af.png~

<img width="1164" alt="image" src="https://user-images.githubusercontent.com/43496356/194955272-96ae4753-d6af-44a8-9e86-48d33f38f5b7.png">


#### Do the grommet docs need to be updated?

No

#### Should this PR be mentioned in the release notes?

No

#### Is this change backwards compatible or is it a breaking change?

No