### PR TITLE
Fix types of drop props in components

### DIFF
--- a/src/js/components/DropButton/index.d.ts
+++ b/src/js/components/DropButton/index.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ButtonProps } from '../Button';
-import { DropProps } from '../Drop';
+import { DropType } from '../Drop';
 import { Omit } from '../../utils';
 
 export interface DropButtonProps {
@@ -12,7 +12,7 @@ export interface DropButtonProps {
   };
   dropContent: JSX.Element;
   dropTarget?: object;
-  dropProps?: DropProps;
+  dropProps?: DropType;
   onClose?: React.MouseEventHandler<HTMLDocument | HTMLButtonElement>;
   onOpen?: React.MouseEventHandler<HTMLButtonElement>;
   open?: boolean;

--- a/src/js/components/MaskedInput/index.d.ts
+++ b/src/js/components/MaskedInput/index.d.ts
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import { A11yTitleType, Omit, TextAlignType } from '../../utils';
-import { DropProps } from '../Drop';
+import { DropType } from '../Drop';
 
 export interface MaskedInputProps {
   a11yTitle?: A11yTitleType;
   dropHeight?: 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | string;
-  dropProps?: DropProps;
+  dropProps?: DropType;
   focusIndicator?: boolean;
   icon?: JSX.Element;
   id?: string;

--- a/src/js/components/Menu/index.d.ts
+++ b/src/js/components/Menu/index.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { DropProps } from '../Drop';
+import { DropType } from '../Drop';
 import { ButtonExtendedProps, ButtonType } from '../Button';
 import {
   A11yTitleType,
@@ -28,7 +28,7 @@ export interface MenuProps {
         opacity?: 'weak' | 'medium' | 'strong' | boolean | number;
       };
   dropTarget?: object;
-  dropProps?: DropProps;
+  dropProps?: DropType;
   gridArea?: GridAreaType;
   icon?: boolean | React.ReactNode;
   items: ButtonExtendedProps[] | ButtonExtendedProps[][];

--- a/src/js/components/Select/index.d.ts
+++ b/src/js/components/Select/index.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { DropProps } from '../Drop';
+import { DropType } from '../Drop';
 import {
   A11yTitleType,
   AlignSelfType,
@@ -23,7 +23,7 @@ export interface BasicSelectProps {
   };
   dropHeight?: 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | string;
   dropTarget?: object;
-  dropProps?: DropProps;
+  dropProps?: DropType;
   emptySearchMessage?: string | React.ReactNode;
   focusIndicator?: boolean;
   icon?: boolean | ((...args: any[]) => any) | React.ReactNode | React.FC;

--- a/src/js/components/TextInput/index.d.ts
+++ b/src/js/components/TextInput/index.d.ts
@@ -5,7 +5,7 @@ import {
   PlaceHolderType,
   TextAlignType,
 } from '../../utils';
-import { DropProps } from '../Drop';
+import { DropType } from '../Drop';
 
 export interface TextInputProps
   extends Omit<
@@ -21,7 +21,7 @@ export interface TextInputProps
   };
   dropHeight?: 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | string;
   dropTarget?: object;
-  dropProps?: DropProps;
+  dropProps?: DropType;
   focusIndicator?: boolean;
   defaultSuggestion?: number;
   icon?: JSX.Element;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
It's a follow-up to #6431 
The goal is for `dropProps` to accept `style` as a property. This behavior already exists in DateInput, Tip, but also needs alignment for other components as this PR suggests.

#### Where should the reviewer start?
Any ts file
#### What testing has been done on this PR?
local
#### How should this be manually tested?
Use `style` prop with `dropProps` before/after the fix.
#### Do Jest tests follow these best practices?
N/A

#### Any background context you want to provide?
It's a follow-up to #6431 

#### What are the relevant issues?
Any bucket of TS bugs.
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
nope
#### Should this PR be mentioned in the release notes?
Yes, as a TS fix.
#### Is this change backwards compatible or is it a breaking change?
Yes. It extends the type of `dropProps`