### PR TITLE
Correct types for onChange() params of FileInput

### DIFF
--- a/src/js/components/FileInput/index.d.ts
+++ b/src/js/components/FileInput/index.d.ts
@@ -24,8 +24,8 @@ export interface FileInputProps {
   name?: string;
   onChange?: (
     event?: React.ChangeEvent<HTMLInputElement>,
-    { files }?: { files: object },
-    { target }?: { target: { files: object } },
+    { files }?: { files: File[] },
+    { target }?: { target: { files: FileList } },
   ) => void;
   renderFile?: (...args: any[]) => void;
 }


### PR DESCRIPTION
#### What does this PR do?

It corrects types definitions for additional params of `onChange` property of `FileInput` component.

#### Where should the reviewer start?

`FileInput` component.

#### What testing has been done on this PR?

Manual testing with the app that's using TypeScript.

#### How should this be manually tested?

Add `FileInput` with `onChange` property to the render of your component. Try to describe params of `onChange` precisely.

#### What are the relevant issues?

https://github.com/grommet/grommet/pull/6145 (the fix is incomplete).

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

I think yes.

#### Is this change backwards compatible or is it a breaking change?

This change might break an app which has incorrect handling of second parameter of `onChange` (e.g., referring to property of `files` which doesn't actually exist, but TS wouldn't warn about this with current type definition).