### PR TITLE
Fix window not defined issue

### DIFF
--- a/src/js/components/FileInput/utils/formatBytes.js
+++ b/src/js/components/FileInput/utils/formatBytes.js
@@ -2,9 +2,11 @@ const SI_CONVERSION_FACTOR = 1000;
 const IEC_CONVERSION_FACTOR = 1024;
 
 const getCurrentOS = () => {
-  const currentOS = ['Win', 'Linux', 'Mac'].find(
-    (v) => window?.navigator?.userAgent?.indexOf(v) >= 0,
-  );
+  const currentOS = ['Win', 'Linux', 'Mac'].find((v) => {
+    if (typeof window !== 'undefined')
+      return window?.navigator?.userAgent?.indexOf(v) >= 0;
+    return undefined;
+  });
 
   return currentOS;
 };


### PR DESCRIPTION
#### What does this PR do?
Follow on work to https://github.com/grommet/grommet/pull/6480. It looks like we need to check that the typeof window is not undefined otherwise we still get the window undefined error.

#### Where should the reviewer start?

#### What testing has been done on this PR?
Tested change on DS site and made sure site built okay

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No
#### Should this PR be mentioned in the release notes?
No
#### Is this change backwards compatible or is it a breaking change?
Backwards compatible