### PR TITLE
fix: RangeInput within formfield off center.

### DIFF
--- a/src/js/components/RangeInput/StyledRangeInput.js
+++ b/src/js/components/RangeInput/StyledRangeInput.js
@@ -217,6 +217,7 @@ const StyledRangeInput = styled.input`
   padding: 0px;
   cursor: ${(props) => (props.disabled ? 'default' : 'pointer')};
   background: transparent;
+  margin: 0px;
 
   ${(props) =>
     props.theme.rangeInput.pad &&

--- a/src/js/components/RangeInput/__tests__/__snapshots__/RangeInput-test.tsx.snap
+++ b/src/js/components/RangeInput/__tests__/__snapshots__/RangeInput-test.tsx.snap
@@ -21,6 +21,7 @@ exports[`RangeInput onBlur 1`] = `
   padding: 0px;
   cursor: pointer;
   background: transparent;
+  margin: 0px;
 }
 
 .c1::-moz-focus-inner {
@@ -165,6 +166,7 @@ exports[`RangeInput onChange 1`] = `
   padding: 0px;
   cursor: pointer;
   background: transparent;
+  margin: 0px;
 }
 
 .c1::-moz-focus-inner {
@@ -309,6 +311,7 @@ exports[`RangeInput onFocus 1`] = `
   padding: 0px;
   cursor: pointer;
   background: transparent;
+  margin: 0px;
 }
 
 .c1::-moz-focus-inner {
@@ -507,6 +510,7 @@ exports[`RangeInput renders 1`] = `
   padding: 0px;
   cursor: pointer;
   background: transparent;
+  margin: 0px;
 }
 
 .c1::-moz-focus-inner {
@@ -651,6 +655,7 @@ exports[`RangeInput should have no accessibility violations 1`] = `
   padding: 0px;
   cursor: pointer;
   background: transparent;
+  margin: 0px;
 }
 
 .c1::-moz-focus-inner {
@@ -796,6 +801,7 @@ exports[`RangeInput track themed 1`] = `
   padding: 0px;
   cursor: pointer;
   background: transparent;
+  margin: 0px;
 }
 
 .c1::-moz-focus-inner {
@@ -940,6 +946,7 @@ exports[`RangeInput track themed with color and opacity 1`] = `
   padding: 0px;
   cursor: pointer;
   background: transparent;
+  margin: 0px;
 }
 
 .c1::-moz-focus-inner {
@@ -1084,6 +1091,7 @@ exports[`RangeInput with min and max offset 1`] = `
   padding: 0px;
   cursor: pointer;
   background: transparent;
+  margin: 0px;
 }
 
 .c1::-moz-focus-inner {
@@ -1228,6 +1236,7 @@ exports[`RangeInput with multi color 1`] = `
   padding: 0px;
   cursor: pointer;
   background: transparent;
+  margin: 0px;
 }
 
 .c1::-moz-focus-inner {
@@ -1373,6 +1382,7 @@ exports[`RangeInput with single color 1`] = `
   padding: 0px;
   cursor: pointer;
   background: transparent;
+  margin: 0px;
 }
 
 .c1::-moz-focus-inner {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fix the bug when using RangeInput in the FormField component.

#### Where should the reviewer start?
StyledRangeInput.js

#### What testing has been done on this PR?
Updated the snapshot for this component

#### How should this be manually tested?
Using storybook via wrapping the RangeInput from the `FormField` or `div`

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
Yes, the `user-agent-stylesheet` adds the default margin to this component as the Input type of Range.

#### What are the relevant issues?
closes #6487 

#### Screenshots (if appropriate)
added in the issue #6487 

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
backwards compatible.
