### PR TITLE
Changed Select to fix an issue with null value.

### DIFF
--- a/src/js/components/Select/SelectContainer.js
+++ b/src/js/components/Select/SelectContainer.js
@@ -177,7 +177,7 @@ const SelectContainer = forwardRef(
                 return valueValue === optionVal;
               });
             }
-          } else if (valueKey && typeof value === 'object') {
+          } else if (valueKey && value !== null && typeof value === 'object') {
             const valueValue =
               typeof valueKey === 'function'
                 ? valueKey(value)


### PR DESCRIPTION
#### What does this PR do?

Changed Select to fix an issue with null value.

The problem comes from `null` being a javascript object. So, `typeof value === 'object'` is `true` when value is `null`

#### Where should the reviewer start?

one line change

#### What testing has been done on this PR?

changed OrderOptions story to start with a `null` value instead of `''`

#### How should this be manually tested?

^^^

#### Do Jest tests follow these best practices?

no test changes

#### Any background context you want to provide?

no

#### What are the relevant issues?

#6476 

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
