### PR TITLE
Check that node is defined in `withinDropPortal` function

### DIFF
--- a/src/js/utils/DOM.js
+++ b/src/js/utils/DOM.js
@@ -66,7 +66,7 @@ export const containsFocus = (node) => {
 };
 
 export const withinDropPortal = (node, portalContext) => {
-  const root = node.getRootNode();
+  const root = node?.getRootNode();
   let element = node;
   let portalId;
   while (element && element !== root) {


### PR DESCRIPTION
#### What does this PR do?
Fixes an issue where if you tab beyond a formField and focus doesn't move to another element the node passed to `withinDropPortal` is undefined, resulting in the following error:

<img width="451" alt="Screen Shot 2023-01-20 at 2 37 42 PM" src="https://user-images.githubusercontent.com/54560994/213809755-a49d1a78-12e8-40b6-9945-044317f06d3e.png">
#### Where should the reviewer start?

#### What testing has been done on this PR?
Tested with the following story:
```javascript
import React from 'react';

import { Box, DateInput, Form, FormField } from 'grommet';

export const Test = () => (
  <Box fill align="center" justify="center">
    <Form validate="blur">
      <FormField label="Enter a date">
        <DateInput format="mm/dd/yyyy-mm/dd/yyyy" />
      </FormField>
    </Form>
  </Box>
);

export default {
  title: 'Input/Form/Test',
};

```
#### How should this be manually tested?
Using the above story tab past the DateInput

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No
#### Should this PR be mentioned in the release notes?
Yes
#### Is this change backwards compatible or is it a breaking change?
Backwards compatible