### PR TITLE
fix:prevent-extra-div-container-in-drop-component

### DIFF
--- a/src/js/components/Drop/Drop.js
+++ b/src/js/components/Drop/Drop.js
@@ -1,4 +1,10 @@
-import React, { forwardRef, useEffect, useState, useContext } from 'react';
+import React, {
+  forwardRef,
+  useEffect,
+  useState,
+  useContext,
+  useRef,
+} from 'react';
 import { createPortal } from 'react-dom';
 
 import { ThemeContext } from 'styled-components';
@@ -24,13 +30,15 @@ const Drop = forwardRef(
     useEffect(() => setOriginalFocusedElement(document.activeElement), []);
     const [dropContainer, setDropContainer] = useState();
     const containerTarget = useContext(ContainerTargetContext);
-    useEffect(
-      () =>
+    const containerChildNodesLenght = useRef(null);
+    useEffect(() => {
+      if (!containerChildNodesLenght?.current) {
+        containerChildNodesLenght.current = containerTarget.childNodes.length;
         setDropContainer(
           !inline ? getNewContainer(containerTarget) : undefined,
-        ),
-      [containerTarget, inline],
-    );
+        );
+      }
+    }, [containerTarget, inline]);
 
     // just a few things to clean up when the Drop is unmounted
     useEffect(

--- a/src/js/components/Drop/Drop.js
+++ b/src/js/components/Drop/Drop.js
@@ -30,10 +30,13 @@ const Drop = forwardRef(
     useEffect(() => setOriginalFocusedElement(document.activeElement), []);
     const [dropContainer, setDropContainer] = useState();
     const containerTarget = useContext(ContainerTargetContext);
-    const containerChildNodesLenght = useRef(null);
+    const containerChildNodesLength = useRef(null);
     useEffect(() => {
-      if (!containerChildNodesLenght?.current) {
-        containerChildNodesLenght.current = containerTarget.childNodes.length;
+      // we need this condition to prevent getNewContainer to run multiple times
+      // in the event that the component gets created, destroyed, and recreated.
+      // see https://reactjs.org/docs/strict-mode.html#ensuring-reusable-state
+      if (!containerChildNodesLength?.current) {
+        containerChildNodesLength.current = containerTarget.childNodes.length;
         setDropContainer(
           !inline ? getNewContainer(containerTarget) : undefined,
         );


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
It prevent Drop.js Component from creating multiple divs when running App in StrictMode

#### Where should the reviewer start?
From Drop.js in src/js/components/Drop/Drop.js

#### What testing has been done on this PR?
I tested it on a local environment adding Grommet as a library and creating a very simple react App (in StrictMode) with one Tip component that uses the Drop component inside. (I basically reproduced the codebox example of the issue #6371 ). Eventually I ran storybook to see possible regressions and found none.

#### How should this be manually tested?
I was not able to reproduce it without wrapping the App in StrictMode

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
I encountered this issue on  a personal project by using the Tip Component, I found out that only in a dev-build I was seeing this issue and prod build were bug free.

#### What are the relevant issues?
it closes #6371

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
it is backwards compatible
