### PR TITLE
Fix DataTable flex and pagination issue

### DIFF
--- a/src/js/components/DataTable/DataTable.js
+++ b/src/js/components/DataTable/DataTable.js
@@ -352,7 +352,7 @@ const DataTable = ({
   // should remain in its location
   const OverflowContainer = paginate ? Box : Fragment;
   const overflowContainerProps = paginate
-    ? { overflow: { horizontal: 'auto' }, flex: true }
+    ? { overflow: { horizontal: 'auto' } }
     : undefined;
 
   // necessary for Firefox, otherwise paginated DataTable will
@@ -567,7 +567,13 @@ const DataTable = ({
       adjustedData.length > paginationStep &&
       items &&
       items.length ? (
-        <Pagination alignSelf="end" {...paginationProps} />
+        <Pagination
+          alignSelf="end"
+          // flex none needed for Pagination controls to stay in correct
+          // location and prevent overflow outside container
+          style={{ flex: 'none' }}
+          {...paginationProps}
+        />
       ) : null}
     </Container>
   );

--- a/src/js/components/DataTable/DataTable.js
+++ b/src/js/components/DataTable/DataTable.js
@@ -571,7 +571,6 @@ const DataTable = ({
           alignSelf="end"
           // flex false is needed for Pagination controls to stay in
           // correct location and prevent overflow outside container
-          flex={false}
           {...paginationProps}
         />
       ) : null}

--- a/src/js/components/DataTable/DataTable.js
+++ b/src/js/components/DataTable/DataTable.js
@@ -569,9 +569,9 @@ const DataTable = ({
       items.length ? (
         <Pagination
           alignSelf="end"
-          // flex none needed for Pagination controls to stay in correct
-          // location and prevent overflow outside container
-          style={{ flex: 'none' }}
+          // flex false is needed for Pagination controls to stay in
+          // correct location and prevent overflow outside container
+          flex={false}
           {...paginationProps}
         />
       ) : null}

--- a/src/js/components/DataTable/DataTable.js
+++ b/src/js/components/DataTable/DataTable.js
@@ -567,12 +567,7 @@ const DataTable = ({
       adjustedData.length > paginationStep &&
       items &&
       items.length ? (
-        <Pagination
-          alignSelf="end"
-          // flex false is needed for Pagination controls to stay in
-          // correct location and prevent overflow outside container
-          {...paginationProps}
-        />
+        <Pagination alignSelf="end" {...paginationProps} />
       ) : null}
     </Container>
   );

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -21403,6 +21403,9 @@ exports[`DataTable should apply pagination styling 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c13 {
@@ -23511,7 +23514,6 @@ exports[`DataTable should apply pagination styling 1`] = `
     />
     <div
       class="c12 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
-      style="flex: 0 0 auto;"
     >
       <nav
         aria-label="Pagination Navigation"
@@ -24163,6 +24165,9 @@ exports[`DataTable should paginate 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c13 {
@@ -26265,7 +26270,6 @@ exports[`DataTable should paginate 1`] = `
     />
     <div
       class="c12 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
-      style="flex: 0 0 auto;"
     >
       <nav
         aria-label="Pagination Navigation"
@@ -26499,6 +26503,9 @@ exports[`DataTable should pin and paginate 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c14 {
@@ -28610,7 +28617,6 @@ exports[`DataTable should pin and paginate 1`] = `
     />
     <div
       class="c13 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
-      style="flex: 0 0 auto;"
     >
       <nav
         aria-label="Pagination Navigation"
@@ -28844,6 +28850,9 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c13 {
@@ -29830,7 +29839,6 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
     />
     <div
       class="c12 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
-      style="flex: 0 0 auto;"
     >
       <nav
         aria-label="Pagination Navigation"
@@ -30134,6 +30142,9 @@ exports[`DataTable should render new data when page changes 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c13 {
@@ -32236,7 +32247,6 @@ exports[`DataTable should render new data when page changes 1`] = `
     />
     <div
       class="c12 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
-      style="flex: 0 0 auto;"
     >
       <nav
         aria-label="Pagination Navigation"
@@ -33784,8 +33794,7 @@ exports[`DataTable should render new data when page changes 2`] = `
       class="StyledBox__StyledBoxGap-sc-13pk1d4-1 grsgKE"
     />
     <div
-      class="StyledBox-sc-13pk1d4-0 dQObhs Pagination__StyledPaginationContainer-sc-rnlw6m-0"
-      style="flex: 0 0 auto;"
+      class="StyledBox-sc-13pk1d4-0 cSsESN Pagination__StyledPaginationContainer-sc-rnlw6m-0"
     >
       <nav
         aria-label="Pagination Navigation"
@@ -34019,6 +34028,9 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c13 {
@@ -36121,7 +36133,6 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
     />
     <div
       class="c12 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
-      style="flex: 0 0 auto;"
     >
       <nav
         aria-label="Pagination Navigation"
@@ -36355,6 +36366,9 @@ exports[`DataTable should show correct page when "show" is { page: # } 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c13 {
@@ -38302,7 +38316,6 @@ exports[`DataTable should show correct page when "show" is { page: # } 1`] = `
     />
     <div
       class="c12 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
-      style="flex: 0 0 auto;"
     >
       <nav
         aria-label="Pagination Navigation"

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -21366,9 +21366,6 @@ exports[`DataTable should apply pagination styling 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 1 1;
-  -ms-flex: 1 1;
-  flex: 1 1;
   overflow-x: auto;
 }
 
@@ -23514,6 +23511,7 @@ exports[`DataTable should apply pagination styling 1`] = `
     />
     <div
       class="c12 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
+      style="flex: 0 0 auto;"
     >
       <nav
         aria-label="Pagination Navigation"
@@ -23644,9 +23642,6 @@ exports[`DataTable should not show paginate controls when data is empty array 1`
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 1 1;
-  -ms-flex: 1 1;
-  flex: 1 1;
   overflow-x: auto;
 }
 
@@ -23800,9 +23795,6 @@ exports[`DataTable should not show paginate controls when length of data < step 
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 1 1;
-  -ms-flex: 1 1;
-  flex: 1 1;
   overflow-x: auto;
 }
 
@@ -24136,9 +24128,6 @@ exports[`DataTable should paginate 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 1 1;
-  -ms-flex: 1 1;
-  flex: 1 1;
   overflow-x: auto;
 }
 
@@ -26276,6 +26265,7 @@ exports[`DataTable should paginate 1`] = `
     />
     <div
       class="c12 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
+      style="flex: 0 0 auto;"
     >
       <nav
         aria-label="Pagination Navigation"
@@ -26474,9 +26464,6 @@ exports[`DataTable should pin and paginate 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 1 1;
-  -ms-flex: 1 1;
-  flex: 1 1;
   overflow-x: auto;
 }
 
@@ -28623,6 +28610,7 @@ exports[`DataTable should pin and paginate 1`] = `
     />
     <div
       class="c13 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
+      style="flex: 0 0 auto;"
     >
       <nav
         aria-label="Pagination Navigation"
@@ -28821,9 +28809,6 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 1 1;
-  -ms-flex: 1 1;
-  flex: 1 1;
   overflow-x: auto;
 }
 
@@ -29845,6 +29830,7 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
     />
     <div
       class="c12 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
+      style="flex: 0 0 auto;"
     >
       <nav
         aria-label="Pagination Navigation"
@@ -30113,9 +30099,6 @@ exports[`DataTable should render new data when page changes 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 1 1;
-  -ms-flex: 1 1;
-  flex: 1 1;
   overflow-x: auto;
 }
 
@@ -32253,6 +32236,7 @@ exports[`DataTable should render new data when page changes 1`] = `
     />
     <div
       class="c12 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
+      style="flex: 0 0 auto;"
     >
       <nav
         aria-label="Pagination Navigation"
@@ -32354,7 +32338,7 @@ exports[`DataTable should render new data when page changes 2`] = `
     class="StyledBox-sc-13pk1d4-0 hUSFEE StyledDataTable__StyledContainer-sc-xrlyjm-1 iuBBg"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 gSGGou"
+      class="StyledBox-sc-13pk1d4-0 huRNCA"
     >
       <table
         class="StyledTable-sc-1m3u5g-6 kfnLZF StyledDataTable-sc-xrlyjm-0 CMHtZ"
@@ -33801,6 +33785,7 @@ exports[`DataTable should render new data when page changes 2`] = `
     />
     <div
       class="StyledBox-sc-13pk1d4-0 dQObhs Pagination__StyledPaginationContainer-sc-rnlw6m-0"
+      style="flex: 0 0 auto;"
     >
       <nav
         aria-label="Pagination Navigation"
@@ -33999,9 +33984,6 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 1 1;
-  -ms-flex: 1 1;
-  flex: 1 1;
   overflow-x: auto;
 }
 
@@ -36139,6 +36121,7 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
     />
     <div
       class="c12 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
+      style="flex: 0 0 auto;"
     >
       <nav
         aria-label="Pagination Navigation"
@@ -36337,9 +36320,6 @@ exports[`DataTable should show correct page when "show" is { page: # } 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 1 1;
-  -ms-flex: 1 1;
-  flex: 1 1;
   overflow-x: auto;
 }
 
@@ -38322,6 +38302,7 @@ exports[`DataTable should show correct page when "show" is { page: # } 1`] = `
     />
     <div
       class="c12 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
+      style="flex: 0 0 auto;"
     >
       <nav
         aria-label="Pagination Navigation"

--- a/src/js/components/List/__tests__/__snapshots__/List-test.js.snap
+++ b/src/js/components/List/__tests__/__snapshots__/List-test.js.snap
@@ -4333,6 +4333,9 @@ exports[`List events should apply pagination styling 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c8 {
@@ -5489,6 +5492,9 @@ exports[`List events should paginate 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c8 {
@@ -6488,6 +6494,9 @@ exports[`List events should render correct num items per page (step) 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c8 {
@@ -7377,6 +7386,9 @@ exports[`List events should render new data when page changes 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c8 {
@@ -11796,7 +11808,7 @@ exports[`List events should render new data when page changes 2`] = `
       class="StyledBox__StyledBoxGap-sc-13pk1d4-1 grsgKE"
     />
     <div
-      class="StyledBox-sc-13pk1d4-0 dQObhs Pagination__StyledPaginationContainer-sc-rnlw6m-0"
+      class="StyledBox-sc-13pk1d4-0 cSsESN Pagination__StyledPaginationContainer-sc-rnlw6m-0"
     >
       <nav
         aria-label="Pagination Navigation"
@@ -12043,6 +12055,9 @@ exports[`List events should show correct item index when "show" is a number 1`] 
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c8 {
@@ -13042,6 +13057,9 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c8 {

--- a/src/js/components/Pagination/Pagination.js
+++ b/src/js/components/Pagination/Pagination.js
@@ -184,7 +184,11 @@ const Pagination = forwardRef(
     }));
 
     return (
-      <StyledPaginationContainer {...theme.pagination.container} {...rest}>
+      <StyledPaginationContainer
+        flex={false}
+        {...theme.pagination.container}
+        {...rest}
+      >
         <Nav
           a11yTitle={ariaLabel || a11yTitle || 'Pagination Navigation'}
           ref={ref}

--- a/src/js/components/Pagination/__tests__/__snapshots__/Pagination-test.tsx.snap
+++ b/src/js/components/Pagination/__tests__/__snapshots__/Pagination-test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Pagination should allow user to control page via state with page +
   onChange 1`] = `
-.c7 {
+.c6 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -13,25 +13,25 @@ exports[`Pagination should allow user to control page via state with page +
   stroke: #000000;
 }
 
-.c7 g {
+.c6 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c7 *:not([stroke])[fill="none"] {
+.c6 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c7 *[stroke*="#"],
-.c7 *[STROKE*="#"] {
+.c6 *[stroke*="#"],
+.c6 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c7 *[fill-rule],
-.c7 *[FILL-RULE],
-.c7 *[fill*="#"],
-.c7 *[FILL*="#"] {
+.c6 *[fill-rule],
+.c6 *[FILL-RULE],
+.c6 *[fill*="#"],
+.c6 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -58,26 +58,12 @@ exports[`Pagination should allow user to control page via state with page +
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-}
-
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
 }
 
-.c3 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -97,7 +83,7 @@ exports[`Pagination should allow user to control page via state with page +
   padding: 0px;
 }
 
-.c8 {
+.c7 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -107,12 +93,12 @@ exports[`Pagination should allow user to control page via state with page +
   width: 3px;
 }
 
-.c11 {
+.c10 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c10 {
+.c9 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -132,82 +118,6 @@ exports[`Pagination should allow user to control page via state with page +
   line-height: 24px;
   background-color: rgba(51,51,51,0.06274509803921569);
   color: #444444;
-  text-align: center;
-  -webkit-transition-property: color,background-color,border-color,box-shadow;
-  transition-property: color,background-color,border-color,box-shadow;
-  -webkit-transition-duration: 0.1s;
-  transition-duration: 0.1s;
-  -webkit-transition-timing-function: ease-in-out;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
-}
-
-.c10:hover {
-  background-color: rgba(51,51,51,0.06274509803921569);
-}
-
-.c10:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c10:focus > circle,
-.c10:focus > ellipse,
-.c10:focus > line,
-.c10:focus > path,
-.c10:focus > polygon,
-.c10:focus > polyline,
-.c10:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c10:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c10:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c10:focus:not(:focus-visible) > circle,
-.c10:focus:not(:focus-visible) > ellipse,
-.c10:focus:not(:focus-visible) > line,
-.c10:focus:not(:focus-visible) > path,
-.c10:focus:not(:focus-visible) > polygon,
-.c10:focus:not(:focus-visible) > polyline,
-.c10:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c10:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c9 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 24px;
-  color: #000000;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
   transition-property: color,background-color,border-color,box-shadow;
@@ -267,7 +177,7 @@ exports[`Pagination should allow user to control page via state with page +
   border: 0;
 }
 
-.c5 {
+.c8 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -299,7 +209,83 @@ exports[`Pagination should allow user to control page via state with page +
   flex: 1 0 auto;
 }
 
-.c5 > svg {
+.c8:hover {
+  background-color: rgba(51,51,51,0.06274509803921569);
+}
+
+.c8:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus > circle,
+.c8:focus > ellipse,
+.c8:focus > line,
+.c8:focus > path,
+.c8:focus > polygon,
+.c8:focus > polyline,
+.c8:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c8:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c8:focus:not(:focus-visible) > circle,
+.c8:focus:not(:focus-visible) > ellipse,
+.c8:focus:not(:focus-visible) > line,
+.c8:focus:not(:focus-visible) > path,
+.c8:focus:not(:focus-visible) > polygon,
+.c8:focus:not(:focus-visible) > polyline,
+.c8:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c8:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c4 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  color: #000000;
+  text-align: center;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c4 > svg {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -310,60 +296,60 @@ exports[`Pagination should allow user to control page via state with page +
   vertical-align: middle;
 }
 
-.c5:hover {
+.c4:hover {
   background-color: rgba(51,51,51,0.06274509803921569);
 }
 
-.c5:focus {
+.c4:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c4:focus > circle,
+.c4:focus > ellipse,
+.c4:focus > line,
+.c4:focus > path,
+.c4:focus > polygon,
+.c4:focus > polyline,
+.c4:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c4:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c4:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c4:focus:not(:focus-visible) > circle,
+.c4:focus:not(:focus-visible) > ellipse,
+.c4:focus:not(:focus-visible) > line,
+.c4:focus:not(:focus-visible) > path,
+.c4:focus:not(:focus-visible) > polygon,
+.c4:focus:not(:focus-visible) > polyline,
+.c4:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c4:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c6 {
+.c5 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c6 > svg {
+.c5 > svg {
   margin: 0 auto;
 }
 
-.c4 {
+.c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -381,26 +367,26 @@ exports[`Pagination should allow user to control page via state with page +
   min-width: 36px;
 }
 
-.c12 {
+.c11 {
   font-weight: bold;
   font-size: 18px;
   line-height: 24px;
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c7 {
     width: 2px;
   }
 }
@@ -413,22 +399,22 @@ exports[`Pagination should allow user to control page via state with page +
   >
     <nav
       aria-label="Pagination Navigation"
-      class="c2"
+      class="c1"
     >
       <ul
-        class="c3"
+        class="c2"
       >
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to previous page"
-            class="c5 c6"
+            class="c4 c5"
             type="button"
           >
             <svg
               aria-label="Previous"
-              class="c7"
+              class="c6"
               viewBox="0 0 24 24"
             >
               <path
@@ -441,116 +427,116 @@ exports[`Pagination should allow user to control page via state with page +
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 1"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             1
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-current="page"
             aria-label="Go to page 2"
-            class="c10 c6"
+            class="c9 c5"
             type="button"
           >
             2
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 3"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             3
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 4"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             4
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 5"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             5
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <span
-            class="c11 c12"
+            class="c10 c11"
           >
             …
           </span>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 24"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             24
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to next page"
-            class="c5 c6"
+            class="c4 c5"
             type="button"
           >
             <svg
               aria-label="Next"
-              class="c7"
+              class="c6"
               viewBox="0 0 24 24"
             >
               <path
@@ -569,7 +555,7 @@ exports[`Pagination should allow user to control page via state with page +
 `;
 
 exports[`Pagination should apply a11yTitle and aria-label 1`] = `
-.c7 {
+.c6 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -580,30 +566,30 @@ exports[`Pagination should apply a11yTitle and aria-label 1`] = `
   stroke: #666666;
 }
 
-.c7 g {
+.c6 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c7 *:not([stroke])[fill="none"] {
+.c6 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c7 *[stroke*="#"],
-.c7 *[STROKE*="#"] {
+.c6 *[stroke*="#"],
+.c6 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c7 *[fill-rule],
-.c7 *[FILL-RULE],
-.c7 *[fill*="#"],
-.c7 *[FILL*="#"] {
+.c6 *[fill-rule],
+.c6 *[FILL-RULE],
+.c6 *[fill*="#"],
+.c6 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
 
-.c14 {
+.c13 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -614,25 +600,25 @@ exports[`Pagination should apply a11yTitle and aria-label 1`] = `
   stroke: #000000;
 }
 
-.c14 g {
+.c13 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c14 *:not([stroke])[fill="none"] {
+.c13 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c14 *[stroke*="#"],
-.c14 *[STROKE*="#"] {
+.c13 *[stroke*="#"],
+.c13 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c14 *[fill-rule],
-.c14 *[FILL-RULE],
-.c14 *[fill*="#"],
-.c14 *[FILL*="#"] {
+.c13 *[fill-rule],
+.c13 *[FILL-RULE],
+.c13 *[fill*="#"],
+.c13 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -659,26 +645,12 @@ exports[`Pagination should apply a11yTitle and aria-label 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-}
-
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
 }
 
-.c3 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -698,7 +670,7 @@ exports[`Pagination should apply a11yTitle and aria-label 1`] = `
   padding: 0px;
 }
 
-.c8 {
+.c7 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -708,12 +680,12 @@ exports[`Pagination should apply a11yTitle and aria-label 1`] = `
   width: 3px;
 }
 
-.c11 {
+.c10 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c5 {
+.c4 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -746,7 +718,7 @@ exports[`Pagination should apply a11yTitle and aria-label 1`] = `
   flex: 1 0 auto;
 }
 
-.c5 > svg {
+.c4 > svg {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -757,47 +729,47 @@ exports[`Pagination should apply a11yTitle and aria-label 1`] = `
   vertical-align: middle;
 }
 
-.c5:focus {
+.c4:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c4:focus > circle,
+.c4:focus > ellipse,
+.c4:focus > line,
+.c4:focus > path,
+.c4:focus > polygon,
+.c4:focus > polyline,
+.c4:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c4:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c4:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c4:focus:not(:focus-visible) > circle,
+.c4:focus:not(:focus-visible) > ellipse,
+.c4:focus:not(:focus-visible) > line,
+.c4:focus:not(:focus-visible) > path,
+.c4:focus:not(:focus-visible) > polygon,
+.c4:focus:not(:focus-visible) > polyline,
+.c4:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c4:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c9 {
+.c8 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -817,6 +789,82 @@ exports[`Pagination should apply a11yTitle and aria-label 1`] = `
   line-height: 24px;
   background-color: rgba(51,51,51,0.06274509803921569);
   color: #444444;
+  text-align: center;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c8:hover {
+  background-color: rgba(51,51,51,0.06274509803921569);
+}
+
+.c8:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus > circle,
+.c8:focus > ellipse,
+.c8:focus > line,
+.c8:focus > path,
+.c8:focus > polygon,
+.c8:focus > polyline,
+.c8:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c8:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c8:focus:not(:focus-visible) > circle,
+.c8:focus:not(:focus-visible) > ellipse,
+.c8:focus:not(:focus-visible) > line,
+.c8:focus:not(:focus-visible) > path,
+.c8:focus:not(:focus-visible) > polygon,
+.c8:focus:not(:focus-visible) > polyline,
+.c8:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c8:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c9 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  color: #000000;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
   transition-property: color,background-color,border-color,box-shadow;
@@ -876,7 +924,7 @@ exports[`Pagination should apply a11yTitle and aria-label 1`] = `
   border: 0;
 }
 
-.c10 {
+.c12 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -908,83 +956,7 @@ exports[`Pagination should apply a11yTitle and aria-label 1`] = `
   flex: 1 0 auto;
 }
 
-.c10:hover {
-  background-color: rgba(51,51,51,0.06274509803921569);
-}
-
-.c10:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c10:focus > circle,
-.c10:focus > ellipse,
-.c10:focus > line,
-.c10:focus > path,
-.c10:focus > polygon,
-.c10:focus > polyline,
-.c10:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c10:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c10:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c10:focus:not(:focus-visible) > circle,
-.c10:focus:not(:focus-visible) > ellipse,
-.c10:focus:not(:focus-visible) > line,
-.c10:focus:not(:focus-visible) > path,
-.c10:focus:not(:focus-visible) > polygon,
-.c10:focus:not(:focus-visible) > polyline,
-.c10:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c10:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c13 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 24px;
-  color: #000000;
-  text-align: center;
-  -webkit-transition-property: color,background-color,border-color,box-shadow;
-  transition-property: color,background-color,border-color,box-shadow;
-  -webkit-transition-duration: 0.1s;
-  transition-duration: 0.1s;
-  -webkit-transition-timing-function: ease-in-out;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
-}
-
-.c13 > svg {
+.c12 > svg {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -995,60 +967,60 @@ exports[`Pagination should apply a11yTitle and aria-label 1`] = `
   vertical-align: middle;
 }
 
-.c13:hover {
+.c12:hover {
   background-color: rgba(51,51,51,0.06274509803921569);
 }
 
-.c13:focus {
+.c12:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus > circle,
-.c13:focus > ellipse,
-.c13:focus > line,
-.c13:focus > path,
-.c13:focus > polygon,
-.c13:focus > polyline,
-.c13:focus > rect {
+.c12:focus > circle,
+.c12:focus > ellipse,
+.c12:focus > line,
+.c12:focus > path,
+.c12:focus > polygon,
+.c12:focus > polyline,
+.c12:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus::-moz-focus-inner {
+.c12:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c13:focus:not(:focus-visible) {
+.c12:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible) > circle,
-.c13:focus:not(:focus-visible) > ellipse,
-.c13:focus:not(:focus-visible) > line,
-.c13:focus:not(:focus-visible) > path,
-.c13:focus:not(:focus-visible) > polygon,
-.c13:focus:not(:focus-visible) > polyline,
-.c13:focus:not(:focus-visible) > rect {
+.c12:focus:not(:focus-visible) > circle,
+.c12:focus:not(:focus-visible) > ellipse,
+.c12:focus:not(:focus-visible) > line,
+.c12:focus:not(:focus-visible) > path,
+.c12:focus:not(:focus-visible) > polygon,
+.c12:focus:not(:focus-visible) > polyline,
+.c12:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible)::-moz-focus-inner {
+.c12:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c6 {
+.c5 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c6 > svg {
+.c5 > svg {
   margin: 0 auto;
 }
 
-.c4 {
+.c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1066,26 +1038,26 @@ exports[`Pagination should apply a11yTitle and aria-label 1`] = `
   min-width: 36px;
 }
 
-.c12 {
+.c11 {
   font-weight: bold;
   font-size: 18px;
   line-height: 24px;
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c7 {
     width: 2px;
   }
 }
@@ -1098,24 +1070,24 @@ exports[`Pagination should apply a11yTitle and aria-label 1`] = `
   >
     <nav
       aria-label="pagination-test"
-      class="c2"
+      class="c1"
     >
       <ul
-        class="c3"
+        class="c2"
       >
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-disabled="true"
             aria-label="Go to previous page"
-            class="c5 c6"
+            class="c4 c5"
             disabled=""
             type="button"
           >
             <svg
               aria-label="Previous"
-              class="c7"
+              class="c6"
               viewBox="0 0 24 24"
             >
               <path
@@ -1128,116 +1100,116 @@ exports[`Pagination should apply a11yTitle and aria-label 1`] = `
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-current="page"
             aria-label="Go to page 1"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             1
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 2"
-            class="c10 c6"
+            class="c9 c5"
             type="button"
           >
             2
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 3"
-            class="c10 c6"
+            class="c9 c5"
             type="button"
           >
             3
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 4"
-            class="c10 c6"
+            class="c9 c5"
             type="button"
           >
             4
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 5"
-            class="c10 c6"
+            class="c9 c5"
             type="button"
           >
             5
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <span
-            class="c11 c12"
+            class="c10 c11"
           >
             …
           </span>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 24"
-            class="c10 c6"
+            class="c9 c5"
             type="button"
           >
             24
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to next page"
-            class="c13 c6"
+            class="c12 c5"
             type="button"
           >
             <svg
               aria-label="Next"
-              class="c14"
+              class="c13"
               viewBox="0 0 24 24"
             >
               <path
@@ -1257,24 +1229,24 @@ exports[`Pagination should apply a11yTitle and aria-label 1`] = `
   >
     <nav
       aria-label="pagination-test-2"
-      class="c2"
+      class="c1"
     >
       <ul
-        class="c3"
+        class="c2"
       >
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-disabled="true"
             aria-label="Go to previous page"
-            class="c5 c6"
+            class="c4 c5"
             disabled=""
             type="button"
           >
             <svg
               aria-label="Previous"
-              class="c7"
+              class="c6"
               viewBox="0 0 24 24"
             >
               <path
@@ -1287,116 +1259,116 @@ exports[`Pagination should apply a11yTitle and aria-label 1`] = `
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-current="page"
             aria-label="Go to page 1"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             1
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 2"
-            class="c10 c6"
+            class="c9 c5"
             type="button"
           >
             2
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 3"
-            class="c10 c6"
+            class="c9 c5"
             type="button"
           >
             3
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 4"
-            class="c10 c6"
+            class="c9 c5"
             type="button"
           >
             4
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 5"
-            class="c10 c6"
+            class="c9 c5"
             type="button"
           >
             5
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <span
-            class="c11 c12"
+            class="c10 c11"
           >
             …
           </span>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 24"
-            class="c10 c6"
+            class="c9 c5"
             type="button"
           >
             24
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to next page"
-            class="c13 c6"
+            class="c12 c5"
             type="button"
           >
             <svg
               aria-label="Next"
-              class="c14"
+              class="c13"
               viewBox="0 0 24 24"
             >
               <path
@@ -1415,7 +1387,7 @@ exports[`Pagination should apply a11yTitle and aria-label 1`] = `
 `;
 
 exports[`Pagination should apply button kind style when referenced by a string 1`] = `
-.c7 {
+.c6 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -1426,25 +1398,25 @@ exports[`Pagination should apply button kind style when referenced by a string 1
   stroke: #000000;
 }
 
-.c7 g {
+.c6 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c7 *:not([stroke])[fill="none"] {
+.c6 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c7 *[stroke*="#"],
-.c7 *[STROKE*="#"] {
+.c6 *[stroke*="#"],
+.c6 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c7 *[fill-rule],
-.c7 *[FILL-RULE],
-.c7 *[fill*="#"],
-.c7 *[FILL*="#"] {
+.c6 *[fill-rule],
+.c6 *[FILL-RULE],
+.c6 *[fill*="#"],
+.c6 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -1471,26 +1443,12 @@ exports[`Pagination should apply button kind style when referenced by a string 1
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-}
-
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
 }
 
-.c3 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1510,7 +1468,7 @@ exports[`Pagination should apply button kind style when referenced by a string 1
   padding: 0px;
 }
 
-.c8 {
+.c7 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -1520,12 +1478,12 @@ exports[`Pagination should apply button kind style when referenced by a string 1
   width: 3px;
 }
 
-.c11 {
+.c10 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c5 {
+.c4 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -1564,7 +1522,7 @@ exports[`Pagination should apply button kind style when referenced by a string 1
   flex: 1 0 auto;
 }
 
-.c5 > svg {
+.c4 > svg {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1575,47 +1533,47 @@ exports[`Pagination should apply button kind style when referenced by a string 1
   vertical-align: middle;
 }
 
-.c5:focus {
+.c4:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c4:focus > circle,
+.c4:focus > ellipse,
+.c4:focus > line,
+.c4:focus > path,
+.c4:focus > polygon,
+.c4:focus > polyline,
+.c4:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c4:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c4:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c4:focus:not(:focus-visible) > circle,
+.c4:focus:not(:focus-visible) > ellipse,
+.c4:focus:not(:focus-visible) > line,
+.c4:focus:not(:focus-visible) > path,
+.c4:focus:not(:focus-visible) > polygon,
+.c4:focus:not(:focus-visible) > polyline,
+.c4:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c4:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c9 {
+.c8 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -1657,6 +1615,82 @@ exports[`Pagination should apply button kind style when referenced by a string 1
   flex: 1 0 auto;
 }
 
+.c8:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus > circle,
+.c8:focus > ellipse,
+.c8:focus > line,
+.c8:focus > path,
+.c8:focus > polygon,
+.c8:focus > polyline,
+.c8:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c8:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c8:focus:not(:focus-visible) > circle,
+.c8:focus:not(:focus-visible) > ellipse,
+.c8:focus:not(:focus-visible) > line,
+.c8:focus:not(:focus-visible) > path,
+.c8:focus:not(:focus-visible) > polygon,
+.c8:focus:not(:focus-visible) > polyline,
+.c8:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c8:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c9 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 18px;
+  padding: 4px 22px;
+  font-size: 18px;
+  line-height: 24px;
+  color: #000000;
+  border-style: solid;
+  border-width: 2px;
+  border-color: skyblue;
+  padding: 2px 20px;
+  text-align: center;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
 .c9:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
@@ -1697,7 +1731,7 @@ exports[`Pagination should apply button kind style when referenced by a string 1
   border: 0;
 }
 
-.c10 {
+.c12 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -1733,83 +1767,7 @@ exports[`Pagination should apply button kind style when referenced by a string 1
   flex: 1 0 auto;
 }
 
-.c10:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c10:focus > circle,
-.c10:focus > ellipse,
-.c10:focus > line,
-.c10:focus > path,
-.c10:focus > polygon,
-.c10:focus > polyline,
-.c10:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c10:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c10:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c10:focus:not(:focus-visible) > circle,
-.c10:focus:not(:focus-visible) > ellipse,
-.c10:focus:not(:focus-visible) > line,
-.c10:focus:not(:focus-visible) > path,
-.c10:focus:not(:focus-visible) > polygon,
-.c10:focus:not(:focus-visible) > polyline,
-.c10:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c10:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c13 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
-  font-size: 18px;
-  line-height: 24px;
-  color: #000000;
-  border-style: solid;
-  border-width: 2px;
-  border-color: skyblue;
-  padding: 2px 20px;
-  text-align: center;
-  -webkit-transition-property: color,background-color,border-color,box-shadow;
-  transition-property: color,background-color,border-color,box-shadow;
-  -webkit-transition-duration: 0.1s;
-  transition-duration: 0.1s;
-  -webkit-transition-timing-function: ease-in-out;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
-}
-
-.c13 > svg {
+.c12 > svg {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1820,51 +1778,51 @@ exports[`Pagination should apply button kind style when referenced by a string 1
   vertical-align: middle;
 }
 
-.c13:focus {
+.c12:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus > circle,
-.c13:focus > ellipse,
-.c13:focus > line,
-.c13:focus > path,
-.c13:focus > polygon,
-.c13:focus > polyline,
-.c13:focus > rect {
+.c12:focus > circle,
+.c12:focus > ellipse,
+.c12:focus > line,
+.c12:focus > path,
+.c12:focus > polygon,
+.c12:focus > polyline,
+.c12:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus::-moz-focus-inner {
+.c12:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c13:focus:not(:focus-visible) {
+.c12:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible) > circle,
-.c13:focus:not(:focus-visible) > ellipse,
-.c13:focus:not(:focus-visible) > line,
-.c13:focus:not(:focus-visible) > path,
-.c13:focus:not(:focus-visible) > polygon,
-.c13:focus:not(:focus-visible) > polyline,
-.c13:focus:not(:focus-visible) > rect {
+.c12:focus:not(:focus-visible) > circle,
+.c12:focus:not(:focus-visible) > ellipse,
+.c12:focus:not(:focus-visible) > line,
+.c12:focus:not(:focus-visible) > path,
+.c12:focus:not(:focus-visible) > polygon,
+.c12:focus:not(:focus-visible) > polyline,
+.c12:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible)::-moz-focus-inner {
+.c12:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c6 > svg {
+.c5 > svg {
   margin: 0 auto;
 }
 
-.c4 {
+.c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1880,26 +1838,26 @@ exports[`Pagination should apply button kind style when referenced by a string 1
   max-width: 100%;
 }
 
-.c12 {
+.c11 {
   font-weight: bold;
   font-size: undefined;
   line-height: undefined;
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c7 {
     width: 2px;
   }
 }
@@ -1912,24 +1870,24 @@ exports[`Pagination should apply button kind style when referenced by a string 1
   >
     <nav
       aria-label="Pagination Navigation"
-      class="c2"
+      class="c1"
     >
       <ul
-        class="c3"
+        class="c2"
       >
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-disabled="true"
             aria-label="Go to previous page"
-            class="c5 c6"
+            class="c4 c5"
             disabled=""
             type="button"
           >
             <svg
               aria-label="Previous"
-              class="c7"
+              class="c6"
               viewBox="0 0 24 24"
             >
               <path
@@ -1942,116 +1900,116 @@ exports[`Pagination should apply button kind style when referenced by a string 1
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-current="page"
             aria-label="Go to page 1"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             1
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 2"
-            class="c10 c6"
+            class="c9 c5"
             type="button"
           >
             2
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 3"
-            class="c10 c6"
+            class="c9 c5"
             type="button"
           >
             3
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 4"
-            class="c10 c6"
+            class="c9 c5"
             type="button"
           >
             4
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 5"
-            class="c10 c6"
+            class="c9 c5"
             type="button"
           >
             5
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <span
-            class="c11 c12"
+            class="c10 c11"
           >
             …
           </span>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 24"
-            class="c10 c6"
+            class="c9 c5"
             type="button"
           >
             24
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to next page"
-            class="c13 c6"
+            class="c12 c5"
             type="button"
           >
             <svg
               aria-label="Next"
-              class="c7"
+              class="c6"
               viewBox="0 0 24 24"
             >
               <path
@@ -2070,697 +2028,6 @@ exports[`Pagination should apply button kind style when referenced by a string 1
 `;
 
 exports[`Pagination should apply custom theme 1`] = `
-.c8 {
-  display: inline-block;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
-  fill: #666666;
-  stroke: #666666;
-}
-
-.c8 g {
-  fill: inherit;
-  stroke: inherit;
-}
-
-.c8 *:not([stroke])[fill="none"] {
-  stroke-width: 0;
-}
-
-.c8 *[stroke*="#"],
-.c8 *[STROKE*="#"] {
-  stroke: inherit;
-  fill: none;
-}
-
-.c8 *[fill-rule],
-.c8 *[FILL-RULE],
-.c8 *[fill*="#"],
-.c8 *[FILL*="#"] {
-  fill: inherit;
-  stroke: none;
-}
-
-.c15 {
-  display: inline-block;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
-  fill: #000000;
-  stroke: #000000;
-}
-
-.c15 g {
-  fill: inherit;
-  stroke: inherit;
-}
-
-.c15 *:not([stroke])[fill="none"] {
-  stroke-width: 0;
-}
-
-.c15 *[stroke*="#"],
-.c15 *[STROKE*="#"] {
-  stroke: inherit;
-  fill: none;
-}
-
-.c15 *[fill-rule],
-.c15 *[FILL-RULE],
-.c15 *[fill*="#"],
-.c15 *[FILL*="#"] {
-  fill: inherit;
-  stroke: none;
-}
-
-.c0 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-}
-
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  margin: 0px;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  padding: 0px;
-}
-
-.c9 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  -webkit-align-self: stretch;
-  -ms-flex-item-align: stretch;
-  align-self: stretch;
-  width: 3px;
-}
-
-.c12 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c6 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 24px;
-  text-align: center;
-  opacity: 0.3;
-  cursor: default;
-  -webkit-transition-property: color,background-color,border-color,box-shadow;
-  transition-property: color,background-color,border-color,box-shadow;
-  -webkit-transition-duration: 0.1s;
-  transition-duration: 0.1s;
-  -webkit-transition-timing-function: ease-in-out;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
-}
-
-.c6 > svg {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
-  vertical-align: middle;
-}
-
-.c6:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c6:focus > circle,
-.c6:focus > ellipse,
-.c6:focus > line,
-.c6:focus > path,
-.c6:focus > polygon,
-.c6:focus > polyline,
-.c6:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c6:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c6:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c6:focus:not(:focus-visible) > circle,
-.c6:focus:not(:focus-visible) > ellipse,
-.c6:focus:not(:focus-visible) > line,
-.c6:focus:not(:focus-visible) > path,
-.c6:focus:not(:focus-visible) > polygon,
-.c6:focus:not(:focus-visible) > polyline,
-.c6:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c6:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c10 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  background-color: rgba(221,221,221,0.4);
-  color: #000000;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 24px;
-  background-color: rgba(51,51,51,0.06274509803921569);
-  color: #444444;
-  text-align: center;
-  -webkit-transition-property: color,background-color,border-color,box-shadow;
-  transition-property: color,background-color,border-color,box-shadow;
-  -webkit-transition-duration: 0.1s;
-  transition-duration: 0.1s;
-  -webkit-transition-timing-function: ease-in-out;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
-}
-
-.c10:hover {
-  background-color: rgba(51,51,51,0.06274509803921569);
-}
-
-.c10:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c10:focus > circle,
-.c10:focus > ellipse,
-.c10:focus > line,
-.c10:focus > path,
-.c10:focus > polygon,
-.c10:focus > polyline,
-.c10:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c10:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c10:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c10:focus:not(:focus-visible) > circle,
-.c10:focus:not(:focus-visible) > ellipse,
-.c10:focus:not(:focus-visible) > line,
-.c10:focus:not(:focus-visible) > path,
-.c10:focus:not(:focus-visible) > polygon,
-.c10:focus:not(:focus-visible) > polyline,
-.c10:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c10:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c11 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 24px;
-  color: #000000;
-  text-align: center;
-  -webkit-transition-property: color,background-color,border-color,box-shadow;
-  transition-property: color,background-color,border-color,box-shadow;
-  -webkit-transition-duration: 0.1s;
-  transition-duration: 0.1s;
-  -webkit-transition-timing-function: ease-in-out;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
-}
-
-.c11:hover {
-  background-color: rgba(51,51,51,0.06274509803921569);
-}
-
-.c11:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c11:focus > circle,
-.c11:focus > ellipse,
-.c11:focus > line,
-.c11:focus > path,
-.c11:focus > polygon,
-.c11:focus > polyline,
-.c11:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c11:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c11:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c11:focus:not(:focus-visible) > circle,
-.c11:focus:not(:focus-visible) > ellipse,
-.c11:focus:not(:focus-visible) > line,
-.c11:focus:not(:focus-visible) > path,
-.c11:focus:not(:focus-visible) > polygon,
-.c11:focus:not(:focus-visible) > polyline,
-.c11:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c11:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c14 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 24px;
-  color: #000000;
-  text-align: center;
-  -webkit-transition-property: color,background-color,border-color,box-shadow;
-  transition-property: color,background-color,border-color,box-shadow;
-  -webkit-transition-duration: 0.1s;
-  transition-duration: 0.1s;
-  -webkit-transition-timing-function: ease-in-out;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
-}
-
-.c14 > svg {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
-  vertical-align: middle;
-}
-
-.c14:hover {
-  background-color: rgba(51,51,51,0.06274509803921569);
-}
-
-.c14:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c14:focus > circle,
-.c14:focus > ellipse,
-.c14:focus > line,
-.c14:focus > path,
-.c14:focus > polygon,
-.c14:focus > polyline,
-.c14:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c14:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c14:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c14:focus:not(:focus-visible) > circle,
-.c14:focus:not(:focus-visible) > ellipse,
-.c14:focus:not(:focus-visible) > line,
-.c14:focus:not(:focus-visible) > path,
-.c14:focus:not(:focus-visible) > polygon,
-.c14:focus:not(:focus-visible) > polyline,
-.c14:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c14:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c7 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c7 > svg {
-  margin: 0 auto;
-}
-
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  max-width: 100%;
-  height: 36px;
-  min-width: 36px;
-}
-
-.c13 {
-  font-weight: bold;
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c2 {
-  background: red;
-}
-
-@media only screen and (max-width:768px) {
-  .c4 {
-    margin: 0px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c4 {
-    padding: 0px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c9 {
-    width: 2px;
-  }
-}
-
-<div
-  class="c0"
->
-  <div
-    class="c1 c2"
-  >
-    <nav
-      aria-label="Pagination Navigation"
-      class="c3"
-    >
-      <ul
-        class="c4"
-      >
-        <li
-          class="c5"
-        >
-          <button
-            aria-disabled="true"
-            aria-label="Go to previous page"
-            class="c6 c7"
-            disabled=""
-            type="button"
-          >
-            <svg
-              aria-label="Previous"
-              class="c8"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M17 2 7 12l10 10"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </button>
-        </li>
-        <div
-          class="c9"
-        />
-        <li
-          class="c5"
-        >
-          <button
-            aria-current="page"
-            aria-label="Go to page 1"
-            class="c10 c7"
-            type="button"
-          >
-            1
-          </button>
-        </li>
-        <div
-          class="c9"
-        />
-        <li
-          class="c5"
-        >
-          <button
-            aria-label="Go to page 2"
-            class="c11 c7"
-            type="button"
-          >
-            2
-          </button>
-        </li>
-        <div
-          class="c9"
-        />
-        <li
-          class="c5"
-        >
-          <button
-            aria-label="Go to page 3"
-            class="c11 c7"
-            type="button"
-          >
-            3
-          </button>
-        </li>
-        <div
-          class="c9"
-        />
-        <li
-          class="c5"
-        >
-          <button
-            aria-label="Go to page 4"
-            class="c11 c7"
-            type="button"
-          >
-            4
-          </button>
-        </li>
-        <div
-          class="c9"
-        />
-        <li
-          class="c5"
-        >
-          <button
-            aria-label="Go to page 5"
-            class="c11 c7"
-            type="button"
-          >
-            5
-          </button>
-        </li>
-        <div
-          class="c9"
-        />
-        <li
-          class="c5"
-        >
-          <span
-            class="c12 c13"
-          >
-            …
-          </span>
-        </li>
-        <div
-          class="c9"
-        />
-        <li
-          class="c5"
-        >
-          <button
-            aria-label="Go to page 24"
-            class="c11 c7"
-            type="button"
-          >
-            24
-          </button>
-        </li>
-        <div
-          class="c9"
-        />
-        <li
-          class="c5"
-        >
-          <button
-            aria-label="Go to next page"
-            class="c14 c7"
-            type="button"
-          >
-            <svg
-              aria-label="Next"
-              class="c15"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="m7 2 10 10L7 22"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </button>
-        </li>
-      </ul>
-    </nav>
-  </div>
-</div>
-`;
-
-exports[`Pagination should apply size 1`] = `
 .c7 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
@@ -2851,20 +2118,6 @@ exports[`Pagination should apply size 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-}
-
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -2903,16 +2156,6 @@ exports[`Pagination should apply size 1`] = `
 .c11 {
   font-size: 18px;
   line-height: 24px;
-}
-
-.c20 {
-  font-size: 14px;
-  line-height: 20px;
-}
-
-.c28 {
-  font-size: 22px;
-  line-height: 28px;
 }
 
 .c5 {
@@ -3241,7 +2484,694 @@ exports[`Pagination should apply size 1`] = `
   border: 0;
 }
 
-.c16 {
+.c6 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c6 > svg {
+  margin: 0 auto;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  max-width: 100%;
+  height: 36px;
+  min-width: 36px;
+}
+
+.c12 {
+  font-weight: bold;
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c2 {
+  background: red;
+}
+
+@media only screen and (max-width:768px) {
+  .c3 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c3 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c8 {
+    width: 2px;
+  }
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1 c2"
+  >
+    <nav
+      aria-label="Pagination Navigation"
+      class="c1"
+    >
+      <ul
+        class="c3"
+      >
+        <li
+          class="c4"
+        >
+          <button
+            aria-disabled="true"
+            aria-label="Go to previous page"
+            class="c5 c6"
+            disabled=""
+            type="button"
+          >
+            <svg
+              aria-label="Previous"
+              class="c7"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M17 2 7 12l10 10"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </li>
+        <div
+          class="c8"
+        />
+        <li
+          class="c4"
+        >
+          <button
+            aria-current="page"
+            aria-label="Go to page 1"
+            class="c9 c6"
+            type="button"
+          >
+            1
+          </button>
+        </li>
+        <div
+          class="c8"
+        />
+        <li
+          class="c4"
+        >
+          <button
+            aria-label="Go to page 2"
+            class="c10 c6"
+            type="button"
+          >
+            2
+          </button>
+        </li>
+        <div
+          class="c8"
+        />
+        <li
+          class="c4"
+        >
+          <button
+            aria-label="Go to page 3"
+            class="c10 c6"
+            type="button"
+          >
+            3
+          </button>
+        </li>
+        <div
+          class="c8"
+        />
+        <li
+          class="c4"
+        >
+          <button
+            aria-label="Go to page 4"
+            class="c10 c6"
+            type="button"
+          >
+            4
+          </button>
+        </li>
+        <div
+          class="c8"
+        />
+        <li
+          class="c4"
+        >
+          <button
+            aria-label="Go to page 5"
+            class="c10 c6"
+            type="button"
+          >
+            5
+          </button>
+        </li>
+        <div
+          class="c8"
+        />
+        <li
+          class="c4"
+        >
+          <span
+            class="c11 c12"
+          >
+            …
+          </span>
+        </li>
+        <div
+          class="c8"
+        />
+        <li
+          class="c4"
+        >
+          <button
+            aria-label="Go to page 24"
+            class="c10 c6"
+            type="button"
+          >
+            24
+          </button>
+        </li>
+        <div
+          class="c8"
+        />
+        <li
+          class="c4"
+        >
+          <button
+            aria-label="Go to next page"
+            class="c13 c6"
+            type="button"
+          >
+            <svg
+              aria-label="Next"
+              class="c14"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m7 2 10 10L7 22"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</div>
+`;
+
+exports[`Pagination should apply size 1`] = `
+.c6 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #666666;
+  stroke: #666666;
+}
+
+.c6 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c6 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c6 *[stroke*="#"],
+.c6 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c6 *[fill-rule],
+.c6 *[FILL-RULE],
+.c6 *[fill*="#"],
+.c6 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c13 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #000000;
+  stroke: #000000;
+}
+
+.c13 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c13 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c13 *[stroke*="#"],
+.c13 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c13 *[fill-rule],
+.c13 *[FILL-RULE],
+.c13 *[fill*="#"],
+.c13 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin: 0px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  padding: 0px;
+}
+
+.c7 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  width: 3px;
+}
+
+.c10 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c19 {
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.c27 {
+  font-size: 22px;
+  line-height: 28px;
+}
+
+.c4 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  text-align: center;
+  opacity: 0.3;
+  cursor: default;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c4 > svg {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  vertical-align: middle;
+}
+
+.c4:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus > circle,
+.c4:focus > ellipse,
+.c4:focus > line,
+.c4:focus > path,
+.c4:focus > polygon,
+.c4:focus > polyline,
+.c4:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c4:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c4:focus:not(:focus-visible) > circle,
+.c4:focus:not(:focus-visible) > ellipse,
+.c4:focus:not(:focus-visible) > line,
+.c4:focus:not(:focus-visible) > path,
+.c4:focus:not(:focus-visible) > polygon,
+.c4:focus:not(:focus-visible) > polyline,
+.c4:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c4:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c8 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  background-color: rgba(51,51,51,0.06274509803921569);
+  color: #444444;
+  text-align: center;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c8:hover {
+  background-color: rgba(51,51,51,0.06274509803921569);
+}
+
+.c8:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus > circle,
+.c8:focus > ellipse,
+.c8:focus > line,
+.c8:focus > path,
+.c8:focus > polygon,
+.c8:focus > polyline,
+.c8:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c8:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c8:focus:not(:focus-visible) > circle,
+.c8:focus:not(:focus-visible) > ellipse,
+.c8:focus:not(:focus-visible) > line,
+.c8:focus:not(:focus-visible) > path,
+.c8:focus:not(:focus-visible) > polygon,
+.c8:focus:not(:focus-visible) > polyline,
+.c8:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c8:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c9 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  color: #000000;
+  text-align: center;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c9:hover {
+  background-color: rgba(51,51,51,0.06274509803921569);
+}
+
+.c9:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9:focus > circle,
+.c9:focus > ellipse,
+.c9:focus > line,
+.c9:focus > path,
+.c9:focus > polygon,
+.c9:focus > polyline,
+.c9:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c9:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c9:focus:not(:focus-visible) > circle,
+.c9:focus:not(:focus-visible) > ellipse,
+.c9:focus:not(:focus-visible) > line,
+.c9:focus:not(:focus-visible) > path,
+.c9:focus:not(:focus-visible) > polygon,
+.c9:focus:not(:focus-visible) > polyline,
+.c9:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c9:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c12 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  color: #000000;
+  text-align: center;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c12 > svg {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  vertical-align: middle;
+}
+
+.c12:hover {
+  background-color: rgba(51,51,51,0.06274509803921569);
+}
+
+.c12:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c12:focus > circle,
+.c12:focus > ellipse,
+.c12:focus > line,
+.c12:focus > path,
+.c12:focus > polygon,
+.c12:focus > polyline,
+.c12:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c12:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c12:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c12:focus:not(:focus-visible) > circle,
+.c12:focus:not(:focus-visible) > ellipse,
+.c12:focus:not(:focus-visible) > line,
+.c12:focus:not(:focus-visible) > path,
+.c12:focus:not(:focus-visible) > polygon,
+.c12:focus:not(:focus-visible) > polyline,
+.c12:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c12:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c15 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -3274,7 +3204,7 @@ exports[`Pagination should apply size 1`] = `
   flex: 1 0 auto;
 }
 
-.c16 > svg {
+.c15 > svg {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3285,47 +3215,47 @@ exports[`Pagination should apply size 1`] = `
   vertical-align: middle;
 }
 
-.c16:focus {
+.c15:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c16:focus > circle,
-.c16:focus > ellipse,
-.c16:focus > line,
-.c16:focus > path,
-.c16:focus > polygon,
-.c16:focus > polyline,
-.c16:focus > rect {
+.c15:focus > circle,
+.c15:focus > ellipse,
+.c15:focus > line,
+.c15:focus > path,
+.c15:focus > polygon,
+.c15:focus > polyline,
+.c15:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c16:focus::-moz-focus-inner {
+.c15:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c16:focus:not(:focus-visible) {
+.c15:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c16:focus:not(:focus-visible) > circle,
-.c16:focus:not(:focus-visible) > ellipse,
-.c16:focus:not(:focus-visible) > line,
-.c16:focus:not(:focus-visible) > path,
-.c16:focus:not(:focus-visible) > polygon,
-.c16:focus:not(:focus-visible) > polyline,
-.c16:focus:not(:focus-visible) > rect {
+.c15:focus:not(:focus-visible) > circle,
+.c15:focus:not(:focus-visible) > ellipse,
+.c15:focus:not(:focus-visible) > line,
+.c15:focus:not(:focus-visible) > path,
+.c15:focus:not(:focus-visible) > polygon,
+.c15:focus:not(:focus-visible) > polyline,
+.c15:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c16:focus:not(:focus-visible)::-moz-focus-inner {
+.c15:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c18 {
+.c17 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -3345,6 +3275,82 @@ exports[`Pagination should apply size 1`] = `
   line-height: 20px;
   background-color: rgba(51,51,51,0.06274509803921569);
   color: #444444;
+  text-align: center;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c17:hover {
+  background-color: rgba(51,51,51,0.06274509803921569);
+}
+
+.c17:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c17:focus > circle,
+.c17:focus > ellipse,
+.c17:focus > line,
+.c17:focus > path,
+.c17:focus > polygon,
+.c17:focus > polyline,
+.c17:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c17:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c17:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c17:focus:not(:focus-visible) > circle,
+.c17:focus:not(:focus-visible) > ellipse,
+.c17:focus:not(:focus-visible) > line,
+.c17:focus:not(:focus-visible) > path,
+.c17:focus:not(:focus-visible) > polygon,
+.c17:focus:not(:focus-visible) > polyline,
+.c17:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c17:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c18 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 3px;
+  padding: 4px 4px;
+  font-size: 14px;
+  line-height: 20px;
+  color: #000000;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
   transition-property: color,background-color,border-color,box-shadow;
@@ -3404,7 +3410,7 @@ exports[`Pagination should apply size 1`] = `
   border: 0;
 }
 
-.c19 {
+.c21 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -3436,83 +3442,7 @@ exports[`Pagination should apply size 1`] = `
   flex: 1 0 auto;
 }
 
-.c19:hover {
-  background-color: rgba(51,51,51,0.06274509803921569);
-}
-
-.c19:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c19:focus > circle,
-.c19:focus > ellipse,
-.c19:focus > line,
-.c19:focus > path,
-.c19:focus > polygon,
-.c19:focus > polyline,
-.c19:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c19:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c19:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c19:focus:not(:focus-visible) > circle,
-.c19:focus:not(:focus-visible) > ellipse,
-.c19:focus:not(:focus-visible) > line,
-.c19:focus:not(:focus-visible) > path,
-.c19:focus:not(:focus-visible) > polygon,
-.c19:focus:not(:focus-visible) > polyline,
-.c19:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c19:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c22 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 3px;
-  padding: 4px 4px;
-  font-size: 14px;
-  line-height: 20px;
-  color: #000000;
-  text-align: center;
-  -webkit-transition-property: color,background-color,border-color,box-shadow;
-  transition-property: color,background-color,border-color,box-shadow;
-  -webkit-transition-duration: 0.1s;
-  transition-duration: 0.1s;
-  -webkit-transition-timing-function: ease-in-out;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
-}
-
-.c22 > svg {
+.c21 > svg {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3523,51 +3453,51 @@ exports[`Pagination should apply size 1`] = `
   vertical-align: middle;
 }
 
-.c22:hover {
+.c21:hover {
   background-color: rgba(51,51,51,0.06274509803921569);
 }
 
-.c22:focus {
+.c21:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c22:focus > circle,
-.c22:focus > ellipse,
-.c22:focus > line,
-.c22:focus > path,
-.c22:focus > polygon,
-.c22:focus > polyline,
-.c22:focus > rect {
+.c21:focus > circle,
+.c21:focus > ellipse,
+.c21:focus > line,
+.c21:focus > path,
+.c21:focus > polygon,
+.c21:focus > polyline,
+.c21:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c22:focus::-moz-focus-inner {
+.c21:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c22:focus:not(:focus-visible) {
+.c21:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c22:focus:not(:focus-visible) > circle,
-.c22:focus:not(:focus-visible) > ellipse,
-.c22:focus:not(:focus-visible) > line,
-.c22:focus:not(:focus-visible) > path,
-.c22:focus:not(:focus-visible) > polygon,
-.c22:focus:not(:focus-visible) > polyline,
-.c22:focus:not(:focus-visible) > rect {
+.c21:focus:not(:focus-visible) > circle,
+.c21:focus:not(:focus-visible) > ellipse,
+.c21:focus:not(:focus-visible) > line,
+.c21:focus:not(:focus-visible) > path,
+.c21:focus:not(:focus-visible) > polygon,
+.c21:focus:not(:focus-visible) > polyline,
+.c21:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c22:focus:not(:focus-visible)::-moz-focus-inner {
+.c21:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c24 {
+.c23 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -3600,7 +3530,7 @@ exports[`Pagination should apply size 1`] = `
   flex: 1 0 auto;
 }
 
-.c24 > svg {
+.c23 > svg {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3611,47 +3541,47 @@ exports[`Pagination should apply size 1`] = `
   vertical-align: middle;
 }
 
-.c24:focus {
+.c23:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c24:focus > circle,
-.c24:focus > ellipse,
-.c24:focus > line,
-.c24:focus > path,
-.c24:focus > polygon,
-.c24:focus > polyline,
-.c24:focus > rect {
+.c23:focus > circle,
+.c23:focus > ellipse,
+.c23:focus > line,
+.c23:focus > path,
+.c23:focus > polygon,
+.c23:focus > polyline,
+.c23:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c24:focus::-moz-focus-inner {
+.c23:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c24:focus:not(:focus-visible) {
+.c23:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c24:focus:not(:focus-visible) > circle,
-.c24:focus:not(:focus-visible) > ellipse,
-.c24:focus:not(:focus-visible) > line,
-.c24:focus:not(:focus-visible) > path,
-.c24:focus:not(:focus-visible) > polygon,
-.c24:focus:not(:focus-visible) > polyline,
-.c24:focus:not(:focus-visible) > rect {
+.c23:focus:not(:focus-visible) > circle,
+.c23:focus:not(:focus-visible) > ellipse,
+.c23:focus:not(:focus-visible) > line,
+.c23:focus:not(:focus-visible) > path,
+.c23:focus:not(:focus-visible) > polygon,
+.c23:focus:not(:focus-visible) > polyline,
+.c23:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c24:focus:not(:focus-visible)::-moz-focus-inner {
+.c23:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c26 {
+.c25 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -3671,6 +3601,82 @@ exports[`Pagination should apply size 1`] = `
   line-height: 28px;
   background-color: rgba(51,51,51,0.06274509803921569);
   color: #444444;
+  text-align: center;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c25:hover {
+  background-color: rgba(51,51,51,0.06274509803921569);
+}
+
+.c25:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c25:focus > circle,
+.c25:focus > ellipse,
+.c25:focus > line,
+.c25:focus > path,
+.c25:focus > polygon,
+.c25:focus > polyline,
+.c25:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c25:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c25:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c25:focus:not(:focus-visible) > circle,
+.c25:focus:not(:focus-visible) > ellipse,
+.c25:focus:not(:focus-visible) > line,
+.c25:focus:not(:focus-visible) > path,
+.c25:focus:not(:focus-visible) > polygon,
+.c25:focus:not(:focus-visible) > polyline,
+.c25:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c25:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c26 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 6px;
+  padding: 4px 4px;
+  font-size: 22px;
+  line-height: 28px;
+  color: #000000;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
   transition-property: color,background-color,border-color,box-shadow;
@@ -3730,7 +3736,7 @@ exports[`Pagination should apply size 1`] = `
   border: 0;
 }
 
-.c27 {
+.c29 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -3762,83 +3768,7 @@ exports[`Pagination should apply size 1`] = `
   flex: 1 0 auto;
 }
 
-.c27:hover {
-  background-color: rgba(51,51,51,0.06274509803921569);
-}
-
-.c27:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c27:focus > circle,
-.c27:focus > ellipse,
-.c27:focus > line,
-.c27:focus > path,
-.c27:focus > polygon,
-.c27:focus > polyline,
-.c27:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c27:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c27:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c27:focus:not(:focus-visible) > circle,
-.c27:focus:not(:focus-visible) > ellipse,
-.c27:focus:not(:focus-visible) > line,
-.c27:focus:not(:focus-visible) > path,
-.c27:focus:not(:focus-visible) > polygon,
-.c27:focus:not(:focus-visible) > polyline,
-.c27:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c27:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c30 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 6px;
-  padding: 4px 4px;
-  font-size: 22px;
-  line-height: 28px;
-  color: #000000;
-  text-align: center;
-  -webkit-transition-property: color,background-color,border-color,box-shadow;
-  transition-property: color,background-color,border-color,box-shadow;
-  -webkit-transition-duration: 0.1s;
-  transition-duration: 0.1s;
-  -webkit-transition-timing-function: ease-in-out;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
-}
-
-.c30 > svg {
+.c29 > svg {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3849,78 +3779,78 @@ exports[`Pagination should apply size 1`] = `
   vertical-align: middle;
 }
 
-.c30:hover {
+.c29:hover {
   background-color: rgba(51,51,51,0.06274509803921569);
 }
 
-.c30:focus {
+.c29:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c30:focus > circle,
-.c30:focus > ellipse,
-.c30:focus > line,
-.c30:focus > path,
-.c30:focus > polygon,
-.c30:focus > polyline,
-.c30:focus > rect {
+.c29:focus > circle,
+.c29:focus > ellipse,
+.c29:focus > line,
+.c29:focus > path,
+.c29:focus > polygon,
+.c29:focus > polyline,
+.c29:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c30:focus::-moz-focus-inner {
+.c29:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c30:focus:not(:focus-visible) {
+.c29:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c30:focus:not(:focus-visible) > circle,
-.c30:focus:not(:focus-visible) > ellipse,
-.c30:focus:not(:focus-visible) > line,
-.c30:focus:not(:focus-visible) > path,
-.c30:focus:not(:focus-visible) > polygon,
-.c30:focus:not(:focus-visible) > polyline,
-.c30:focus:not(:focus-visible) > rect {
+.c29:focus:not(:focus-visible) > circle,
+.c29:focus:not(:focus-visible) > ellipse,
+.c29:focus:not(:focus-visible) > line,
+.c29:focus:not(:focus-visible) > path,
+.c29:focus:not(:focus-visible) > polygon,
+.c29:focus:not(:focus-visible) > polyline,
+.c29:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c30:focus:not(:focus-visible)::-moz-focus-inner {
+.c29:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c6 {
+.c5 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c6 > svg {
+.c5 > svg {
   margin: 0 auto;
 }
 
-.c17 {
+.c16 {
   font-size: 14px;
   line-height: 20px;
 }
 
-.c17 > svg {
+.c16 > svg {
   margin: 0 auto;
 }
 
-.c25 {
+.c24 {
   font-size: 22px;
   line-height: 28px;
 }
 
-.c25 > svg {
+.c24 > svg {
   margin: 0 auto;
 }
 
-.c4 {
+.c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3938,7 +3868,7 @@ exports[`Pagination should apply size 1`] = `
   min-width: 36px;
 }
 
-.c15 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3956,7 +3886,7 @@ exports[`Pagination should apply size 1`] = `
   min-width: 30px;
 }
 
-.c23 {
+.c22 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3974,38 +3904,38 @@ exports[`Pagination should apply size 1`] = `
   min-width: 48px;
 }
 
-.c12 {
+.c11 {
   font-weight: bold;
   font-size: 18px;
   line-height: 24px;
 }
 
-.c21 {
+.c20 {
   font-weight: bold;
   font-size: 14px;
   line-height: 20px;
 }
 
-.c29 {
+.c28 {
   font-weight: bold;
   font-size: 22px;
   line-height: 28px;
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c7 {
     width: 2px;
   }
 }
@@ -4018,24 +3948,24 @@ exports[`Pagination should apply size 1`] = `
   >
     <nav
       aria-label="Pagination Navigation"
-      class="c2"
+      class="c1"
     >
       <ul
-        class="c3"
+        class="c2"
       >
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-disabled="true"
             aria-label="Go to previous page"
-            class="c5 c6"
+            class="c4 c5"
             disabled=""
             type="button"
           >
             <svg
               aria-label="Previous"
-              class="c7"
+              class="c6"
               viewBox="0 0 24 24"
             >
               <path
@@ -4048,116 +3978,116 @@ exports[`Pagination should apply size 1`] = `
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-current="page"
             aria-label="Go to page 1"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             1
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 2"
-            class="c10 c6"
+            class="c9 c5"
             type="button"
           >
             2
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 3"
-            class="c10 c6"
+            class="c9 c5"
             type="button"
           >
             3
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 4"
-            class="c10 c6"
+            class="c9 c5"
             type="button"
           >
             4
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 5"
-            class="c10 c6"
+            class="c9 c5"
             type="button"
           >
             5
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <span
-            class="c11 c12"
+            class="c10 c11"
           >
             …
           </span>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 24"
-            class="c10 c6"
+            class="c9 c5"
             type="button"
           >
             24
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to next page"
-            class="c13 c6"
+            class="c12 c5"
             type="button"
           >
             <svg
               aria-label="Next"
-              class="c14"
+              class="c13"
               viewBox="0 0 24 24"
             >
               <path
@@ -4177,24 +4107,24 @@ exports[`Pagination should apply size 1`] = `
   >
     <nav
       aria-label="Pagination Navigation"
-      class="c2"
+      class="c1"
     >
       <ul
-        class="c3"
+        class="c2"
       >
         <li
-          class="c15"
+          class="c14"
         >
           <button
             aria-disabled="true"
             aria-label="Go to previous page"
-            class="c16 c17"
+            class="c15 c16"
             disabled=""
             type="button"
           >
             <svg
               aria-label="Previous"
-              class="c7"
+              class="c6"
               viewBox="0 0 24 24"
             >
               <path
@@ -4207,116 +4137,116 @@ exports[`Pagination should apply size 1`] = `
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c15"
+          class="c14"
         >
           <button
             aria-current="page"
             aria-label="Go to page 1"
-            class="c18 c17"
+            class="c17 c16"
             type="button"
           >
             1
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c15"
+          class="c14"
         >
           <button
             aria-label="Go to page 2"
-            class="c19 c17"
+            class="c18 c16"
             type="button"
           >
             2
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c15"
+          class="c14"
         >
           <button
             aria-label="Go to page 3"
-            class="c19 c17"
+            class="c18 c16"
             type="button"
           >
             3
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c15"
+          class="c14"
         >
           <button
             aria-label="Go to page 4"
-            class="c19 c17"
+            class="c18 c16"
             type="button"
           >
             4
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c15"
+          class="c14"
         >
           <button
             aria-label="Go to page 5"
-            class="c19 c17"
+            class="c18 c16"
             type="button"
           >
             5
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c15"
+          class="c14"
         >
           <span
-            class="c20 c21"
+            class="c19 c20"
           >
             …
           </span>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c15"
+          class="c14"
         >
           <button
             aria-label="Go to page 24"
-            class="c19 c17"
+            class="c18 c16"
             type="button"
           >
             24
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c15"
+          class="c14"
         >
           <button
             aria-label="Go to next page"
-            class="c22 c17"
+            class="c21 c16"
             type="button"
           >
             <svg
               aria-label="Next"
-              class="c14"
+              class="c13"
               viewBox="0 0 24 24"
             >
               <path
@@ -4336,24 +4266,24 @@ exports[`Pagination should apply size 1`] = `
   >
     <nav
       aria-label="Pagination Navigation"
-      class="c2"
+      class="c1"
     >
       <ul
-        class="c3"
+        class="c2"
       >
         <li
-          class="c23"
+          class="c22"
         >
           <button
             aria-disabled="true"
             aria-label="Go to previous page"
-            class="c24 c25"
+            class="c23 c24"
             disabled=""
             type="button"
           >
             <svg
               aria-label="Previous"
-              class="c7"
+              class="c6"
               viewBox="0 0 24 24"
             >
               <path
@@ -4366,116 +4296,116 @@ exports[`Pagination should apply size 1`] = `
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c23"
+          class="c22"
         >
           <button
             aria-current="page"
             aria-label="Go to page 1"
-            class="c26 c25"
+            class="c25 c24"
             type="button"
           >
             1
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c23"
+          class="c22"
         >
           <button
             aria-label="Go to page 2"
-            class="c27 c25"
+            class="c26 c24"
             type="button"
           >
             2
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c23"
+          class="c22"
         >
           <button
             aria-label="Go to page 3"
-            class="c27 c25"
+            class="c26 c24"
             type="button"
           >
             3
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c23"
+          class="c22"
         >
           <button
             aria-label="Go to page 4"
-            class="c27 c25"
+            class="c26 c24"
             type="button"
           >
             4
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c23"
+          class="c22"
         >
           <button
             aria-label="Go to page 5"
-            class="c27 c25"
+            class="c26 c24"
             type="button"
           >
             5
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c23"
+          class="c22"
         >
           <span
-            class="c28 c29"
+            class="c27 c28"
           >
             …
           </span>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c23"
+          class="c22"
         >
           <button
             aria-label="Go to page 24"
-            class="c27 c25"
+            class="c26 c24"
             type="button"
           >
             24
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c23"
+          class="c22"
         >
           <button
             aria-label="Go to next page"
-            class="c30 c25"
+            class="c29 c24"
             type="button"
           >
             <svg
               aria-label="Next"
-              class="c14"
+              class="c13"
               viewBox="0 0 24 24"
             >
               <path
@@ -4494,7 +4424,7 @@ exports[`Pagination should apply size 1`] = `
 `;
 
 exports[`Pagination should change the page on prop change 1`] = `
-.c7 {
+.c6 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -4505,25 +4435,25 @@ exports[`Pagination should change the page on prop change 1`] = `
   stroke: #000000;
 }
 
-.c7 g {
+.c6 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c7 *:not([stroke])[fill="none"] {
+.c6 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c7 *[stroke*="#"],
-.c7 *[STROKE*="#"] {
+.c6 *[stroke*="#"],
+.c6 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c7 *[fill-rule],
-.c7 *[FILL-RULE],
-.c7 *[fill*="#"],
-.c7 *[FILL*="#"] {
+.c6 *[fill-rule],
+.c6 *[FILL-RULE],
+.c6 *[fill*="#"],
+.c6 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -4550,26 +4480,12 @@ exports[`Pagination should change the page on prop change 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-}
-
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
 }
 
-.c3 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4589,7 +4505,7 @@ exports[`Pagination should change the page on prop change 1`] = `
   padding: 0px;
 }
 
-.c8 {
+.c7 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -4599,12 +4515,12 @@ exports[`Pagination should change the page on prop change 1`] = `
   width: 3px;
 }
 
-.c11 {
+.c10 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c10 {
+.c9 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -4624,82 +4540,6 @@ exports[`Pagination should change the page on prop change 1`] = `
   line-height: 24px;
   background-color: rgba(51,51,51,0.06274509803921569);
   color: #444444;
-  text-align: center;
-  -webkit-transition-property: color,background-color,border-color,box-shadow;
-  transition-property: color,background-color,border-color,box-shadow;
-  -webkit-transition-duration: 0.1s;
-  transition-duration: 0.1s;
-  -webkit-transition-timing-function: ease-in-out;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
-}
-
-.c10:hover {
-  background-color: rgba(51,51,51,0.06274509803921569);
-}
-
-.c10:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c10:focus > circle,
-.c10:focus > ellipse,
-.c10:focus > line,
-.c10:focus > path,
-.c10:focus > polygon,
-.c10:focus > polyline,
-.c10:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c10:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c10:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c10:focus:not(:focus-visible) > circle,
-.c10:focus:not(:focus-visible) > ellipse,
-.c10:focus:not(:focus-visible) > line,
-.c10:focus:not(:focus-visible) > path,
-.c10:focus:not(:focus-visible) > polygon,
-.c10:focus:not(:focus-visible) > polyline,
-.c10:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c10:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c9 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 24px;
-  color: #000000;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
   transition-property: color,background-color,border-color,box-shadow;
@@ -4759,7 +4599,7 @@ exports[`Pagination should change the page on prop change 1`] = `
   border: 0;
 }
 
-.c5 {
+.c8 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -4791,7 +4631,83 @@ exports[`Pagination should change the page on prop change 1`] = `
   flex: 1 0 auto;
 }
 
-.c5 > svg {
+.c8:hover {
+  background-color: rgba(51,51,51,0.06274509803921569);
+}
+
+.c8:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus > circle,
+.c8:focus > ellipse,
+.c8:focus > line,
+.c8:focus > path,
+.c8:focus > polygon,
+.c8:focus > polyline,
+.c8:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c8:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c8:focus:not(:focus-visible) > circle,
+.c8:focus:not(:focus-visible) > ellipse,
+.c8:focus:not(:focus-visible) > line,
+.c8:focus:not(:focus-visible) > path,
+.c8:focus:not(:focus-visible) > polygon,
+.c8:focus:not(:focus-visible) > polyline,
+.c8:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c8:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c4 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  color: #000000;
+  text-align: center;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c4 > svg {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4802,60 +4718,60 @@ exports[`Pagination should change the page on prop change 1`] = `
   vertical-align: middle;
 }
 
-.c5:hover {
+.c4:hover {
   background-color: rgba(51,51,51,0.06274509803921569);
 }
 
-.c5:focus {
+.c4:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c4:focus > circle,
+.c4:focus > ellipse,
+.c4:focus > line,
+.c4:focus > path,
+.c4:focus > polygon,
+.c4:focus > polyline,
+.c4:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c4:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c4:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c4:focus:not(:focus-visible) > circle,
+.c4:focus:not(:focus-visible) > ellipse,
+.c4:focus:not(:focus-visible) > line,
+.c4:focus:not(:focus-visible) > path,
+.c4:focus:not(:focus-visible) > polygon,
+.c4:focus:not(:focus-visible) > polyline,
+.c4:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c4:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c6 {
+.c5 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c6 > svg {
+.c5 > svg {
   margin: 0 auto;
 }
 
-.c4 {
+.c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4873,26 +4789,26 @@ exports[`Pagination should change the page on prop change 1`] = `
   min-width: 36px;
 }
 
-.c12 {
+.c11 {
   font-weight: bold;
   font-size: 18px;
   line-height: 24px;
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c7 {
     width: 2px;
   }
 }
@@ -4905,22 +4821,22 @@ exports[`Pagination should change the page on prop change 1`] = `
   >
     <nav
       aria-label="Pagination Navigation"
-      class="c2"
+      class="c1"
     >
       <ul
-        class="c3"
+        class="c2"
       >
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to previous page"
-            class="c5 c6"
+            class="c4 c5"
             type="button"
           >
             <svg
               aria-label="Previous"
-              class="c7"
+              class="c6"
               viewBox="0 0 24 24"
             >
               <path
@@ -4933,116 +4849,116 @@ exports[`Pagination should change the page on prop change 1`] = `
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 1"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             1
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-current="page"
             aria-label="Go to page 2"
-            class="c10 c6"
+            class="c9 c5"
             type="button"
           >
             2
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 3"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             3
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 4"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             4
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 5"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             5
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <span
-            class="c11 c12"
+            class="c10 c11"
           >
             …
           </span>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 24"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             24
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to next page"
-            class="c5 c6"
+            class="c4 c5"
             type="button"
           >
             <svg
               aria-label="Next"
-              class="c7"
+              class="c6"
               viewBox="0 0 24 24"
             >
               <path
@@ -5061,7 +4977,7 @@ exports[`Pagination should change the page on prop change 1`] = `
 `;
 
 exports[`Pagination should disable next button if on last page 1`] = `
-.c7 {
+.c6 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -5072,30 +4988,30 @@ exports[`Pagination should disable next button if on last page 1`] = `
   stroke: #000000;
 }
 
-.c7 g {
+.c6 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c7 *:not([stroke])[fill="none"] {
+.c6 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c7 *[stroke*="#"],
-.c7 *[STROKE*="#"] {
+.c6 *[stroke*="#"],
+.c6 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c7 *[fill-rule],
-.c7 *[FILL-RULE],
-.c7 *[fill*="#"],
-.c7 *[FILL*="#"] {
+.c6 *[fill-rule],
+.c6 *[FILL-RULE],
+.c6 *[fill*="#"],
+.c6 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
 
-.c14 {
+.c13 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -5106,25 +5022,25 @@ exports[`Pagination should disable next button if on last page 1`] = `
   stroke: #666666;
 }
 
-.c14 g {
+.c13 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c14 *:not([stroke])[fill="none"] {
+.c13 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c14 *[stroke*="#"],
-.c14 *[STROKE*="#"] {
+.c13 *[stroke*="#"],
+.c13 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c14 *[fill-rule],
-.c14 *[FILL-RULE],
-.c14 *[fill*="#"],
-.c14 *[FILL*="#"] {
+.c13 *[fill-rule],
+.c13 *[FILL-RULE],
+.c13 *[fill*="#"],
+.c13 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -5151,26 +5067,12 @@ exports[`Pagination should disable next button if on last page 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-}
-
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
 }
 
-.c3 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5190,7 +5092,7 @@ exports[`Pagination should disable next button if on last page 1`] = `
   padding: 0px;
 }
 
-.c8 {
+.c7 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -5200,12 +5102,12 @@ exports[`Pagination should disable next button if on last page 1`] = `
   width: 3px;
 }
 
-.c10 {
+.c9 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c5 {
+.c4 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -5237,7 +5139,7 @@ exports[`Pagination should disable next button if on last page 1`] = `
   flex: 1 0 auto;
 }
 
-.c5 > svg {
+.c4 > svg {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5248,47 +5150,1859 @@ exports[`Pagination should disable next button if on last page 1`] = `
   vertical-align: middle;
 }
 
-.c5:hover {
+.c4:hover {
   background-color: rgba(51,51,51,0.06274509803921569);
 }
 
-.c5:focus {
+.c4:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c4:focus > circle,
+.c4:focus > ellipse,
+.c4:focus > line,
+.c4:focus > path,
+.c4:focus > polygon,
+.c4:focus > polyline,
+.c4:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c4:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c4:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c4:focus:not(:focus-visible) > circle,
+.c4:focus:not(:focus-visible) > ellipse,
+.c4:focus:not(:focus-visible) > line,
+.c4:focus:not(:focus-visible) > path,
+.c4:focus:not(:focus-visible) > polygon,
+.c4:focus:not(:focus-visible) > polyline,
+.c4:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c4:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c8 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  color: #000000;
+  text-align: center;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c8:hover {
+  background-color: rgba(51,51,51,0.06274509803921569);
+}
+
+.c8:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus > circle,
+.c8:focus > ellipse,
+.c8:focus > line,
+.c8:focus > path,
+.c8:focus > polygon,
+.c8:focus > polyline,
+.c8:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c8:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c8:focus:not(:focus-visible) > circle,
+.c8:focus:not(:focus-visible) > ellipse,
+.c8:focus:not(:focus-visible) > line,
+.c8:focus:not(:focus-visible) > path,
+.c8:focus:not(:focus-visible) > polygon,
+.c8:focus:not(:focus-visible) > polyline,
+.c8:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c8:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c11 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  background-color: rgba(51,51,51,0.06274509803921569);
+  color: #444444;
+  text-align: center;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c11:hover {
+  background-color: rgba(51,51,51,0.06274509803921569);
+}
+
+.c11:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus > circle,
+.c11:focus > ellipse,
+.c11:focus > line,
+.c11:focus > path,
+.c11:focus > polygon,
+.c11:focus > polyline,
+.c11:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c11:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c11:focus:not(:focus-visible) > circle,
+.c11:focus:not(:focus-visible) > ellipse,
+.c11:focus:not(:focus-visible) > line,
+.c11:focus:not(:focus-visible) > path,
+.c11:focus:not(:focus-visible) > polygon,
+.c11:focus:not(:focus-visible) > polyline,
+.c11:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c11:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c12 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  text-align: center;
+  opacity: 0.3;
+  cursor: default;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c12 > svg {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  vertical-align: middle;
+}
+
+.c12:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c12:focus > circle,
+.c12:focus > ellipse,
+.c12:focus > line,
+.c12:focus > path,
+.c12:focus > polygon,
+.c12:focus > polyline,
+.c12:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c12:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c12:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c12:focus:not(:focus-visible) > circle,
+.c12:focus:not(:focus-visible) > ellipse,
+.c12:focus:not(:focus-visible) > line,
+.c12:focus:not(:focus-visible) > path,
+.c12:focus:not(:focus-visible) > polygon,
+.c12:focus:not(:focus-visible) > polyline,
+.c12:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c12:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c5 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c5 > svg {
+  margin: 0 auto;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  max-width: 100%;
+  height: 36px;
+  min-width: 36px;
+}
+
+.c10 {
+  font-weight: bold;
+  font-size: 18px;
+  line-height: 24px;
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    width: 2px;
+  }
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
+  >
+    <nav
+      aria-label="Pagination Navigation"
+      class="c1"
+    >
+      <ul
+        class="c2"
+      >
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to previous page"
+            class="c4 c5"
+            type="button"
+          >
+            <svg
+              aria-label="Previous"
+              class="c6"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M17 2 7 12l10 10"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </li>
+        <div
+          class="c7"
+        />
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 1"
+            class="c8 c5"
+            type="button"
+          >
+            1
+          </button>
+        </li>
+        <div
+          class="c7"
+        />
+        <li
+          class="c3"
+        >
+          <span
+            class="c9 c10"
+          >
+            …
+          </span>
+        </li>
+        <div
+          class="c7"
+        />
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 20"
+            class="c8 c5"
+            type="button"
+          >
+            20
+          </button>
+        </li>
+        <div
+          class="c7"
+        />
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 21"
+            class="c8 c5"
+            type="button"
+          >
+            21
+          </button>
+        </li>
+        <div
+          class="c7"
+        />
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 22"
+            class="c8 c5"
+            type="button"
+          >
+            22
+          </button>
+        </li>
+        <div
+          class="c7"
+        />
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 23"
+            class="c8 c5"
+            type="button"
+          >
+            23
+          </button>
+        </li>
+        <div
+          class="c7"
+        />
+        <li
+          class="c3"
+        >
+          <button
+            aria-current="page"
+            aria-label="Go to page 24"
+            class="c11 c5"
+            type="button"
+          >
+            24
+          </button>
+        </li>
+        <div
+          class="c7"
+        />
+        <li
+          class="c3"
+        >
+          <button
+            aria-disabled="true"
+            aria-label="Go to next page"
+            class="c12 c5"
+            disabled=""
+            type="button"
+          >
+            <svg
+              aria-label="Next"
+              class="c13"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m7 2 10 10L7 22"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</div>
+`;
+
+exports[`Pagination should disable previous and next controls when numberItems
+  < step 1`] = `
+.c6 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #666666;
+  stroke: #666666;
+}
+
+.c6 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c6 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c6 *[stroke*="#"],
+.c6 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c6 *[fill-rule],
+.c6 *[FILL-RULE],
+.c6 *[fill*="#"],
+.c6 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin: 0px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  padding: 0px;
+}
+
+.c7 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  width: 3px;
+}
+
+.c4 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  text-align: center;
+  opacity: 0.3;
+  cursor: default;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c4 > svg {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  vertical-align: middle;
+}
+
+.c4:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus > circle,
+.c4:focus > ellipse,
+.c4:focus > line,
+.c4:focus > path,
+.c4:focus > polygon,
+.c4:focus > polyline,
+.c4:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c4:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c4:focus:not(:focus-visible) > circle,
+.c4:focus:not(:focus-visible) > ellipse,
+.c4:focus:not(:focus-visible) > line,
+.c4:focus:not(:focus-visible) > path,
+.c4:focus:not(:focus-visible) > polygon,
+.c4:focus:not(:focus-visible) > polyline,
+.c4:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c4:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c8 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  background-color: rgba(51,51,51,0.06274509803921569);
+  color: #444444;
+  text-align: center;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c8:hover {
+  background-color: rgba(51,51,51,0.06274509803921569);
+}
+
+.c8:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus > circle,
+.c8:focus > ellipse,
+.c8:focus > line,
+.c8:focus > path,
+.c8:focus > polygon,
+.c8:focus > polyline,
+.c8:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c8:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c8:focus:not(:focus-visible) > circle,
+.c8:focus:not(:focus-visible) > ellipse,
+.c8:focus:not(:focus-visible) > line,
+.c8:focus:not(:focus-visible) > path,
+.c8:focus:not(:focus-visible) > polygon,
+.c8:focus:not(:focus-visible) > polyline,
+.c8:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c8:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c5 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c5 > svg {
+  margin: 0 auto;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  max-width: 100%;
+  height: 36px;
+  min-width: 36px;
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    width: 2px;
+  }
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
+  >
+    <nav
+      aria-label="Pagination Navigation"
+      class="c1"
+    >
+      <ul
+        class="c2"
+      >
+        <li
+          class="c3"
+        >
+          <button
+            aria-disabled="true"
+            aria-label="Go to previous page"
+            class="c4 c5"
+            disabled=""
+            type="button"
+          >
+            <svg
+              aria-label="Previous"
+              class="c6"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M17 2 7 12l10 10"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </li>
+        <div
+          class="c7"
+        />
+        <li
+          class="c3"
+        >
+          <button
+            aria-current="page"
+            aria-label="Go to page 1"
+            class="c8 c5"
+            type="button"
+          >
+            1
+          </button>
+        </li>
+        <div
+          class="c7"
+        />
+        <li
+          class="c3"
+        >
+          <button
+            aria-disabled="true"
+            aria-label="Go to next page"
+            class="c4 c5"
+            disabled=""
+            type="button"
+          >
+            <svg
+              aria-label="Next"
+              class="c6"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m7 2 10 10L7 22"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</div>
+`;
+
+exports[`Pagination should disable previous and next controls when numberItems
+  === 0 1`] = `
+.c6 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #666666;
+  stroke: #666666;
+}
+
+.c6 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c6 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c6 *[stroke*="#"],
+.c6 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c6 *[fill-rule],
+.c6 *[FILL-RULE],
+.c6 *[fill*="#"],
+.c6 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin: 0px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  padding: 0px;
+}
+
+.c7 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  width: 3px;
+}
+
+.c4 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  text-align: center;
+  opacity: 0.3;
+  cursor: default;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c4 > svg {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  vertical-align: middle;
+}
+
+.c4:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus > circle,
+.c4:focus > ellipse,
+.c4:focus > line,
+.c4:focus > path,
+.c4:focus > polygon,
+.c4:focus > polyline,
+.c4:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c4:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c4:focus:not(:focus-visible) > circle,
+.c4:focus:not(:focus-visible) > ellipse,
+.c4:focus:not(:focus-visible) > line,
+.c4:focus:not(:focus-visible) > path,
+.c4:focus:not(:focus-visible) > polygon,
+.c4:focus:not(:focus-visible) > polyline,
+.c4:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c4:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c5 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c5 > svg {
+  margin: 0 auto;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  max-width: 100%;
+  height: 36px;
+  min-width: 36px;
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    width: 2px;
+  }
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
+  >
+    <nav
+      aria-label="Pagination Navigation"
+      class="c1"
+    >
+      <ul
+        class="c2"
+      >
+        <li
+          class="c3"
+        >
+          <button
+            aria-disabled="true"
+            aria-label="Go to previous page"
+            class="c4 c5"
+            disabled=""
+            type="button"
+          >
+            <svg
+              aria-label="Previous"
+              class="c6"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M17 2 7 12l10 10"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </li>
+        <div
+          class="c7"
+        />
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to next page"
+            class="c4 c5"
+            disabled=""
+            type="button"
+          >
+            <svg
+              aria-label="Next"
+              class="c6"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m7 2 10 10L7 22"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</div>
+`;
+
+exports[`Pagination should disable previous and next controls when numberItems
+  === step 1`] = `
+.c6 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #666666;
+  stroke: #666666;
+}
+
+.c6 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c6 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c6 *[stroke*="#"],
+.c6 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c6 *[fill-rule],
+.c6 *[FILL-RULE],
+.c6 *[fill*="#"],
+.c6 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin: 0px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  padding: 0px;
+}
+
+.c7 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  width: 3px;
+}
+
+.c4 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  text-align: center;
+  opacity: 0.3;
+  cursor: default;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c4 > svg {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  vertical-align: middle;
+}
+
+.c4:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus > circle,
+.c4:focus > ellipse,
+.c4:focus > line,
+.c4:focus > path,
+.c4:focus > polygon,
+.c4:focus > polyline,
+.c4:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c4:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c4:focus:not(:focus-visible) > circle,
+.c4:focus:not(:focus-visible) > ellipse,
+.c4:focus:not(:focus-visible) > line,
+.c4:focus:not(:focus-visible) > path,
+.c4:focus:not(:focus-visible) > polygon,
+.c4:focus:not(:focus-visible) > polyline,
+.c4:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c4:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c8 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  background-color: rgba(51,51,51,0.06274509803921569);
+  color: #444444;
+  text-align: center;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c8:hover {
+  background-color: rgba(51,51,51,0.06274509803921569);
+}
+
+.c8:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus > circle,
+.c8:focus > ellipse,
+.c8:focus > line,
+.c8:focus > path,
+.c8:focus > polygon,
+.c8:focus > polyline,
+.c8:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c8:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c8:focus:not(:focus-visible) > circle,
+.c8:focus:not(:focus-visible) > ellipse,
+.c8:focus:not(:focus-visible) > line,
+.c8:focus:not(:focus-visible) > path,
+.c8:focus:not(:focus-visible) > polygon,
+.c8:focus:not(:focus-visible) > polyline,
+.c8:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c8:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c5 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c5 > svg {
+  margin: 0 auto;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  max-width: 100%;
+  height: 36px;
+  min-width: 36px;
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    width: 2px;
+  }
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
+  >
+    <nav
+      aria-label="Pagination Navigation"
+      class="c1"
+    >
+      <ul
+        class="c2"
+      >
+        <li
+          class="c3"
+        >
+          <button
+            aria-disabled="true"
+            aria-label="Go to previous page"
+            class="c4 c5"
+            disabled=""
+            type="button"
+          >
+            <svg
+              aria-label="Previous"
+              class="c6"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M17 2 7 12l10 10"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </li>
+        <div
+          class="c7"
+        />
+        <li
+          class="c3"
+        >
+          <button
+            aria-current="page"
+            aria-label="Go to page 1"
+            class="c8 c5"
+            type="button"
+          >
+            1
+          </button>
+        </li>
+        <div
+          class="c7"
+        />
+        <li
+          class="c3"
+        >
+          <button
+            aria-disabled="true"
+            aria-label="Go to next page"
+            class="c4 c5"
+            disabled=""
+            type="button"
+          >
+            <svg
+              aria-label="Next"
+              class="c6"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m7 2 10 10L7 22"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</div>
+`;
+
+exports[`Pagination should disable previous button if on first page 1`] = `
+.c6 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #666666;
+  stroke: #666666;
+}
+
+.c6 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c6 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c6 *[stroke*="#"],
+.c6 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c6 *[fill-rule],
+.c6 *[FILL-RULE],
+.c6 *[fill*="#"],
+.c6 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c13 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #000000;
+  stroke: #000000;
+}
+
+.c13 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c13 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c13 *[stroke*="#"],
+.c13 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c13 *[fill-rule],
+.c13 *[FILL-RULE],
+.c13 *[fill*="#"],
+.c13 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin: 0px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  padding: 0px;
+}
+
+.c7 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  width: 3px;
+}
+
+.c10 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c4 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  text-align: center;
+  opacity: 0.3;
+  cursor: default;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c4 > svg {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  vertical-align: middle;
+}
+
+.c4:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus > circle,
+.c4:focus > ellipse,
+.c4:focus > line,
+.c4:focus > path,
+.c4:focus > polygon,
+.c4:focus > polyline,
+.c4:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c4:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c4:focus:not(:focus-visible) > circle,
+.c4:focus:not(:focus-visible) > ellipse,
+.c4:focus:not(:focus-visible) > line,
+.c4:focus:not(:focus-visible) > path,
+.c4:focus:not(:focus-visible) > polygon,
+.c4:focus:not(:focus-visible) > polyline,
+.c4:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c4:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c8 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  background-color: rgba(51,51,51,0.06274509803921569);
+  color: #444444;
+  text-align: center;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c8:hover {
+  background-color: rgba(51,51,51,0.06274509803921569);
+}
+
+.c8:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus > circle,
+.c8:focus > ellipse,
+.c8:focus > line,
+.c8:focus > path,
+.c8:focus > polygon,
+.c8:focus > polyline,
+.c8:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c8:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c8:focus:not(:focus-visible) > circle,
+.c8:focus:not(:focus-visible) > ellipse,
+.c8:focus:not(:focus-visible) > line,
+.c8:focus:not(:focus-visible) > path,
+.c8:focus:not(:focus-visible) > polygon,
+.c8:focus:not(:focus-visible) > polyline,
+.c8:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c8:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
@@ -5379,15 +7093,12 @@ exports[`Pagination should disable next button if on last page 1`] = `
   background: transparent;
   overflow: visible;
   text-transform: none;
-  background-color: rgba(221,221,221,0.4);
-  color: #000000;
   border: none;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
-  background-color: rgba(51,51,51,0.06274509803921569);
-  color: #444444;
+  color: #000000;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
   transition-property: color,background-color,border-color,box-shadow;
@@ -5401,6 +7112,17 @@ exports[`Pagination should disable next button if on last page 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+}
+
+.c12 > svg {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  vertical-align: middle;
 }
 
 .c12:hover {
@@ -5447,100 +7169,16 @@ exports[`Pagination should disable next button if on last page 1`] = `
   border: 0;
 }
 
-.c13 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 24px;
-  text-align: center;
-  opacity: 0.3;
-  cursor: default;
-  -webkit-transition-property: color,background-color,border-color,box-shadow;
-  transition-property: color,background-color,border-color,box-shadow;
-  -webkit-transition-duration: 0.1s;
-  transition-duration: 0.1s;
-  -webkit-transition-timing-function: ease-in-out;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
-}
-
-.c13 > svg {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
-  vertical-align: middle;
-}
-
-.c13:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c13:focus > circle,
-.c13:focus > ellipse,
-.c13:focus > line,
-.c13:focus > path,
-.c13:focus > polygon,
-.c13:focus > polyline,
-.c13:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c13:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c13:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c13:focus:not(:focus-visible) > circle,
-.c13:focus:not(:focus-visible) > ellipse,
-.c13:focus:not(:focus-visible) > line,
-.c13:focus:not(:focus-visible) > path,
-.c13:focus:not(:focus-visible) > polygon,
-.c13:focus:not(:focus-visible) > polyline,
-.c13:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c13:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c6 {
+.c5 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c6 > svg {
+.c5 > svg {
   margin: 0 auto;
 }
 
-.c4 {
+.c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5565,19 +7203,19 @@ exports[`Pagination should disable next button if on last page 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c7 {
     width: 2px;
   }
 }
@@ -5590,22 +7228,24 @@ exports[`Pagination should disable next button if on last page 1`] = `
   >
     <nav
       aria-label="Pagination Navigation"
-      class="c2"
+      class="c1"
     >
       <ul
-        class="c3"
+        class="c2"
       >
         <li
-          class="c4"
+          class="c3"
         >
           <button
+            aria-disabled="true"
             aria-label="Go to previous page"
-            class="c5 c6"
+            class="c4 c5"
+            disabled=""
             type="button"
           >
             <svg
               aria-label="Previous"
-              class="c7"
+              class="c6"
               viewBox="0 0 24 24"
             >
               <path
@@ -5618,24 +7258,81 @@ exports[`Pagination should disable next button if on last page 1`] = `
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
+            aria-current="page"
             aria-label="Go to page 1"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             1
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 2"
+            class="c9 c5"
+            type="button"
+          >
+            2
+          </button>
+        </li>
+        <div
+          class="c7"
+        />
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 3"
+            class="c9 c5"
+            type="button"
+          >
+            3
+          </button>
+        </li>
+        <div
+          class="c7"
+        />
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 4"
+            class="c9 c5"
+            type="button"
+          >
+            4
+          </button>
+        </li>
+        <div
+          class="c7"
+        />
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 5"
+            class="c9 c5"
+            type="button"
+          >
+            5
+          </button>
+        </li>
+        <div
+          class="c7"
+        />
+        <li
+          class="c3"
         >
           <span
             class="c10 c11"
@@ -5644,1884 +7341,33 @@ exports[`Pagination should disable next button if on last page 1`] = `
           </span>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
-            aria-label="Go to page 20"
-            class="c9 c6"
-            type="button"
-          >
-            20
-          </button>
-        </li>
-        <div
-          class="c8"
-        />
-        <li
-          class="c4"
-        >
-          <button
-            aria-label="Go to page 21"
-            class="c9 c6"
-            type="button"
-          >
-            21
-          </button>
-        </li>
-        <div
-          class="c8"
-        />
-        <li
-          class="c4"
-        >
-          <button
-            aria-label="Go to page 22"
-            class="c9 c6"
-            type="button"
-          >
-            22
-          </button>
-        </li>
-        <div
-          class="c8"
-        />
-        <li
-          class="c4"
-        >
-          <button
-            aria-label="Go to page 23"
-            class="c9 c6"
-            type="button"
-          >
-            23
-          </button>
-        </li>
-        <div
-          class="c8"
-        />
-        <li
-          class="c4"
-        >
-          <button
-            aria-current="page"
             aria-label="Go to page 24"
-            class="c12 c6"
+            class="c9 c5"
             type="button"
           >
             24
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
-            aria-disabled="true"
             aria-label="Go to next page"
-            class="c13 c6"
-            disabled=""
+            class="c12 c5"
             type="button"
           >
             <svg
               aria-label="Next"
-              class="c14"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="m7 2 10 10L7 22"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </button>
-        </li>
-      </ul>
-    </nav>
-  </div>
-</div>
-`;
-
-exports[`Pagination should disable previous and next controls when numberItems
-  < step 1`] = `
-.c7 {
-  display: inline-block;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
-  fill: #666666;
-  stroke: #666666;
-}
-
-.c7 g {
-  fill: inherit;
-  stroke: inherit;
-}
-
-.c7 *:not([stroke])[fill="none"] {
-  stroke-width: 0;
-}
-
-.c7 *[stroke*="#"],
-.c7 *[STROKE*="#"] {
-  stroke: inherit;
-  fill: none;
-}
-
-.c7 *[fill-rule],
-.c7 *[FILL-RULE],
-.c7 *[fill*="#"],
-.c7 *[FILL*="#"] {
-  fill: inherit;
-  stroke: none;
-}
-
-.c0 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-}
-
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  margin: 0px;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  padding: 0px;
-}
-
-.c8 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  -webkit-align-self: stretch;
-  -ms-flex-item-align: stretch;
-  align-self: stretch;
-  width: 3px;
-}
-
-.c5 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 24px;
-  text-align: center;
-  opacity: 0.3;
-  cursor: default;
-  -webkit-transition-property: color,background-color,border-color,box-shadow;
-  transition-property: color,background-color,border-color,box-shadow;
-  -webkit-transition-duration: 0.1s;
-  transition-duration: 0.1s;
-  -webkit-transition-timing-function: ease-in-out;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
-}
-
-.c5 > svg {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
-  vertical-align: middle;
-}
-
-.c5:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c5:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c5:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c9 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  background-color: rgba(221,221,221,0.4);
-  color: #000000;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 24px;
-  background-color: rgba(51,51,51,0.06274509803921569);
-  color: #444444;
-  text-align: center;
-  -webkit-transition-property: color,background-color,border-color,box-shadow;
-  transition-property: color,background-color,border-color,box-shadow;
-  -webkit-transition-duration: 0.1s;
-  transition-duration: 0.1s;
-  -webkit-transition-timing-function: ease-in-out;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
-}
-
-.c9:hover {
-  background-color: rgba(51,51,51,0.06274509803921569);
-}
-
-.c9:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c9:focus > circle,
-.c9:focus > ellipse,
-.c9:focus > line,
-.c9:focus > path,
-.c9:focus > polygon,
-.c9:focus > polyline,
-.c9:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c9:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c9:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c9:focus:not(:focus-visible) > circle,
-.c9:focus:not(:focus-visible) > ellipse,
-.c9:focus:not(:focus-visible) > line,
-.c9:focus:not(:focus-visible) > path,
-.c9:focus:not(:focus-visible) > polygon,
-.c9:focus:not(:focus-visible) > polyline,
-.c9:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c9:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c6 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c6 > svg {
-  margin: 0 auto;
-}
-
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  max-width: 100%;
-  height: 36px;
-  min-width: 36px;
-}
-
-@media only screen and (max-width:768px) {
-  .c3 {
-    margin: 0px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c3 {
-    padding: 0px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c8 {
-    width: 2px;
-  }
-}
-
-<div
-  class="c0"
->
-  <div
-    class="c1 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
-  >
-    <nav
-      aria-label="Pagination Navigation"
-      class="c2"
-    >
-      <ul
-        class="c3"
-      >
-        <li
-          class="c4"
-        >
-          <button
-            aria-disabled="true"
-            aria-label="Go to previous page"
-            class="c5 c6"
-            disabled=""
-            type="button"
-          >
-            <svg
-              aria-label="Previous"
-              class="c7"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M17 2 7 12l10 10"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </button>
-        </li>
-        <div
-          class="c8"
-        />
-        <li
-          class="c4"
-        >
-          <button
-            aria-current="page"
-            aria-label="Go to page 1"
-            class="c9 c6"
-            type="button"
-          >
-            1
-          </button>
-        </li>
-        <div
-          class="c8"
-        />
-        <li
-          class="c4"
-        >
-          <button
-            aria-disabled="true"
-            aria-label="Go to next page"
-            class="c5 c6"
-            disabled=""
-            type="button"
-          >
-            <svg
-              aria-label="Next"
-              class="c7"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="m7 2 10 10L7 22"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </button>
-        </li>
-      </ul>
-    </nav>
-  </div>
-</div>
-`;
-
-exports[`Pagination should disable previous and next controls when numberItems
-  === 0 1`] = `
-.c7 {
-  display: inline-block;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
-  fill: #666666;
-  stroke: #666666;
-}
-
-.c7 g {
-  fill: inherit;
-  stroke: inherit;
-}
-
-.c7 *:not([stroke])[fill="none"] {
-  stroke-width: 0;
-}
-
-.c7 *[stroke*="#"],
-.c7 *[STROKE*="#"] {
-  stroke: inherit;
-  fill: none;
-}
-
-.c7 *[fill-rule],
-.c7 *[FILL-RULE],
-.c7 *[fill*="#"],
-.c7 *[FILL*="#"] {
-  fill: inherit;
-  stroke: none;
-}
-
-.c0 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-}
-
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  margin: 0px;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  padding: 0px;
-}
-
-.c8 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  -webkit-align-self: stretch;
-  -ms-flex-item-align: stretch;
-  align-self: stretch;
-  width: 3px;
-}
-
-.c5 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 24px;
-  text-align: center;
-  opacity: 0.3;
-  cursor: default;
-  -webkit-transition-property: color,background-color,border-color,box-shadow;
-  transition-property: color,background-color,border-color,box-shadow;
-  -webkit-transition-duration: 0.1s;
-  transition-duration: 0.1s;
-  -webkit-transition-timing-function: ease-in-out;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
-}
-
-.c5 > svg {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
-  vertical-align: middle;
-}
-
-.c5:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c5:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c5:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c6 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c6 > svg {
-  margin: 0 auto;
-}
-
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  max-width: 100%;
-  height: 36px;
-  min-width: 36px;
-}
-
-@media only screen and (max-width:768px) {
-  .c3 {
-    margin: 0px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c3 {
-    padding: 0px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c8 {
-    width: 2px;
-  }
-}
-
-<div
-  class="c0"
->
-  <div
-    class="c1 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
-  >
-    <nav
-      aria-label="Pagination Navigation"
-      class="c2"
-    >
-      <ul
-        class="c3"
-      >
-        <li
-          class="c4"
-        >
-          <button
-            aria-disabled="true"
-            aria-label="Go to previous page"
-            class="c5 c6"
-            disabled=""
-            type="button"
-          >
-            <svg
-              aria-label="Previous"
-              class="c7"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M17 2 7 12l10 10"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </button>
-        </li>
-        <div
-          class="c8"
-        />
-        <li
-          class="c4"
-        >
-          <button
-            aria-label="Go to next page"
-            class="c5 c6"
-            disabled=""
-            type="button"
-          >
-            <svg
-              aria-label="Next"
-              class="c7"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="m7 2 10 10L7 22"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </button>
-        </li>
-      </ul>
-    </nav>
-  </div>
-</div>
-`;
-
-exports[`Pagination should disable previous and next controls when numberItems
-  === step 1`] = `
-.c7 {
-  display: inline-block;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
-  fill: #666666;
-  stroke: #666666;
-}
-
-.c7 g {
-  fill: inherit;
-  stroke: inherit;
-}
-
-.c7 *:not([stroke])[fill="none"] {
-  stroke-width: 0;
-}
-
-.c7 *[stroke*="#"],
-.c7 *[STROKE*="#"] {
-  stroke: inherit;
-  fill: none;
-}
-
-.c7 *[fill-rule],
-.c7 *[FILL-RULE],
-.c7 *[fill*="#"],
-.c7 *[FILL*="#"] {
-  fill: inherit;
-  stroke: none;
-}
-
-.c0 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-}
-
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  margin: 0px;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  padding: 0px;
-}
-
-.c8 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  -webkit-align-self: stretch;
-  -ms-flex-item-align: stretch;
-  align-self: stretch;
-  width: 3px;
-}
-
-.c5 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 24px;
-  text-align: center;
-  opacity: 0.3;
-  cursor: default;
-  -webkit-transition-property: color,background-color,border-color,box-shadow;
-  transition-property: color,background-color,border-color,box-shadow;
-  -webkit-transition-duration: 0.1s;
-  transition-duration: 0.1s;
-  -webkit-transition-timing-function: ease-in-out;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
-}
-
-.c5 > svg {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
-  vertical-align: middle;
-}
-
-.c5:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c5:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c5:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c9 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  background-color: rgba(221,221,221,0.4);
-  color: #000000;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 24px;
-  background-color: rgba(51,51,51,0.06274509803921569);
-  color: #444444;
-  text-align: center;
-  -webkit-transition-property: color,background-color,border-color,box-shadow;
-  transition-property: color,background-color,border-color,box-shadow;
-  -webkit-transition-duration: 0.1s;
-  transition-duration: 0.1s;
-  -webkit-transition-timing-function: ease-in-out;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
-}
-
-.c9:hover {
-  background-color: rgba(51,51,51,0.06274509803921569);
-}
-
-.c9:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c9:focus > circle,
-.c9:focus > ellipse,
-.c9:focus > line,
-.c9:focus > path,
-.c9:focus > polygon,
-.c9:focus > polyline,
-.c9:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c9:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c9:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c9:focus:not(:focus-visible) > circle,
-.c9:focus:not(:focus-visible) > ellipse,
-.c9:focus:not(:focus-visible) > line,
-.c9:focus:not(:focus-visible) > path,
-.c9:focus:not(:focus-visible) > polygon,
-.c9:focus:not(:focus-visible) > polyline,
-.c9:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c9:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c6 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c6 > svg {
-  margin: 0 auto;
-}
-
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  max-width: 100%;
-  height: 36px;
-  min-width: 36px;
-}
-
-@media only screen and (max-width:768px) {
-  .c3 {
-    margin: 0px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c3 {
-    padding: 0px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c8 {
-    width: 2px;
-  }
-}
-
-<div
-  class="c0"
->
-  <div
-    class="c1 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
-  >
-    <nav
-      aria-label="Pagination Navigation"
-      class="c2"
-    >
-      <ul
-        class="c3"
-      >
-        <li
-          class="c4"
-        >
-          <button
-            aria-disabled="true"
-            aria-label="Go to previous page"
-            class="c5 c6"
-            disabled=""
-            type="button"
-          >
-            <svg
-              aria-label="Previous"
-              class="c7"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M17 2 7 12l10 10"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </button>
-        </li>
-        <div
-          class="c8"
-        />
-        <li
-          class="c4"
-        >
-          <button
-            aria-current="page"
-            aria-label="Go to page 1"
-            class="c9 c6"
-            type="button"
-          >
-            1
-          </button>
-        </li>
-        <div
-          class="c8"
-        />
-        <li
-          class="c4"
-        >
-          <button
-            aria-disabled="true"
-            aria-label="Go to next page"
-            class="c5 c6"
-            disabled=""
-            type="button"
-          >
-            <svg
-              aria-label="Next"
-              class="c7"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="m7 2 10 10L7 22"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </button>
-        </li>
-      </ul>
-    </nav>
-  </div>
-</div>
-`;
-
-exports[`Pagination should disable previous button if on first page 1`] = `
-.c7 {
-  display: inline-block;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
-  fill: #666666;
-  stroke: #666666;
-}
-
-.c7 g {
-  fill: inherit;
-  stroke: inherit;
-}
-
-.c7 *:not([stroke])[fill="none"] {
-  stroke-width: 0;
-}
-
-.c7 *[stroke*="#"],
-.c7 *[STROKE*="#"] {
-  stroke: inherit;
-  fill: none;
-}
-
-.c7 *[fill-rule],
-.c7 *[FILL-RULE],
-.c7 *[fill*="#"],
-.c7 *[FILL*="#"] {
-  fill: inherit;
-  stroke: none;
-}
-
-.c14 {
-  display: inline-block;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
-  fill: #000000;
-  stroke: #000000;
-}
-
-.c14 g {
-  fill: inherit;
-  stroke: inherit;
-}
-
-.c14 *:not([stroke])[fill="none"] {
-  stroke-width: 0;
-}
-
-.c14 *[stroke*="#"],
-.c14 *[STROKE*="#"] {
-  stroke: inherit;
-  fill: none;
-}
-
-.c14 *[fill-rule],
-.c14 *[FILL-RULE],
-.c14 *[fill*="#"],
-.c14 *[FILL*="#"] {
-  fill: inherit;
-  stroke: none;
-}
-
-.c0 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-}
-
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  margin: 0px;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  padding: 0px;
-}
-
-.c8 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  -webkit-align-self: stretch;
-  -ms-flex-item-align: stretch;
-  align-self: stretch;
-  width: 3px;
-}
-
-.c11 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c5 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 24px;
-  text-align: center;
-  opacity: 0.3;
-  cursor: default;
-  -webkit-transition-property: color,background-color,border-color,box-shadow;
-  transition-property: color,background-color,border-color,box-shadow;
-  -webkit-transition-duration: 0.1s;
-  transition-duration: 0.1s;
-  -webkit-transition-timing-function: ease-in-out;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
-}
-
-.c5 > svg {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
-  vertical-align: middle;
-}
-
-.c5:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c5:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c5:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c9 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  background-color: rgba(221,221,221,0.4);
-  color: #000000;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 24px;
-  background-color: rgba(51,51,51,0.06274509803921569);
-  color: #444444;
-  text-align: center;
-  -webkit-transition-property: color,background-color,border-color,box-shadow;
-  transition-property: color,background-color,border-color,box-shadow;
-  -webkit-transition-duration: 0.1s;
-  transition-duration: 0.1s;
-  -webkit-transition-timing-function: ease-in-out;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
-}
-
-.c9:hover {
-  background-color: rgba(51,51,51,0.06274509803921569);
-}
-
-.c9:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c9:focus > circle,
-.c9:focus > ellipse,
-.c9:focus > line,
-.c9:focus > path,
-.c9:focus > polygon,
-.c9:focus > polyline,
-.c9:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c9:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c9:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c9:focus:not(:focus-visible) > circle,
-.c9:focus:not(:focus-visible) > ellipse,
-.c9:focus:not(:focus-visible) > line,
-.c9:focus:not(:focus-visible) > path,
-.c9:focus:not(:focus-visible) > polygon,
-.c9:focus:not(:focus-visible) > polyline,
-.c9:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c9:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c10 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 24px;
-  color: #000000;
-  text-align: center;
-  -webkit-transition-property: color,background-color,border-color,box-shadow;
-  transition-property: color,background-color,border-color,box-shadow;
-  -webkit-transition-duration: 0.1s;
-  transition-duration: 0.1s;
-  -webkit-transition-timing-function: ease-in-out;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
-}
-
-.c10:hover {
-  background-color: rgba(51,51,51,0.06274509803921569);
-}
-
-.c10:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c10:focus > circle,
-.c10:focus > ellipse,
-.c10:focus > line,
-.c10:focus > path,
-.c10:focus > polygon,
-.c10:focus > polyline,
-.c10:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c10:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c10:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c10:focus:not(:focus-visible) > circle,
-.c10:focus:not(:focus-visible) > ellipse,
-.c10:focus:not(:focus-visible) > line,
-.c10:focus:not(:focus-visible) > path,
-.c10:focus:not(:focus-visible) > polygon,
-.c10:focus:not(:focus-visible) > polyline,
-.c10:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c10:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c13 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 24px;
-  color: #000000;
-  text-align: center;
-  -webkit-transition-property: color,background-color,border-color,box-shadow;
-  transition-property: color,background-color,border-color,box-shadow;
-  -webkit-transition-duration: 0.1s;
-  transition-duration: 0.1s;
-  -webkit-transition-timing-function: ease-in-out;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
-}
-
-.c13 > svg {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
-  vertical-align: middle;
-}
-
-.c13:hover {
-  background-color: rgba(51,51,51,0.06274509803921569);
-}
-
-.c13:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c13:focus > circle,
-.c13:focus > ellipse,
-.c13:focus > line,
-.c13:focus > path,
-.c13:focus > polygon,
-.c13:focus > polyline,
-.c13:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c13:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c13:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c13:focus:not(:focus-visible) > circle,
-.c13:focus:not(:focus-visible) > ellipse,
-.c13:focus:not(:focus-visible) > line,
-.c13:focus:not(:focus-visible) > path,
-.c13:focus:not(:focus-visible) > polygon,
-.c13:focus:not(:focus-visible) > polyline,
-.c13:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c13:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c6 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c6 > svg {
-  margin: 0 auto;
-}
-
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  max-width: 100%;
-  height: 36px;
-  min-width: 36px;
-}
-
-.c12 {
-  font-weight: bold;
-  font-size: 18px;
-  line-height: 24px;
-}
-
-@media only screen and (max-width:768px) {
-  .c3 {
-    margin: 0px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c3 {
-    padding: 0px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c8 {
-    width: 2px;
-  }
-}
-
-<div
-  class="c0"
->
-  <div
-    class="c1 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
-  >
-    <nav
-      aria-label="Pagination Navigation"
-      class="c2"
-    >
-      <ul
-        class="c3"
-      >
-        <li
-          class="c4"
-        >
-          <button
-            aria-disabled="true"
-            aria-label="Go to previous page"
-            class="c5 c6"
-            disabled=""
-            type="button"
-          >
-            <svg
-              aria-label="Previous"
-              class="c7"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M17 2 7 12l10 10"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </button>
-        </li>
-        <div
-          class="c8"
-        />
-        <li
-          class="c4"
-        >
-          <button
-            aria-current="page"
-            aria-label="Go to page 1"
-            class="c9 c6"
-            type="button"
-          >
-            1
-          </button>
-        </li>
-        <div
-          class="c8"
-        />
-        <li
-          class="c4"
-        >
-          <button
-            aria-label="Go to page 2"
-            class="c10 c6"
-            type="button"
-          >
-            2
-          </button>
-        </li>
-        <div
-          class="c8"
-        />
-        <li
-          class="c4"
-        >
-          <button
-            aria-label="Go to page 3"
-            class="c10 c6"
-            type="button"
-          >
-            3
-          </button>
-        </li>
-        <div
-          class="c8"
-        />
-        <li
-          class="c4"
-        >
-          <button
-            aria-label="Go to page 4"
-            class="c10 c6"
-            type="button"
-          >
-            4
-          </button>
-        </li>
-        <div
-          class="c8"
-        />
-        <li
-          class="c4"
-        >
-          <button
-            aria-label="Go to page 5"
-            class="c10 c6"
-            type="button"
-          >
-            5
-          </button>
-        </li>
-        <div
-          class="c8"
-        />
-        <li
-          class="c4"
-        >
-          <span
-            class="c11 c12"
-          >
-            …
-          </span>
-        </li>
-        <div
-          class="c8"
-        />
-        <li
-          class="c4"
-        >
-          <button
-            aria-label="Go to page 24"
-            class="c10 c6"
-            type="button"
-          >
-            24
-          </button>
-        </li>
-        <div
-          class="c8"
-        />
-        <li
-          class="c4"
-        >
-          <button
-            aria-label="Go to next page"
-            class="c13 c6"
-            type="button"
-          >
-            <svg
-              aria-label="Next"
-              class="c14"
+              class="c13"
               viewBox="0 0 24 24"
             >
               <path
@@ -7541,7 +7387,7 @@ exports[`Pagination should disable previous button if on first page 1`] = `
 
 exports[`Pagination should display next page of results when "next" is
   selected 1`] = `
-.c7 {
+.c6 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -7552,25 +7398,25 @@ exports[`Pagination should display next page of results when "next" is
   stroke: #000000;
 }
 
-.c7 g {
+.c6 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c7 *:not([stroke])[fill="none"] {
+.c6 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c7 *[stroke*="#"],
-.c7 *[STROKE*="#"] {
+.c6 *[stroke*="#"],
+.c6 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c7 *[fill-rule],
-.c7 *[FILL-RULE],
-.c7 *[fill*="#"],
-.c7 *[FILL*="#"] {
+.c6 *[fill-rule],
+.c6 *[FILL-RULE],
+.c6 *[fill*="#"],
+.c6 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -7597,26 +7443,12 @@ exports[`Pagination should display next page of results when "next" is
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-}
-
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
 }
 
-.c3 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7636,7 +7468,7 @@ exports[`Pagination should display next page of results when "next" is
   padding: 0px;
 }
 
-.c8 {
+.c7 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -7646,12 +7478,12 @@ exports[`Pagination should display next page of results when "next" is
   width: 3px;
 }
 
-.c11 {
+.c10 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c10 {
+.c9 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -7671,82 +7503,6 @@ exports[`Pagination should display next page of results when "next" is
   line-height: 24px;
   background-color: rgba(51,51,51,0.06274509803921569);
   color: #444444;
-  text-align: center;
-  -webkit-transition-property: color,background-color,border-color,box-shadow;
-  transition-property: color,background-color,border-color,box-shadow;
-  -webkit-transition-duration: 0.1s;
-  transition-duration: 0.1s;
-  -webkit-transition-timing-function: ease-in-out;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
-}
-
-.c10:hover {
-  background-color: rgba(51,51,51,0.06274509803921569);
-}
-
-.c10:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c10:focus > circle,
-.c10:focus > ellipse,
-.c10:focus > line,
-.c10:focus > path,
-.c10:focus > polygon,
-.c10:focus > polyline,
-.c10:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c10:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c10:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c10:focus:not(:focus-visible) > circle,
-.c10:focus:not(:focus-visible) > ellipse,
-.c10:focus:not(:focus-visible) > line,
-.c10:focus:not(:focus-visible) > path,
-.c10:focus:not(:focus-visible) > polygon,
-.c10:focus:not(:focus-visible) > polyline,
-.c10:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c10:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c9 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 24px;
-  color: #000000;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
   transition-property: color,background-color,border-color,box-shadow;
@@ -7806,7 +7562,7 @@ exports[`Pagination should display next page of results when "next" is
   border: 0;
 }
 
-.c5 {
+.c8 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -7838,7 +7594,83 @@ exports[`Pagination should display next page of results when "next" is
   flex: 1 0 auto;
 }
 
-.c5 > svg {
+.c8:hover {
+  background-color: rgba(51,51,51,0.06274509803921569);
+}
+
+.c8:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus > circle,
+.c8:focus > ellipse,
+.c8:focus > line,
+.c8:focus > path,
+.c8:focus > polygon,
+.c8:focus > polyline,
+.c8:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c8:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c8:focus:not(:focus-visible) > circle,
+.c8:focus:not(:focus-visible) > ellipse,
+.c8:focus:not(:focus-visible) > line,
+.c8:focus:not(:focus-visible) > path,
+.c8:focus:not(:focus-visible) > polygon,
+.c8:focus:not(:focus-visible) > polyline,
+.c8:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c8:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c4 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  color: #000000;
+  text-align: center;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c4 > svg {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7849,60 +7681,60 @@ exports[`Pagination should display next page of results when "next" is
   vertical-align: middle;
 }
 
-.c5:hover {
+.c4:hover {
   background-color: rgba(51,51,51,0.06274509803921569);
 }
 
-.c5:focus {
+.c4:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c4:focus > circle,
+.c4:focus > ellipse,
+.c4:focus > line,
+.c4:focus > path,
+.c4:focus > polygon,
+.c4:focus > polyline,
+.c4:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c4:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c4:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c4:focus:not(:focus-visible) > circle,
+.c4:focus:not(:focus-visible) > ellipse,
+.c4:focus:not(:focus-visible) > line,
+.c4:focus:not(:focus-visible) > path,
+.c4:focus:not(:focus-visible) > polygon,
+.c4:focus:not(:focus-visible) > polyline,
+.c4:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c4:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c6 {
+.c5 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c6 > svg {
+.c5 > svg {
   margin: 0 auto;
 }
 
-.c4 {
+.c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7920,26 +7752,26 @@ exports[`Pagination should display next page of results when "next" is
   min-width: 36px;
 }
 
-.c12 {
+.c11 {
   font-weight: bold;
   font-size: 18px;
   line-height: 24px;
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c7 {
     width: 2px;
   }
 }
@@ -7952,22 +7784,22 @@ exports[`Pagination should display next page of results when "next" is
   >
     <nav
       aria-label="Pagination Navigation"
-      class="c2"
+      class="c1"
     >
       <ul
-        class="c3"
+        class="c2"
       >
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to previous page"
-            class="c5 c6"
+            class="c4 c5"
             type="button"
           >
             <svg
               aria-label="Previous"
-              class="c7"
+              class="c6"
               viewBox="0 0 24 24"
             >
               <path
@@ -7980,116 +7812,116 @@ exports[`Pagination should display next page of results when "next" is
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 1"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             1
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-current="page"
             aria-label="Go to page 2"
-            class="c10 c6"
+            class="c9 c5"
             type="button"
           >
             2
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 3"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             3
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 4"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             4
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 5"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             5
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <span
-            class="c11 c12"
+            class="c10 c11"
           >
             …
           </span>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 24"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             24
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to next page"
-            class="c5 c6"
+            class="c4 c5"
             type="button"
           >
             <svg
               aria-label="Next"
-              class="c7"
+              class="c6"
               viewBox="0 0 24 24"
             >
               <path
@@ -8113,7 +7945,7 @@ exports[`Pagination should display next page of results when "next" is
   class="StyledGrommet-sc-19lkkz7-0 ioQEen"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 hUSFEE Pagination__StyledPaginationContainer-sc-rnlw6m-0"
+    class="StyledBox-sc-13pk1d4-0 jKAhip Pagination__StyledPaginationContainer-sc-rnlw6m-0"
   >
     <nav
       aria-label="Pagination Navigation"
@@ -8274,7 +8106,7 @@ exports[`Pagination should display next page of results when "next" is
 
 exports[`Pagination should display page 'n' of results when "page n" is
   selected 1`] = `
-.c7 {
+.c6 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -8285,25 +8117,25 @@ exports[`Pagination should display page 'n' of results when "page n" is
   stroke: #000000;
 }
 
-.c7 g {
+.c6 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c7 *:not([stroke])[fill="none"] {
+.c6 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c7 *[stroke*="#"],
-.c7 *[STROKE*="#"] {
+.c6 *[stroke*="#"],
+.c6 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c7 *[fill-rule],
-.c7 *[FILL-RULE],
-.c7 *[fill*="#"],
-.c7 *[FILL*="#"] {
+.c6 *[fill-rule],
+.c6 *[FILL-RULE],
+.c6 *[fill*="#"],
+.c6 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -8330,26 +8162,12 @@ exports[`Pagination should display page 'n' of results when "page n" is
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-}
-
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
 }
 
-.c3 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8369,7 +8187,7 @@ exports[`Pagination should display page 'n' of results when "page n" is
   padding: 0px;
 }
 
-.c8 {
+.c7 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -8379,12 +8197,12 @@ exports[`Pagination should display page 'n' of results when "page n" is
   width: 3px;
 }
 
-.c11 {
+.c10 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c10 {
+.c9 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -8404,82 +8222,6 @@ exports[`Pagination should display page 'n' of results when "page n" is
   line-height: 24px;
   background-color: rgba(51,51,51,0.06274509803921569);
   color: #444444;
-  text-align: center;
-  -webkit-transition-property: color,background-color,border-color,box-shadow;
-  transition-property: color,background-color,border-color,box-shadow;
-  -webkit-transition-duration: 0.1s;
-  transition-duration: 0.1s;
-  -webkit-transition-timing-function: ease-in-out;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
-}
-
-.c10:hover {
-  background-color: rgba(51,51,51,0.06274509803921569);
-}
-
-.c10:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c10:focus > circle,
-.c10:focus > ellipse,
-.c10:focus > line,
-.c10:focus > path,
-.c10:focus > polygon,
-.c10:focus > polyline,
-.c10:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c10:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c10:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c10:focus:not(:focus-visible) > circle,
-.c10:focus:not(:focus-visible) > ellipse,
-.c10:focus:not(:focus-visible) > line,
-.c10:focus:not(:focus-visible) > path,
-.c10:focus:not(:focus-visible) > polygon,
-.c10:focus:not(:focus-visible) > polyline,
-.c10:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c10:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c9 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 24px;
-  color: #000000;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
   transition-property: color,background-color,border-color,box-shadow;
@@ -8539,7 +8281,7 @@ exports[`Pagination should display page 'n' of results when "page n" is
   border: 0;
 }
 
-.c5 {
+.c8 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -8571,7 +8313,83 @@ exports[`Pagination should display page 'n' of results when "page n" is
   flex: 1 0 auto;
 }
 
-.c5 > svg {
+.c8:hover {
+  background-color: rgba(51,51,51,0.06274509803921569);
+}
+
+.c8:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus > circle,
+.c8:focus > ellipse,
+.c8:focus > line,
+.c8:focus > path,
+.c8:focus > polygon,
+.c8:focus > polyline,
+.c8:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c8:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c8:focus:not(:focus-visible) > circle,
+.c8:focus:not(:focus-visible) > ellipse,
+.c8:focus:not(:focus-visible) > line,
+.c8:focus:not(:focus-visible) > path,
+.c8:focus:not(:focus-visible) > polygon,
+.c8:focus:not(:focus-visible) > polyline,
+.c8:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c8:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c4 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  color: #000000;
+  text-align: center;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c4 > svg {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8582,60 +8400,60 @@ exports[`Pagination should display page 'n' of results when "page n" is
   vertical-align: middle;
 }
 
-.c5:hover {
+.c4:hover {
   background-color: rgba(51,51,51,0.06274509803921569);
 }
 
-.c5:focus {
+.c4:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c4:focus > circle,
+.c4:focus > ellipse,
+.c4:focus > line,
+.c4:focus > path,
+.c4:focus > polygon,
+.c4:focus > polyline,
+.c4:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c4:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c4:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c4:focus:not(:focus-visible) > circle,
+.c4:focus:not(:focus-visible) > ellipse,
+.c4:focus:not(:focus-visible) > line,
+.c4:focus:not(:focus-visible) > path,
+.c4:focus:not(:focus-visible) > polygon,
+.c4:focus:not(:focus-visible) > polyline,
+.c4:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c4:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c6 {
+.c5 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c6 > svg {
+.c5 > svg {
   margin: 0 auto;
 }
 
-.c4 {
+.c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8653,26 +8471,26 @@ exports[`Pagination should display page 'n' of results when "page n" is
   min-width: 36px;
 }
 
-.c12 {
+.c11 {
   font-weight: bold;
   font-size: 18px;
   line-height: 24px;
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c7 {
     width: 2px;
   }
 }
@@ -8685,22 +8503,22 @@ exports[`Pagination should display page 'n' of results when "page n" is
   >
     <nav
       aria-label="Pagination Navigation"
-      class="c2"
+      class="c1"
     >
       <ul
-        class="c3"
+        class="c2"
       >
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to previous page"
-            class="c5 c6"
+            class="c4 c5"
             type="button"
           >
             <svg
               aria-label="Previous"
-              class="c7"
+              class="c6"
               viewBox="0 0 24 24"
             >
               <path
@@ -8713,116 +8531,116 @@ exports[`Pagination should display page 'n' of results when "page n" is
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 1"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             1
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-current="page"
             aria-label="Go to page 2"
-            class="c10 c6"
+            class="c9 c5"
             type="button"
           >
             2
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 3"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             3
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 4"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             4
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 5"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             5
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <span
-            class="c11 c12"
+            class="c10 c11"
           >
             …
           </span>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 24"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             24
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to next page"
-            class="c5 c6"
+            class="c4 c5"
             type="button"
           >
             <svg
               aria-label="Next"
-              class="c7"
+              class="c6"
               viewBox="0 0 24 24"
             >
               <path
@@ -8842,7 +8660,7 @@ exports[`Pagination should display page 'n' of results when "page n" is
 
 exports[`Pagination should display previous page of results when "previous" is
   selected 1`] = `
-.c7 {
+.c6 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -8853,25 +8671,25 @@ exports[`Pagination should display previous page of results when "previous" is
   stroke: #000000;
 }
 
-.c7 g {
+.c6 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c7 *:not([stroke])[fill="none"] {
+.c6 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c7 *[stroke*="#"],
-.c7 *[STROKE*="#"] {
+.c6 *[stroke*="#"],
+.c6 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c7 *[fill-rule],
-.c7 *[FILL-RULE],
-.c7 *[fill*="#"],
-.c7 *[FILL*="#"] {
+.c6 *[fill-rule],
+.c6 *[FILL-RULE],
+.c6 *[fill*="#"],
+.c6 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -8898,26 +8716,12 @@ exports[`Pagination should display previous page of results when "previous" is
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-}
-
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
 }
 
-.c3 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8937,7 +8741,7 @@ exports[`Pagination should display previous page of results when "previous" is
   padding: 0px;
 }
 
-.c8 {
+.c7 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -8947,12 +8751,12 @@ exports[`Pagination should display previous page of results when "previous" is
   width: 3px;
 }
 
-.c11 {
+.c10 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c5 {
+.c4 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -8984,7 +8788,7 @@ exports[`Pagination should display previous page of results when "previous" is
   flex: 1 0 auto;
 }
 
-.c5 > svg {
+.c4 > svg {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8995,51 +8799,51 @@ exports[`Pagination should display previous page of results when "previous" is
   vertical-align: middle;
 }
 
-.c5:hover {
+.c4:hover {
   background-color: rgba(51,51,51,0.06274509803921569);
 }
 
-.c5:focus {
+.c4:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c4:focus > circle,
+.c4:focus > ellipse,
+.c4:focus > line,
+.c4:focus > path,
+.c4:focus > polygon,
+.c4:focus > polyline,
+.c4:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c4:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c4:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c4:focus:not(:focus-visible) > circle,
+.c4:focus:not(:focus-visible) > ellipse,
+.c4:focus:not(:focus-visible) > line,
+.c4:focus:not(:focus-visible) > path,
+.c4:focus:not(:focus-visible) > polygon,
+.c4:focus:not(:focus-visible) > polyline,
+.c4:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c4:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c9 {
+.c8 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -9056,6 +8860,85 @@ exports[`Pagination should display previous page of results when "previous" is
   font-size: 18px;
   line-height: 24px;
   color: #000000;
+  text-align: center;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c8:hover {
+  background-color: rgba(51,51,51,0.06274509803921569);
+}
+
+.c8:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus > circle,
+.c8:focus > ellipse,
+.c8:focus > line,
+.c8:focus > path,
+.c8:focus > polygon,
+.c8:focus > polyline,
+.c8:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c8:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c8:focus:not(:focus-visible) > circle,
+.c8:focus:not(:focus-visible) > ellipse,
+.c8:focus:not(:focus-visible) > line,
+.c8:focus:not(:focus-visible) > path,
+.c8:focus:not(:focus-visible) > polygon,
+.c8:focus:not(:focus-visible) > polyline,
+.c8:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c8:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c9 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  background-color: rgba(51,51,51,0.06274509803921569);
+  color: #444444;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
   transition-property: color,background-color,border-color,box-shadow;
@@ -9115,95 +8998,16 @@ exports[`Pagination should display previous page of results when "previous" is
   border: 0;
 }
 
-.c10 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  background-color: rgba(221,221,221,0.4);
-  color: #000000;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 24px;
-  background-color: rgba(51,51,51,0.06274509803921569);
-  color: #444444;
-  text-align: center;
-  -webkit-transition-property: color,background-color,border-color,box-shadow;
-  transition-property: color,background-color,border-color,box-shadow;
-  -webkit-transition-duration: 0.1s;
-  transition-duration: 0.1s;
-  -webkit-transition-timing-function: ease-in-out;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
-}
-
-.c10:hover {
-  background-color: rgba(51,51,51,0.06274509803921569);
-}
-
-.c10:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c10:focus > circle,
-.c10:focus > ellipse,
-.c10:focus > line,
-.c10:focus > path,
-.c10:focus > polygon,
-.c10:focus > polyline,
-.c10:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c10:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c10:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c10:focus:not(:focus-visible) > circle,
-.c10:focus:not(:focus-visible) > ellipse,
-.c10:focus:not(:focus-visible) > line,
-.c10:focus:not(:focus-visible) > path,
-.c10:focus:not(:focus-visible) > polygon,
-.c10:focus:not(:focus-visible) > polyline,
-.c10:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c10:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c6 {
+.c5 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c6 > svg {
+.c5 > svg {
   margin: 0 auto;
 }
 
-.c4 {
+.c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -9221,26 +9025,26 @@ exports[`Pagination should display previous page of results when "previous" is
   min-width: 36px;
 }
 
-.c12 {
+.c11 {
   font-weight: bold;
   font-size: 18px;
   line-height: 24px;
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c7 {
     width: 2px;
   }
 }
@@ -9253,22 +9057,22 @@ exports[`Pagination should display previous page of results when "previous" is
   >
     <nav
       aria-label="Pagination Navigation"
-      class="c2"
+      class="c1"
     >
       <ul
-        class="c3"
+        class="c2"
       >
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to previous page"
-            class="c5 c6"
+            class="c4 c5"
             type="button"
           >
             <svg
               aria-label="Previous"
-              class="c7"
+              class="c6"
               viewBox="0 0 24 24"
             >
               <path
@@ -9281,116 +9085,116 @@ exports[`Pagination should display previous page of results when "previous" is
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 1"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             1
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-current="page"
             aria-label="Go to page 2"
-            class="c10 c6"
+            class="c9 c5"
             type="button"
           >
             2
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 3"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             3
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 4"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             4
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 5"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             5
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <span
-            class="c11 c12"
+            class="c10 c11"
           >
             …
           </span>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 24"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             24
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to next page"
-            class="c5 c6"
+            class="c4 c5"
             type="button"
           >
             <svg
               aria-label="Next"
-              class="c7"
+              class="c6"
               viewBox="0 0 24 24"
             >
               <path
@@ -9414,7 +9218,7 @@ exports[`Pagination should display previous page of results when "previous" is
   class="StyledGrommet-sc-19lkkz7-0 ioQEen"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 hUSFEE Pagination__StyledPaginationContainer-sc-rnlw6m-0"
+    class="StyledBox-sc-13pk1d4-0 jKAhip Pagination__StyledPaginationContainer-sc-rnlw6m-0"
   >
     <nav
       aria-label="Pagination Navigation"
@@ -9575,7 +9379,7 @@ exports[`Pagination should display previous page of results when "previous" is
 
 exports[`Pagination should display the correct last page based on items length
   and step 1`] = `
-.c7 {
+.c6 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -9586,30 +9390,30 @@ exports[`Pagination should display the correct last page based on items length
   stroke: #666666;
 }
 
-.c7 g {
+.c6 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c7 *:not([stroke])[fill="none"] {
+.c6 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c7 *[stroke*="#"],
-.c7 *[STROKE*="#"] {
+.c6 *[stroke*="#"],
+.c6 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c7 *[fill-rule],
-.c7 *[FILL-RULE],
-.c7 *[fill*="#"],
-.c7 *[FILL*="#"] {
+.c6 *[fill-rule],
+.c6 *[FILL-RULE],
+.c6 *[fill*="#"],
+.c6 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
 
-.c14 {
+.c13 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -9620,25 +9424,25 @@ exports[`Pagination should display the correct last page based on items length
   stroke: #000000;
 }
 
-.c14 g {
+.c13 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c14 *:not([stroke])[fill="none"] {
+.c13 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c14 *[stroke*="#"],
-.c14 *[STROKE*="#"] {
+.c13 *[stroke*="#"],
+.c13 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c14 *[fill-rule],
-.c14 *[FILL-RULE],
-.c14 *[fill*="#"],
-.c14 *[FILL*="#"] {
+.c13 *[fill-rule],
+.c13 *[FILL-RULE],
+.c13 *[fill*="#"],
+.c13 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -9665,26 +9469,12 @@ exports[`Pagination should display the correct last page based on items length
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-}
-
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
 }
 
-.c3 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -9704,7 +9494,7 @@ exports[`Pagination should display the correct last page based on items length
   padding: 0px;
 }
 
-.c8 {
+.c7 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -9714,12 +9504,12 @@ exports[`Pagination should display the correct last page based on items length
   width: 3px;
 }
 
-.c11 {
+.c10 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c5 {
+.c4 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -9752,7 +9542,7 @@ exports[`Pagination should display the correct last page based on items length
   flex: 1 0 auto;
 }
 
-.c5 > svg {
+.c4 > svg {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -9763,47 +9553,47 @@ exports[`Pagination should display the correct last page based on items length
   vertical-align: middle;
 }
 
-.c5:focus {
+.c4:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c4:focus > circle,
+.c4:focus > ellipse,
+.c4:focus > line,
+.c4:focus > path,
+.c4:focus > polygon,
+.c4:focus > polyline,
+.c4:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c4:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c4:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c4:focus:not(:focus-visible) > circle,
+.c4:focus:not(:focus-visible) > ellipse,
+.c4:focus:not(:focus-visible) > line,
+.c4:focus:not(:focus-visible) > path,
+.c4:focus:not(:focus-visible) > polygon,
+.c4:focus:not(:focus-visible) > polyline,
+.c4:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c4:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c9 {
+.c8 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -9823,6 +9613,82 @@ exports[`Pagination should display the correct last page based on items length
   line-height: 24px;
   background-color: rgba(51,51,51,0.06274509803921569);
   color: #444444;
+  text-align: center;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c8:hover {
+  background-color: rgba(51,51,51,0.06274509803921569);
+}
+
+.c8:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus > circle,
+.c8:focus > ellipse,
+.c8:focus > line,
+.c8:focus > path,
+.c8:focus > polygon,
+.c8:focus > polyline,
+.c8:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c8:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c8:focus:not(:focus-visible) > circle,
+.c8:focus:not(:focus-visible) > ellipse,
+.c8:focus:not(:focus-visible) > line,
+.c8:focus:not(:focus-visible) > path,
+.c8:focus:not(:focus-visible) > polygon,
+.c8:focus:not(:focus-visible) > polyline,
+.c8:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c8:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c9 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  color: #000000;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
   transition-property: color,background-color,border-color,box-shadow;
@@ -9882,7 +9748,7 @@ exports[`Pagination should display the correct last page based on items length
   border: 0;
 }
 
-.c10 {
+.c12 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -9914,83 +9780,7 @@ exports[`Pagination should display the correct last page based on items length
   flex: 1 0 auto;
 }
 
-.c10:hover {
-  background-color: rgba(51,51,51,0.06274509803921569);
-}
-
-.c10:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c10:focus > circle,
-.c10:focus > ellipse,
-.c10:focus > line,
-.c10:focus > path,
-.c10:focus > polygon,
-.c10:focus > polyline,
-.c10:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c10:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c10:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c10:focus:not(:focus-visible) > circle,
-.c10:focus:not(:focus-visible) > ellipse,
-.c10:focus:not(:focus-visible) > line,
-.c10:focus:not(:focus-visible) > path,
-.c10:focus:not(:focus-visible) > polygon,
-.c10:focus:not(:focus-visible) > polyline,
-.c10:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c10:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c13 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 24px;
-  color: #000000;
-  text-align: center;
-  -webkit-transition-property: color,background-color,border-color,box-shadow;
-  transition-property: color,background-color,border-color,box-shadow;
-  -webkit-transition-duration: 0.1s;
-  transition-duration: 0.1s;
-  -webkit-transition-timing-function: ease-in-out;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
-}
-
-.c13 > svg {
+.c12 > svg {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -10001,60 +9791,60 @@ exports[`Pagination should display the correct last page based on items length
   vertical-align: middle;
 }
 
-.c13:hover {
+.c12:hover {
   background-color: rgba(51,51,51,0.06274509803921569);
 }
 
-.c13:focus {
+.c12:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus > circle,
-.c13:focus > ellipse,
-.c13:focus > line,
-.c13:focus > path,
-.c13:focus > polygon,
-.c13:focus > polyline,
-.c13:focus > rect {
+.c12:focus > circle,
+.c12:focus > ellipse,
+.c12:focus > line,
+.c12:focus > path,
+.c12:focus > polygon,
+.c12:focus > polyline,
+.c12:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus::-moz-focus-inner {
+.c12:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c13:focus:not(:focus-visible) {
+.c12:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible) > circle,
-.c13:focus:not(:focus-visible) > ellipse,
-.c13:focus:not(:focus-visible) > line,
-.c13:focus:not(:focus-visible) > path,
-.c13:focus:not(:focus-visible) > polygon,
-.c13:focus:not(:focus-visible) > polyline,
-.c13:focus:not(:focus-visible) > rect {
+.c12:focus:not(:focus-visible) > circle,
+.c12:focus:not(:focus-visible) > ellipse,
+.c12:focus:not(:focus-visible) > line,
+.c12:focus:not(:focus-visible) > path,
+.c12:focus:not(:focus-visible) > polygon,
+.c12:focus:not(:focus-visible) > polyline,
+.c12:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible)::-moz-focus-inner {
+.c12:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c6 {
+.c5 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c6 > svg {
+.c5 > svg {
   margin: 0 auto;
 }
 
-.c4 {
+.c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -10072,26 +9862,26 @@ exports[`Pagination should display the correct last page based on items length
   min-width: 36px;
 }
 
-.c12 {
+.c11 {
   font-weight: bold;
   font-size: 18px;
   line-height: 24px;
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c7 {
     width: 2px;
   }
 }
@@ -10104,24 +9894,24 @@ exports[`Pagination should display the correct last page based on items length
   >
     <nav
       aria-label="Pagination Navigation"
-      class="c2"
+      class="c1"
     >
       <ul
-        class="c3"
+        class="c2"
       >
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-disabled="true"
             aria-label="Go to previous page"
-            class="c5 c6"
+            class="c4 c5"
             disabled=""
             type="button"
           >
             <svg
               aria-label="Previous"
-              class="c7"
+              class="c6"
               viewBox="0 0 24 24"
             >
               <path
@@ -10134,116 +9924,116 @@ exports[`Pagination should display the correct last page based on items length
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-current="page"
             aria-label="Go to page 1"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             1
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 2"
-            class="c10 c6"
+            class="c9 c5"
             type="button"
           >
             2
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 3"
-            class="c10 c6"
+            class="c9 c5"
             type="button"
           >
             3
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 4"
-            class="c10 c6"
+            class="c9 c5"
             type="button"
           >
             4
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 5"
-            class="c10 c6"
+            class="c9 c5"
             type="button"
           >
             5
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <span
-            class="c11 c12"
+            class="c10 c11"
           >
             …
           </span>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 24"
-            class="c10 c6"
+            class="c9 c5"
             type="button"
           >
             24
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to next page"
-            class="c13 c6"
+            class="c12 c5"
             type="button"
           >
             <svg
               aria-label="Next"
-              class="c14"
+              class="c13"
               viewBox="0 0 24 24"
             >
               <path
@@ -10262,7 +10052,7 @@ exports[`Pagination should display the correct last page based on items length
 `;
 
 exports[`Pagination should render correct numberEdgePages 1`] = `
-.c7 {
+.c6 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -10273,25 +10063,25 @@ exports[`Pagination should render correct numberEdgePages 1`] = `
   stroke: #000000;
 }
 
-.c7 g {
+.c6 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c7 *:not([stroke])[fill="none"] {
+.c6 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c7 *[stroke*="#"],
-.c7 *[STROKE*="#"] {
+.c6 *[stroke*="#"],
+.c6 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c7 *[fill-rule],
-.c7 *[FILL-RULE],
-.c7 *[fill*="#"],
-.c7 *[FILL*="#"] {
+.c6 *[fill-rule],
+.c6 *[FILL-RULE],
+.c6 *[fill*="#"],
+.c6 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -10318,26 +10108,12 @@ exports[`Pagination should render correct numberEdgePages 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-}
-
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
 }
 
-.c3 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -10357,7 +10133,7 @@ exports[`Pagination should render correct numberEdgePages 1`] = `
   padding: 0px;
 }
 
-.c8 {
+.c7 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -10367,12 +10143,12 @@ exports[`Pagination should render correct numberEdgePages 1`] = `
   width: 3px;
 }
 
-.c10 {
+.c9 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c5 {
+.c4 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -10404,7 +10180,7 @@ exports[`Pagination should render correct numberEdgePages 1`] = `
   flex: 1 0 auto;
 }
 
-.c5 > svg {
+.c4 > svg {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -10415,51 +10191,51 @@ exports[`Pagination should render correct numberEdgePages 1`] = `
   vertical-align: middle;
 }
 
-.c5:hover {
+.c4:hover {
   background-color: rgba(51,51,51,0.06274509803921569);
 }
 
-.c5:focus {
+.c4:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c4:focus > circle,
+.c4:focus > ellipse,
+.c4:focus > line,
+.c4:focus > path,
+.c4:focus > polygon,
+.c4:focus > polyline,
+.c4:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c4:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c4:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c4:focus:not(:focus-visible) > circle,
+.c4:focus:not(:focus-visible) > ellipse,
+.c4:focus:not(:focus-visible) > line,
+.c4:focus:not(:focus-visible) > path,
+.c4:focus:not(:focus-visible) > polygon,
+.c4:focus:not(:focus-visible) > polyline,
+.c4:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c4:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c9 {
+.c8 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -10491,51 +10267,51 @@ exports[`Pagination should render correct numberEdgePages 1`] = `
   flex: 1 0 auto;
 }
 
-.c9:hover {
+.c8:hover {
   background-color: rgba(51,51,51,0.06274509803921569);
 }
 
-.c9:focus {
+.c8:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c9:focus > circle,
-.c9:focus > ellipse,
-.c9:focus > line,
-.c9:focus > path,
-.c9:focus > polygon,
-.c9:focus > polyline,
-.c9:focus > rect {
+.c8:focus > circle,
+.c8:focus > ellipse,
+.c8:focus > line,
+.c8:focus > path,
+.c8:focus > polygon,
+.c8:focus > polyline,
+.c8:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c9:focus::-moz-focus-inner {
+.c8:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c9:focus:not(:focus-visible) {
+.c8:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c9:focus:not(:focus-visible) > circle,
-.c9:focus:not(:focus-visible) > ellipse,
-.c9:focus:not(:focus-visible) > line,
-.c9:focus:not(:focus-visible) > path,
-.c9:focus:not(:focus-visible) > polygon,
-.c9:focus:not(:focus-visible) > polyline,
-.c9:focus:not(:focus-visible) > rect {
+.c8:focus:not(:focus-visible) > circle,
+.c8:focus:not(:focus-visible) > ellipse,
+.c8:focus:not(:focus-visible) > line,
+.c8:focus:not(:focus-visible) > path,
+.c8:focus:not(:focus-visible) > polygon,
+.c8:focus:not(:focus-visible) > polyline,
+.c8:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c9:focus:not(:focus-visible)::-moz-focus-inner {
+.c8:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c12 {
+.c11 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -10570,60 +10346,60 @@ exports[`Pagination should render correct numberEdgePages 1`] = `
   flex: 1 0 auto;
 }
 
-.c12:hover {
+.c11:hover {
   background-color: rgba(51,51,51,0.06274509803921569);
 }
 
-.c12:focus {
+.c11:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus > circle,
-.c12:focus > ellipse,
-.c12:focus > line,
-.c12:focus > path,
-.c12:focus > polygon,
-.c12:focus > polyline,
-.c12:focus > rect {
+.c11:focus > circle,
+.c11:focus > ellipse,
+.c11:focus > line,
+.c11:focus > path,
+.c11:focus > polygon,
+.c11:focus > polyline,
+.c11:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus::-moz-focus-inner {
+.c11:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c12:focus:not(:focus-visible) {
+.c11:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible) > circle,
-.c12:focus:not(:focus-visible) > ellipse,
-.c12:focus:not(:focus-visible) > line,
-.c12:focus:not(:focus-visible) > path,
-.c12:focus:not(:focus-visible) > polygon,
-.c12:focus:not(:focus-visible) > polyline,
-.c12:focus:not(:focus-visible) > rect {
+.c11:focus:not(:focus-visible) > circle,
+.c11:focus:not(:focus-visible) > ellipse,
+.c11:focus:not(:focus-visible) > line,
+.c11:focus:not(:focus-visible) > path,
+.c11:focus:not(:focus-visible) > polygon,
+.c11:focus:not(:focus-visible) > polyline,
+.c11:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible)::-moz-focus-inner {
+.c11:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c6 {
+.c5 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c6 > svg {
+.c5 > svg {
   margin: 0 auto;
 }
 
-.c4 {
+.c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -10641,26 +10417,26 @@ exports[`Pagination should render correct numberEdgePages 1`] = `
   min-width: 36px;
 }
 
-.c11 {
+.c10 {
   font-weight: bold;
   font-size: 18px;
   line-height: 24px;
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c7 {
     width: 2px;
   }
 }
@@ -10673,22 +10449,22 @@ exports[`Pagination should render correct numberEdgePages 1`] = `
   >
     <nav
       aria-label="Pagination Navigation"
-      class="c2"
+      class="c1"
     >
       <ul
-        class="c3"
+        class="c2"
       >
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to previous page"
-            class="c5 c6"
+            class="c4 c5"
             type="button"
           >
             <svg
               aria-label="Previous"
-              class="c7"
+              class="c6"
               viewBox="0 0 24 24"
             >
               <path
@@ -10701,170 +10477,170 @@ exports[`Pagination should render correct numberEdgePages 1`] = `
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 1"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             1
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 2"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             2
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 3"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             3
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <span
-            class="c10 c11"
+            class="c9 c10"
           >
             …
           </span>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 9"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             9
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-current="page"
             aria-label="Go to page 10"
-            class="c12 c6"
+            class="c11 c5"
             type="button"
           >
             10
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 11"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             11
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <span
-            class="c10 c11"
+            class="c9 c10"
           >
             …
           </span>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 22"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             22
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 23"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             23
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 24"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             24
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to next page"
-            class="c5 c6"
+            class="c4 c5"
             type="button"
           >
             <svg
               aria-label="Next"
-              class="c7"
+              class="c6"
               viewBox="0 0 24 24"
             >
               <path
@@ -10883,7 +10659,7 @@ exports[`Pagination should render correct numberEdgePages 1`] = `
 `;
 
 exports[`Pagination should render correct numberMiddlePages when even 1`] = `
-.c7 {
+.c6 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -10894,25 +10670,25 @@ exports[`Pagination should render correct numberMiddlePages when even 1`] = `
   stroke: #000000;
 }
 
-.c7 g {
+.c6 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c7 *:not([stroke])[fill="none"] {
+.c6 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c7 *[stroke*="#"],
-.c7 *[STROKE*="#"] {
+.c6 *[stroke*="#"],
+.c6 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c7 *[fill-rule],
-.c7 *[FILL-RULE],
-.c7 *[fill*="#"],
-.c7 *[FILL*="#"] {
+.c6 *[fill-rule],
+.c6 *[FILL-RULE],
+.c6 *[fill*="#"],
+.c6 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -10939,26 +10715,12 @@ exports[`Pagination should render correct numberMiddlePages when even 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-}
-
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
 }
 
-.c3 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -10978,7 +10740,7 @@ exports[`Pagination should render correct numberMiddlePages when even 1`] = `
   padding: 0px;
 }
 
-.c8 {
+.c7 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -10988,12 +10750,12 @@ exports[`Pagination should render correct numberMiddlePages when even 1`] = `
   width: 3px;
 }
 
-.c10 {
+.c9 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c5 {
+.c4 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -11025,7 +10787,7 @@ exports[`Pagination should render correct numberMiddlePages when even 1`] = `
   flex: 1 0 auto;
 }
 
-.c5 > svg {
+.c4 > svg {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -11036,51 +10798,51 @@ exports[`Pagination should render correct numberMiddlePages when even 1`] = `
   vertical-align: middle;
 }
 
-.c5:hover {
+.c4:hover {
   background-color: rgba(51,51,51,0.06274509803921569);
 }
 
-.c5:focus {
+.c4:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c4:focus > circle,
+.c4:focus > ellipse,
+.c4:focus > line,
+.c4:focus > path,
+.c4:focus > polygon,
+.c4:focus > polyline,
+.c4:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c4:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c4:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c4:focus:not(:focus-visible) > circle,
+.c4:focus:not(:focus-visible) > ellipse,
+.c4:focus:not(:focus-visible) > line,
+.c4:focus:not(:focus-visible) > path,
+.c4:focus:not(:focus-visible) > polygon,
+.c4:focus:not(:focus-visible) > polyline,
+.c4:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c4:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c9 {
+.c8 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -11112,51 +10874,51 @@ exports[`Pagination should render correct numberMiddlePages when even 1`] = `
   flex: 1 0 auto;
 }
 
-.c9:hover {
+.c8:hover {
   background-color: rgba(51,51,51,0.06274509803921569);
 }
 
-.c9:focus {
+.c8:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c9:focus > circle,
-.c9:focus > ellipse,
-.c9:focus > line,
-.c9:focus > path,
-.c9:focus > polygon,
-.c9:focus > polyline,
-.c9:focus > rect {
+.c8:focus > circle,
+.c8:focus > ellipse,
+.c8:focus > line,
+.c8:focus > path,
+.c8:focus > polygon,
+.c8:focus > polyline,
+.c8:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c9:focus::-moz-focus-inner {
+.c8:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c9:focus:not(:focus-visible) {
+.c8:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c9:focus:not(:focus-visible) > circle,
-.c9:focus:not(:focus-visible) > ellipse,
-.c9:focus:not(:focus-visible) > line,
-.c9:focus:not(:focus-visible) > path,
-.c9:focus:not(:focus-visible) > polygon,
-.c9:focus:not(:focus-visible) > polyline,
-.c9:focus:not(:focus-visible) > rect {
+.c8:focus:not(:focus-visible) > circle,
+.c8:focus:not(:focus-visible) > ellipse,
+.c8:focus:not(:focus-visible) > line,
+.c8:focus:not(:focus-visible) > path,
+.c8:focus:not(:focus-visible) > polygon,
+.c8:focus:not(:focus-visible) > polyline,
+.c8:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c9:focus:not(:focus-visible)::-moz-focus-inner {
+.c8:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c12 {
+.c11 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -11191,60 +10953,60 @@ exports[`Pagination should render correct numberMiddlePages when even 1`] = `
   flex: 1 0 auto;
 }
 
-.c12:hover {
+.c11:hover {
   background-color: rgba(51,51,51,0.06274509803921569);
 }
 
-.c12:focus {
+.c11:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus > circle,
-.c12:focus > ellipse,
-.c12:focus > line,
-.c12:focus > path,
-.c12:focus > polygon,
-.c12:focus > polyline,
-.c12:focus > rect {
+.c11:focus > circle,
+.c11:focus > ellipse,
+.c11:focus > line,
+.c11:focus > path,
+.c11:focus > polygon,
+.c11:focus > polyline,
+.c11:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus::-moz-focus-inner {
+.c11:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c12:focus:not(:focus-visible) {
+.c11:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible) > circle,
-.c12:focus:not(:focus-visible) > ellipse,
-.c12:focus:not(:focus-visible) > line,
-.c12:focus:not(:focus-visible) > path,
-.c12:focus:not(:focus-visible) > polygon,
-.c12:focus:not(:focus-visible) > polyline,
-.c12:focus:not(:focus-visible) > rect {
+.c11:focus:not(:focus-visible) > circle,
+.c11:focus:not(:focus-visible) > ellipse,
+.c11:focus:not(:focus-visible) > line,
+.c11:focus:not(:focus-visible) > path,
+.c11:focus:not(:focus-visible) > polygon,
+.c11:focus:not(:focus-visible) > polyline,
+.c11:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible)::-moz-focus-inner {
+.c11:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c6 {
+.c5 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c6 > svg {
+.c5 > svg {
   margin: 0 auto;
 }
 
-.c4 {
+.c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -11262,26 +11024,26 @@ exports[`Pagination should render correct numberMiddlePages when even 1`] = `
   min-width: 36px;
 }
 
-.c11 {
+.c10 {
   font-weight: bold;
   font-size: 18px;
   line-height: 24px;
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c7 {
     width: 2px;
   }
 }
@@ -11294,22 +11056,22 @@ exports[`Pagination should render correct numberMiddlePages when even 1`] = `
   >
     <nav
       aria-label="Pagination Navigation"
-      class="c2"
+      class="c1"
     >
       <ul
-        class="c3"
+        class="c2"
       >
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to previous page"
-            class="c5 c6"
+            class="c4 c5"
             type="button"
           >
             <svg
               aria-label="Previous"
-              class="c7"
+              class="c6"
               viewBox="0 0 24 24"
             >
               <path
@@ -11322,128 +11084,128 @@ exports[`Pagination should render correct numberMiddlePages when even 1`] = `
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 1"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             1
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <span
-            class="c10 c11"
+            class="c9 c10"
           >
             …
           </span>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 9"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             9
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-current="page"
             aria-label="Go to page 10"
-            class="c12 c6"
+            class="c11 c5"
             type="button"
           >
             10
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 11"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             11
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 12"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             12
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <span
-            class="c10 c11"
+            class="c9 c10"
           >
             …
           </span>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 24"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             24
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to next page"
-            class="c5 c6"
+            class="c4 c5"
             type="button"
           >
             <svg
               aria-label="Next"
-              class="c7"
+              class="c6"
               viewBox="0 0 24 24"
             >
               <path
@@ -11462,7 +11224,7 @@ exports[`Pagination should render correct numberMiddlePages when even 1`] = `
 `;
 
 exports[`Pagination should render correct numberMiddlePages when odd 1`] = `
-.c7 {
+.c6 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -11473,25 +11235,25 @@ exports[`Pagination should render correct numberMiddlePages when odd 1`] = `
   stroke: #000000;
 }
 
-.c7 g {
+.c6 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c7 *:not([stroke])[fill="none"] {
+.c6 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c7 *[stroke*="#"],
-.c7 *[STROKE*="#"] {
+.c6 *[stroke*="#"],
+.c6 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c7 *[fill-rule],
-.c7 *[FILL-RULE],
-.c7 *[fill*="#"],
-.c7 *[FILL*="#"] {
+.c6 *[fill-rule],
+.c6 *[FILL-RULE],
+.c6 *[fill*="#"],
+.c6 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -11518,26 +11280,12 @@ exports[`Pagination should render correct numberMiddlePages when odd 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-}
-
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
 }
 
-.c3 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -11557,7 +11305,7 @@ exports[`Pagination should render correct numberMiddlePages when odd 1`] = `
   padding: 0px;
 }
 
-.c8 {
+.c7 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -11567,12 +11315,12 @@ exports[`Pagination should render correct numberMiddlePages when odd 1`] = `
   width: 3px;
 }
 
-.c10 {
+.c9 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c5 {
+.c4 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -11604,7 +11352,7 @@ exports[`Pagination should render correct numberMiddlePages when odd 1`] = `
   flex: 1 0 auto;
 }
 
-.c5 > svg {
+.c4 > svg {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -11615,51 +11363,51 @@ exports[`Pagination should render correct numberMiddlePages when odd 1`] = `
   vertical-align: middle;
 }
 
-.c5:hover {
+.c4:hover {
   background-color: rgba(51,51,51,0.06274509803921569);
 }
 
-.c5:focus {
+.c4:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c4:focus > circle,
+.c4:focus > ellipse,
+.c4:focus > line,
+.c4:focus > path,
+.c4:focus > polygon,
+.c4:focus > polyline,
+.c4:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c4:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c4:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c4:focus:not(:focus-visible) > circle,
+.c4:focus:not(:focus-visible) > ellipse,
+.c4:focus:not(:focus-visible) > line,
+.c4:focus:not(:focus-visible) > path,
+.c4:focus:not(:focus-visible) > polygon,
+.c4:focus:not(:focus-visible) > polyline,
+.c4:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c4:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c9 {
+.c8 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -11691,51 +11439,51 @@ exports[`Pagination should render correct numberMiddlePages when odd 1`] = `
   flex: 1 0 auto;
 }
 
-.c9:hover {
+.c8:hover {
   background-color: rgba(51,51,51,0.06274509803921569);
 }
 
-.c9:focus {
+.c8:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c9:focus > circle,
-.c9:focus > ellipse,
-.c9:focus > line,
-.c9:focus > path,
-.c9:focus > polygon,
-.c9:focus > polyline,
-.c9:focus > rect {
+.c8:focus > circle,
+.c8:focus > ellipse,
+.c8:focus > line,
+.c8:focus > path,
+.c8:focus > polygon,
+.c8:focus > polyline,
+.c8:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c9:focus::-moz-focus-inner {
+.c8:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c9:focus:not(:focus-visible) {
+.c8:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c9:focus:not(:focus-visible) > circle,
-.c9:focus:not(:focus-visible) > ellipse,
-.c9:focus:not(:focus-visible) > line,
-.c9:focus:not(:focus-visible) > path,
-.c9:focus:not(:focus-visible) > polygon,
-.c9:focus:not(:focus-visible) > polyline,
-.c9:focus:not(:focus-visible) > rect {
+.c8:focus:not(:focus-visible) > circle,
+.c8:focus:not(:focus-visible) > ellipse,
+.c8:focus:not(:focus-visible) > line,
+.c8:focus:not(:focus-visible) > path,
+.c8:focus:not(:focus-visible) > polygon,
+.c8:focus:not(:focus-visible) > polyline,
+.c8:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c9:focus:not(:focus-visible)::-moz-focus-inner {
+.c8:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c12 {
+.c11 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -11770,60 +11518,60 @@ exports[`Pagination should render correct numberMiddlePages when odd 1`] = `
   flex: 1 0 auto;
 }
 
-.c12:hover {
+.c11:hover {
   background-color: rgba(51,51,51,0.06274509803921569);
 }
 
-.c12:focus {
+.c11:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus > circle,
-.c12:focus > ellipse,
-.c12:focus > line,
-.c12:focus > path,
-.c12:focus > polygon,
-.c12:focus > polyline,
-.c12:focus > rect {
+.c11:focus > circle,
+.c11:focus > ellipse,
+.c11:focus > line,
+.c11:focus > path,
+.c11:focus > polygon,
+.c11:focus > polyline,
+.c11:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus::-moz-focus-inner {
+.c11:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c12:focus:not(:focus-visible) {
+.c11:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible) > circle,
-.c12:focus:not(:focus-visible) > ellipse,
-.c12:focus:not(:focus-visible) > line,
-.c12:focus:not(:focus-visible) > path,
-.c12:focus:not(:focus-visible) > polygon,
-.c12:focus:not(:focus-visible) > polyline,
-.c12:focus:not(:focus-visible) > rect {
+.c11:focus:not(:focus-visible) > circle,
+.c11:focus:not(:focus-visible) > ellipse,
+.c11:focus:not(:focus-visible) > line,
+.c11:focus:not(:focus-visible) > path,
+.c11:focus:not(:focus-visible) > polygon,
+.c11:focus:not(:focus-visible) > polyline,
+.c11:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible)::-moz-focus-inner {
+.c11:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c6 {
+.c5 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c6 > svg {
+.c5 > svg {
   margin: 0 auto;
 }
 
-.c4 {
+.c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -11841,26 +11589,26 @@ exports[`Pagination should render correct numberMiddlePages when odd 1`] = `
   min-width: 36px;
 }
 
-.c11 {
+.c10 {
   font-weight: bold;
   font-size: 18px;
   line-height: 24px;
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c7 {
     width: 2px;
   }
 }
@@ -11873,22 +11621,22 @@ exports[`Pagination should render correct numberMiddlePages when odd 1`] = `
   >
     <nav
       aria-label="Pagination Navigation"
-      class="c2"
+      class="c1"
     >
       <ul
-        class="c3"
+        class="c2"
       >
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to previous page"
-            class="c5 c6"
+            class="c4 c5"
             type="button"
           >
             <svg
               aria-label="Previous"
-              class="c7"
+              class="c6"
               viewBox="0 0 24 24"
             >
               <path
@@ -11901,142 +11649,142 @@ exports[`Pagination should render correct numberMiddlePages when odd 1`] = `
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 1"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             1
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <span
-            class="c10 c11"
+            class="c9 c10"
           >
             …
           </span>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 8"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             8
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 9"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             9
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-current="page"
             aria-label="Go to page 10"
-            class="c12 c6"
+            class="c11 c5"
             type="button"
           >
             10
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 11"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             11
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 12"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             12
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <span
-            class="c10 c11"
+            class="c9 c10"
           >
             …
           </span>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 24"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             24
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to next page"
-            class="c5 c6"
+            class="c4 c5"
             type="button"
           >
             <svg
               aria-label="Next"
-              class="c7"
+              class="c6"
               viewBox="0 0 24 24"
             >
               <path
@@ -12055,7 +11803,7 @@ exports[`Pagination should render correct numberMiddlePages when odd 1`] = `
 `;
 
 exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 1`] = `
-.c7 {
+.c6 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -12066,30 +11814,30 @@ exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 
   stroke: #666666;
 }
 
-.c7 g {
+.c6 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c7 *:not([stroke])[fill="none"] {
+.c6 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c7 *[stroke*="#"],
-.c7 *[STROKE*="#"] {
+.c6 *[stroke*="#"],
+.c6 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c7 *[fill-rule],
-.c7 *[FILL-RULE],
-.c7 *[fill*="#"],
-.c7 *[FILL*="#"] {
+.c6 *[fill-rule],
+.c6 *[FILL-RULE],
+.c6 *[fill*="#"],
+.c6 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
 
-.c14 {
+.c13 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -12100,25 +11848,25 @@ exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 
   stroke: #000000;
 }
 
-.c14 g {
+.c13 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c14 *:not([stroke])[fill="none"] {
+.c13 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c14 *[stroke*="#"],
-.c14 *[STROKE*="#"] {
+.c13 *[stroke*="#"],
+.c13 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c14 *[fill-rule],
-.c14 *[FILL-RULE],
-.c14 *[fill*="#"],
-.c14 *[FILL*="#"] {
+.c13 *[fill-rule],
+.c13 *[FILL-RULE],
+.c13 *[fill*="#"],
+.c13 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -12145,26 +11893,12 @@ exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-}
-
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
 }
 
-.c3 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -12184,7 +11918,7 @@ exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 
   padding: 0px;
 }
 
-.c8 {
+.c7 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -12194,12 +11928,12 @@ exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 
   width: 3px;
 }
 
-.c11 {
+.c10 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c5 {
+.c4 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -12232,7 +11966,7 @@ exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 
   flex: 1 0 auto;
 }
 
-.c5 > svg {
+.c4 > svg {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -12243,47 +11977,47 @@ exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 
   vertical-align: middle;
 }
 
-.c5:focus {
+.c4:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c4:focus > circle,
+.c4:focus > ellipse,
+.c4:focus > line,
+.c4:focus > path,
+.c4:focus > polygon,
+.c4:focus > polyline,
+.c4:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c4:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c4:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c4:focus:not(:focus-visible) > circle,
+.c4:focus:not(:focus-visible) > ellipse,
+.c4:focus:not(:focus-visible) > line,
+.c4:focus:not(:focus-visible) > path,
+.c4:focus:not(:focus-visible) > polygon,
+.c4:focus:not(:focus-visible) > polyline,
+.c4:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c4:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c9 {
+.c8 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -12303,6 +12037,82 @@ exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 
   line-height: 24px;
   background-color: rgba(51,51,51,0.06274509803921569);
   color: #444444;
+  text-align: center;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c8:hover {
+  background-color: rgba(51,51,51,0.06274509803921569);
+}
+
+.c8:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus > circle,
+.c8:focus > ellipse,
+.c8:focus > line,
+.c8:focus > path,
+.c8:focus > polygon,
+.c8:focus > polyline,
+.c8:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c8:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c8:focus:not(:focus-visible) > circle,
+.c8:focus:not(:focus-visible) > ellipse,
+.c8:focus:not(:focus-visible) > line,
+.c8:focus:not(:focus-visible) > path,
+.c8:focus:not(:focus-visible) > polygon,
+.c8:focus:not(:focus-visible) > polyline,
+.c8:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c8:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c9 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  color: #000000;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
   transition-property: color,background-color,border-color,box-shadow;
@@ -12362,7 +12172,7 @@ exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 
   border: 0;
 }
 
-.c10 {
+.c12 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -12394,83 +12204,7 @@ exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 
   flex: 1 0 auto;
 }
 
-.c10:hover {
-  background-color: rgba(51,51,51,0.06274509803921569);
-}
-
-.c10:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c10:focus > circle,
-.c10:focus > ellipse,
-.c10:focus > line,
-.c10:focus > path,
-.c10:focus > polygon,
-.c10:focus > polyline,
-.c10:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c10:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c10:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c10:focus:not(:focus-visible) > circle,
-.c10:focus:not(:focus-visible) > ellipse,
-.c10:focus:not(:focus-visible) > line,
-.c10:focus:not(:focus-visible) > path,
-.c10:focus:not(:focus-visible) > polygon,
-.c10:focus:not(:focus-visible) > polyline,
-.c10:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c10:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c13 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 24px;
-  color: #000000;
-  text-align: center;
-  -webkit-transition-property: color,background-color,border-color,box-shadow;
-  transition-property: color,background-color,border-color,box-shadow;
-  -webkit-transition-duration: 0.1s;
-  transition-duration: 0.1s;
-  -webkit-transition-timing-function: ease-in-out;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
-}
-
-.c13 > svg {
+.c12 > svg {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -12481,60 +12215,60 @@ exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 
   vertical-align: middle;
 }
 
-.c13:hover {
+.c12:hover {
   background-color: rgba(51,51,51,0.06274509803921569);
 }
 
-.c13:focus {
+.c12:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus > circle,
-.c13:focus > ellipse,
-.c13:focus > line,
-.c13:focus > path,
-.c13:focus > polygon,
-.c13:focus > polyline,
-.c13:focus > rect {
+.c12:focus > circle,
+.c12:focus > ellipse,
+.c12:focus > line,
+.c12:focus > path,
+.c12:focus > polygon,
+.c12:focus > polyline,
+.c12:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus::-moz-focus-inner {
+.c12:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c13:focus:not(:focus-visible) {
+.c12:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible) > circle,
-.c13:focus:not(:focus-visible) > ellipse,
-.c13:focus:not(:focus-visible) > line,
-.c13:focus:not(:focus-visible) > path,
-.c13:focus:not(:focus-visible) > polygon,
-.c13:focus:not(:focus-visible) > polyline,
-.c13:focus:not(:focus-visible) > rect {
+.c12:focus:not(:focus-visible) > circle,
+.c12:focus:not(:focus-visible) > ellipse,
+.c12:focus:not(:focus-visible) > line,
+.c12:focus:not(:focus-visible) > path,
+.c12:focus:not(:focus-visible) > polygon,
+.c12:focus:not(:focus-visible) > polyline,
+.c12:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible)::-moz-focus-inner {
+.c12:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c6 {
+.c5 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c6 > svg {
+.c5 > svg {
   margin: 0 auto;
 }
 
-.c4 {
+.c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -12552,26 +12286,26 @@ exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 
   min-width: 36px;
 }
 
-.c12 {
+.c11 {
   font-weight: bold;
   font-size: 18px;
   line-height: 24px;
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c7 {
     width: 2px;
   }
 }
@@ -12584,24 +12318,24 @@ exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 
   >
     <nav
       aria-label="Pagination Navigation"
-      class="c2"
+      class="c1"
     >
       <ul
-        class="c3"
+        class="c2"
       >
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-disabled="true"
             aria-label="Go to previous page"
-            class="c5 c6"
+            class="c4 c5"
             disabled=""
             type="button"
           >
             <svg
               aria-label="Previous"
-              class="c7"
+              class="c6"
               viewBox="0 0 24 24"
             >
               <path
@@ -12614,88 +12348,88 @@ exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-current="page"
             aria-label="Go to page 1"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             1
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 2"
-            class="c10 c6"
+            class="c9 c5"
             type="button"
           >
             2
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 3"
-            class="c10 c6"
+            class="c9 c5"
             type="button"
           >
             3
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <span
-            class="c11 c12"
+            class="c10 c11"
           >
             …
           </span>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 24"
-            class="c10 c6"
+            class="c9 c5"
             type="button"
           >
             24
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to next page"
-            class="c13 c6"
+            class="c12 c5"
             type="button"
           >
             <svg
               aria-label="Next"
-              class="c14"
+              class="c13"
               viewBox="0 0 24 24"
             >
               <path
@@ -12715,7 +12449,7 @@ exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 
 
 exports[`Pagination should set page to last page if page prop > total possible
   pages 1`] = `
-.c7 {
+.c6 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -12726,30 +12460,30 @@ exports[`Pagination should set page to last page if page prop > total possible
   stroke: #000000;
 }
 
-.c7 g {
+.c6 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c7 *:not([stroke])[fill="none"] {
+.c6 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c7 *[stroke*="#"],
-.c7 *[STROKE*="#"] {
+.c6 *[stroke*="#"],
+.c6 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c7 *[fill-rule],
-.c7 *[FILL-RULE],
-.c7 *[fill*="#"],
-.c7 *[FILL*="#"] {
+.c6 *[fill-rule],
+.c6 *[FILL-RULE],
+.c6 *[fill*="#"],
+.c6 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
 
-.c14 {
+.c13 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -12760,25 +12494,25 @@ exports[`Pagination should set page to last page if page prop > total possible
   stroke: #666666;
 }
 
-.c14 g {
+.c13 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c14 *:not([stroke])[fill="none"] {
+.c13 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c14 *[stroke*="#"],
-.c14 *[STROKE*="#"] {
+.c13 *[stroke*="#"],
+.c13 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c14 *[fill-rule],
-.c14 *[FILL-RULE],
-.c14 *[fill*="#"],
-.c14 *[FILL*="#"] {
+.c13 *[fill-rule],
+.c13 *[FILL-RULE],
+.c13 *[fill*="#"],
+.c13 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -12805,26 +12539,12 @@ exports[`Pagination should set page to last page if page prop > total possible
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-}
-
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
 }
 
-.c3 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -12844,7 +12564,7 @@ exports[`Pagination should set page to last page if page prop > total possible
   padding: 0px;
 }
 
-.c8 {
+.c7 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -12854,12 +12574,12 @@ exports[`Pagination should set page to last page if page prop > total possible
   width: 3px;
 }
 
-.c10 {
+.c9 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c5 {
+.c4 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -12891,7 +12611,7 @@ exports[`Pagination should set page to last page if page prop > total possible
   flex: 1 0 auto;
 }
 
-.c5 > svg {
+.c4 > svg {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -12902,51 +12622,51 @@ exports[`Pagination should set page to last page if page prop > total possible
   vertical-align: middle;
 }
 
-.c5:hover {
+.c4:hover {
   background-color: rgba(51,51,51,0.06274509803921569);
 }
 
-.c5:focus {
+.c4:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c4:focus > circle,
+.c4:focus > ellipse,
+.c4:focus > line,
+.c4:focus > path,
+.c4:focus > polygon,
+.c4:focus > polyline,
+.c4:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c4:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c5:focus:not(:focus-visible) {
+.c4:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible) > circle,
-.c5:focus:not(:focus-visible) > ellipse,
-.c5:focus:not(:focus-visible) > line,
-.c5:focus:not(:focus-visible) > path,
-.c5:focus:not(:focus-visible) > polygon,
-.c5:focus:not(:focus-visible) > polyline,
-.c5:focus:not(:focus-visible) > rect {
+.c4:focus:not(:focus-visible) > circle,
+.c4:focus:not(:focus-visible) > ellipse,
+.c4:focus:not(:focus-visible) > line,
+.c4:focus:not(:focus-visible) > path,
+.c4:focus:not(:focus-visible) > polygon,
+.c4:focus:not(:focus-visible) > polyline,
+.c4:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c5:focus:not(:focus-visible)::-moz-focus-inner {
+.c4:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c9 {
+.c8 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -12978,51 +12698,51 @@ exports[`Pagination should set page to last page if page prop > total possible
   flex: 1 0 auto;
 }
 
-.c9:hover {
+.c8:hover {
   background-color: rgba(51,51,51,0.06274509803921569);
 }
 
-.c9:focus {
+.c8:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c9:focus > circle,
-.c9:focus > ellipse,
-.c9:focus > line,
-.c9:focus > path,
-.c9:focus > polygon,
-.c9:focus > polyline,
-.c9:focus > rect {
+.c8:focus > circle,
+.c8:focus > ellipse,
+.c8:focus > line,
+.c8:focus > path,
+.c8:focus > polygon,
+.c8:focus > polyline,
+.c8:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c9:focus::-moz-focus-inner {
+.c8:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c9:focus:not(:focus-visible) {
+.c8:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c9:focus:not(:focus-visible) > circle,
-.c9:focus:not(:focus-visible) > ellipse,
-.c9:focus:not(:focus-visible) > line,
-.c9:focus:not(:focus-visible) > path,
-.c9:focus:not(:focus-visible) > polygon,
-.c9:focus:not(:focus-visible) > polyline,
-.c9:focus:not(:focus-visible) > rect {
+.c8:focus:not(:focus-visible) > circle,
+.c8:focus:not(:focus-visible) > ellipse,
+.c8:focus:not(:focus-visible) > line,
+.c8:focus:not(:focus-visible) > path,
+.c8:focus:not(:focus-visible) > polygon,
+.c8:focus:not(:focus-visible) > polyline,
+.c8:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c9:focus:not(:focus-visible)::-moz-focus-inner {
+.c8:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c12 {
+.c11 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -13057,8 +12777,92 @@ exports[`Pagination should set page to last page if page prop > total possible
   flex: 1 0 auto;
 }
 
-.c12:hover {
+.c11:hover {
   background-color: rgba(51,51,51,0.06274509803921569);
+}
+
+.c11:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus > circle,
+.c11:focus > ellipse,
+.c11:focus > line,
+.c11:focus > path,
+.c11:focus > polygon,
+.c11:focus > polyline,
+.c11:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c11:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c11:focus:not(:focus-visible) > circle,
+.c11:focus:not(:focus-visible) > ellipse,
+.c11:focus:not(:focus-visible) > line,
+.c11:focus:not(:focus-visible) > path,
+.c11:focus:not(:focus-visible) > polygon,
+.c11:focus:not(:focus-visible) > polyline,
+.c11:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c11:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c12 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  text-align: center;
+  opacity: 0.3;
+  cursor: default;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c12 > svg {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  vertical-align: middle;
 }
 
 .c12:focus {
@@ -13101,100 +12905,16 @@ exports[`Pagination should set page to last page if page prop > total possible
   border: 0;
 }
 
-.c13 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 24px;
-  text-align: center;
-  opacity: 0.3;
-  cursor: default;
-  -webkit-transition-property: color,background-color,border-color,box-shadow;
-  transition-property: color,background-color,border-color,box-shadow;
-  -webkit-transition-duration: 0.1s;
-  transition-duration: 0.1s;
-  -webkit-transition-timing-function: ease-in-out;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
-}
-
-.c13 > svg {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
-  vertical-align: middle;
-}
-
-.c13:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c13:focus > circle,
-.c13:focus > ellipse,
-.c13:focus > line,
-.c13:focus > path,
-.c13:focus > polygon,
-.c13:focus > polyline,
-.c13:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c13:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c13:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c13:focus:not(:focus-visible) > circle,
-.c13:focus:not(:focus-visible) > ellipse,
-.c13:focus:not(:focus-visible) > line,
-.c13:focus:not(:focus-visible) > path,
-.c13:focus:not(:focus-visible) > polygon,
-.c13:focus:not(:focus-visible) > polyline,
-.c13:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c13:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c6 {
+.c5 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c6 > svg {
+.c5 > svg {
   margin: 0 auto;
 }
 
-.c4 {
+.c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -13212,26 +12932,26 @@ exports[`Pagination should set page to last page if page prop > total possible
   min-width: 36px;
 }
 
-.c11 {
+.c10 {
   font-weight: bold;
   font-size: 18px;
   line-height: 24px;
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c3 {
+  .c2 {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c7 {
     width: 2px;
   }
 }
@@ -13244,22 +12964,22 @@ exports[`Pagination should set page to last page if page prop > total possible
   >
     <nav
       aria-label="Pagination Navigation"
-      class="c2"
+      class="c1"
     >
       <ul
-        class="c3"
+        class="c2"
       >
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to previous page"
-            class="c5 c6"
+            class="c4 c5"
             type="button"
           >
             <svg
               aria-label="Previous"
-              class="c7"
+              class="c6"
               viewBox="0 0 24 24"
             >
               <path
@@ -13272,118 +12992,118 @@ exports[`Pagination should set page to last page if page prop > total possible
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 1"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             1
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <span
-            class="c10 c11"
+            class="c9 c10"
           >
             …
           </span>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 6"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             6
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 7"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             7
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 8"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             8
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-label="Go to page 9"
-            class="c9 c6"
+            class="c8 c5"
             type="button"
           >
             9
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-current="page"
             aria-label="Go to page 10"
-            class="c12 c6"
+            class="c11 c5"
             type="button"
           >
             10
           </button>
         </li>
         <div
-          class="c8"
+          class="c7"
         />
         <li
-          class="c4"
+          class="c3"
         >
           <button
             aria-disabled="true"
             aria-label="Go to next page"
-            class="c13 c6"
+            class="c12 c5"
             disabled=""
             type="button"
           >
             <svg
               aria-label="Next"
-              class="c14"
+              class="c13"
               viewBox="0 0 24 24"
             >
               <path


### PR DESCRIPTION
#### What does this PR do?
Fixed an issue introduced in #6439 that caused cells to stretch (see screenshots). This PR reverts the change from #6439 but still fixes the original issue https://github.com/grommet/grommet/issues/6333.

Cells are stretching:
<img width="632" alt="Screen Shot 2022-11-16 at 12 20 47 PM" src="https://user-images.githubusercontent.com/54560994/202291695-a5a1c05a-708b-4b09-a0f6-34fe63f34b9f.png">

Fixed:
<img width="659" alt="Screen Shot 2022-11-16 at 12 20 23 PM" src="https://user-images.githubusercontent.com/54560994/202291739-be01af3c-5d39-4d1a-8ef1-20ee62917ff0.png">


#### Where should the reviewer start?

#### What testing has been done on this PR?
Tested with the code from #6333 and tested with the MultiplePins story by adding `step={3}` and `paginate`.

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
#6333
https://github.com/grommet/hpe-design-system/issues/2949

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Yes

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible