### PR TITLE
Remove unnecessary focus() on List click

### DIFF
--- a/src/js/components/List/List.js
+++ b/src/js/components/List/List.js
@@ -478,9 +478,6 @@ const List = React.forwardRef(
                         adjustedEvent.item = item;
                         adjustedEvent.index = index;
                         onClickItem(adjustedEvent);
-                        // put focus on the List container to meet WCAG
-                        // accessibility guidelines that focus remains on `ul`
-                        listRef.current.focus();
                         sendAnalytics({
                           type: 'listItemClick',
                           element: listRef.current,


### PR DESCRIPTION
When a List allows clicking on items via the `onClickItem`, it sets focus on the List container for various reasons including accessibility and WCAG compliance. However that .focus() causes the the browser to automatically scroll the container in some cases even though it's not necessary in this situation.

#### What does this PR do?
This removes the call to set focus() on the List container on item click. It turns out this really doesn't seem to be needed anymore. Without this extra focus() call, clicking on an item does cause the container to get focus, and it does it without causing an extra scroll attempt to make sure it's visible (which isn't needed in this situation.)  

#### Where should the reviewer start?
List.js

#### What testing has been done on this PR?
Manual, jest, existing storybook.

#### How should this be manually tested?
- In storybook go to the List/onClickItem.
- Make the  window sized so that the list has a scrollbar
- click on an item
Before the change the List will scroll so it's at the very top of the viewport. After the change the List will not scroll (arrowing around or using the Tab key to navigate can still cause the viewport to scroll as needed.)

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Fixes #6574 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Not required but...yes

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible
