### PR TITLE
Fix accessibility violation for DataTable Controlled story

### DIFF
--- a/src/js/components/DataTable/stories/Controlled.js
+++ b/src/js/components/DataTable/stories/Controlled.js
@@ -39,6 +39,7 @@ export const ControlledDataTable = () => {
                 key={name}
                 checked={checked.indexOf(name) !== -1}
                 onChange={(e) => onCheck(e, name)}
+                aria-label="row checkbox"
               />
             ),
             header: (
@@ -48,6 +49,7 @@ export const ControlledDataTable = () => {
                   checked.length > 0 && checked.length < DATA.length
                 }
                 onChange={onCheckAll}
+                aria-label="header checkbox"
               />
             ),
             sortable: false,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fixing an accessibility violation for DataTable Controlled story
#### Where should the reviewer start?
Storybook
#### What testing has been done on this PR?
yarn test + Storybook
#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
#6124
#### Screenshots (if appropriate)
<img width="1696" alt="Screen Shot 2022-10-19 at 4 17 34 PM" src="https://user-images.githubusercontent.com/14626506/196816272-3a9d6d59-2425-43ef-a372-1ca76423eba8.png">
<img width="1693" alt="Screen Shot 2022-10-19 at 4 17 20 PM" src="https://user-images.githubusercontent.com/14626506/196816316-bb9c0525-7569-432c-b350-62d9e6edee02.png">

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
