### PR TITLE
add metric if responsiveMetric is undefined

### DIFF
--- a/src/js/components/Box/StyledBox.js
+++ b/src/js/components/Box/StyledBox.js
@@ -289,7 +289,7 @@ const gapStyle = (directionProp, gap, responsive, border, theme) => {
     const responsiveBorderOffset =
       responsiveBorderMetric &&
       `${
-        parseMetricToNum(responsiveMetric) / 2 -
+        parseMetricToNum(responsiveMetric || metric) / 2 -
         parseMetricToNum(responsiveBorderMetric) / 2
       }px`;
 

--- a/src/js/components/Box/__tests__/Box-test.tsx
+++ b/src/js/components/Box/__tests__/Box-test.tsx
@@ -735,6 +735,22 @@ describe('Box', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  test('renders border=between and gap=pixle value', () => {
+    const { container } = render(
+      <Grommet>
+        <Box gap="12px" border="top" pad="medium">
+          <Box pad="small" background="dark-3">
+            Test 1
+          </Box>
+          <Box pad="medium" background="light-3">
+            Test 2
+          </Box>
+        </Box>
+      </Grommet>,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
   test('renders a11yTitle and aria-label', () => {
     const { container, getByLabelText } = render(
       <Grommet>

--- a/src/js/components/Box/__tests__/Box-test.tsx
+++ b/src/js/components/Box/__tests__/Box-test.tsx
@@ -738,7 +738,7 @@ describe('Box', () => {
   test('renders border=between and gap=pixle value', () => {
     const { container } = render(
       <Grommet>
-        <Box gap="12px" border="top" pad="medium">
+        <Box gap="12px" border="between" pad="medium">
           <Box pad="small" background="dark-3">
             Test 1
           </Box>

--- a/src/js/components/Box/__tests__/Box-test.tsx
+++ b/src/js/components/Box/__tests__/Box-test.tsx
@@ -735,7 +735,7 @@ describe('Box', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test('renders border=between and gap=pixle value', () => {
+  test('renders border=between and gap=pixel value', () => {
     const { container } = render(
       <Grommet>
         <Box gap="12px" border="between" pad="medium">

--- a/src/js/components/Box/__tests__/__snapshots__/Box-test.tsx.snap
+++ b/src/js/components/Box/__tests__/__snapshots__/Box-test.tsx.snap
@@ -4826,7 +4826,7 @@ exports[`Box renders a11yTitle and aria-label 1`] = `
 </div>
 `;
 
-exports[`Box renders border=between and gap=pixle value 1`] = `
+exports[`Box renders border=between and gap=pixel value 1`] = `
 .c0 {
   font-size: 18px;
   line-height: 24px;

--- a/src/js/components/Box/__tests__/__snapshots__/Box-test.tsx.snap
+++ b/src/js/components/Box/__tests__/__snapshots__/Box-test.tsx.snap
@@ -4844,7 +4844,6 @@ exports[`Box renders border=between and gap=pixle value 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  border-top: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -4895,12 +4894,15 @@ exports[`Box renders border=between and gap=pixle value 1`] = `
   -ms-flex-item-align: stretch;
   align-self: stretch;
   height: 12px;
+  position: relative;
 }
 
-@media only screen and (max-width:768px) {
-  .c1 {
-    border-top: solid 1px rgba(0,0,0,0.33);
-  }
+.c3:after {
+  content: '';
+  position: absolute;
+  width: 100%;
+  top: 5.5px;
+  border-top: solid 1px rgba(0,0,0,0.33);
 }
 
 @media only screen and (max-width:768px) {
@@ -4918,6 +4920,19 @@ exports[`Box renders border=between and gap=pixle value 1`] = `
 @media only screen and (max-width:768px) {
   .c4 {
     padding: 12px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c3:after {
+    border-top: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c3:after {
+    content: '';
+    top: 5.5px;
   }
 }
 

--- a/src/js/components/Box/__tests__/__snapshots__/Box-test.tsx.snap
+++ b/src/js/components/Box/__tests__/__snapshots__/Box-test.tsx.snap
@@ -4826,6 +4826,124 @@ exports[`Box renders a11yTitle and aria-label 1`] = `
 </div>
 `;
 
+exports[`Box renders border=between and gap=pixle value 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border-top: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 24px;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  background-color: #777777;
+  color: #f8f8f8;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 12px;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  background-color: #EDEDED;
+  color: #444444;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 24px;
+}
+
+.c3 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  height: 12px;
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    border-top: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    padding: 12px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    padding: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c4 {
+    padding: 12px;
+  }
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+  >
+    <div
+      class="c2"
+    >
+      Test 1
+    </div>
+    <div
+      class="c3"
+    />
+    <div
+      class="c4"
+    >
+      Test 2
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Box responsive 1`] = `
 .c0 {
   font-size: 18px;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
fixes bug when using `border=between` and `gap` with a pixel value
#### Where should the reviewer start?
styledBox.js
#### What testing has been done on this PR?
wrote a test and storybook
#### How should this be manually tested?
storybook
#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
In the If statement for `border="between"` it uses `responsive metric to define `responsiveBorderMetric` which is undefined when a user passes a pixel value. 
#### What are the relevant issues?
closes #6485 
#### Screenshots (if appropriate)
no
#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
backwards compatible