### PR TITLE
Fix for visual rowDetails in DataTable

### DIFF
--- a/src/js/components/DataTable/Body.js
+++ b/src/js/components/DataTable/Body.js
@@ -2,7 +2,6 @@
 import React, { forwardRef, memo, useContext } from 'react';
 import { ThemeContext } from 'styled-components';
 
-import { useKeyboard } from '../../utils';
 import { CheckBox } from '../CheckBox';
 import { InfiniteScroll } from '../InfiniteScroll';
 import { TableRow } from '../TableRow';
@@ -185,11 +184,7 @@ const Body = forwardRef(
     const [active, setActive] = React.useState();
     const [lastActive, setLastActive] = React.useState();
 
-    // Determine if using a keyboard to cover focus behavior
-    const usingKeyboard = useKeyboard();
-
-    const onFocusActive =
-      active ?? lastActive ?? (usingKeyboard ? 0 : undefined);
+    const onFocusActive = active ?? lastActive;
 
     const selectRow = () => {
       const primaryValue = data[active]?.[primaryProperty];

--- a/src/js/components/DataTable/ExpanderCell.js
+++ b/src/js/components/DataTable/ExpanderCell.js
@@ -31,7 +31,14 @@ const ExpanderControl = ({ context, expanded, onToggle, pad, ...rest }) => {
   delete normalizedThemeProps.pad;
 
   content = (
-    <Box {...normalizedThemeProps} {...rest} align="center" fill pad={pad}>
+    <Box
+      {...normalizedThemeProps}
+      {...rest}
+      align="center"
+      fill
+      pad={pad}
+      justify="center"
+    >
       {content}
     </Box>
   );

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -5230,6 +5230,10 @@ exports[`DataTable groupBy 1`] = `
   flex-direction: column;
   width: 100%;
   height: 100%;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
   padding-left: 12px;
   padding-right: 12px;
   padding-top: 6px;
@@ -5645,7 +5649,7 @@ exports[`DataTable groupBy 2`] = `
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 jsAhdo"
+                class="StyledBox-sc-13pk1d4-0 hjqrGQ"
               >
                 <svg
                   aria-label="FormDown"
@@ -5712,7 +5716,7 @@ exports[`DataTable groupBy 2`] = `
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 jsAhdo"
+                class="StyledBox-sc-13pk1d4-0 hjqrGQ"
               >
                 <svg
                   aria-label="FormDown"
@@ -5768,7 +5772,7 @@ exports[`DataTable groupBy 2`] = `
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 jsAhdo"
+                class="StyledBox-sc-13pk1d4-0 hjqrGQ"
               >
                 <svg
                   aria-label="FormDown"
@@ -5928,6 +5932,10 @@ exports[`DataTable groupBy expand 1`] = `
   flex-direction: column;
   width: 100%;
   height: 100%;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
   padding-left: 12px;
   padding-right: 12px;
   padding-top: 6px;
@@ -6530,6 +6538,10 @@ exports[`DataTable groupBy property 1`] = `
   flex-direction: column;
   width: 100%;
   height: 100%;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
   padding-left: 12px;
   padding-right: 12px;
   padding-top: 6px;
@@ -6945,7 +6957,7 @@ exports[`DataTable groupBy property 2`] = `
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 jsAhdo"
+                class="StyledBox-sc-13pk1d4-0 hjqrGQ"
               >
                 <svg
                   aria-label="FormDown"
@@ -7012,7 +7024,7 @@ exports[`DataTable groupBy property 2`] = `
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 jsAhdo"
+                class="StyledBox-sc-13pk1d4-0 hjqrGQ"
               >
                 <svg
                   aria-label="FormDown"
@@ -7068,7 +7080,7 @@ exports[`DataTable groupBy property 2`] = `
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 jsAhdo"
+                class="StyledBox-sc-13pk1d4-0 hjqrGQ"
               >
                 <svg
                   aria-label="FormDown"
@@ -7479,6 +7491,10 @@ exports[`DataTable groupBy toggle 2`] = `
   flex-direction: column;
   width: 100%;
   height: 100%;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
   padding-left: 12px;
   padding-right: 12px;
   padding-top: 6px;
@@ -7726,6 +7742,10 @@ exports[`DataTable groupBy toggle 2`] = `
   flex-direction: column;
   width: 100%;
   height: 100%;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
   padding-left: 12px;
   padding-right: 12px;
   padding-top: 6px;
@@ -8321,6 +8341,10 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
   flex-direction: column;
   width: 100%;
   height: 100%;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
   padding-left: 12px;
   padding-right: 12px;
   padding-top: 6px;
@@ -9259,6 +9283,10 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
   flex-direction: column;
   width: 100%;
   height: 100%;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
   padding-left: 12px;
   padding-right: 12px;
   padding-top: 6px;
@@ -9975,6 +10003,10 @@ exports[`DataTable onSelect + groupBy should select all items within a group 1`]
   flex-direction: column;
   width: 100%;
   height: 100%;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
   padding-left: 12px;
   padding-right: 12px;
   padding-top: 6px;
@@ -10723,6 +10755,10 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 1`
   flex-direction: column;
   width: 100%;
   height: 100%;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
   padding-left: 12px;
   padding-right: 12px;
   padding-top: 6px;
@@ -11354,7 +11390,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 jsAhdo"
+                class="StyledBox-sc-13pk1d4-0 hjqrGQ"
               >
                 <svg
                   aria-label="FormDown"
@@ -11482,7 +11518,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 jsAhdo"
+                class="StyledBox-sc-13pk1d4-0 hjqrGQ"
               >
                 <svg
                   aria-label="FormDown"
@@ -11598,7 +11634,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 jsAhdo"
+                class="StyledBox-sc-13pk1d4-0 hjqrGQ"
               >
                 <svg
                   aria-label="FormDown"
@@ -11729,7 +11765,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 jsAhdo"
+                class="StyledBox-sc-13pk1d4-0 hjqrGQ"
               >
                 <svg
                   aria-label="FormDown"
@@ -11822,7 +11858,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 jsAhdo"
+                class="StyledBox-sc-13pk1d4-0 hjqrGQ"
               >
                 <svg
                   aria-label="FormDown"
@@ -11903,7 +11939,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 jsAhdo"
+                class="StyledBox-sc-13pk1d4-0 hjqrGQ"
               >
                 <svg
                   aria-label="FormDown"
@@ -18703,6 +18739,10 @@ exports[`DataTable rowDetails 1`] = `
   flex-direction: column;
   width: 100%;
   height: 100%;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
   padding-left: 12px;
   padding-right: 12px;
   padding-top: 6px;
@@ -19301,6 +19341,10 @@ exports[`DataTable rowDetails condtional 1`] = `
   flex-direction: column;
   width: 100%;
   height: 100%;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
   padding-left: 12px;
   padding-right: 12px;
   padding-top: 6px;


### PR DESCRIPTION


<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
1. Added a `justify="center"` to the ExpanderControl component to make the icon vertically centered and to handle non-standard themes or styling.
2. Fixed a rendering problem where the first line of the Datatable was selected if using Cmd-Tab to move back to the browser window and triggering an event in `use-keyboard.js` which caused this effect. Removed the "usingKeyboard", the only case I could find where this would be applicable would be using the `onSelect` use-case, but that still works as intended after manual testing. I would appreciate some input whether which is correct though.

#### Where should the reviewer start?
`src/components/DataTable/ExpanderCell.js` and `src/components/DataTable/Body.js` are the only files changed except the updated snapshot.

#### What testing has been done on this PR?
1. Manual testing with different themes to verify the icon's position. The snapshot changes also indicate that the only affected are vertical (flexbox) alignment.
2. Manual tests of the removal of the `usingKeyboard`, I might need help here to verify it's not affecting something I'm not aware of, I'm not too familiar with grommet.

#### How should this be manually tested?
The storybooks should suffice.

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
This partially resolved https://github.com/grommet/grommet/issues/6344

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible