### PR TITLE
Column Search Causes Jumpy Header Text

### DIFF
--- a/src/js/components/DataTable/Header.js
+++ b/src/js/components/DataTable/Header.js
@@ -375,7 +375,11 @@ const Header = forwardRef(
               // will be wrapped with an additional Box, preventing this Box
               // from automatically filling the vertical space.
               content = (
-                <Box flex="grow" fill={onResize || search ? 'vertical' : false}>
+                <Box
+                  flex="grow"
+                  fill={onResize || search ? 'vertical' : false}
+                  justify={(!align && 'center') || align}
+                >
                   {content}
                 </Box>
               );

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -26,6 +26,10 @@ exports[`DataTable !primaryKey 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c8 {
@@ -229,6 +233,10 @@ exports[`DataTable absoluteColumnSizes 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c9 {
@@ -477,6 +485,10 @@ exports[`DataTable aggregate 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c8 {
@@ -729,6 +741,10 @@ exports[`DataTable aggregate with nested object 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c8 {
@@ -1028,6 +1044,10 @@ exports[`DataTable background 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c8 {
@@ -1609,6 +1629,10 @@ exports[`DataTable basic 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c8 {
@@ -1820,6 +1844,10 @@ exports[`DataTable border 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c7 {
@@ -2475,6 +2503,10 @@ exports[`DataTable click 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c9 {
@@ -2643,7 +2675,7 @@ exports[`DataTable click 2`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 cUuGOF"
+            class="StyledBox-sc-13pk1d4-0 dCZrDR"
           >
             <span
               class="StyledText-sc-1sadyjn-0 jbJJSg"
@@ -2749,6 +2781,10 @@ exports[`DataTable custom theme 1`] = `
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
   height: 100%;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c9 {
@@ -3395,7 +3431,7 @@ exports[`DataTable custom theme 2`] = `
             style="position: relative;"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 dexCrH"
+              class="StyledBox-sc-13pk1d4-0 kcpMrH"
             >
               <button
                 class="StyledButton-sc-323bzc-0 bxbfiz Header__StyledHeaderCellButton-sc-1baku5q-0 jRVSDa"
@@ -3585,6 +3621,10 @@ exports[`DataTable disabled click 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c9 {
@@ -3754,7 +3794,7 @@ exports[`DataTable disabled click 2`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 cUuGOF"
+            class="StyledBox-sc-13pk1d4-0 dCZrDR"
           >
             <span
               class="StyledText-sc-1sadyjn-0 jbJJSg"
@@ -3903,6 +3943,10 @@ exports[`DataTable disabled select 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c19 {
@@ -4385,6 +4429,10 @@ exports[`DataTable fill 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c8 {
@@ -4923,6 +4971,10 @@ exports[`DataTable footer 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c8 {
@@ -5251,6 +5303,10 @@ exports[`DataTable groupBy 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c14 {
@@ -5668,7 +5724,7 @@ exports[`DataTable groupBy 2`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 cUuGOF"
+            class="StyledBox-sc-13pk1d4-0 dCZrDR"
           >
             <span
               class="StyledText-sc-1sadyjn-0 jbJJSg"
@@ -5682,7 +5738,7 @@ exports[`DataTable groupBy 2`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 cUuGOF"
+            class="StyledBox-sc-13pk1d4-0 dCZrDR"
           >
             <span
               class="StyledText-sc-1sadyjn-0 jbJJSg"
@@ -5949,6 +6005,10 @@ exports[`DataTable groupBy expand 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c14 {
@@ -6551,6 +6611,10 @@ exports[`DataTable groupBy property 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c14 {
@@ -6968,7 +7032,7 @@ exports[`DataTable groupBy property 2`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 cUuGOF"
+            class="StyledBox-sc-13pk1d4-0 dCZrDR"
           >
             <span
               class="StyledText-sc-1sadyjn-0 jbJJSg"
@@ -6982,7 +7046,7 @@ exports[`DataTable groupBy property 2`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 cUuGOF"
+            class="StyledBox-sc-13pk1d4-0 dCZrDR"
           >
             <span
               class="StyledText-sc-1sadyjn-0 jbJJSg"
@@ -7139,6 +7203,10 @@ exports[`DataTable groupBy toggle 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c8 {
@@ -7617,7 +7685,7 @@ exports[`DataTable groupBy toggle 2`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 cUuGOF"
+            class="StyledBox-sc-13pk1d4-0 dCZrDR"
           >
             <span
               class="StyledText-sc-1sadyjn-0 jbJJSg"
@@ -7631,7 +7699,7 @@ exports[`DataTable groupBy toggle 2`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 cUuGOF"
+            class="StyledBox-sc-13pk1d4-0 dCZrDR"
           >
             <span
               class="StyledText-sc-1sadyjn-0 jbJJSg"
@@ -7995,7 +8063,7 @@ exports[`DataTable groupBy toggle 3`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 cUuGOF"
+            class="StyledBox-sc-13pk1d4-0 dCZrDR"
           >
             <span
               class="StyledText-sc-1sadyjn-0 jbJJSg"
@@ -8009,7 +8077,7 @@ exports[`DataTable groupBy toggle 3`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 cUuGOF"
+            class="StyledBox-sc-13pk1d4-0 dCZrDR"
           >
             <span
               class="StyledText-sc-1sadyjn-0 jbJJSg"
@@ -8408,6 +8476,10 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c23 {
@@ -9346,6 +9418,10 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c23 {
@@ -10062,6 +10138,10 @@ exports[`DataTable onSelect + groupBy should select all items within a group 1`]
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c24 {
@@ -10810,6 +10890,10 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 1`
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c22 {
@@ -11438,7 +11522,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 cUuGOF"
+            class="StyledBox-sc-13pk1d4-0 dCZrDR"
           >
             <span
               class="StyledText-sc-1sadyjn-0 jbJJSg"
@@ -11452,7 +11536,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 cUuGOF"
+            class="StyledBox-sc-13pk1d4-0 dCZrDR"
           >
             <span
               class="StyledText-sc-1sadyjn-0 jbJJSg"
@@ -11778,7 +11862,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 cUuGOF"
+            class="StyledBox-sc-13pk1d4-0 dCZrDR"
           >
             <span
               class="StyledText-sc-1sadyjn-0 jbJJSg"
@@ -11792,7 +11876,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 cUuGOF"
+            class="StyledBox-sc-13pk1d4-0 dCZrDR"
           >
             <span
               class="StyledText-sc-1sadyjn-0 jbJJSg"
@@ -12065,6 +12149,10 @@ exports[`DataTable onSelect select/unselect all 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c16 {
@@ -12583,7 +12671,7 @@ exports[`DataTable onSelect select/unselect all 2`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 cUuGOF"
+            class="StyledBox-sc-13pk1d4-0 dCZrDR"
           >
             <span
               class="StyledText-sc-1sadyjn-0 jbJJSg"
@@ -12597,7 +12685,7 @@ exports[`DataTable onSelect select/unselect all 2`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 cUuGOF"
+            class="StyledBox-sc-13pk1d4-0 dCZrDR"
           >
             <span
               class="StyledText-sc-1sadyjn-0 jbJJSg"
@@ -12992,7 +13080,7 @@ exports[`DataTable onSelect select/unselect all 3`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 cUuGOF"
+            class="StyledBox-sc-13pk1d4-0 dCZrDR"
           >
             <span
               class="StyledText-sc-1sadyjn-0 jbJJSg"
@@ -13006,7 +13094,7 @@ exports[`DataTable onSelect select/unselect all 3`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 cUuGOF"
+            class="StyledBox-sc-13pk1d4-0 dCZrDR"
           >
             <span
               class="StyledText-sc-1sadyjn-0 jbJJSg"
@@ -13275,6 +13363,10 @@ exports[`DataTable onSort 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c7 {
@@ -13605,7 +13697,7 @@ exports[`DataTable onSort 2`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 cUuGOF"
+            class="StyledBox-sc-13pk1d4-0 dCZrDR"
           >
             <button
               class="StyledButton-sc-323bzc-0 bxbfiz Header__StyledHeaderCellButton-sc-1baku5q-0 jxDSTI"
@@ -13697,7 +13789,7 @@ exports[`DataTable onSort 2`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 cUuGOF"
+            class="StyledBox-sc-13pk1d4-0 dCZrDR"
           >
             <button
               class="StyledButton-sc-323bzc-0 bxbfiz Header__StyledHeaderCellButton-sc-1baku5q-0 jxDSTI"
@@ -13878,6 +13970,10 @@ exports[`DataTable onSort external 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c7 {
@@ -14239,7 +14335,7 @@ exports[`DataTable onSort external 2`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 cUuGOF"
+            class="StyledBox-sc-13pk1d4-0 dCZrDR"
           >
             <button
               class="StyledButton-sc-323bzc-0 bxbfiz Header__StyledHeaderCellButton-sc-1baku5q-0 jxDSTI"
@@ -14315,7 +14411,7 @@ exports[`DataTable onSort external 2`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 cUuGOF"
+            class="StyledBox-sc-13pk1d4-0 dCZrDR"
           >
             <button
               class="StyledButton-sc-323bzc-0 bxbfiz Header__StyledHeaderCellButton-sc-1baku5q-0 jxDSTI"
@@ -14462,6 +14558,10 @@ exports[`DataTable pad 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c8 {
@@ -15024,6 +15124,10 @@ exports[`DataTable paths 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c8 {
@@ -15235,6 +15339,10 @@ exports[`DataTable pin + background 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c11 {
@@ -15858,6 +15966,10 @@ exports[`DataTable pin + background context 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c12 {
@@ -16500,6 +16612,10 @@ exports[`DataTable pin 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c11 {
@@ -17064,6 +17180,10 @@ exports[`DataTable placeholder 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c8 {
@@ -17530,6 +17650,10 @@ exports[`DataTable primaryKey 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c8 {
@@ -17741,6 +17865,10 @@ exports[`DataTable relativeColumnSizes 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c9 {
@@ -17989,6 +18117,10 @@ exports[`DataTable replace 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c8 {
@@ -18253,6 +18385,10 @@ exports[`DataTable resizeable 1`] = `
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
   height: 100%;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c10 {
@@ -18665,6 +18801,10 @@ exports[`DataTable rowDetails 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c9 {
@@ -19263,6 +19403,10 @@ exports[`DataTable rowDetails condtional 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c9 {
@@ -19830,6 +19974,10 @@ exports[`DataTable rowProps 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c8 {
@@ -20152,6 +20300,10 @@ exports[`DataTable search 1`] = `
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
   height: 100%;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c12 {
@@ -20442,7 +20594,7 @@ exports[`DataTable search 2`] = `
             class="StyledBox-sc-13pk1d4-0 glMZQD"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 dexCrH"
+              class="StyledBox-sc-13pk1d4-0 kcpMrH"
             >
               <span
                 class="StyledText-sc-1sadyjn-0 jbJJSg"
@@ -20688,6 +20840,10 @@ exports[`DataTable select 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c16 {
@@ -21117,7 +21273,7 @@ exports[`DataTable select 2`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 cUuGOF"
+            class="StyledBox-sc-13pk1d4-0 dCZrDR"
           >
             <span
               class="StyledText-sc-1sadyjn-0 jbJJSg"
@@ -21384,6 +21540,10 @@ exports[`DataTable should apply pagination styling 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c12 {
@@ -23662,6 +23822,10 @@ exports[`DataTable should not show paginate controls when data is empty array 1`
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c7 {
@@ -23815,6 +23979,10 @@ exports[`DataTable should not show paginate controls when length of data < step 
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c7 {
@@ -24148,6 +24316,10 @@ exports[`DataTable should paginate 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c12 {
@@ -26486,6 +26658,10 @@ exports[`DataTable should pin and paginate 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c13 {
@@ -28833,6 +29009,10 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c12 {
@@ -30125,6 +30305,10 @@ exports[`DataTable should render new data when page changes 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c12 {
@@ -32364,7 +32548,7 @@ exports[`DataTable should render new data when page changes 2`] = `
               scope="col"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 cUuGOF"
+                class="StyledBox-sc-13pk1d4-0 dCZrDR"
               >
                 <span
                   class="StyledText-sc-1sadyjn-0 jbJJSg"
@@ -32378,7 +32562,7 @@ exports[`DataTable should render new data when page changes 2`] = `
               scope="col"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 cUuGOF"
+                class="StyledBox-sc-13pk1d4-0 dCZrDR"
               >
                 <span
                   class="StyledText-sc-1sadyjn-0 jbJJSg"
@@ -34011,6 +34195,10 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c12 {
@@ -36349,6 +36537,10 @@ exports[`DataTable should show correct page when "show" is { page: # } 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c12 {
@@ -38469,6 +38661,10 @@ exports[`DataTable sort 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c7 {
@@ -38873,6 +39069,10 @@ exports[`DataTable sort controlled 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c8 {
@@ -39353,6 +39553,10 @@ exports[`DataTable sort controlled 2`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c8 {
@@ -39832,6 +40036,10 @@ exports[`DataTable sort external 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c7 {
@@ -40235,6 +40443,10 @@ exports[`DataTable sort nested object 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c7 {
@@ -40638,6 +40850,10 @@ exports[`DataTable sort nested object with onSort 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c7 {
@@ -41007,6 +41223,10 @@ exports[`DataTable sort null data 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c7 {
@@ -41482,7 +41702,7 @@ exports[`DataTable sort null data 2`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 cUuGOF"
+            class="StyledBox-sc-13pk1d4-0 dCZrDR"
           >
             <button
               class="StyledButton-sc-323bzc-0 bxbfiz Header__StyledHeaderCellButton-sc-1baku5q-0 jxDSTI"
@@ -41574,7 +41794,7 @@ exports[`DataTable sort null data 2`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 cUuGOF"
+            class="StyledBox-sc-13pk1d4-0 dCZrDR"
           >
             <button
               class="StyledButton-sc-323bzc-0 bxbfiz Header__StyledHeaderCellButton-sc-1baku5q-0 jxDSTI"
@@ -41597,7 +41817,7 @@ exports[`DataTable sort null data 2`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 cUuGOF"
+            class="StyledBox-sc-13pk1d4-0 dCZrDR"
           >
             <button
               class="StyledButton-sc-323bzc-0 bxbfiz Header__StyledHeaderCellButton-sc-1baku5q-0 jxDSTI"
@@ -41620,7 +41840,7 @@ exports[`DataTable sort null data 2`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 cUuGOF"
+            class="StyledBox-sc-13pk1d4-0 dCZrDR"
           >
             <button
               class="StyledButton-sc-323bzc-0 bxbfiz Header__StyledHeaderCellButton-sc-1baku5q-0 jxDSTI"
@@ -41886,7 +42106,7 @@ exports[`DataTable sort null data 3`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 cUuGOF"
+            class="StyledBox-sc-13pk1d4-0 dCZrDR"
           >
             <button
               class="StyledButton-sc-323bzc-0 bxbfiz Header__StyledHeaderCellButton-sc-1baku5q-0 jxDSTI"
@@ -41909,7 +42129,7 @@ exports[`DataTable sort null data 3`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 cUuGOF"
+            class="StyledBox-sc-13pk1d4-0 dCZrDR"
           >
             <button
               class="StyledButton-sc-323bzc-0 bxbfiz Header__StyledHeaderCellButton-sc-1baku5q-0 jxDSTI"
@@ -41932,7 +42152,7 @@ exports[`DataTable sort null data 3`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 cUuGOF"
+            class="StyledBox-sc-13pk1d4-0 dCZrDR"
           >
             <button
               class="StyledButton-sc-323bzc-0 bxbfiz Header__StyledHeaderCellButton-sc-1baku5q-0 jxDSTI"
@@ -42024,7 +42244,7 @@ exports[`DataTable sort null data 3`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 cUuGOF"
+            class="StyledBox-sc-13pk1d4-0 dCZrDR"
           >
             <button
               class="StyledButton-sc-323bzc-0 bxbfiz Header__StyledHeaderCellButton-sc-1baku5q-0 jxDSTI"
@@ -42290,7 +42510,7 @@ exports[`DataTable sort null data 4`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 cUuGOF"
+            class="StyledBox-sc-13pk1d4-0 dCZrDR"
           >
             <button
               class="StyledButton-sc-323bzc-0 bxbfiz Header__StyledHeaderCellButton-sc-1baku5q-0 jxDSTI"
@@ -42313,7 +42533,7 @@ exports[`DataTable sort null data 4`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 cUuGOF"
+            class="StyledBox-sc-13pk1d4-0 dCZrDR"
           >
             <button
               class="StyledButton-sc-323bzc-0 bxbfiz Header__StyledHeaderCellButton-sc-1baku5q-0 jxDSTI"
@@ -42336,7 +42556,7 @@ exports[`DataTable sort null data 4`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 cUuGOF"
+            class="StyledBox-sc-13pk1d4-0 dCZrDR"
           >
             <button
               class="StyledButton-sc-323bzc-0 bxbfiz Header__StyledHeaderCellButton-sc-1baku5q-0 jxDSTI"
@@ -42359,7 +42579,7 @@ exports[`DataTable sort null data 4`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 cUuGOF"
+            class="StyledBox-sc-13pk1d4-0 dCZrDR"
           >
             <button
               class="StyledButton-sc-323bzc-0 bxbfiz Header__StyledHeaderCellButton-sc-1baku5q-0 jxDSTI"
@@ -42702,6 +42922,10 @@ exports[`DataTable sortable 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c7 {
@@ -43032,7 +43256,7 @@ exports[`DataTable sortable 2`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 cUuGOF"
+            class="StyledBox-sc-13pk1d4-0 dCZrDR"
           >
             <button
               class="StyledButton-sc-323bzc-0 bxbfiz Header__StyledHeaderCellButton-sc-1baku5q-0 jxDSTI"
@@ -43124,7 +43348,7 @@ exports[`DataTable sortable 2`] = `
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 cUuGOF"
+            class="StyledBox-sc-13pk1d4-0 dCZrDR"
           >
             <button
               class="StyledButton-sc-323bzc-0 bxbfiz Header__StyledHeaderCellButton-sc-1baku5q-0 jxDSTI"
@@ -43271,6 +43495,10 @@ exports[`DataTable themeColumnSizes 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c9 {
@@ -43519,6 +43747,10 @@ exports[`DataTable units 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c6 {
@@ -43805,6 +44037,10 @@ exports[`DataTable verticalAlign 1`] = `
   -webkit-flex: 1 0 auto;
   -ms-flex: 1 0 auto;
   flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c5 {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fix the bug when selecting the search icon within a column header the text 

#### Where should the reviewer start?
Header.js

#### What testing has been done on this PR?
Updated the snapshot for this component

#### How should this be manually tested?
I used the storybook to test this component.

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
If not passing any align property through the column header, default set to center.

#### What are the relevant issues?
Closes #6493

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
backwards compatible.
