### PR TITLE
Added `pad` prop in the anchor component.

### DIFF
--- a/src/js/components/Anchor/Anchor.js
+++ b/src/js/components/Anchor/Anchor.js
@@ -34,6 +34,7 @@ const Anchor = forwardRef(
       onClick: onClickProp,
       onFocus,
       reverse,
+      pad,
       ...rest
     },
     ref,

--- a/src/js/components/Anchor/Anchor.js
+++ b/src/js/components/Anchor/Anchor.js
@@ -89,6 +89,7 @@ const Anchor = forwardRef(
         reverse={reverse}
         href={!disabled ? href : undefined}
         onClick={!disabled ? onClick : undefined}
+        pad={pad}
         onFocus={(event) => {
           setFocus(true);
           if (onFocus) onFocus(event);

--- a/src/js/components/Anchor/StyledAnchor.js
+++ b/src/js/components/Anchor/StyledAnchor.js
@@ -59,11 +59,7 @@ const StyledAnchor = styled.a.withConfig({
       }
     `}
   ${(props) =>
-    props.hasIcon &&
-    !props.hasLabel &&
-    `
-    padding: ${props.theme.global.edgeSize.small};
-  `}
+    props.pad && `padding: ${props.theme.global.edgeSize[props.pad]};`}
   ${(props) => props.disabled && disabledStyle}
   ${(props) => props.focus && focusStyle()}
   ${(props) => props.theme.anchor.extend}

--- a/src/js/components/Anchor/__tests__/__snapshots__/Anchor-test.tsx.snap
+++ b/src/js/components/Anchor/__tests__/__snapshots__/Anchor-test.tsx.snap
@@ -950,7 +950,6 @@ exports[`Anchor warns about invalid icon render 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
-  padding: 12px;
 }
 
 .c1:hover {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fix the bug when using the Anchor component containing padding.

#### Where should the reviewer start?
Anchor.js

#### What testing has been done on this PR?
Updated the snapshot for this component

#### How should this be manually tested?
I am using the storybook by adding a custom props `pad` in the stories.

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
Yes, I removed the padding CSS and made this CSS dependent on the props passing from the stories/usage side.

#### What are the relevant issues?
#2595

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
backwards compatible.
