### PR TITLE
fix useForwardedRef

### DIFF
--- a/src/js/components/DateInput/DateInput.js
+++ b/src/js/components/DateInput/DateInput.js
@@ -193,7 +193,7 @@ Use the icon prop instead.`,
                 if (onChange) onChange({ value: normalizedValue });
                 if (open && !range) {
                   closeCalendar();
-                  setTimeout(() => ref.current.focus(), 1);
+                  setTimeout(() => ref.current?.focus(), 1);
                 }
               }
         }

--- a/src/js/utils/refs.js
+++ b/src/js/utils/refs.js
@@ -1,21 +1,7 @@
-import { useEffect, useRef } from 'react';
-import { useLayoutEffect } from './use-isomorphic-layout-effect';
+import { useImperativeHandle, useRef } from 'react';
 
-const updateRef = (ref, innerRef) => {
-  if (!ref) return;
-  if (typeof ref === 'function') {
-    ref(innerRef.current);
-  } else {
-    // eslint-disable-next-line no-param-reassign
-    ref.current = innerRef.current;
-  }
-};
-
-// https://medium.com/the-non-traditional-developer/how-to-use-the-forwarded-ref-in-react-1fb108f4e6af
 export const useForwardedRef = (ref) => {
   const innerRef = useRef(null);
-  updateRef(ref, innerRef);
-  useLayoutEffect(() => updateRef(ref, innerRef));
-  useEffect(() => updateRef(ref, innerRef));
+  useImperativeHandle(ref, () => innerRef.current);
   return innerRef;
 };


### PR DESCRIPTION
#### What does this PR do?
Change the implementation of `useForwardedRef` to not modify the associated ref during render. The preferred method of updating the forwarded ref according to React is its `useImperativeHandle` hook.

See #6551 for details on the issue.

The change to the DateInput-test is basically because the `.focus()` done via a setTimeout() can actually happen after the DOM has gone away (even though the timeout is only 1ms.)

#### Where should the reviewer start?
refs.js

#### What testing has been done on this PR?
jest, manual and storybook

#### How should this be manually tested?
Go to the DateInput "Format" story and click on the icon to open the Calendar. Then click on a date in the calendar and close it.  It should use the ref that the Calendar forwarded from DateInput to set focus on the DateInput input field.

pass a ref into any component that uses `useForwardedRef()` and then display that ref from a `useEffect`.

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
#6551 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Yes

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible
