### PR TITLE
Add some DateInput tests to testcafe

### DIFF
--- a/.testcaferc.json
+++ b/.testcaferc.json
@@ -1,0 +1,5 @@
+{
+  "clientScripts": [
+    { "module": "@testing-library/dom/dist/@testing-library/dom.umd.js" }
+  ]
+}

--- a/e2e/src/App.js
+++ b/e2e/src/App.js
@@ -1,5 +1,10 @@
 import React from 'react';
 import {
+  Box,
+  Button,
+  DateInput,
+  Form,
+  FormField,
   Grommet,
   Heading,
   Page,
@@ -18,6 +23,18 @@ const App = () => (
           commodo gravida tincidunt. Nunc fringilla blandit tortor, id accumsan
           nisi dictum quis. Aenean porttitor at mi id semper.
         </Paragraph>
+        <Box width="medium">
+          <Form validate="blur">
+            <FormField label="Enter a date" name="date-field" required>
+              <DateInput
+                name="date-field"
+                calendarProps={{ reference: '2023-01-01' }}
+                format="mm/dd/yyyy-mm/dd/yyyy"
+              />
+            </FormField>
+            <Button type="submit" label="Submit" primary />
+          </Form>
+        </Box>
       </PageContent>
     </Page>
   </Grommet>

--- a/e2e/tests/dateinput-test.js
+++ b/e2e/tests/dateinput-test.js
@@ -1,0 +1,27 @@
+import { screen } from '@testing-library/testcafe';
+
+fixture('DateInput').page(`http://localhost:8080/`);
+
+test('onBlur validation with a drop component', async (t) => {
+  await t.click(screen.getByRole('button', { name: 'Calendar' }));
+  // validation shouldn't trigger yet
+  await t.expect(screen.queryAllByText('required').exists).notOk();
+  // close DateInput
+  await t.pressKey('esc');
+  await t.click(screen.getByRole('button', { name: 'Submit' }));
+  // validation should trigger
+  await t.expect(screen.queryAllByText('required')).exists;
+});
+
+test('DateInput range onBlur validation', async (t) => {
+  // open DateInput
+  await t.click(screen.getByRole('button', { name: 'Calendar' }));
+  await t.click(screen.getByRole('button', { name: 'Sun Jan 01 2023' }));
+  await t.click(screen.getByRole('button', { name: 'Go to February 2023' }));
+  await t.click(screen.getByRole('button', { name: 'Mon Feb 06 2023' }));
+  // close DateInput
+  await t.pressKey('esc');
+  await t
+    .expect(screen.getByRole('textbox').value)
+    .eql('01/01/2023-02/06/2023');
+});


### PR DESCRIPTION
#### What does this PR do?
Adds end to end tests for the issues addressed in https://github.com/grommet/grommet/pull/6436#discussion_r1000999264 and https://github.com/grommet/grommet/pull/6566

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
https://github.com/grommet/hpe-design-system/issues/2344

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No
#### Should this PR be mentioned in the release notes?
No
#### Is this change backwards compatible or is it a breaking change?
Backwards compatible