### PR TITLE
Changed RangeSelector to add label

### DIFF
--- a/src/js/components/FormField/FormField.js
+++ b/src/js/components/FormField/FormField.js
@@ -34,6 +34,7 @@ const grommetInputNames = [
   'FileInput',
   'RadioButtonGroup',
   'RangeInput',
+  'RangeSelector',
   'StarRating',
   'ThumbsRating',
 ];
@@ -42,6 +43,7 @@ const grommetInputPadNames = [
   'CheckBoxGroup',
   'RadioButtonGroup',
   'RangeInput',
+  'RangeSelector',
 ];
 
 const isGrommetInput = (comp) =>

--- a/src/js/components/RangeSelector/RangeSelector.js
+++ b/src/js/components/RangeSelector/RangeSelector.js
@@ -55,7 +55,8 @@ const RangeSelector = forwardRef(
 
     const [values, setValues] = formContext.useFormInput({
       name,
-      value: valuesProp,
+      // ensure values are within min/max
+      value: valuesProp?.map((n) => Math.min(max, Math.max(min, n))),
       initialValue: defaultValues,
     });
 
@@ -202,27 +203,17 @@ const RangeSelector = forwardRef(
     else layoutProps.height = thickness;
     if (size === 'full') layoutProps.alignSelf = 'stretch';
 
-    return (
+    let content = (
       <Container
         ref={containerRef}
         direction={direction === 'vertical' ? 'column' : 'row'}
         align="center"
         fill
-        {...rest}
+        {...(label ? {} : rest)}
         tabIndex="-1"
         onClick={onClick}
         onTouchMove={onTouchMove}
       >
-        {label && (
-          <Text
-            ref={minRef}
-            textAlign="end"
-            size="small"
-            margin={{ horizontal: 'small' }}
-          >
-            {typeof label === 'function' ? label(lower) : lower}
-          </Text>
-        )}
         <Box
           style={{ flex: `${lower - min} 0 0` }}
           background={
@@ -322,13 +313,34 @@ const RangeSelector = forwardRef(
           {...layoutProps}
           round={round}
         />
-        {label && (
+      </Container>
+    );
+
+    if (label) {
+      content = (
+        <Box
+          direction={direction === 'vertical' ? 'column' : 'row'}
+          align="center"
+          fill
+          {...rest}
+        >
+          <Text
+            ref={minRef}
+            textAlign="end"
+            size="small"
+            margin={{ horizontal: 'small' }}
+          >
+            {typeof label === 'function' ? label(lower) : lower}
+          </Text>
+          {content}
           <Text ref={maxRef} size="small" margin={{ horizontal: 'small' }}>
             {typeof label === 'function' ? label(upper) : upper}
           </Text>
-        )}
-      </Container>
-    );
+        </Box>
+      );
+    }
+
+    return content;
   },
 );
 

--- a/src/js/components/RangeSelector/RangeSelector.js
+++ b/src/js/components/RangeSelector/RangeSelector.js
@@ -7,10 +7,12 @@ import React, {
   useState,
 } from 'react';
 import styled, { ThemeContext } from 'styled-components';
+import { useLayoutEffect } from '../../utils/use-isomorphic-layout-effect';
 
 import { Box } from '../Box';
 import { EdgeControl } from './EdgeControl';
 import { FormContext } from '../Form/FormContext';
+import { Text } from '../Text';
 import { parseMetricToNum } from '../../utils';
 import { MessageContext } from '../../contexts/MessageContext';
 import { RangeSelectorPropTypes } from './propTypes';
@@ -26,6 +28,7 @@ const RangeSelector = forwardRef(
       defaultValues = [],
       direction = 'horizontal',
       invert,
+      label,
       max = 100,
       messages,
       min = 0,
@@ -47,6 +50,8 @@ const RangeSelector = forwardRef(
     const [lastChange, setLastChange] = useState();
     const [moveValue, setMoveValue] = useState();
     const containerRef = useRef();
+    const maxRef = useRef();
+    const minRef = useRef();
 
     const [values, setValues] = formContext.useFormInput({
       name,
@@ -173,6 +178,18 @@ const RangeSelector = forwardRef(
       [onMouseMove],
     );
 
+    // keep the text values size consistent
+    useLayoutEffect(() => {
+      if (maxRef.current && minRef.current) {
+        const width = Math.max(
+          maxRef.current.getBoundingClientRect().width,
+          minRef.current.getBoundingClientRect().width,
+        );
+        maxRef.current.style.width = `${width}px`;
+        minRef.current.style.width = `${width}px`;
+      }
+    });
+
     const [lower, upper] = values;
     // It needs to be true when vertical, due to how browsers manage height
     // const fill = direction === 'vertical' ? true : 'horizontal';
@@ -196,6 +213,16 @@ const RangeSelector = forwardRef(
         onClick={onClick}
         onTouchMove={onTouchMove}
       >
+        {label && (
+          <Text
+            ref={minRef}
+            textAlign="end"
+            size="small"
+            margin={{ horizontal: 'small' }}
+          >
+            {typeof label === 'function' ? label(lower) : lower}
+          </Text>
+        )}
         <Box
           style={{ flex: `${lower - min} 0 0` }}
           background={
@@ -295,6 +322,11 @@ const RangeSelector = forwardRef(
           {...layoutProps}
           round={round}
         />
+        {label && (
+          <Text ref={maxRef} size="small" margin={{ horizontal: 'small' }}>
+            {typeof label === 'function' ? label(upper) : upper}
+          </Text>
+        )}
       </Container>
     );
   },

--- a/src/js/components/RangeSelector/RangeSelector.js
+++ b/src/js/components/RangeSelector/RangeSelector.js
@@ -182,6 +182,8 @@ const RangeSelector = forwardRef(
     // keep the text values size consistent
     useLayoutEffect(() => {
       if (maxRef.current && minRef.current) {
+        maxRef.current.style.width = '';
+        minRef.current.style.width = '';
         const width = Math.max(
           maxRef.current.getBoundingClientRect().width,
           minRef.current.getBoundingClientRect().width,

--- a/src/js/components/RangeSelector/RangeSelector.js
+++ b/src/js/components/RangeSelector/RangeSelector.js
@@ -52,6 +52,7 @@ const RangeSelector = forwardRef(
     const containerRef = useRef();
     const maxRef = useRef();
     const minRef = useRef();
+    const labelWidthRef = useRef(0);
 
     const [values, setValues] = formContext.useFormInput({
       name,
@@ -185,11 +186,13 @@ const RangeSelector = forwardRef(
         maxRef.current.style.width = '';
         minRef.current.style.width = '';
         const width = Math.max(
+          labelWidthRef.current,
           maxRef.current.getBoundingClientRect().width,
           minRef.current.getBoundingClientRect().width,
         );
         maxRef.current.style.width = `${width}px`;
         minRef.current.style.width = `${width}px`;
+        labelWidthRef.current = width;
       }
     });
 

--- a/src/js/components/RangeSelector/__tests__/RangeSelector-test.js
+++ b/src/js/components/RangeSelector/__tests__/RangeSelector-test.js
@@ -84,6 +84,17 @@ describe('RangeSelector', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  test('label', () => {
+    const { container } = render(
+      <Grommet>
+        <RangeSelector label values={[20, 30]} />
+        <RangeSelector label={(value) => `${value}%`} values={[20, 30]} />
+      </Grommet>,
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
   test('opacity', () => {
     const { container } = render(
       <Grommet>

--- a/src/js/components/RangeSelector/__tests__/__snapshots__/RangeSelector-test.js.snap
+++ b/src/js/components/RangeSelector/__tests__/__snapshots__/RangeSelector-test.js.snap
@@ -1691,10 +1691,30 @@ exports[`RangeSelector label 1`] = `
   flex-direction: row;
   width: 100%;
   height: 100%;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  width: 100%;
+  height: 100%;
   cursor: pointer;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1710,7 +1730,7 @@ exports[`RangeSelector label 1`] = `
   width: 100%;
 }
 
-.c5 {
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1736,7 +1756,7 @@ exports[`RangeSelector label 1`] = `
   overflow: visible;
 }
 
-.c6 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1761,7 +1781,7 @@ exports[`RangeSelector label 1`] = `
   justify-content: center;
 }
 
-.c7 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1780,7 +1800,7 @@ exports[`RangeSelector label 1`] = `
   border-radius: 100%;
 }
 
-.c8 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1798,7 +1818,7 @@ exports[`RangeSelector label 1`] = `
   width: 100%;
 }
 
-.c3 {
+.c2 {
   margin-left: 12px;
   margin-right: 12px;
   font-size: 14px;
@@ -1806,14 +1826,14 @@ exports[`RangeSelector label 1`] = `
   text-align: right;
 }
 
-.c9 {
+.c10 {
   margin-left: 12px;
   margin-right: 12px;
   font-size: 14px;
   line-height: 20px;
 }
 
-.c2 {
+.c4 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -1824,134 +1844,142 @@ exports[`RangeSelector label 1`] = `
   class="c0"
 >
   <div
-    class="c1 c2"
-    tabindex="-1"
+    class="c1"
   >
     <span
-      class="c3"
+      class="c2"
       style="width: 0px;"
     >
       20
     </span>
     <div
-      class="c4"
-      style="flex: 20 0 0px;"
-    />
-    <div
-      class="c5"
-      style="flex: 0 0 1px;"
+      class="c3 c4"
+      tabindex="-1"
     >
       <div
-        aria-label="Lower Bounds"
-        aria-valuemax="100"
-        aria-valuemin="0"
-        aria-valuenow="20"
-        class="c6"
-        role="slider"
-        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 1;"
-        tabindex="0"
-      >
-        <div
-          class="c7 EdgeControl__StyledBox-sc-1xo2yt9-0"
-        />
-      </div>
-    </div>
-    <div
-      class="c8"
-      style="flex: 11 0 0px; cursor: ew-resize;"
-    />
-    <div
-      class="c5"
-      style="flex: 0 0 1px;"
-    >
+        class="c5"
+        style="flex: 20 0 0px;"
+      />
       <div
-        aria-label="Upper Bounds"
-        aria-valuemax="100"
-        aria-valuemin="0"
-        aria-valuenow="30"
         class="c6"
-        role="slider"
-        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 1;"
-        tabindex="0"
+        style="flex: 0 0 1px;"
       >
         <div
-          class="c7 EdgeControl__StyledBox-sc-1xo2yt9-0"
-        />
+          aria-label="Lower Bounds"
+          aria-valuemax="100"
+          aria-valuemin="0"
+          aria-valuenow="20"
+          class="c7"
+          role="slider"
+          style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 1;"
+          tabindex="0"
+        >
+          <div
+            class="c8 EdgeControl__StyledBox-sc-1xo2yt9-0"
+          />
+        </div>
       </div>
+      <div
+        class="c9"
+        style="flex: 11 0 0px; cursor: ew-resize;"
+      />
+      <div
+        class="c6"
+        style="flex: 0 0 1px;"
+      >
+        <div
+          aria-label="Upper Bounds"
+          aria-valuemax="100"
+          aria-valuemin="0"
+          aria-valuenow="30"
+          class="c7"
+          role="slider"
+          style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 1;"
+          tabindex="0"
+        >
+          <div
+            class="c8 EdgeControl__StyledBox-sc-1xo2yt9-0"
+          />
+        </div>
+      </div>
+      <div
+        class="c5"
+        style="flex: 70 0 0px;"
+      />
     </div>
-    <div
-      class="c4"
-      style="flex: 70 0 0px;"
-    />
     <span
-      class="c9"
+      class="c10"
       style="width: 0px;"
     >
       30
     </span>
   </div>
   <div
-    class="c1 c2"
-    tabindex="-1"
+    class="c1"
   >
     <span
-      class="c3"
+      class="c2"
       style="width: 0px;"
     >
       20%
     </span>
     <div
-      class="c4"
-      style="flex: 20 0 0px;"
-    />
-    <div
-      class="c5"
-      style="flex: 0 0 1px;"
+      class="c3 c4"
+      tabindex="-1"
     >
       <div
-        aria-label="Lower Bounds"
-        aria-valuemax="100"
-        aria-valuemin="0"
-        aria-valuenow="20"
-        class="c6"
-        role="slider"
-        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 1;"
-        tabindex="0"
-      >
-        <div
-          class="c7 EdgeControl__StyledBox-sc-1xo2yt9-0"
-        />
-      </div>
-    </div>
-    <div
-      class="c8"
-      style="flex: 11 0 0px; cursor: ew-resize;"
-    />
-    <div
-      class="c5"
-      style="flex: 0 0 1px;"
-    >
+        class="c5"
+        style="flex: 20 0 0px;"
+      />
       <div
-        aria-label="Upper Bounds"
-        aria-valuemax="100"
-        aria-valuemin="0"
-        aria-valuenow="30"
         class="c6"
-        role="slider"
-        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 1;"
-        tabindex="0"
+        style="flex: 0 0 1px;"
       >
         <div
-          class="c7 EdgeControl__StyledBox-sc-1xo2yt9-0"
-        />
+          aria-label="Lower Bounds"
+          aria-valuemax="100"
+          aria-valuemin="0"
+          aria-valuenow="20"
+          class="c7"
+          role="slider"
+          style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 1;"
+          tabindex="0"
+        >
+          <div
+            class="c8 EdgeControl__StyledBox-sc-1xo2yt9-0"
+          />
+        </div>
       </div>
+      <div
+        class="c9"
+        style="flex: 11 0 0px; cursor: ew-resize;"
+      />
+      <div
+        class="c6"
+        style="flex: 0 0 1px;"
+      >
+        <div
+          aria-label="Upper Bounds"
+          aria-valuemax="100"
+          aria-valuemin="0"
+          aria-valuenow="30"
+          class="c7"
+          role="slider"
+          style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 1;"
+          tabindex="0"
+        >
+          <div
+            class="c8 EdgeControl__StyledBox-sc-1xo2yt9-0"
+          />
+        </div>
+      </div>
+      <div
+        class="c5"
+        style="flex: 70 0 0px;"
+      />
     </div>
-    <div
-      class="c4"
-      style="flex: 70 0 0px;"
-    />
     <span
-      class="c9"
+      class="c10"
       style="width: 0px;"
     >
       30%

--- a/src/js/components/RangeSelector/__tests__/__snapshots__/RangeSelector-test.js.snap
+++ b/src/js/components/RangeSelector/__tests__/__snapshots__/RangeSelector-test.js.snap
@@ -1662,6 +1662,304 @@ exports[`RangeSelector invert 1`] = `
 </div>
 `;
 
+exports[`RangeSelector label 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  width: 100%;
+  height: 100%;
+  cursor: pointer;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 24px;
+  width: 100%;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  overflow: visible;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex-basis: 100%;
+  -ms-flex-preferred-size: 100%;
+  flex-basis: 100%;
+  height: 100%;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  background-color: #7D4CDB;
+  color: #f8f8f8;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 12px;
+  width: 12px;
+  border-radius: 100%;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  background-color: rgba(125,76,219,0.4);
+  color: #444444;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 24px;
+  width: 100%;
+}
+
+.c3 {
+  margin-left: 12px;
+  margin-right: 12px;
+  font-size: 14px;
+  line-height: 20px;
+  text-align: right;
+}
+
+.c9 {
+  margin-left: 12px;
+  margin-right: 12px;
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.c2 {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1 c2"
+    tabindex="-1"
+  >
+    <span
+      class="c3"
+      style="width: 0px;"
+    >
+      20
+    </span>
+    <div
+      class="c4"
+      style="flex: 20 0 0px;"
+    />
+    <div
+      class="c5"
+      style="flex: 0 0 1px;"
+    >
+      <div
+        aria-label="Lower Bounds"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="20"
+        class="c6"
+        role="slider"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 1;"
+        tabindex="0"
+      >
+        <div
+          class="c7 EdgeControl__StyledBox-sc-1xo2yt9-0"
+        />
+      </div>
+    </div>
+    <div
+      class="c8"
+      style="flex: 11 0 0px; cursor: ew-resize;"
+    />
+    <div
+      class="c5"
+      style="flex: 0 0 1px;"
+    >
+      <div
+        aria-label="Upper Bounds"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="30"
+        class="c6"
+        role="slider"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 1;"
+        tabindex="0"
+      >
+        <div
+          class="c7 EdgeControl__StyledBox-sc-1xo2yt9-0"
+        />
+      </div>
+    </div>
+    <div
+      class="c4"
+      style="flex: 70 0 0px;"
+    />
+    <span
+      class="c9"
+      style="width: 0px;"
+    >
+      30
+    </span>
+  </div>
+  <div
+    class="c1 c2"
+    tabindex="-1"
+  >
+    <span
+      class="c3"
+      style="width: 0px;"
+    >
+      20%
+    </span>
+    <div
+      class="c4"
+      style="flex: 20 0 0px;"
+    />
+    <div
+      class="c5"
+      style="flex: 0 0 1px;"
+    >
+      <div
+        aria-label="Lower Bounds"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="20"
+        class="c6"
+        role="slider"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 1;"
+        tabindex="0"
+      >
+        <div
+          class="c7 EdgeControl__StyledBox-sc-1xo2yt9-0"
+        />
+      </div>
+    </div>
+    <div
+      class="c8"
+      style="flex: 11 0 0px; cursor: ew-resize;"
+    />
+    <div
+      class="c5"
+      style="flex: 0 0 1px;"
+    >
+      <div
+        aria-label="Upper Bounds"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="30"
+        class="c6"
+        role="slider"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 1;"
+        tabindex="0"
+      >
+        <div
+          class="c7 EdgeControl__StyledBox-sc-1xo2yt9-0"
+        />
+      </div>
+    </div>
+    <div
+      class="c4"
+      style="flex: 70 0 0px;"
+    />
+    <span
+      class="c9"
+      style="width: 0px;"
+    >
+      30%
+    </span>
+  </div>
+</div>
+`;
+
 exports[`RangeSelector max 1`] = `
 .c0 {
   font-size: 18px;

--- a/src/js/components/RangeSelector/index.d.ts
+++ b/src/js/components/RangeSelector/index.d.ts
@@ -6,6 +6,7 @@ export interface RangeSelectorProps {
   defaultValues?: number[];
   direction?: 'horizontal' | 'vertical';
   invert?: boolean;
+  label?: boolean | ((value: number) => React.ReactNode);
   max?: number;
   messages?: { lower?: string; upper?: string };
   min?: number;

--- a/src/js/components/RangeSelector/propTypes.js
+++ b/src/js/components/RangeSelector/propTypes.js
@@ -8,6 +8,7 @@ if (process.env.NODE_ENV !== 'production') {
     defaultValues: PropTypes.arrayOf(PropTypes.number),
     direction: PropTypes.oneOf(['horizontal', 'vertical']),
     invert: PropTypes.bool,
+    label: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
     max: PropTypes.number,
     messages: PropTypes.shape({
       lower: PropTypes.string,

--- a/src/js/components/RangeSelector/stories/Label.js
+++ b/src/js/components/RangeSelector/stories/Label.js
@@ -1,0 +1,46 @@
+import React, { useState } from 'react';
+import { Box, FormField } from 'grommet';
+import { RangeSelector } from '../RangeSelector';
+
+export const Label = () => {
+  const [range, setRange] = useState([0, 100]);
+  const [range2, setRange2] = useState([0, 100]);
+
+  return (
+    // Uncomment <Grommet> lines when using outside of storybook
+    // <Grommet theme={...}>
+    <Box pad="xlarge" align="center">
+      <Box width="medium">
+        <FormField name="range" htmlFor="range" label="Range">
+          <RangeSelector
+            id="range"
+            min={0}
+            max={100}
+            label
+            values={range}
+            onChange={(nextRange) => {
+              setRange(nextRange);
+            }}
+          />
+        </FormField>
+        <FormField name="range2" htmlFor="range2" label="Range units">
+          <RangeSelector
+            id="range2"
+            min={0}
+            max={100}
+            label={(value) => `${value}%`}
+            values={range2}
+            onChange={(nextRange) => {
+              setRange2(nextRange);
+            }}
+          />
+        </FormField>
+      </Box>
+    </Box>
+    // </Grommet>
+  );
+};
+
+export default {
+  title: 'Input/RangeSelector/Label',
+};

--- a/src/js/components/RangeSelector/stories/Simple.js
+++ b/src/js/components/RangeSelector/stories/Simple.js
@@ -1,0 +1,27 @@
+import React, { useState } from 'react';
+import { Box } from 'grommet';
+import { RangeSelector } from '../RangeSelector';
+
+export const Simple = () => {
+  const [range, setRange] = useState();
+
+  return (
+    // Uncomment <Grommet> lines when using outside of storybook
+    // <Grommet theme={...}>
+    <Box pad="xlarge">
+      <RangeSelector
+        min={0}
+        max={100}
+        values={range}
+        onChange={(nextRange) => {
+          setRange(nextRange);
+        }}
+      />
+    </Box>
+    // </Grommet>
+  );
+};
+
+export default {
+  title: 'Input/RangeSelector/Simple',
+};

--- a/src/js/components/RangeSelector/stories/Simple.js
+++ b/src/js/components/RangeSelector/stories/Simple.js
@@ -3,7 +3,7 @@ import { Box } from 'grommet';
 import { RangeSelector } from '../RangeSelector';
 
 export const Simple = () => {
-  const [range, setRange] = useState();
+  const [range, setRange] = useState([10, 40]);
 
   return (
     // Uncomment <Grommet> lines when using outside of storybook

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -760,6 +760,7 @@ exports[`Components loads 1`] = `
       "defaultValues": [Function],
       "direction": [Function],
       "invert": [Function],
+      "label": [Function],
       "max": [Function],
       "messages": [Function],
       "min": [Function],


### PR DESCRIPTION
#### What does this PR do?

Changed RangeSelector to add `label`. This moves the functionality from being inside DataFilter to be part of RangeSelector directly.

#### Where should the reviewer start?

index.d.ts

#### What testing has been done on this PR?

Added a story and unit tests.

#### How should this be manually tested?

Storybook

#### Do Jest tests follow these best practices?

No change to existing unit tests for RangeSelector. They should be updated to Typescript at some point.

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

Follow on from the `<Data />` work.

#### Screenshots (if appropriate)

<img width="444" alt="Screenshot 2022-12-21 at 1 29 44 PM" src="https://user-images.githubusercontent.com/11637956/209005948-263e82fb-d288-43ab-be38-b9090b2d3012.png">

#### Do the grommet docs need to be updated?

yes

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
