### PR TITLE
Fix Storybook accessibility violations for the file input (#6124)

### DIFF
--- a/src/js/components/FileInput/stories/CustomThemed/Custom.js
+++ b/src/js/components/FileInput/stories/CustomThemed/Custom.js
@@ -47,6 +47,7 @@ export const Custom = () => (
     <Box fill align="center" justify="start" pad="large">
       <Box width="medium">
         <FileInput
+          aria-label="Choose files"
           renderFile={(file) => (
             <Box>
               <Text weight="bold" truncate>

--- a/src/js/components/FileInput/stories/MaxFileCount.js
+++ b/src/js/components/FileInput/stories/MaxFileCount.js
@@ -8,6 +8,7 @@ export const MaxFileCount = () => (
       <Form validate="submit">
         <FormField name="fileInput" htmlFor="fileInput" required>
           <FileInput
+            aria-label="Choose files"
             name="fileInput"
             id="fileInput"
             multiple={{

--- a/src/js/components/FileInput/stories/Multiple.js
+++ b/src/js/components/FileInput/stories/Multiple.js
@@ -6,6 +6,7 @@ export const Multiple = () => (
   <Box fill align="center" justify="start" pad="large">
     <Box width="medium">
       <FileInput
+        aria-label="Choose files"
         multiple={{
           max: 5,
         }}

--- a/src/js/components/FileInput/stories/Simple.js
+++ b/src/js/components/FileInput/stories/Simple.js
@@ -6,6 +6,7 @@ export const Simple = () => (
   <Box fill align="center" justify="start" pad="large">
     <Box width="medium">
       <FileInput
+        aria-label="Choose files"
         onChange={(event, { files }) => {
           const fileList = files;
           for (let i = 0; i < fileList.length; i += 1) {


### PR DESCRIPTION
Hello there,

This should fix up the accessibility violations reported across some of the `FileInput` stories.

It seems like using a `label` element, explicit or implicit, appears to be the preferred way to work around such violations. In the interest of preserving the existing story visuals, I opted for `aria-label`. If the former is more desirable, I can update my changes.

---

#### What does this PR do?
Resolve accessibility violations for `FileInput` stories.

#### Where should the reviewer start?
Changes are confined to the file input stories reporting violations.

#### What testing has been done on this PR?
Confirmed the violations no longer appear in the Storybook.

#### How should this be manually tested?
As above.

#### Do Jest tests follow these best practices?
N/A.
- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
None.

#### What are the relevant issues?
Refer to #6124.

#### Screenshots (if appropriate)
N/A.

#### Do the grommet docs need to be updated?
Don't think so.

#### Should this PR be mentioned in the release notes?
Up to maintainers to decide.

#### Is this change backwards compatible or is it a breaking change?
Should have no impact on consumers of the library.