### PR TITLE
Add optional chaining to formatBytes

### DIFF
--- a/src/js/components/FileInput/utils/formatBytes.js
+++ b/src/js/components/FileInput/utils/formatBytes.js
@@ -3,7 +3,7 @@ const IEC_CONVERSION_FACTOR = 1024;
 
 const getCurrentOS = () => {
   const currentOS = ['Win', 'Linux', 'Mac'].find(
-    (v) => window.navigator.userAgent.indexOf(v) >= 0,
+    (v) => window?.navigator?.userAgent?.indexOf(v) >= 0,
   );
 
   return currentOS;

--- a/src/js/themes/__tests__/__snapshots__/theme-test.js.snap
+++ b/src/js/themes/__tests__/__snapshots__/theme-test.js.snap
@@ -1742,7 +1742,7 @@ exports[`Grommet hpe theme 1`] = `
   box-sizing: border-box;
   max-width: 100%;
   background-color: #01A982;
-  color: #FFFFFFE6;
+  color: #C0CADC;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -1821,7 +1821,7 @@ exports[`Grommet hpe theme 1`] = `
   box-sizing: border-box;
   max-width: 100%;
   background-color: #00739D;
-  color: #FFFFFFE6;
+  color: #C0CADC;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -1837,7 +1837,7 @@ exports[`Grommet hpe theme 1`] = `
   box-sizing: border-box;
   max-width: 100%;
   background-color: #7630EA;
-  color: #FFFFFFE6;
+  color: #C0CADC;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -1933,7 +1933,7 @@ exports[`Grommet hpe theme 1`] = `
   box-sizing: border-box;
   max-width: 100%;
   background-color: #444444;
-  color: #FFFFFFE6;
+  color: #C0CADC;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;

--- a/src/js/themes/__tests__/__snapshots__/theme-test.js.snap
+++ b/src/js/themes/__tests__/__snapshots__/theme-test.js.snap
@@ -1742,7 +1742,7 @@ exports[`Grommet hpe theme 1`] = `
   box-sizing: border-box;
   max-width: 100%;
   background-color: #01A982;
-  color: #C0CADC;
+  color: #FFFFFFE6;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -1821,7 +1821,7 @@ exports[`Grommet hpe theme 1`] = `
   box-sizing: border-box;
   max-width: 100%;
   background-color: #00739D;
-  color: #C0CADC;
+  color: #FFFFFFE6;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -1837,7 +1837,7 @@ exports[`Grommet hpe theme 1`] = `
   box-sizing: border-box;
   max-width: 100%;
   background-color: #7630EA;
-  color: #C0CADC;
+  color: #FFFFFFE6;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -1933,7 +1933,7 @@ exports[`Grommet hpe theme 1`] = `
   box-sizing: border-box;
   max-width: 100%;
   background-color: #444444;
-  color: #C0CADC;
+  color: #FFFFFFE6;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Adds `?.` notation to formatBytes function for cases where `window` may not be defined yet.

#### Where should the reviewer start?
src/js/components/FileInput/utils/formatBytes.js

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Related to https://github.com/grommet/grommet/pull/6427

#### Screenshots (if appropriate)

Ran into this error on DS site.

<img width="1049" alt="Screen Shot 2022-11-03 at 1 42 24 PM" src="https://user-images.githubusercontent.com/12522275/199832249-70ab7074-4bb4-4f29-89b9-456d37d60af9.png">

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?
No. Change was only on stable branch not a release.

#### Is this change backwards compatible or is it a breaking change?
