### PR TITLE
Update Select value type definition

### DIFF
--- a/src/js/components/Select/index.d.ts
+++ b/src/js/components/Select/index.d.ts
@@ -56,7 +56,7 @@ export interface SelectProps extends BasicSelectProps {
   defaultValue?: string | number | object | (string | number | object)[];
   multiple?: boolean;
   selected?: number | number[];
-  value?: string | JSX.Element | object | (string | number | object)[];
+  value?: string | JSX.Element | number | object | (string | number | object)[];
 }
 
 // Try without Omit<> to see where we define our own attributes for overrides


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Fixes Select `value` type definition to include `number` which is documented.

#### Where should the reviewer start?

src/js/components/Select/index.d.ts

#### What testing has been done on this PR?

Tested locally in storybook to make sure `number` is supported.

#### How should this be manually tested?

Set Select value to a number that is included in the options array.

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

Closes #6522 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
Yes. Typescript fix.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.