### PR TITLE
Fix Storybook accessibility violations for the chart (#6124)

### DIFF
--- a/src/js/components/Chart/stories/Pattern.js
+++ b/src/js/components/Chart/stories/Pattern.js
@@ -15,7 +15,7 @@ export const Pattern = () => (
       'stripesDiagonalUp',
     ].map((pattern) => (
       <Chart
-        id="area"
+        id={`area-${pattern}`}
         type="area"
         pattern={pattern}
         thickness="xsmall"


### PR DESCRIPTION
Hello there,

This should fix up the accessibility violation being reported in the "Pattern" story for the `Chart` component.

---

#### What does this PR do?
Resolve an accessibility violation for the `Chart` component.

#### Where should the reviewer start?
Changes are confined to the "Pattern" story.

#### What testing has been done on this PR?
Confirmed the violation no longer appears in Storybook.

#### How should this be manually tested?
As above.

#### Do Jest tests follow these best practices?
N/A.
- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
None.

#### What are the relevant issues?
Refer to #6124.

#### Screenshots (if appropriate)
N/A.

#### Do the grommet docs need to be updated?
Don't think so.

#### Should this PR be mentioned in the release notes?
Up to maintainers to decide.

#### Is this change backwards compatible or is it a breaking change?
Should have no impact on consumers of the library.