### PR TITLE
Fix `event.path` deprecated on Layer onClickOutside

### DIFF
--- a/src/js/components/Layer/LayerContainer.js
+++ b/src/js/components/Layer/LayerContainer.js
@@ -124,7 +124,10 @@ const LayerContainer = forwardRef(
         // determine which portal id the target is in, if any
         let clickedPortalId = null;
         let node =
-          containerTarget === document.body ? event.target : event?.path[0];
+          containerTarget === document.body
+            ? event.target
+            : event.composedPath();
+
         while (clickedPortalId === null && node !== document && node !== null) {
           // check if user click occurred within the layer
           const attr = node.getAttribute('data-g-portal-id');


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
event.path has been deprecated and no longer works in firefox,
`composedPath()` method returns path of listeners of that click event which is being used to determine whether the click occur outside of the Layer portal or not.

#### Where should the reviewer start?
```
src/js/components/Layer/LayerContainer.js
```
#### What testing has been done on this PR?
```
yarn test
```

#### How should this be manually tested?
Test storybooks like this [one](https://storybook.grommet.io/?path=/story/layout-layer-center--center-layer) and 
ensure clicking outside of either the first or second modal closes it.

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
No

#### What are the relevant issues?
See #6452 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
backwards compatible