### PR TITLE
fix: Datatable onSearch argument use object type

### DIFF
--- a/src/js/components/DataTable/index.d.ts
+++ b/src/js/components/DataTable/index.d.ts
@@ -126,7 +126,7 @@ export interface DataTableProps<TRowType = any> {
     | 'select'
     | ((event: MouseClick<TRowType> | KeyPress<TRowType>) => void);
   onMore?: () => void;
-  onSearch?: (search: string) => void;
+  onSearch?: (search: object) => void;
   onSelect?: (select: (string | number)[], datum: TRowType) => void;
   onSort?: (sort: SortDefinition) => void;
   onUpdate?: (datatableState: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
update the type of `onSearch` function in `src/js/components/DataTable/index.d.ts`
#### Where should the reviewer start?

#### What testing has been done on this PR?
`yarn test` was run
#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
https://github.com/grommet/grommet/issues/6555
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No
#### Should this PR be mentioned in the release notes?
No
#### Is this change backwards compatible or is it a breaking change?
Breaking change