### PR TITLE
Refactored List key/value handling to reduce code duplication and fix issues with itemKey being a function when ordering

### DIFF
--- a/src/js/components/List/List.js
+++ b/src/js/components/List/List.js
@@ -109,8 +109,10 @@ const reorder = (array, pinnedArray, source, target) => {
 // getItemId returns something appropriate to use as a unique DOM
 // id for an item in the list
 const getItemId = (item, index, itemKey, primaryKey) => {
-  if (itemKey) return getValue(item, index, itemKey);
+  // we do primaryKey first to be backward compatible, even though
+  // itemKey is probably technically the better choice for a DOM id.
   if (primaryKey) return getValue(item, index, primaryKey);
+  if (itemKey) return getValue(item, index, itemKey);
   return getValue(item, index) ?? index; // do our best w/o *key properties
 };
 

--- a/src/js/components/List/List.js
+++ b/src/js/components/List/List.js
@@ -81,11 +81,11 @@ const StyledContainer = styled(Box)`
     props.theme.list.container.extend};
 `;
 
-const normalize = (item, index, property) => {
-  if (typeof property === 'function') {
-    return property(item, index);
-  }
-  return item[property];
+const getValue = (item, index, key) => {
+  if (typeof key === 'function') return key(item, index);
+  if (typeof item === 'string') return item;
+  if (key !== undefined) return item[key];
+  return undefined;
 };
 
 const reorder = (array, pinnedArray, source, target) => {
@@ -106,35 +106,12 @@ const reorder = (array, pinnedArray, source, target) => {
   return result;
 };
 
-// Determine the primary content for a row. If the List
-// has a primaryKey defined this returns the item data
-// based on this primary key. If no primaryKey property
-// is defined this will return unknown. The intent of
-// the content from the primary key is that it is unique
-// within the list.
-const getPrimaryContent = (item, index, primaryKey) => {
-  let primaryContent;
-  if (primaryKey) {
-    if (typeof primaryKey === 'function') {
-      primaryContent = primaryKey(item, index);
-    } else {
-      primaryContent = normalize(item, index, primaryKey);
-    }
-  }
-
-  return primaryContent;
-};
-
-const getKey = (item, index, primaryContent) => {
-  if (typeof primaryContent === 'string') {
-    return primaryContent;
-  }
-  return typeof item === 'string' ? item : index;
-};
-
-const getItemId = (item, index, primaryKey) => {
-  const primaryContent = getPrimaryContent(item, index, primaryKey);
-  return getKey(item, index, primaryContent);
+// getItemId returns something appropriate to use as a unique DOM
+// id for an item in the list
+const getItemId = (item, index, itemKey, primaryKey) => {
+  if (itemKey) return getValue(item, index, itemKey);
+  if (primaryKey) return getValue(item, index, primaryKey);
+  return getValue(item, index) ?? index; // do our best w/o *key properties
 };
 
 const List = React.forwardRef(
@@ -208,7 +185,7 @@ const List = React.forwardRef(
         return [currentData, { data: pinnedData, indexes: pinnedIndexes }];
 
       currentData.forEach((item, index) => {
-        const key = typeof item === 'object' ? item[itemKey] : item;
+        const key = getValue(item, index, itemKey);
         if (pinned.includes(key)) {
           pinnedData.push(item);
           pinnedIndexes.push(index);
@@ -250,11 +227,17 @@ const List = React.forwardRef(
         activeId = `${getItemId(
           orderableData[itemIndex],
           itemIndex,
+          itemKey,
           primaryKey,
         )}${buttonId}`;
       } else if (onClickItem) {
         // The whole list item is active. Figure out an id
-        activeId = getItemId(orderableData[active], active, primaryKey);
+        activeId = getItemId(
+          orderableData[active],
+          active,
+          itemKey,
+          primaryKey,
+        );
       }
       ariaProps['aria-activedescendant'] = activeId;
     }
@@ -286,9 +269,7 @@ const List = React.forwardRef(
                     }
                   } else if (
                     disabledItems?.includes(
-                      typeof itemKey === 'function'
-                        ? itemKey(data[active])
-                        : data[active],
+                      getValue(data[active], active, itemKey),
                     )
                   ) {
                     event.preventDefault();
@@ -366,7 +347,6 @@ const List = React.forwardRef(
               {(item, index) => {
                 let content;
                 let boxProps = {};
-                let itemId;
 
                 if (children) {
                   content = children(
@@ -375,28 +355,29 @@ const List = React.forwardRef(
                     onClickItem ? { active: active === index } : undefined,
                   );
                 } else if (primaryKey) {
-                  if (typeof primaryKey === 'function') {
-                    itemId = primaryKey(item, index);
-                    content = itemId;
-                  } else {
-                    itemId = normalize(item, index, primaryKey);
-                    content = (
+                  const primary = getValue(item, index, primaryKey);
+                  content =
+                    typeof primary === 'string' ||
+                    typeof primary === 'number' ? (
                       <Text key="p" weight="bold">
-                        {itemId}
+                        {primary}
                       </Text>
+                    ) : (
+                      primary
                     );
-                  }
                   if (secondaryKey) {
-                    if (typeof secondaryKey === 'function') {
-                      content = [content, secondaryKey(item, index)];
-                    } else {
-                      content = [
-                        content,
+                    const secondary = getValue(item, index, secondaryKey);
+                    content = [
+                      content,
+                      typeof secondary === 'string' ||
+                      typeof secondary === 'number' ? (
                         <Text key="s">
-                          {normalize(item, index, secondaryKey)}
-                        </Text>,
-                      ];
-                    }
+                          {getValue(item, index, secondaryKey)}
+                        </Text>
+                      ) : (
+                        secondary
+                      ),
+                    ];
                     boxProps = {
                       direction: 'row',
                       align: 'center',
@@ -410,21 +391,12 @@ const List = React.forwardRef(
                   content = item;
                 }
 
-                if (itemKey) {
-                  if (typeof itemKey === 'function') {
-                    itemId = itemKey(item);
-                  } else {
-                    itemId = normalize(item, index, itemKey);
-                  }
-                }
+                const key = getValue(item, index, itemKey) || index;
 
-                const key = itemKey ? itemId : getKey(item, index, itemId);
-
-                const orderableIndex = orderableData.findIndex((ordItem) => {
-                  const ordItemKey =
-                    typeof ordItem === 'object' ? ordItem[itemKey] : ordItem;
-                  return ordItemKey === key;
-                });
+                const orderableIndex = orderableData.findIndex(
+                  (ordItem, ordIndex) =>
+                    getValue(ordItem, ordIndex, itemKey) === key,
+                );
 
                 let isDisabled;
                 if (disabledItems) {
@@ -639,7 +611,11 @@ const List = React.forwardRef(
 
                   // wrap the main content and use
                   // the boxProps defined for the content
-                  content = <Box flex {...boxProps}>{content}</Box>;
+                  content = (
+                    <Box flex {...boxProps}>
+                      {content}
+                    </Box>
+                  );
 
                   // Adjust the boxProps to account for the order controls
                   boxProps = {
@@ -648,7 +624,6 @@ const List = React.forwardRef(
                       (defaultItemProps && defaultItemProps.align) || 'center',
                     gap: 'medium',
                   };
-
                 }
 
                 let itemAriaProps;


### PR DESCRIPTION
#### What does this PR do?

Refactored List key/value handling to reduce code duplication and fix issues with itemKey being a function when ordering.

Without this change, if `itemKey` was a function then the list ordering wouldn't work because it was only treating it as a string:
```
const ordItemKey =
   typeof ordItem === 'object' ? ordItem[itemKey] : ordItem;
```

This issue was uncovered within grommet-designer.

#### Where should the reviewer start?

List.js

#### What testing has been done on this PR?

unit tests
various storybook stories
used with grommet-designer to re-order grouped Menu items

#### How should this be manually tested?

storybook

#### Do Jest tests follow these best practices?

no tests were canged

#### Any background context you want to provide?

See above

#### What are the relevant issues?

no issue

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
