### PR TITLE
Integrate DataTable sorting with Data

### DIFF
--- a/src/js/components/Data/stories/SpaceX.js
+++ b/src/js/components/Data/stories/SpaceX.js
@@ -203,13 +203,7 @@ export const SpaceX = () => {
           onView={setView}
           toolbar
         >
-          <DataTable
-            columns={columns}
-            sort={{ ...view.sort, external: true }}
-            // TODO: in some other pull request,
-            // integrate sorting between Data and DataTable
-            // onSort={(opts) => setSort(opts)}
-          />
+          <DataTable columns={columns} sortable />
           {result.filteredTotal > view.step && (
             <Footer>
               <Text>

--- a/src/js/components/DataFilters/DataFilters.js
+++ b/src/js/components/DataFilters/DataFilters.js
@@ -4,6 +4,7 @@ import { Box } from '../Box';
 import { Button } from '../Button';
 import { DataFilter } from '../DataFilter';
 import { DataForm } from '../Data/DataForm';
+import { DataSort } from '../DataSort';
 import { DropButton } from '../DropButton';
 import { Header } from '../Header';
 import { Heading } from '../Heading';
@@ -16,7 +17,8 @@ const dropProps = {
 };
 
 export const DataFilters = ({ drop, children, heading, ...rest }) => {
-  const { clearFilters, data, messages, properties } = useContext(DataContext);
+  const { clearFilters, data, messages, properties, view } =
+    useContext(DataContext);
   const { format } = useContext(MessageContext);
   const [showContent, setShowContent] = useState();
   // touched is a map of form field name to its value, it only has fields that
@@ -59,6 +61,9 @@ export const DataFilters = ({ drop, children, heading, ...rest }) => {
     filters = filtersFor.map((property) => (
       <DataFilter key={property} property={property} />
     ));
+    if (view?.sort) {
+      filters.push(<DataSort key="_sort" />);
+    }
   }
 
   const content = (

--- a/src/js/components/DataSort/DataSort.js
+++ b/src/js/components/DataSort/DataSort.js
@@ -1,7 +1,7 @@
 import React, { useContext, useMemo } from 'react';
 import { DataContext } from '../../contexts/DataContext';
 import { RadioButtonGroup } from '../RadioButtonGroup';
-import { DataForm } from '../Data';
+import { DataForm } from '../Data/DataForm';
 import { FormContext } from '../Form/FormContext';
 import { FormField } from '../FormField';
 import { Select } from '../Select';

--- a/src/js/components/DataTable/DataTable.js
+++ b/src/js/components/DataTable/DataTable.js
@@ -90,7 +90,12 @@ const DataTable = ({
   ...rest
 }) => {
   const theme = useContext(ThemeContext) || defaultProps.theme;
-  const { view, data: contextData, properties } = useContext(DataContext);
+  const {
+    view,
+    data: contextData,
+    properties,
+    onView,
+  } = useContext(DataContext);
   const data = dataProp || contextData || emptyData;
 
   const columns = useMemo(() => {
@@ -136,7 +141,8 @@ const DataTable = ({
   const [sort, setSort] = useState(sortProp || {});
   useEffect(() => {
     if (sortProp) setSort(sortProp);
-  }, [sortProp]);
+    else if (view?.sort) setSort(view.sort);
+  }, [sortProp, view]);
 
   // the data filtered and sorted, if needed
   // Note: onUpdate mode expects the data to be passed
@@ -274,6 +280,9 @@ const DataTable = ({
     else direction = 'asc';
     const nextSort = { property, direction, external };
     setSort(nextSort);
+    if (onView) {
+      onView({ ...view, sort: { property, direction } });
+    }
     if (onUpdate) {
       const opts = {
         count: limit,


### PR DESCRIPTION
#### What does this PR do?

Integrate DataTable sorting with Data.
Build DataTable's internal `sort` state based on any `view.sort` and pass any `onSort` within DataTable up to `onView` in Data.

#### Where should the reviewer start?

DataTable.js

#### What testing has been done on this PR?

Modified SpaceX story to leverage this.

#### How should this be manually tested?

SpaceX story

#### Do Jest tests follow these best practices?

no changes to tests

#### Do the grommet docs need to be updated?

yes

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
