### PR TITLE
FormField -- include required text in screen reader only

### DIFF
--- a/src/js/components/FormField/FormField.js
+++ b/src/js/components/FormField/FormField.js
@@ -69,6 +69,17 @@ const RequiredText = styled(Text)`
   line-height: inherit;
 `;
 
+const ScreenReaderOnly = styled(Text)`
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+`;
+
 const Message = ({ error, info, message, type, ...rest }) => {
   const theme = useContext(ThemeContext) || defaultProps.theme;
 
@@ -450,10 +461,17 @@ const FormField = forwardRef(
 
     let { requiredIndicator } = theme.formField.label;
     if (requiredIndicator === true)
-      // a11yTitle necessary so screenreader announces as "required"
-      // as opposed to "star"
       // accessibility resource: https://www.deque.com/blog/anatomy-of-accessible-forms-required-form-fields/
-      requiredIndicator = <RequiredText a11yTitle="required">*</RequiredText>;
+      // this approach allows the required indicator to be hidden visually,
+      // but present for assistive tech.
+      // using aria-hidden so screen does not read out "star" and
+      // just reads out "required"
+      requiredIndicator = (
+        <>
+          <RequiredText aria-hidden="true">*</RequiredText>
+          <ScreenReaderOnly>required</ScreenReaderOnly>
+        </>
+      );
 
     let showRequiredIndicator = required && requiredIndicator;
     if (typeof required === 'object' && required.indicator === false)

--- a/src/js/components/FormField/__tests__/__snapshots__/FormField-test.js.snap
+++ b/src/js/components/FormField/__tests__/__snapshots__/FormField-test.js.snap
@@ -2705,7 +2705,7 @@ exports[`FormField should render asterisk when requiredIndicator === true 1`] = 
   flex-direction: column;
 }
 
-.c5 {
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2734,7 +2734,7 @@ exports[`FormField should render asterisk when requiredIndicator === true 1`] = 
   line-height: 24px;
 }
 
-.c7 {
+.c8 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -2752,33 +2752,33 @@ exports[`FormField should render asterisk when requiredIndicator === true 1`] = 
   border: none;
 }
 
-.c7::-webkit-input-placeholder {
+.c8::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-moz-placeholder {
+.c8::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c7:-ms-input-placeholder {
+.c8:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-webkit-search-decoration {
+.c8::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c7::-moz-focus-inner {
+.c8::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c7:-moz-placeholder,
-.c7::-moz-placeholder {
+.c8:-moz-placeholder,
+.c8::-moz-placeholder {
   opacity: 1;
 }
 
-.c6 {
+.c7 {
   position: relative;
   width: 100%;
 }
@@ -2789,6 +2789,18 @@ exports[`FormField should render asterisk when requiredIndicator === true 1`] = 
   line-height: inherit;
 }
 
+.c5 {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  -webkit-clip: rect(0,0,0,0);
+  clip: rect(0,0,0,0);
+  border: 0;
+}
+
 @media only screen and (max-width:768px) {
   .c1 {
     margin-bottom: 6px;
@@ -2796,7 +2808,7 @@ exports[`FormField should render asterisk when requiredIndicator === true 1`] = 
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c6 {
     border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
@@ -2813,21 +2825,26 @@ exports[`FormField should render asterisk when requiredIndicator === true 1`] = 
       >
         label
         <span
-          aria-label="required"
+          aria-hidden="true"
           class="c3 c4"
         >
           *
         </span>
+        <span
+          class="c3 c5"
+        >
+          required
+        </span>
       </label>
       <div
-        class="c5 FormField__FormFieldContentBox-sc-m9hood-1"
+        class="c6 FormField__FormFieldContentBox-sc-m9hood-1"
       >
         <div
-          class="c6"
+          class="c7"
         >
           <input
             autocomplete="off"
-            class="c7"
+            class="c8"
             value=""
           />
         </div>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

This updates our approach to marking required fields with a required indicator. Previously, we relied on aria-label to put a "required" string on the * span. However, certain screen readers like JAWS/NVDA do not read aria-labels on spans. This takes an improved approach (mirroring an approach [Bootstrap](https://getbootstrap.com/docs/4.0/utilities/screenreaders/) has taken) to include "required" in the DOM but keeping it only visible for screen readers.

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Relates to #6524 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
Yes. Improved screen reader support for required form fields.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.