### PR TITLE
fix: dropProps should accept inline style

### DIFF
--- a/src/js/components/Tip/index.d.ts
+++ b/src/js/components/Tip/index.d.ts
@@ -1,11 +1,10 @@
 import * as React from 'react';
-// import { Omit } from "../../utils";
-import { DropProps } from '../Drop';
+import { DropType } from '../Drop';
 
 export interface TipProps {
   children?: React.ReactNode;
   content?: React.ReactNode;
-  dropProps?: DropProps;
+  dropProps?: DropType;
   plain?: boolean;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Allows `dropProps` of Tip to accept inline style.

#### Where should the reviewer start?
Tip types
#### What testing has been done on this PR?
local
#### How should this be manually tested?
Use `style` prop inline with `dropProps` of Tip 
#### Do Jest tests follow these best practices?
N/A

#### Any background context you want to provide?

#### What are the relevant issues?
#types
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
types
#### Should this PR be mentioned in the release notes?
As a TS issue
#### Is this change backward compatible or is it a breaking change?
backward compatible