### PR TITLE
(Deps) update grommet-icons to avoid build issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "styled-components": ">= 5.1"
   },
   "dependencies": {
-    "grommet-icons": "^4.7.0",
+    "grommet-icons": "^4.8.0",
     "hoist-non-react-statics": "^3.2.0",
     "markdown-to-jsx": "^7.1.5",
     "prop-types": "^15.8.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7472,7 +7472,7 @@ graphlib@^2.1.5:
   dependencies:
     lodash "^4.17.15"
 
-grommet-icons@^4.7.0:
+grommet-icons@^4.8.0:
   version "4.8.0"
   resolved "https://registry.yarnpkg.com/grommet-icons/-/grommet-icons-4.8.0.tgz#3c9922b3662d0b9e22913ecbaa7b1101031b554b"
   integrity sha512-8cS1zVib88SIyLfsWFFazMzYz/8k5MvXZqopUjN/Bnl8HvQBUe0Z87F+JXRb1AMMYkuqXQW9Pg6XfBB3Ro9VdQ==


### PR DESCRIPTION
Newer version of `grommet-icons` is required since https://github.com/grommet/grommet/pull/6249/files, but version in package.json was overwritten in https://github.com/grommet/grommet/pull/6329/files. 

#### What does this PR do?
Fix local build issue: `Failed to resolve 'grommet-icons/icons/FormPin' from './node_modules/grommet/es6/themes/base.js'` 

#### Where should the reviewer start?
package.json

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
Having `grommet-icons` and `grommet` in my package.json will end up with node modules structure like this using yarn
```
node_modules/grommet-icons // v4.8.0
node_modules/grommet/node_modues/grommet-icons // v4.7.0, missing icons
```

Can be fix locally by adding `resolutions` entry, but still 4.8.0 is now min compat version users need.

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no

#### Should this PR be mentioned in the release notes?
no

#### Is this change backwards compatible or is it a breaking change?
backwards compatible