### PR TITLE
add simple stories for new rating inputs

### DIFF
--- a/src/js/components/Form/stories/SolicitedFeedback.js
+++ b/src/js/components/Form/stories/SolicitedFeedback.js
@@ -41,7 +41,7 @@ export const SolicitedFeedback = () => {
           name="rating"
           label="Was this content helpful?"
         >
-          <StarRating id="star-rating" name="rating" color="brand" />
+          <StarRating id="star-rating" name="rating" />
         </FormField>
         <FormField
           label="What would have improved your experience"

--- a/src/js/components/StarRating/stories/simple.js
+++ b/src/js/components/StarRating/stories/simple.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+import { Box, StarRating } from 'grommet';
+
+export const Simple = () => (
+  <Box align="center" justify="center" pad="small">
+    <StarRating id="star-rating" name="rating" />
+  </Box>
+);
+
+export default {
+  title: 'Input/StarRating/Simple',
+};

--- a/src/js/components/ThumbsRating/stories/simple.js
+++ b/src/js/components/ThumbsRating/stories/simple.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+import { Box, ThumbsRating } from 'grommet';
+
+export const Simple = () => (
+  <Box align="center" justify="center" pad="small">
+    <ThumbsRating id="thumb-rating" name="rating" />
+  </Box>
+);
+
+export default {
+  title: 'Input/ThumbsRating/Simple',
+};


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
adds simple stories for starRating and ThumbRating
takes out `color` prop in old story
#### Where should the reviewer start?
StarRating/stories
ThumbsRating/stories
#### What testing has been done on this PR?
local
#### How should this be manually tested?
storybook
#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
closes #6547 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible 