### PR TITLE
Update DOM functions to fix shadow root bug

### DIFF
--- a/src/js/components/FormField/FormField.js
+++ b/src/js/components/FormField/FormField.js
@@ -494,7 +494,10 @@ const FormField = forwardRef(
         {...outerProps}
         style={outerStyle}
         onFocus={(event) => {
-          setFocus(containsFocus(formFieldRef.current) && shouldKeepFocus());
+          const root = formFieldRef.current.getRootNode();
+          setFocus(
+            containsFocus(formFieldRef.current) && shouldKeepFocus(root),
+          );
           if (onFocus) onFocus(event);
         }}
         onBlur={(event) => {

--- a/src/js/utils/DOM.js
+++ b/src/js/utils/DOM.js
@@ -56,7 +56,8 @@ export const findScrollParents = (element, horizontal) => {
 };
 
 export const containsFocus = (node) => {
-  let element = document.activeElement;
+  const root = node.getRootNode();
+  let element = root.activeElement;
   while (element) {
     if (element === node) break;
     element = element.parentElement;
@@ -82,8 +83,8 @@ export const getFirstFocusableDescendant = (element) => {
   return undefined;
 };
 
-export const shouldKeepFocus = () => {
-  const element = document.activeElement;
+export const shouldKeepFocus = (root) => {
+  const element = root.activeElement;
   if (isFocusable(element)) return true;
   return !!getFirstFocusableDescendant(element);
 };


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Enhances certain DOM functions that FormField relies on to ensure that activeElement within a shadow DOM is detected.

Reference: https://developer.mozilla.org/en-US/docs/Web/API/Node/getRootNode, https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot/activeElement

#### Where should the reviewer start?
src/js/components/FormField/FormField.js

#### What testing has been done on this PR?
Tested in local storybook where I set up a FormField in a shadow dom (mirroring the scenario from #6232)

The Box inside the shadow DOM now receives the proper highlighting.

https://user-images.githubusercontent.com/12522275/210661218-34ed2c19-c0b4-4c38-833e-bcc525c223d9.mov

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

document.activeElement will not look into a shadow root, so getRootNode() needs to be used to determine if root is document or shadow root.

#### What are the relevant issues?

Closes #6232 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?
Yes.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.