### PR TITLE
fix: keep DataTable container filled when paginate

### DIFF
--- a/src/js/components/DataTable/DataTable.js
+++ b/src/js/components/DataTable/DataTable.js
@@ -352,7 +352,7 @@ const DataTable = ({
   // should remain in its location
   const OverflowContainer = paginate ? Box : Fragment;
   const overflowContainerProps = paginate
-    ? { overflow: { horizontal: 'auto' }, flex: false }
+    ? { overflow: { horizontal: 'auto' }, flex: false, fill }
     : undefined;
 
   // necessary for Firefox, otherwise paginated DataTable will

--- a/src/js/components/DataTable/__tests__/DataTable-test.js
+++ b/src/js/components/DataTable/__tests__/DataTable-test.js
@@ -1188,6 +1188,26 @@ describe('DataTable', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  test('should pin and paginate', () => {
+    const { container, getAllByText } = render(
+      <Grommet>
+        <DataTable
+          columns={[
+            { property: 'a', header: 'A' },
+            { property: 'b', header: 'B' },
+          ]}
+          data={DATA}
+          paginate
+          pin
+        />
+      </Grommet>,
+    );
+
+    const results = getAllByText('entry', { exact: false });
+    expect(results.length).toEqual(50);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
   test('should apply pagination styling', () => {
     const { container } = render(
       <Grommet>
@@ -1428,7 +1448,7 @@ describe('DataTable', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test(`onSelect + groupBy should render indeterminate checkbox on table and 
+  test(`onSelect + groupBy should render indeterminate checkbox on table and
   group if subset of group items are selected`, () => {
     const onSelect = jest.fn();
     const { container, getAllByLabelText, getByLabelText } = render(
@@ -1460,7 +1480,7 @@ describe('DataTable', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test(`onSelect + groupBy should render indeterminate checkbox on table and 
+  test(`onSelect + groupBy should render indeterminate checkbox on table and
   group when controlled`, () => {
     const onSelect = jest.fn();
     const { container } = render(

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -8205,7 +8205,7 @@ exports[`DataTable groupBy toggle 3`] = `
 </div>
 `;
 
-exports[`DataTable onSelect + groupBy should render indeterminate checkbox on table and 
+exports[`DataTable onSelect + groupBy should render indeterminate checkbox on table and
   group if subset of group items are selected 1`] = `
 .c7 {
   display: inline-block;
@@ -9177,7 +9177,7 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
 </div>
 `;
 
-exports[`DataTable onSelect + groupBy should render indeterminate checkbox on table and 
+exports[`DataTable onSelect + groupBy should render indeterminate checkbox on table and
   group when controlled 1`] = `
 .c7 {
   display: inline-block;
@@ -26351,6 +26351,2353 @@ exports[`DataTable should paginate 1`] = `
               <svg
                 aria-label="Next"
                 class="c23"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m7 2 10 10L7 22"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </button>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DataTable should pin and paginate 1`] = `
+.c19 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #666666;
+  stroke: #666666;
+}
+
+.c19 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c19 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c19 *[stroke*="#"],
+.c19 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c19 *[fill-rule],
+.c19 *[FILL-RULE],
+.c19 *[fill*="#"],
+.c19 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c24 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #000000;
+  stroke: #000000;
+}
+
+.c24 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c24 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c24 *[stroke*="#"],
+.c24 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c24 *[fill-rule],
+.c24 *[FILL-RULE],
+.c24 *[fill*="#"],
+.c24 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  overflow-x: auto;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c13 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-self: flex-end;
+  -ms-flex-item-align: end;
+  align-self: flex-end;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c14 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c15 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin: 0px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  padding: 0px;
+}
+
+.c12 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  height: 6px;
+}
+
+.c20 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  width: 3px;
+}
+
+.c8 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c11 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c17 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  text-align: center;
+  opacity: 0.3;
+  cursor: default;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c17 > svg {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  vertical-align: middle;
+}
+
+.c17:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c17:focus > circle,
+.c17:focus > ellipse,
+.c17:focus > line,
+.c17:focus > path,
+.c17:focus > polygon,
+.c17:focus > polyline,
+.c17:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c17:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c17:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c17:focus:not(:focus-visible) > circle,
+.c17:focus:not(:focus-visible) > ellipse,
+.c17:focus:not(:focus-visible) > line,
+.c17:focus:not(:focus-visible) > path,
+.c17:focus:not(:focus-visible) > polygon,
+.c17:focus:not(:focus-visible) > polyline,
+.c17:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c17:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c21 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  background-color: rgba(51,51,51,0.06274509803921569);
+  color: #444444;
+  text-align: center;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c21:hover {
+  background-color: rgba(51,51,51,0.06274509803921569);
+}
+
+.c21:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c21:focus > circle,
+.c21:focus > ellipse,
+.c21:focus > line,
+.c21:focus > path,
+.c21:focus > polygon,
+.c21:focus > polyline,
+.c21:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c21:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c21:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c21:focus:not(:focus-visible) > circle,
+.c21:focus:not(:focus-visible) > ellipse,
+.c21:focus:not(:focus-visible) > line,
+.c21:focus:not(:focus-visible) > path,
+.c21:focus:not(:focus-visible) > polygon,
+.c21:focus:not(:focus-visible) > polyline,
+.c21:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c21:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c22 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  color: #000000;
+  text-align: center;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c22:hover {
+  background-color: rgba(51,51,51,0.06274509803921569);
+}
+
+.c22:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c22:focus > circle,
+.c22:focus > ellipse,
+.c22:focus > line,
+.c22:focus > path,
+.c22:focus > polygon,
+.c22:focus > polyline,
+.c22:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c22:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c22:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c22:focus:not(:focus-visible) > circle,
+.c22:focus:not(:focus-visible) > ellipse,
+.c22:focus:not(:focus-visible) > line,
+.c22:focus:not(:focus-visible) > path,
+.c22:focus:not(:focus-visible) > polygon,
+.c22:focus:not(:focus-visible) > polyline,
+.c22:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c22:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c23 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  color: #000000;
+  text-align: center;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c23 > svg {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  vertical-align: middle;
+}
+
+.c23:hover {
+  background-color: rgba(51,51,51,0.06274509803921569);
+}
+
+.c23:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c23:focus > circle,
+.c23:focus > ellipse,
+.c23:focus > line,
+.c23:focus > path,
+.c23:focus > polygon,
+.c23:focus > polyline,
+.c23:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c23:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c23:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c23:focus:not(:focus-visible) > circle,
+.c23:focus:not(:focus-visible) > ellipse,
+.c23:focus:not(:focus-visible) > line,
+.c23:focus:not(:focus-visible) > path,
+.c23:focus:not(:focus-visible) > polygon,
+.c23:focus:not(:focus-visible) > polyline,
+.c23:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c23:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c5 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  background-color: rgba(237,237,237,0.8);
+  color: #444444;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c10 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c3 {
+  border-spacing: 0;
+  border-collapse: collapse;
+  width: inherit;
+}
+
+.c4 {
+  position: relative;
+  border-spacing: 0;
+  border-collapse: separate;
+  height: 100%;
+}
+
+.c9:focus {
+  outline: 2px solid #6FFFB0;
+}
+
+.c9:focus:not(:focus-visible) {
+  outline: none;
+}
+
+.c6 {
+  position: -webkit-sticky;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.c18 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c18 > svg {
+  margin: 0 auto;
+}
+
+.c16 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  max-width: 100%;
+  height: 36px;
+  min-width: 36px;
+}
+
+@media only screen and (max-width:768px) {
+  .c15 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c15 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c12 {
+    height: 3px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c20 {
+    width: 2px;
+  }
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1 "
+  >
+    <div
+      class="c2"
+    >
+      <table
+        class="c3 c4"
+      >
+        <thead
+          class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
+        >
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c5 c6"
+              scope="col"
+            >
+              <div
+                class="c7"
+              >
+                <span
+                  class="c8"
+                >
+                  A
+                </span>
+              </div>
+            </th>
+            <th
+              class="c5 c6"
+              scope="col"
+            >
+              <div
+                class="c7"
+              >
+                <span
+                  class="c8"
+                >
+                  B
+                </span>
+              </div>
+            </th>
+          </tr>
+        </thead>
+        <tbody
+          class="StyledTable__StyledTableBody-sc-1m3u5g-3 c9"
+        >
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c10 "
+              scope="row"
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c11"
+                >
+                  entry-0
+                </span>
+              </div>
+            </th>
+            <td
+              class="c10 "
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c8"
+                >
+                  0
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c10 "
+              scope="row"
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c11"
+                >
+                  entry-1
+                </span>
+              </div>
+            </th>
+            <td
+              class="c10 "
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c8"
+                >
+                  1
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c10 "
+              scope="row"
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c11"
+                >
+                  entry-2
+                </span>
+              </div>
+            </th>
+            <td
+              class="c10 "
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c8"
+                >
+                  2
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c10 "
+              scope="row"
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c11"
+                >
+                  entry-3
+                </span>
+              </div>
+            </th>
+            <td
+              class="c10 "
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c8"
+                >
+                  3
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c10 "
+              scope="row"
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c11"
+                >
+                  entry-4
+                </span>
+              </div>
+            </th>
+            <td
+              class="c10 "
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c8"
+                >
+                  4
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c10 "
+              scope="row"
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c11"
+                >
+                  entry-5
+                </span>
+              </div>
+            </th>
+            <td
+              class="c10 "
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c8"
+                >
+                  5
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c10 "
+              scope="row"
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c11"
+                >
+                  entry-6
+                </span>
+              </div>
+            </th>
+            <td
+              class="c10 "
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c8"
+                >
+                  6
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c10 "
+              scope="row"
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c11"
+                >
+                  entry-7
+                </span>
+              </div>
+            </th>
+            <td
+              class="c10 "
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c8"
+                >
+                  7
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c10 "
+              scope="row"
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c11"
+                >
+                  entry-8
+                </span>
+              </div>
+            </th>
+            <td
+              class="c10 "
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c8"
+                >
+                  8
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c10 "
+              scope="row"
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c11"
+                >
+                  entry-9
+                </span>
+              </div>
+            </th>
+            <td
+              class="c10 "
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c8"
+                >
+                  9
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c10 "
+              scope="row"
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c11"
+                >
+                  entry-10
+                </span>
+              </div>
+            </th>
+            <td
+              class="c10 "
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c8"
+                >
+                  10
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c10 "
+              scope="row"
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c11"
+                >
+                  entry-11
+                </span>
+              </div>
+            </th>
+            <td
+              class="c10 "
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c8"
+                >
+                  11
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c10 "
+              scope="row"
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c11"
+                >
+                  entry-12
+                </span>
+              </div>
+            </th>
+            <td
+              class="c10 "
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c8"
+                >
+                  12
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c10 "
+              scope="row"
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c11"
+                >
+                  entry-13
+                </span>
+              </div>
+            </th>
+            <td
+              class="c10 "
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c8"
+                >
+                  13
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c10 "
+              scope="row"
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c11"
+                >
+                  entry-14
+                </span>
+              </div>
+            </th>
+            <td
+              class="c10 "
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c8"
+                >
+                  14
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c10 "
+              scope="row"
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c11"
+                >
+                  entry-15
+                </span>
+              </div>
+            </th>
+            <td
+              class="c10 "
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c8"
+                >
+                  15
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c10 "
+              scope="row"
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c11"
+                >
+                  entry-16
+                </span>
+              </div>
+            </th>
+            <td
+              class="c10 "
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c8"
+                >
+                  16
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c10 "
+              scope="row"
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c11"
+                >
+                  entry-17
+                </span>
+              </div>
+            </th>
+            <td
+              class="c10 "
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c8"
+                >
+                  17
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c10 "
+              scope="row"
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c11"
+                >
+                  entry-18
+                </span>
+              </div>
+            </th>
+            <td
+              class="c10 "
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c8"
+                >
+                  18
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c10 "
+              scope="row"
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c11"
+                >
+                  entry-19
+                </span>
+              </div>
+            </th>
+            <td
+              class="c10 "
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c8"
+                >
+                  19
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c10 "
+              scope="row"
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c11"
+                >
+                  entry-20
+                </span>
+              </div>
+            </th>
+            <td
+              class="c10 "
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c8"
+                >
+                  20
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c10 "
+              scope="row"
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c11"
+                >
+                  entry-21
+                </span>
+              </div>
+            </th>
+            <td
+              class="c10 "
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c8"
+                >
+                  21
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c10 "
+              scope="row"
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c11"
+                >
+                  entry-22
+                </span>
+              </div>
+            </th>
+            <td
+              class="c10 "
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c8"
+                >
+                  22
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c10 "
+              scope="row"
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c11"
+                >
+                  entry-23
+                </span>
+              </div>
+            </th>
+            <td
+              class="c10 "
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c8"
+                >
+                  23
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c10 "
+              scope="row"
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c11"
+                >
+                  entry-24
+                </span>
+              </div>
+            </th>
+            <td
+              class="c10 "
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c8"
+                >
+                  24
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c10 "
+              scope="row"
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c11"
+                >
+                  entry-25
+                </span>
+              </div>
+            </th>
+            <td
+              class="c10 "
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c8"
+                >
+                  25
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c10 "
+              scope="row"
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c11"
+                >
+                  entry-26
+                </span>
+              </div>
+            </th>
+            <td
+              class="c10 "
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c8"
+                >
+                  26
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c10 "
+              scope="row"
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c11"
+                >
+                  entry-27
+                </span>
+              </div>
+            </th>
+            <td
+              class="c10 "
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c8"
+                >
+                  27
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c10 "
+              scope="row"
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c11"
+                >
+                  entry-28
+                </span>
+              </div>
+            </th>
+            <td
+              class="c10 "
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c8"
+                >
+                  28
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c10 "
+              scope="row"
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c11"
+                >
+                  entry-29
+                </span>
+              </div>
+            </th>
+            <td
+              class="c10 "
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c8"
+                >
+                  29
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c10 "
+              scope="row"
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c11"
+                >
+                  entry-30
+                </span>
+              </div>
+            </th>
+            <td
+              class="c10 "
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c8"
+                >
+                  30
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c10 "
+              scope="row"
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c11"
+                >
+                  entry-31
+                </span>
+              </div>
+            </th>
+            <td
+              class="c10 "
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c8"
+                >
+                  31
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c10 "
+              scope="row"
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c11"
+                >
+                  entry-32
+                </span>
+              </div>
+            </th>
+            <td
+              class="c10 "
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c8"
+                >
+                  32
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c10 "
+              scope="row"
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c11"
+                >
+                  entry-33
+                </span>
+              </div>
+            </th>
+            <td
+              class="c10 "
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c8"
+                >
+                  33
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c10 "
+              scope="row"
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c11"
+                >
+                  entry-34
+                </span>
+              </div>
+            </th>
+            <td
+              class="c10 "
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c8"
+                >
+                  34
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c10 "
+              scope="row"
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c11"
+                >
+                  entry-35
+                </span>
+              </div>
+            </th>
+            <td
+              class="c10 "
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c8"
+                >
+                  35
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c10 "
+              scope="row"
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c11"
+                >
+                  entry-36
+                </span>
+              </div>
+            </th>
+            <td
+              class="c10 "
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c8"
+                >
+                  36
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c10 "
+              scope="row"
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c11"
+                >
+                  entry-37
+                </span>
+              </div>
+            </th>
+            <td
+              class="c10 "
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c8"
+                >
+                  37
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c10 "
+              scope="row"
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c11"
+                >
+                  entry-38
+                </span>
+              </div>
+            </th>
+            <td
+              class="c10 "
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c8"
+                >
+                  38
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c10 "
+              scope="row"
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c11"
+                >
+                  entry-39
+                </span>
+              </div>
+            </th>
+            <td
+              class="c10 "
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c8"
+                >
+                  39
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c10 "
+              scope="row"
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c11"
+                >
+                  entry-40
+                </span>
+              </div>
+            </th>
+            <td
+              class="c10 "
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c8"
+                >
+                  40
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c10 "
+              scope="row"
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c11"
+                >
+                  entry-41
+                </span>
+              </div>
+            </th>
+            <td
+              class="c10 "
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c8"
+                >
+                  41
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c10 "
+              scope="row"
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c11"
+                >
+                  entry-42
+                </span>
+              </div>
+            </th>
+            <td
+              class="c10 "
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c8"
+                >
+                  42
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c10 "
+              scope="row"
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c11"
+                >
+                  entry-43
+                </span>
+              </div>
+            </th>
+            <td
+              class="c10 "
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c8"
+                >
+                  43
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c10 "
+              scope="row"
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c11"
+                >
+                  entry-44
+                </span>
+              </div>
+            </th>
+            <td
+              class="c10 "
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c8"
+                >
+                  44
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c10 "
+              scope="row"
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c11"
+                >
+                  entry-45
+                </span>
+              </div>
+            </th>
+            <td
+              class="c10 "
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c8"
+                >
+                  45
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c10 "
+              scope="row"
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c11"
+                >
+                  entry-46
+                </span>
+              </div>
+            </th>
+            <td
+              class="c10 "
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c8"
+                >
+                  46
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c10 "
+              scope="row"
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c11"
+                >
+                  entry-47
+                </span>
+              </div>
+            </th>
+            <td
+              class="c10 "
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c8"
+                >
+                  47
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c10 "
+              scope="row"
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c11"
+                >
+                  entry-48
+                </span>
+              </div>
+            </th>
+            <td
+              class="c10 "
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c8"
+                >
+                  48
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c10 "
+              scope="row"
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c11"
+                >
+                  entry-49
+                </span>
+              </div>
+            </th>
+            <td
+              class="c10 "
+            >
+              <div
+                class="c1"
+              >
+                <span
+                  class="c8"
+                >
+                  49
+                </span>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div
+      class="c12"
+    />
+    <div
+      class="c13 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
+    >
+      <nav
+        aria-label="Pagination Navigation"
+        class="c14"
+      >
+        <ul
+          class="c15"
+        >
+          <li
+            class="c16"
+          >
+            <button
+              aria-disabled="true"
+              aria-label="Go to previous page"
+              class="c17 c18"
+              disabled=""
+              type="button"
+            >
+              <svg
+                aria-label="Previous"
+                class="c19"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M17 2 7 12l10 10"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </button>
+          </li>
+          <div
+            class="c20"
+          />
+          <li
+            class="c16"
+          >
+            <button
+              aria-current="page"
+              aria-label="Go to page 1"
+              class="c21 c18"
+              type="button"
+            >
+              1
+            </button>
+          </li>
+          <div
+            class="c20"
+          />
+          <li
+            class="c16"
+          >
+            <button
+              aria-label="Go to page 2"
+              class="c22 c18"
+              type="button"
+            >
+              2
+            </button>
+          </li>
+          <div
+            class="c20"
+          />
+          <li
+            class="c16"
+          >
+            <button
+              aria-label="Go to next page"
+              class="c23 c18"
+              type="button"
+            >
+              <svg
+                aria-label="Next"
+                class="c24"
                 viewBox="0 0 24 24"
               >
                 <path


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
It will keep the fill style when DataTable has pagination

#### Where should the reviewer start?

#### What testing has been done on this PR?
Manual test with other storybooks and one unit test

#### How should this be manually tested?
Copy the component from https://codesandbox.io/s/grommet-v2-not-working-pin-with-paginate-ctth91 

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
https://github.com/grommet/grommet/issues/6333

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
