### PR TITLE
Enhancement - #6175: Added option for responsive Paragraph and Text text

### DIFF
--- a/src/js/components/Anchor/StyledAnchor.js
+++ b/src/js/components/Anchor/StyledAnchor.js
@@ -12,7 +12,7 @@ const disabledStyle = `
 const sizeStyle = (props) => {
   if (props.size) {
     const size = props.size || 'medium';
-    const data = props.theme.text[size];
+    const data = props.theme.text.fontSize[size];
     return css`
       font-size: ${data ? data.size : size};
       line-height: ${data ? data.height : 'normal'};

--- a/src/js/components/Button/StyledButton.js
+++ b/src/js/components/Button/StyledButton.js
@@ -30,7 +30,7 @@ const radiusStyle = (props) => {
 
 const fontStyle = (props) => {
   const size = props.sizeProp || 'medium';
-  const data = props.theme.text[size];
+  const data = props.theme.text.fontSize[size];
   return css`
     font-size: ${data.size};
     line-height: ${data.height};

--- a/src/js/components/Button/StyledButtonKind.js
+++ b/src/js/components/Button/StyledButtonKind.js
@@ -30,7 +30,7 @@ const radiusStyle = (props) => {
 
 const fontStyle = (props) => {
   const size = props.sizeProp || 'medium';
-  const data = props.theme.text[size];
+  const data = props.theme.text.fontSize[size];
   return css`
     font-size: ${data.size};
     line-height: ${data.height};

--- a/src/js/components/Paragraph/StyledParagraph.js
+++ b/src/js/components/Paragraph/StyledParagraph.js
@@ -1,6 +1,11 @@
 import styled, { css } from 'styled-components';
 
-import { genericStyles, normalizeColor, textAlignStyle } from '../../utils';
+import {
+  breakpointStyle,
+  genericStyles,
+  normalizeColor,
+  textAlignStyle,
+} from '../../utils';
 import { defaultProps } from '../../default-props';
 
 const colorStyle = css`
@@ -9,12 +14,42 @@ const colorStyle = css`
 
 const sizeStyle = (props) => {
   const size = props.size || 'medium';
-  const data = props.theme.paragraph.fontSize[size];
-  return css`
-    font-size: ${data ? data.size : size};
-    line-height: ${data ? data.height : 'normal'};
-    max-width: ${props.fillProp ? 'none' : data && data.maxWidth};
-  `;
+  const paragraphTheme = props.theme.paragraph;
+  const data = paragraphTheme.fontSize[size];
+  const styles = [
+    css`
+      font-size: ${data ? data.size : size};
+      line-height: ${data ? data.height : 'normal'};
+      max-width: ${props.fillProp ? 'none' : data && data.maxWidth};
+    `,
+  ];
+  if (props.responsive && paragraphTheme.responsiveBreakpoint) {
+    const breakpoint =
+      props.theme.global.breakpoints[paragraphTheme.responsiveBreakpoint];
+    // create (ordered) Array of sizes to loop through
+    const allSizes = Object.keys(paragraphTheme.fontSize);
+    const sizePosition = allSizes.findIndex(
+      (elementSize) => elementSize === size,
+    );
+    if (breakpoint) {
+      const responsiveData = paragraphTheme.fontSize[allSizes[sizePosition - 1]]
+        ? paragraphTheme.fontSize[allSizes[sizePosition - 1]]
+        : paragraphTheme.fontSize[allSizes[sizePosition]];
+      if (responsiveData) {
+        styles.push(
+          breakpointStyle(
+            breakpoint,
+            `
+              font-size: ${responsiveData.size};
+              line-height: ${responsiveData.height};
+              max-width: ${props.fillProp ? 'none' : responsiveData.maxWidth};
+            `,
+          ),
+        );
+      }
+    }
+  }
+  return styles;
 };
 
 const fontFamily = css`

--- a/src/js/components/Paragraph/StyledParagraph.js
+++ b/src/js/components/Paragraph/StyledParagraph.js
@@ -9,7 +9,7 @@ const colorStyle = css`
 
 const sizeStyle = (props) => {
   const size = props.size || 'medium';
-  const data = props.theme.paragraph[size];
+  const data = props.theme.paragraph.fontSize[size];
   return css`
     font-size: ${data ? data.size : size};
     line-height: ${data ? data.height : 'normal'};

--- a/src/js/components/Text/StyledText.js
+++ b/src/js/components/Text/StyledText.js
@@ -3,9 +3,10 @@ import styled, { css } from 'styled-components';
 import { genericStyles, normalizeColor, textAlignStyle } from '../../utils';
 import { defaultProps } from '../../default-props';
 
-const sizeStyle = props => {
+const sizeStyle = (props) => {
   const size = props.size || 'medium';
-  const data = props.theme.text[size];
+  const textTheme = props.theme.text;
+  const data = textTheme.fontSize[size];
   if (data) {
     return css`
       font-size: ${data.size};
@@ -26,19 +27,19 @@ const truncateStyle = `
 `;
 
 const colorStyle = css`
-  color: ${props => normalizeColor(props.colorProp, props.theme)};
+  color: ${(props) => normalizeColor(props.colorProp, props.theme)};
 `;
 
 const weightStyle = css`
-  font-weight: ${props => props.weight};
+  font-weight: ${(props) => props.weight};
 `;
 
 const wordBreakStyle = css`
-  word-break: ${props => props.wordBreak};
+  word-break: ${(props) => props.wordBreak};
 `;
 
 const fontFamily = css`
-  font-family: ${props => props.theme.text.font.family};
+  font-family: ${(props) => props.theme.text.font.family};
 `;
 
 const StyledText = styled('span').withConfig({
@@ -46,16 +47,16 @@ const StyledText = styled('span').withConfig({
     defaultValidatorFn(prop) && prop !== 'size',
 })`
   ${genericStyles}
-  ${props => sizeStyle(props)}
-  ${props => props.textAlign && textAlignStyle}
-  ${props => props.truncate && truncateStyle}
-  ${props => props.colorProp && colorStyle}
-  ${props => props.weight && weightStyle}
-  ${props => props.wordBreak && wordBreakStyle}
-  ${props =>
+  ${(props) => sizeStyle(props)}
+  ${(props) => props.textAlign && textAlignStyle}
+  ${(props) => props.truncate && truncateStyle}
+  ${(props) => props.colorProp && colorStyle}
+  ${(props) => props.weight && weightStyle}
+  ${(props) => props.wordBreak && wordBreakStyle}
+  ${(props) =>
     props.theme.text.font && props.theme.text.font.family && fontFamily}
 
-  ${props => props.theme.text && props.theme.text.extend}
+  ${(props) => props.theme.text && props.theme.text.extend}
 `;
 
 StyledText.defaultProps = {};

--- a/src/js/components/Text/StyledText.js
+++ b/src/js/components/Text/StyledText.js
@@ -1,22 +1,50 @@
 import styled, { css } from 'styled-components';
 
-import { genericStyles, normalizeColor, textAlignStyle } from '../../utils';
+import {
+  breakpointStyle,
+  genericStyles,
+  normalizeColor,
+  textAlignStyle,
+} from '../../utils';
 import { defaultProps } from '../../default-props';
 
 const sizeStyle = (props) => {
   const size = props.size || 'medium';
   const textTheme = props.theme.text;
   const data = textTheme.fontSize[size];
-  if (data) {
-    return css`
-      font-size: ${data.size};
-      line-height: ${data.height};
-    `;
+  const styles = [
+    css`
+      font-size: ${data ? data.size : size};
+      line-height: ${data ? data.height : 'normal'};
+    `,
+  ];
+  if (props.responsive && textTheme.responsiveBreakpoint) {
+    const breakpoint =
+      props.theme.global.breakpoints[textTheme.responsiveBreakpoint];
+    // create (ordered) Array of sizes to loop through
+    const allSizes = Object.keys(textTheme.fontSize);
+    const sizePosition = allSizes.findIndex(
+      (elementSize) => elementSize === size,
+    );
+    if (breakpoint) {
+      const responsiveData = textTheme.fontSize[allSizes[sizePosition - 1]]
+        ? textTheme.fontSize[allSizes[sizePosition - 1]]
+        : textTheme.fontSize[allSizes[sizePosition]];
+      console.log(responsiveData);
+      if (responsiveData) {
+        styles.push(
+          breakpointStyle(
+            breakpoint,
+            `
+              font-size: ${responsiveData.size};
+              line-height: ${responsiveData.height};
+            `,
+          ),
+        );
+      }
+    }
   }
-  return css`
-    font-size: ${size};
-    line-height: normal;
-  `;
+  return styles;
 };
 
 const truncateStyle = `

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -2505,62 +2505,65 @@ exports[`Components loads 1`] = `
           },
         },
         "text": {
-          "2xl": {
-            "height": "40px",
-            "maxWidth": "816px",
-            "size": "34px",
-          },
-          "3xl": {
-            "height": "48px",
-            "maxWidth": "1008px",
-            "size": "42px",
-          },
-          "4xl": {
-            "height": "60px",
-            "maxWidth": "1296px",
-            "size": "54px",
-          },
-          "5xl": {
-            "height": "76px",
-            "maxWidth": "1680px",
-            "size": "70px",
-          },
-          "6xl": {
-            "height": "96px",
-            "maxWidth": "2160px",
-            "size": "90px",
-          },
           "font": {},
-          "large": {
-            "height": "28px",
-            "maxWidth": "528px",
-            "size": "22px",
+          "fontSize": {
+            "2xl": {
+              "height": "40px",
+              "maxWidth": "816px",
+              "size": "34px",
+            },
+            "3xl": {
+              "height": "48px",
+              "maxWidth": "1008px",
+              "size": "42px",
+            },
+            "4xl": {
+              "height": "60px",
+              "maxWidth": "1296px",
+              "size": "54px",
+            },
+            "5xl": {
+              "height": "76px",
+              "maxWidth": "1680px",
+              "size": "70px",
+            },
+            "6xl": {
+              "height": "96px",
+              "maxWidth": "2160px",
+              "size": "90px",
+            },
+            "large": {
+              "height": "28px",
+              "maxWidth": "528px",
+              "size": "22px",
+            },
+            "medium": {
+              "height": "24px",
+              "maxWidth": "432px",
+              "size": "18px",
+            },
+            "small": {
+              "height": "20px",
+              "maxWidth": "336px",
+              "size": "14px",
+            },
+            "xlarge": {
+              "height": "32px",
+              "maxWidth": "624px",
+              "size": "26px",
+            },
+            "xsmall": {
+              "height": "18px",
+              "maxWidth": "288px",
+              "size": "12px",
+            },
+            "xxlarge": {
+              "height": "40px",
+              "maxWidth": "816px",
+              "size": "34px",
+            },
           },
-          "medium": {
-            "height": "24px",
-            "maxWidth": "432px",
-            "size": "18px",
-          },
-          "small": {
-            "height": "20px",
-            "maxWidth": "336px",
-            "size": "14px",
-          },
-          "xlarge": {
-            "height": "32px",
-            "maxWidth": "624px",
-            "size": "26px",
-          },
-          "xsmall": {
-            "height": "18px",
-            "maxWidth": "288px",
-            "size": "12px",
-          },
-          "xxlarge": {
-            "height": "40px",
-            "maxWidth": "816px",
-            "size": "34px",
-          },
+          "responsiveBreakpoint": "small",
         },
         "textArea": {},
         "textInput": {},
@@ -4444,62 +4447,65 @@ exports[`Components loads 1`] = `
           },
         },
         "text": {
-          "2xl": {
-            "height": "40px",
-            "maxWidth": "816px",
-            "size": "34px",
-          },
-          "3xl": {
-            "height": "48px",
-            "maxWidth": "1008px",
-            "size": "42px",
-          },
-          "4xl": {
-            "height": "60px",
-            "maxWidth": "1296px",
-            "size": "54px",
-          },
-          "5xl": {
-            "height": "76px",
-            "maxWidth": "1680px",
-            "size": "70px",
-          },
-          "6xl": {
-            "height": "96px",
-            "maxWidth": "2160px",
-            "size": "90px",
-          },
           "font": {},
-          "large": {
-            "height": "28px",
-            "maxWidth": "528px",
-            "size": "22px",
+          "fontSize": {
+            "2xl": {
+              "height": "40px",
+              "maxWidth": "816px",
+              "size": "34px",
+            },
+            "3xl": {
+              "height": "48px",
+              "maxWidth": "1008px",
+              "size": "42px",
+            },
+            "4xl": {
+              "height": "60px",
+              "maxWidth": "1296px",
+              "size": "54px",
+            },
+            "5xl": {
+              "height": "76px",
+              "maxWidth": "1680px",
+              "size": "70px",
+            },
+            "6xl": {
+              "height": "96px",
+              "maxWidth": "2160px",
+              "size": "90px",
+            },
+            "large": {
+              "height": "28px",
+              "maxWidth": "528px",
+              "size": "22px",
+            },
+            "medium": {
+              "height": "24px",
+              "maxWidth": "432px",
+              "size": "18px",
+            },
+            "small": {
+              "height": "20px",
+              "maxWidth": "336px",
+              "size": "14px",
+            },
+            "xlarge": {
+              "height": "32px",
+              "maxWidth": "624px",
+              "size": "26px",
+            },
+            "xsmall": {
+              "height": "18px",
+              "maxWidth": "288px",
+              "size": "12px",
+            },
+            "xxlarge": {
+              "height": "40px",
+              "maxWidth": "816px",
+              "size": "34px",
+            },
           },
-          "medium": {
-            "height": "24px",
-            "maxWidth": "432px",
-            "size": "18px",
-          },
-          "small": {
-            "height": "20px",
-            "maxWidth": "336px",
-            "size": "14px",
-          },
-          "xlarge": {
-            "height": "32px",
-            "maxWidth": "624px",
-            "size": "26px",
-          },
-          "xsmall": {
-            "height": "18px",
-            "maxWidth": "288px",
-            "size": "12px",
-          },
-          "xxlarge": {
-            "height": "40px",
-            "maxWidth": "816px",
-            "size": "34px",
-          },
+          "responsiveBreakpoint": "small",
         },
         "textArea": {},
         "textInput": {},

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -2237,31 +2237,34 @@ exports[`Components loads 1`] = `
         },
         "paragraph": {
           "font": {},
-          "large": {
-            "height": "28px",
-            "maxWidth": "528px",
-            "size": "22px",
+          "fontSize": {
+            "large": {
+              "height": "28px",
+              "maxWidth": "528px",
+              "size": "22px",
+            },
+            "medium": {
+              "height": "24px",
+              "maxWidth": "432px",
+              "size": "18px",
+            },
+            "small": {
+              "height": "20px",
+              "maxWidth": "336px",
+              "size": "14px",
+            },
+            "xlarge": {
+              "height": "32px",
+              "maxWidth": "624px",
+              "size": "26px",
+            },
+            "xxlarge": {
+              "height": "40px",
+              "maxWidth": "816px",
+              "size": "34px",
+            },
           },
-          "medium": {
-            "height": "24px",
-            "maxWidth": "432px",
-            "size": "18px",
-          },
-          "small": {
-            "height": "20px",
-            "maxWidth": "336px",
-            "size": "14px",
-          },
-          "xlarge": {
-            "height": "32px",
-            "maxWidth": "624px",
-            "size": "26px",
-          },
-          "xxlarge": {
-            "height": "40px",
-            "maxWidth": "816px",
-            "size": "34px",
-          },
+          "responsiveBreakpoint": "small",
         },
         "radioButton": {
           "border": {
@@ -4173,31 +4176,34 @@ exports[`Components loads 1`] = `
         },
         "paragraph": {
           "font": {},
-          "large": {
-            "height": "28px",
-            "maxWidth": "528px",
-            "size": "22px",
+          "fontSize": {
+            "large": {
+              "height": "28px",
+              "maxWidth": "528px",
+              "size": "22px",
+            },
+            "medium": {
+              "height": "24px",
+              "maxWidth": "432px",
+              "size": "18px",
+            },
+            "small": {
+              "height": "20px",
+              "maxWidth": "336px",
+              "size": "14px",
+            },
+            "xlarge": {
+              "height": "32px",
+              "maxWidth": "624px",
+              "size": "26px",
+            },
+            "xxlarge": {
+              "height": "40px",
+              "maxWidth": "816px",
+              "size": "34px",
+            },
           },
-          "medium": {
-            "height": "24px",
-            "maxWidth": "432px",
-            "size": "18px",
-          },
-          "small": {
-            "height": "20px",
-            "maxWidth": "336px",
-            "size": "14px",
-          },
-          "xlarge": {
-            "height": "32px",
-            "maxWidth": "624px",
-            "size": "26px",
-          },
-          "xxlarge": {
-            "height": "40px",
-            "maxWidth": "816px",
-            "size": "34px",
-          },
+          "responsiveBreakpoint": "small",
         },
         "radioButton": {
           "border": {

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1797,17 +1797,20 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       font: {
         // family: undefined
       },
-      xsmall: { ...fontSizing(-1.5) },
-      small: { ...fontSizing(-1) },
-      medium: { ...fontSizing(0) }, // 18px
-      large: { ...fontSizing(1) }, // 22px
-      xlarge: { ...fontSizing(2) },
-      xxlarge: { ...fontSizing(4) },
-      '2xl': { ...fontSizing(4) },
-      '3xl': { ...fontSizing(6) },
-      '4xl': { ...fontSizing(9) },
-      '5xl': { ...fontSizing(13) },
-      '6xl': { ...fontSizing(18) },
+      fontSize: {
+        xsmall: { ...fontSizing(-1.5) },
+        small: { ...fontSizing(-1) },
+        medium: { ...fontSizing(0) }, // 18px
+        large: { ...fontSizing(1) }, // 22px
+        xlarge: { ...fontSizing(2) },
+        xxlarge: { ...fontSizing(4) },
+        '2xl': { ...fontSizing(4) },
+        '3xl': { ...fontSizing(6) },
+        '4xl': { ...fontSizing(9) },
+        '5xl': { ...fontSizing(13) },
+        '6xl': { ...fontSizing(18) },
+      },
+      responsiveBreakpoint: 'small', // matches Heading & Paragraph
     },
     textArea: {
       // extend: undefined,

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1489,11 +1489,14 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       font: {
         // family: undefined
       },
-      small: { ...fontSizing(-1) },
-      medium: { ...fontSizing(0) },
-      large: { ...fontSizing(1) },
-      xlarge: { ...fontSizing(2) },
-      xxlarge: { ...fontSizing(4) },
+      fontSize: {
+        small: { ...fontSizing(-1) },
+        medium: { ...fontSizing(0) },
+        large: { ...fontSizing(1) },
+        xlarge: { ...fontSizing(2) },
+        xxlarge: { ...fontSizing(4) },
+      },
+      responsiveBreakpoint: 'small', // matches Heading breakpoint
     },
     spinner: {
       container: {

--- a/src/js/utils/styles.js
+++ b/src/js/utils/styles.js
@@ -421,7 +421,7 @@ const placeholderStyle = css`
 `;
 
 const inputSizeStyle = (props) => {
-  const data = props.theme.text[props.size];
+  const data = props.theme.text.fontSize[props.size];
 
   if (!data) {
     return css`
@@ -440,7 +440,7 @@ export const inputStyle = css`
   ${(props) =>
     `font-size: ${
       props.theme.global.input.font.size
-        ? props.theme.text[props.theme.global.input.font.size]?.size ||
+        ? props.theme.text.fontSize[props.theme.global.input.font.size]?.size ||
           props.theme.global.input.font.size
         : 'inherit'
     };`}


### PR DESCRIPTION
#### What does this PR do?
This PR mainly modifies the Paragraph and Text schemas and components to add a `responsiveBreakpoint` that is used to scale down font sizes for resolutions under that breakpoint. The method follows that of `Heading` quite closely, however I did have to change the schema to group the font sizes within one object, in order to create an ordered array to loop through to determine the appropriate smaller size.

#### Where should the reviewer start?
Looking at `base.js`, `StyledParagraph.js` and `StyledText.js`.

#### What testing has been done on this PR?
I ran `yarn test-update` and `yarn test` before each commit and created Paragraph and Text components in my local host, set up with `responsive={true}` and tested the different possible `size`s. I also tried inputting `size`s that didn't exist, to confirm that text still displayed.

#### How should this be manually tested?
In a localhost, set up a Paragraph and Text component with the property `responsive={true}`. Confirm that resolutions under 768px have a smaller font size. Further testing can be done by changing the `size` property.

#### Do Jest tests follow these best practices?
N/A
- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
I followed the existing coding structure that the Heading component uses.

#### What are the relevant issues?
[Link to github issue (6175)](https://github.com/grommet/grommet/issues/6175)

#### Screenshots (if appropriate)
N/A

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
I'm afraid I might be a little unfamiliar with Grommet, do users have the ability to directly target theme props? If so then it should be, so that users can update any references to `props.theme.paragraph` and `props.theme.text`.

#### Is this change backwards compatible or is it a breaking change?
I believe its a breaking change, as modifying the schema for Text resulted in modifying references to `props.theme.text`, which are used in other components.