### PR TITLE
fix: makes SelectMultiple accept undefined or null

### DIFF
--- a/src/js/components/SelectMultiple/SelectMultiple.js
+++ b/src/js/components/SelectMultiple/SelectMultiple.js
@@ -81,7 +81,7 @@ const SelectMultiple = forwardRef(
       onOpen,
       onSearch,
       open: openProp,
-      options: optionsProp,
+      options: rawOptionsProp,
       placeholder,
       plain,
       replace,
@@ -104,7 +104,7 @@ const SelectMultiple = forwardRef(
     const selectBoxRef = useRef();
     const dropButtonRef = useForwardedRef(ref);
     const usingKeyboard = useKeyboard();
-
+    const optionsProp = useMemo(() => rawOptionsProp || [], [rawOptionsProp]);
     // value is used for what we receive in valueProp and the basis for
     // what we send with onChange
     // When 'valueKey' sets 'reduce', the value(s) here should match


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Makes SelectMultiple accept undefined or null

#### Where should the reviewer start?
SelectMultiple component

#### What testing has been done on this PR?
not sure how to test when receiving undefined value

#### How should this be manually tested?
when passing a undefined value for `options` it should not generate a error

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
I'm not sure if I should create a new story showing a loading when the options are taking some time to fetch

#### What are the relevant issues?
closes #6351

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
