### PR TITLE
fix ts for datatable

### DIFF
--- a/src/js/components/DataTable/index.d.ts
+++ b/src/js/components/DataTable/index.d.ts
@@ -82,7 +82,7 @@ export interface DataTableProps<TRowType = any> {
       pad?: PadType;
     };
   };
-  rowDetails?: React.ReactNode;
+  rowDetails?: (row: TRowType) => React.ReactNode;
   size?: 'small' | 'medium' | 'large' | 'xlarge' | string;
 
   // Data


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Update the TS def for `rowDetails` in DataTable
#### Where should the reviewer start?
index.d.ts
#### What testing has been done on this PR?
locally 
#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
```
rowDetails takes a function as its argument. For example:

rowDetails={(row) => {return I am a box;}}

Typescript throws this error:

TS2769: No overload matches this call.
Overload 1 of 2, '(props: DataTableExtendedProps | Readonly<DataTableExtendedProps>): DataTable<...>', gave the following error.
Type '() => JSX.Element' is not assignable to type 'ReactNode'.
Overload 2 of 2, '(props: DataTableExtendedProps, context: any): DataTable', gave the following error.
Type '() => JSX.Element' is not assignable to type 'ReactNode'.

To fix it, I have updated src/js/components/DataTable/index.d.ts

I replace line 86 with this:

rowDetails?: (row: TRowType) => React.ReactNode;
```
#### What are the relevant issues?
closes #6477 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
 backwards compatible