### PR TITLE
fix DateInput format calendar bounds

### DIFF
--- a/src/js/components/DateInput/DateInput.js
+++ b/src/js/components/DateInput/DateInput.js
@@ -27,7 +27,7 @@ import {
   valuesAreEqual,
   valueToText,
   textToValue,
-  validateDateBounds,
+  validateBounds,
 } from './utils';
 import { DateInputPropTypes } from './propTypes';
 import { getOutputFormat } from '../Calendar/Calendar';
@@ -165,8 +165,6 @@ Use the icon prop instead.`,
       [range, value],
     );
 
-    const bounds = calendarProps?.bounds;
-
     const calendar = (
       <Calendar
         ref={inline ? ref : undefined}
@@ -278,10 +276,10 @@ Use the icon prop instead.`,
                   outputFormat,
                 );
 
-                const validatedNextValue = validateDateBounds({
-                  dateBounds: bounds,
-                  selectedDate: nextValue,
-                });
+                const validatedNextValue = validateBounds(
+                  calendarProps?.bounds,
+                  nextValue,
+                );
 
                 if (validatedNextValue !== undefined)
                   setReference(getReference(validatedNextValue));

--- a/src/js/components/DateInput/DateInput.js
+++ b/src/js/components/DateInput/DateInput.js
@@ -27,6 +27,7 @@ import {
   valuesAreEqual,
   valueToText,
   textToValue,
+  validateDateBounds,
 } from './utils';
 import { DateInputPropTypes } from './propTypes';
 import { getOutputFormat } from '../Calendar/Calendar';
@@ -164,6 +165,8 @@ Use the icon prop instead.`,
       [range, value],
     );
 
+    const bounds = calendarProps?.bounds;
+
     const calendar = (
       <Calendar
         ref={inline ? ref : undefined}
@@ -274,14 +277,20 @@ Use the icon prop instead.`,
                   reference,
                   outputFormat,
                 );
-                if (nextValue !== undefined)
-                  setReference(getReference(nextValue));
+
+                const validatedNextValue = validateDateBounds({
+                  dateBounds: bounds,
+                  selectedDate: nextValue,
+                });
+
+                if (validatedNextValue !== undefined)
+                  setReference(getReference(validatedNextValue));
                 // update value even when undefined
-                setValue(nextValue);
+                setValue(validatedNextValue);
                 if (onChange) {
                   event.persist(); // extract from React synthetic event pool
                   const adjustedEvent = event;
-                  adjustedEvent.value = nextValue;
+                  adjustedEvent.value = validatedNextValue;
                   onChange(adjustedEvent);
                 }
               }}

--- a/src/js/components/DateInput/DateInput.js
+++ b/src/js/components/DateInput/DateInput.js
@@ -281,6 +281,10 @@ Use the icon prop instead.`,
                   nextValue,
                 );
 
+                if (!validatedNextValue && nextValue) {
+                  setTextValue('');
+                }
+
                 if (validatedNextValue !== undefined)
                   setReference(getReference(validatedNextValue));
                 // update value even when undefined

--- a/src/js/components/DateInput/__tests__/DateInput-test.tsx
+++ b/src/js/components/DateInput/__tests__/DateInput-test.tsx
@@ -106,6 +106,32 @@ describe('DateInput', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  test('format with date bounds', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Grommet>
+        <DateInput
+          id="item"
+          name="item"
+          format="mm/dd/yyyy"
+          calendarProps={{
+            bounds: ['2022-11-10', '2022-11-20'],
+          }}
+        />
+      </Grommet>,
+    );
+
+    const input = screen.getByRole('textbox');
+
+    await user.type(input, '09/09/2022');
+    expect(input).not.toHaveValue();
+
+    await user.clear(input);
+    await user.type(input, '11/15/2022');
+    expect(input).toHaveValue('11/15/2022');
+  });
+
   test('reverse calendar icon', () => {
     const { container } = render(
       <Grommet>
@@ -277,6 +303,32 @@ describe('DateInput', () => {
       </Grommet>,
     );
     expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test('range format with date bounds', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Grommet>
+        <DateInput
+          id="item"
+          name="item"
+          format="mm/dd/yyyy-mm/dd/yyyy"
+          calendarProps={{
+            bounds: ['2022-11-10', '2022-11-20'],
+          }}
+        />
+      </Grommet>,
+    );
+
+    const input = screen.getByRole('textbox');
+
+    await user.type(input, '09/09/2022-09/09/2022');
+    expect(input).not.toHaveValue();
+
+    await user.clear(input);
+    await user.type(input, '11/15/2022-11/15/2022');
+    expect(input).toHaveValue('11/15/2022-11/15/2022');
   });
 
   test('dates initialized with empty array', async () => {

--- a/src/js/components/DateInput/utils.js
+++ b/src/js/components/DateInput/utils.js
@@ -118,6 +118,30 @@ const pullDigits = (text, index) => {
   return text.slice(index, end);
 };
 
+export const validateDateBounds = ({ dateBounds, selectedDate }) => {
+  if (!dateBounds || !selectedDate) return selectedDate;
+
+  const [startDate, endDate] = dateBounds.map((date) =>
+    new Date(date).toISOString(),
+  );
+
+  const selectedDateArray = Array.isArray(selectedDate)
+    ? selectedDate
+    : [selectedDate];
+
+  const isoSelectedDateArray = selectedDateArray.map((date) =>
+    new Date(date).toISOString(),
+  );
+
+  const allDatesOk = isoSelectedDateArray.every(
+    (isoSelectedDate) =>
+      (!endDate && startDate === isoSelectedDate) ||
+      (isoSelectedDate >= startDate && isoSelectedDate <= endDate),
+  );
+
+  return allDatesOk ? selectedDate : undefined;
+};
+
 export const textToValue = (text, schema, range, reference, outputFormat) => {
   if (!text) return range ? [] : undefined;
 

--- a/src/js/components/DateInput/utils.js
+++ b/src/js/components/DateInput/utils.js
@@ -127,9 +127,7 @@ export const validateBounds = (dateBounds, selectedDate) => {
 
   const isoSelectedDates = (
     Array.isArray(selectedDate) ? selectedDate : [selectedDate]
-  ).map((date) => date.toISOString());
-
-  console.log({ selectedDate, isoSelectedDates });
+  ).map((date) => setHoursWithOffset(date).toISOString());
 
   const validSelection = isoSelectedDates.every(
     (isoSelectedDate) =>

--- a/src/js/components/DateInput/utils.js
+++ b/src/js/components/DateInput/utils.js
@@ -118,28 +118,26 @@ const pullDigits = (text, index) => {
   return text.slice(index, end);
 };
 
-export const validateDateBounds = ({ dateBounds, selectedDate }) => {
+export const validateBounds = (dateBounds, selectedDate) => {
   if (!dateBounds || !selectedDate) return selectedDate;
 
   const [startDate, endDate] = dateBounds.map((date) =>
-    new Date(date).toISOString(),
+    setHoursWithOffset(date).toISOString(),
   );
 
-  const selectedDateArray = Array.isArray(selectedDate)
-    ? selectedDate
-    : [selectedDate];
+  const isoSelectedDates = (
+    Array.isArray(selectedDate) ? selectedDate : [selectedDate]
+  ).map((date) => date.toISOString());
 
-  const isoSelectedDateArray = selectedDateArray.map((date) =>
-    new Date(date).toISOString(),
-  );
+  console.log({ selectedDate, isoSelectedDates });
 
-  const allDatesOk = isoSelectedDateArray.every(
+  const validSelection = isoSelectedDates.every(
     (isoSelectedDate) =>
       (!endDate && startDate === isoSelectedDate) ||
       (isoSelectedDate >= startDate && isoSelectedDate <= endDate),
   );
 
-  return allDatesOk ? selectedDate : undefined;
+  return validSelection ? selectedDate : undefined;
 };
 
 export const textToValue = (text, schema, range, reference, outputFormat) => {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Fix the issue #6159 

#### Where should the reviewer start?

DateInput component

#### What testing has been done on this PR?

- [ ] Test

#### How should this be manually tested?

add  
```js
format="mm/dd/yyyy"
```
 and 
```js
calendarProps={{
  bounds: ['2022-10-10', '2022-10-20'],
}}
``` 

#### Do Jest tests follow these best practices?

- [x] `screen` is used for querying.
- [x] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [x] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

~~I'll need #6424 to be merged first, because I'll need the `setHoursWithOffset` function to solve a issue with dates with wrong offset~~

#### What are the relevant issues?
closes #6159 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
