### PR TITLE
feat: add fowardRef on Table component

### DIFF
--- a/src/js/components/Table/Table.js
+++ b/src/js/components/Table/Table.js
@@ -1,16 +1,16 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import { StyledTable, StyledTableDataCaption } from './StyledTable';
 import { TablePropTypes } from './propTypes';
 
-const Table = ({ caption, children, ...rest }) => (
-  <StyledTable {...rest}>
+const Table = forwardRef(({ caption, children, ...rest }, ref) => (
+  <StyledTable ref={ref} {...rest}>
     {caption ? (
       <StyledTableDataCaption>{caption}</StyledTableDataCaption>
     ) : null}
     {children}
   </StyledTable>
-);
+));
 
 Table.propTypes = TablePropTypes;
 

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -4659,7 +4659,17 @@ exports[`Components loads 1`] = `
     },
     "render": [Function],
   },
-  "Table": [Function],
+  "Table": {
+    "$$typeof": Symbol(react.forward_ref),
+    "propTypes": {
+      "a11yTitle": [Function],
+      "alignSelf": [Function],
+      "caption": [Function],
+      "gridArea": [Function],
+      "margin": [Function],
+    },
+    "render": [Function],
+  },
   "TableBody": {
     "$$typeof": Symbol(react.forward_ref),
     "render": [Function],


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Add fowardRef on Table component

#### Where should the reviewer start?

#### What testing has been done on this PR?
Added a ref attribute on Table component, there was no warning on error on ref

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
https://github.com/grommet/grommet/issues/6370

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
They are backward compatible