### PR TITLE
Fix Storybook accessibility violations for the range input (#6124)

### DIFF
--- a/src/js/components/RangeInput/stories/CustomThemed/Bounds.js
+++ b/src/js/components/RangeInput/stories/CustomThemed/Bounds.js
@@ -42,6 +42,7 @@ export const Bounds = () => {
         />
         <Box align="center" width="medium">
           <RangeInput
+            a11yTitle="Select range value"
             min={0}
             max={10}
             step={1}

--- a/src/js/components/RangeInput/stories/CustomThemed/CustomRange.tsx
+++ b/src/js/components/RangeInput/stories/CustomThemed/CustomRange.tsx
@@ -42,6 +42,7 @@ export const Custom = () => {
         <Volume color="neutral-2" />
         <Box align="center" width="small">
           <RangeInput
+            a11yTitle="Select range value"
             min={0}
             max={1}
             step={0.1}

--- a/src/js/components/RangeInput/stories/CustomThemed/Disabled.js
+++ b/src/js/components/RangeInput/stories/CustomThemed/Disabled.js
@@ -20,12 +20,12 @@ export const Disabled = () => (
   <>
     <Grommet theme={customThemeRangeInput}>
       <Box align="center" pad="large">
-        <RangeInput disabled value={5} />
+        <RangeInput disabled value={5} a11yTitle="Select range value" />
       </Box>
     </Grommet>
     <Grommet theme={grommet}>
       <Box align="center" pad="large">
-        <RangeInput disabled value={5} />
+        <RangeInput disabled value={5} a11yTitle="Select range value" />
       </Box>
     </Grommet>
   </>

--- a/src/js/components/RangeInput/stories/CustomThemed/TrackColor.js
+++ b/src/js/components/RangeInput/stories/CustomThemed/TrackColor.js
@@ -22,6 +22,7 @@ export const TrackColor = () => {
     <Grommet theme={rangeInputTheme}>
       <Box align="center" pad="large" gap="large" width="large">
         <RangeInput
+          a11yTitle="Select range value"
           min={0}
           max={1}
           step={0.1}
@@ -30,6 +31,7 @@ export const TrackColor = () => {
           onChange={onChange1}
         />
         <RangeInput
+          a11yTitle="Select range value"
           min={0}
           max={10}
           step={1}

--- a/src/js/components/RangeInput/stories/SimpleRange.js
+++ b/src/js/components/RangeInput/stories/SimpleRange.js
@@ -9,7 +9,11 @@ export const Simple = () => {
 
   return (
     <Box align="center" pad="large">
-      <RangeInput value={value} onChange={onChange} />
+      <RangeInput
+        a11yTitle="Select range value"
+        value={value}
+        onChange={onChange}
+      />
     </Box>
   );
 };


### PR DESCRIPTION
Hello there,

This should fix up the accessibility violations reported across multiple `RangeInput` component stories.

As an aside, I noticed `a11yTitle` feeds into `aria-label` of the underlying styled range input. Having looked at `FileInput` just the other day, the latter doesn't appear to do the same, so this might be a potential inconsistency worth reviewing?

In any case, there's no reason why we can't also fix the violations here by directly specifying `aria-label` instead of `a11yTitle` because the `RangeInput` appears to feed everything through as spread props.

---

#### What does this PR do?
Resolves an accessibility violations for the `RangeInput` component.

#### Where should the reviewer start?
Across the various stories of the `RangeInput` component.

#### What testing has been done on this PR?
Confirmed the violations no longer appear in Storybook.

#### How should this be manually tested?
As above.

#### Do Jest tests follow these best practices?
N/A.
- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
None.

#### What are the relevant issues?
Refer to #6124.

#### Screenshots (if appropriate)
N/A.

#### Do the grommet docs need to be updated?
Don't think so.

#### Should this PR be mentioned in the release notes?
Up to maintainers to decide.

#### Is this change backwards compatible or is it a breaking change?
Should have no impact on consumers of the library.