### PR TITLE
Changed DataChart to better match legend style to chart style

### DIFF
--- a/src/js/components/DataChart/DataChart.js
+++ b/src/js/components/DataChart/DataChart.js
@@ -344,6 +344,8 @@ const DataChart = forwardRef(
               ...styles,
               ...(result[property] || {}),
             };
+            // unless the new style is has no opacity
+            if (!styles.opacity) delete result[property].opacity;
             if (styles.type === 'point') result[property].point = false;
             if (calcThickness && !result[property].thickness)
               result[property].thickness = calcThickness;

--- a/src/js/components/DataChart/Swatch.js
+++ b/src/js/components/DataChart/Swatch.js
@@ -2,7 +2,16 @@ import React, { useContext } from 'react';
 import { ThemeContext } from 'styled-components';
 import { normalizeColor, parseMetricToNum } from '../../utils';
 
-const Swatch = ({ aspect, color, dash, point, round, thickness, type }) => {
+const Swatch = ({
+  aspect,
+  color,
+  dash,
+  opacity: opacityProp,
+  point,
+  round,
+  thickness,
+  type,
+}) => {
   const theme = useContext(ThemeContext);
   const dim = parseInt(theme.global.spacing, 10) / 2;
   const half = dim / 2;
@@ -90,7 +99,7 @@ const Swatch = ({ aspect, color, dash, point, round, thickness, type }) => {
   }
 
   const opacity =
-    color && color.opacity ? theme.global.opacity[color.opacity] : undefined;
+    theme.global.opacity[color?.opacity || opacityProp] || undefined;
 
   return (
     <svg

--- a/src/js/components/DataChart/stories/Legend.js
+++ b/src/js/components/DataChart/stories/Legend.js
@@ -9,6 +9,7 @@ for (let i = 1; i < 8; i += 1) {
     date: `2020-07-${((i % 30) + 1).toString().padStart(2, 0)}`,
     percent: Math.abs(v * 100),
     amount: Math.round(Math.abs(v * 50)),
+    inverse: 100 - Math.round(Math.abs(v * 50)),
   });
 }
 
@@ -29,15 +30,25 @@ export const Legend = () => (
           property: 'amount',
           label: 'Amount',
         },
+        {
+          property: 'inverse',
+          label: 'Inverse',
+        },
       ]}
       chart={[
         'percent',
         {
-          type: 'line',
           property: 'amount',
+          type: 'line',
           thickness: 'xsmall',
           dash: true,
           round: true,
+        },
+        {
+          property: 'inverse',
+          type: 'point',
+          point: 'star',
+          thickness: 'medium',
         },
       ]}
       legend

--- a/src/js/components/DataChart/stories/StackedBars.js
+++ b/src/js/components/DataChart/stories/StackedBars.js
@@ -7,7 +7,7 @@ for (let i = 0; i < 7; i += 1) {
   data.push({
     date: `2020-07-${((i % 31) + 1).toString().padStart(2, 0)}`,
     usage: Math.floor(Math.abs(Math.sin(i / 2.0) * 100)),
-    bonus: Math.floor(Math.abs(Math.cos(i / 2.0) * 100)),
+    forecast: Math.floor(Math.abs(Math.cos(i / 2.0) * 100)),
   });
 }
 
@@ -30,13 +30,13 @@ export const StackedBars = () => (
           ),
         },
         'usage',
-        'bonus',
+        'forecast',
       ]}
       chart={[
         {
           property: [
             { property: 'usage', thickness: 'medium' },
-            { property: 'bonus', thickness: 'large', opacity: 'medium' },
+            { property: 'forecast', thickness: 'medium', opacity: 'medium' },
           ],
           type: 'bars',
         },

--- a/src/js/components/DataChart/stories/StackedBars.js
+++ b/src/js/components/DataChart/stories/StackedBars.js
@@ -34,7 +34,10 @@ export const StackedBars = () => (
       ]}
       chart={[
         {
-          property: ['usage', 'bonus'],
+          property: [
+            { property: 'usage', thickness: 'medium' },
+            { property: 'bonus', thickness: 'large', opacity: 'medium' },
+          ],
           type: 'bars',
         },
       ]}


### PR DESCRIPTION
#### What does this PR do?

Changed DataChart to better match legend style to chart style.

Previously, opacity wasn't preserved, as can be seen with the legend here:
<img width="453" alt="Screen Shot 2022-10-08 at 8 36 43 PM" src="https://user-images.githubusercontent.com/11637956/194734968-98c42648-0641-4ca0-a84c-51ecadbef498.png">

Now, the legend more accurately aligns to the styling of each property.
<img width="523" alt="Screen Shot 2022-10-08 at 8 51 16 PM" src="https://user-images.githubusercontent.com/11637956/194735429-88f17bd0-ace4-4455-83a2-a5676371873e.png">

This was done by refactoring how the `seriesStyles` are built. That is the essence of these changes. Each chart can set styling, like color and opacity, but also each property can have its own styling for chart types like stacked "bars", "lines", and "areas". In the refactored code, `setPropertyStyle()` is now used across the various permutations and it is passed an object that spreads the chart styles first and then lets any per-property styles supersede them.

#### Where should the reviewer start?

DataChart.js where `seriesStyles` are built, about line 324.

#### What testing has been done on this PR?

Enhanced the Legend and Stacked Bars stories.

#### How should this be manually tested?

DataChart stories

#### Do Jest tests follow these best practices?

no changes to tests, no unit tests were broken in the changing of this code ;)

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
