### PR TITLE
Omit readOnly from Select props

### DIFF
--- a/src/js/components/Select/index.d.ts
+++ b/src/js/components/Select/index.d.ts
@@ -63,7 +63,7 @@ export interface SelectProps extends BasicSelectProps {
 // value, name, id, onChange, placeholder
 export interface SelectExtendedProps
   extends SelectProps,
-    Omit<JSX.IntrinsicElements['input'], keyof SelectProps> {}
+    Omit<JSX.IntrinsicElements['input'], keyof SelectProps | 'readOnly'> {}
 
 declare const Select: React.FC<SelectExtendedProps>;
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Select does not currently support `readOnly` functionality. This aligns the typescript definition with the currently supported behavior.

#### Where should the reviewer start?
src/js/components/Select/index.d.ts

#### What testing has been done on this PR?
In local storybook:

<img width="464" alt="Screen Shot 2022-12-13 at 9 40 41 AM" src="https://user-images.githubusercontent.com/12522275/207406585-7e48a208-2a85-49cf-be98-c61b545f2143.png">

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #6509 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
Yes. Typescript fix.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.