### PR TITLE
(Collapsible) fix: enable animation when initial open prop is true

### DIFF
--- a/src/js/components/Collapsible/Collapsible.js
+++ b/src/js/components/Collapsible/Collapsible.js
@@ -37,7 +37,7 @@ const Collapsible = forwardRef(
       [direction],
     );
     const containerRef = useForwardedRef(ref);
-    const sizeRef = useRef();
+    const sizeRef = useRef(0);
     const shouldOpen = !open && openArg;
     const shouldClose = open && !openArg;
 

--- a/src/js/components/Collapsible/__tests__/__snapshots__/Collapsible-test.tsx.snap
+++ b/src/js/components/Collapsible/__tests__/__snapshots__/Collapsible-test.tsx.snap
@@ -60,7 +60,7 @@ exports[`Collapsible onClick open default 2`] = `
 >
   <div
     aria-hidden="true"
-    class="StyledBox-sc-13pk1d4-0 dEaSmx Collapsible__AnimatedBox-sc-15kniua-0 foFiNe"
+    class="StyledBox-sc-13pk1d4-0 dEaSmx Collapsible__AnimatedBox-sc-15kniua-0 dTvbxu"
     style="max-height: 0px;"
   >
     <span


### PR DESCRIPTION
#### What does this PR do?
Fixes animation speed value. When component is open on init `nextSpeed` value is `NaN` because sizeRef returns undefined at this point and this value is used in nextSpeed computation.

#### Where should the reviewer start?
Collapsible.js

#### What testing has been done on this PR?
manual

#### How should this be manually tested?
set initial open prop to true

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #6523
 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no

#### Should this PR be mentioned in the release notes?
yes

#### Is this change backwards compatible or is it a breaking change?
no