### PR TITLE
Add test for FormField autoFocus

### DIFF
--- a/src/js/components/FormField/__tests__/FormField-test.js
+++ b/src/js/components/FormField/__tests__/FormField-test.js
@@ -12,6 +12,7 @@ import { Form } from '../../Form';
 import { CheckBox } from '../../CheckBox';
 import { FormField } from '..';
 import { TextInput } from '../../TextInput';
+import { TextArea } from '../../TextArea';
 
 const CustomFormField = styled(FormField)`
   font-size: 40px;
@@ -446,5 +447,17 @@ describe('FormField', () => {
     );
 
     expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test('Field with autoFocus', () => {
+    const mockFocus = jest.fn();
+    render(
+      <Grommet>
+        <FormField label="Label" htmlFor="select">
+          <TextArea onFocus={mockFocus} autoFocus />
+        </FormField>
+      </Grommet>,
+    );
+    expect(mockFocus).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
#### What does this PR do?
Adds a test for https://github.com/grommet/grommet/pull/6577 before we release

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [x] `screen` is used for querying.
- [x] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [x] `userEvent` is used in place of `fireEvent`.
- [x] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
https://github.com/grommet/hpe-design-system/issues/3100

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No
#### Should this PR be mentioned in the release notes?
No
#### Is this change backwards compatible or is it a breaking change?
Backwards compatible