### PR TITLE
Drop - flip drop position if part of the drop isn't visible

### DIFF
--- a/src/js/components/Drop/DropContainer.js
+++ b/src/js/components/Drop/DropContainer.js
@@ -48,7 +48,7 @@ const DropContainer = forwardRef(
       onKeyDown,
       overflow = 'auto',
       plain,
-      responsive,
+      responsive = true,
       restrictFocus,
       stretch = 'width',
       trapFocus,
@@ -166,32 +166,20 @@ const DropContainer = forwardRef(
           let bottom;
           let maxHeight = containerRect.height;
           if (align.top) {
-            if (align.top === 'top') {
-              ({ top } = targetRect);
-            } else {
-              top = targetRect.bottom;
-            }
+            const alignToTop = align.top === 'top';
+            const switchTop = !alignToTop ? targetRect.top : targetRect.bottom;
+            top = alignToTop ? targetRect.top : targetRect.bottom;
 
-            // Calculate visible area underneath the control w.r.t window height
-            const percentVisibleAreaBelow =
-              100 - (targetRect.bottom / windowHeight) * 100;
-
-            // Check whether it is within 20% from bottom of the window or
-            // visible area to flip the control
-            // DropContainer doesn't fit well within visible area when
-            // percentVisibleAreaBelow value<=20%
-            // There is enough space from DropContainer to bottom of the window
-            // when percentVisibleAreaBelow>20%.
-
-            if (windowHeight === top || percentVisibleAreaBelow <= 20) {
+            if (
+              responsive &&
+              (windowHeight === top ||
+                (windowHeight < top + containerRect.height &&
+                  windowHeight - top < switchTop))
+            ) {
               // We need more room than we have.
               // We put it below, but there's more room above, put it above
               top = '';
-              if (align.top === 'bottom') {
-                bottom = targetRect.top;
-              } else {
-                ({ bottom } = targetRect);
-              }
+              bottom = alignToTop ? targetRect.bottom : targetRect.top;
               maxHeight = bottom;
               container.style.maxHeight = `${maxHeight}px`;
             } else if (top > 0) {
@@ -201,13 +189,26 @@ const DropContainer = forwardRef(
               maxHeight = windowHeight - top;
             }
           } else if (align.bottom) {
-            if (align.bottom === 'bottom') {
-              ({ bottom } = targetRect);
+            const alignToBottom = align.bottom === 'bottom';
+            const switchBottom = !alignToBottom
+              ? targetRect.bottom
+              : targetRect.top;
+            bottom = alignToBottom ? targetRect.bottom : targetRect.top;
+
+            if (
+              responsive &&
+              (bottom === 0 ||
+                (bottom - containerRect.height < 0 &&
+                  0 + bottom > switchBottom))
+            ) {
+              bottom = '';
+              top = alignToBottom ? targetRect.top : targetRect.bottom;
+              maxHeight = top;
+              container.style.maxHeight = `${maxHeight}px`;
             } else {
-              bottom = targetRect.top;
+              maxHeight = bottom;
+              container.style.maxHeight = `${maxHeight}px`;
             }
-            maxHeight = bottom;
-            container.style.maxHeight = `${maxHeight}px`;
           } else {
             // center
             top =

--- a/src/js/components/Drop/DropContainer.js
+++ b/src/js/components/Drop/DropContainer.js
@@ -161,6 +161,11 @@ const DropContainer = forwardRef(
           let bottom;
           let maxHeight = containerRect.height;
 
+          /* If responsive is true and the Drop doesn't have enough room 
+            to be fully visible and there is more room in the other 
+            direction, change the Drop to display above/below. If there is 
+            less room in the other direction leave the Drop in its current 
+            position. */
           if (
             responsive &&
             ((align.top === 'top' && targetRect.top < 0) ||

--- a/src/js/components/Drop/DropContainer.js
+++ b/src/js/components/Drop/DropContainer.js
@@ -167,14 +167,21 @@ const DropContainer = forwardRef(
           let maxHeight = containerRect.height;
           if (align.top) {
             const alignToTop = align.top === 'top';
-            const switchTop = !alignToTop ? targetRect.top : targetRect.bottom;
+            const switchTarget = !alignToTop
+              ? targetRect.top
+              : targetRect.bottom;
             top = alignToTop ? targetRect.top : targetRect.bottom;
 
+            /* If responsive is true and the Drop doesn't have enough room 
+            to be fully visible and there is more room in the other 
+            direction, change the Drop to display above/below. If there is 
+            less room in the other direction leave the Drop in its current 
+            position. */
             if (
               responsive &&
               (windowHeight === top ||
                 (windowHeight < top + containerRect.height &&
-                  windowHeight - top < switchTop))
+                  windowHeight - top < switchTarget))
             ) {
               // We need more room than we have.
               // We put it below, but there's more room above, put it above
@@ -190,16 +197,21 @@ const DropContainer = forwardRef(
             }
           } else if (align.bottom) {
             const alignToBottom = align.bottom === 'bottom';
-            const switchBottom = !alignToBottom
+            const switchTarget = !alignToBottom
               ? targetRect.bottom
               : targetRect.top;
             bottom = alignToBottom ? targetRect.bottom : targetRect.top;
 
+            /* If responsive is true and the Drop doesn't have enough room 
+            to be fully visible and there is more room in the other 
+            direction, change the Drop to display above/below. If there is 
+            less room in the other direction leave the Drop in its current 
+            position. */
             if (
               responsive &&
               (bottom === 0 ||
                 (bottom - containerRect.height < 0 &&
-                  0 + bottom > switchBottom))
+                  0 + bottom > switchTarget))
             ) {
               bottom = '';
               top = alignToBottom ? targetRect.top : targetRect.bottom;

--- a/src/js/components/Drop/DropContainer.js
+++ b/src/js/components/Drop/DropContainer.js
@@ -160,98 +160,40 @@ const DropContainer = forwardRef(
           let top;
           let bottom;
           let maxHeight = containerRect.height;
-          if (align.top) {
-            const alignToTop = align.top === 'top';
-            const switchTarget = !alignToTop
-              ? targetRect.top
-              : targetRect.bottom;
-            top = alignToTop ? targetRect.top : targetRect.bottom;
 
-            /* If responsive is true and the Drop doesn't have enough room 
-            to be fully visible and there is more room in the other 
-            direction, change the Drop to display above/below. If there is 
-            less room in the other direction leave the Drop in its current 
-            position. */
-            if (
-              responsive &&
-              (windowHeight === top ||
-                (windowHeight < top + containerRect.height &&
-                  windowHeight - top < switchTarget))
-            ) {
-              // We need more room than we have.
-              // We put it below, but there's more room above, put it above
-              top = '';
-              bottom = alignToTop ? targetRect.bottom : targetRect.top;
-              maxHeight = bottom;
-              container.style.maxHeight = `${maxHeight}px`;
-            } else if (top > 0) {
-              maxHeight = windowHeight - top;
-              container.style.maxHeight = `${maxHeight}px`;
-            } else {
-              maxHeight = windowHeight - top;
-            }
-          } else if (align.bottom) {
-            const alignToBottom = align.bottom === 'bottom';
-            const switchTarget = !alignToBottom
-              ? targetRect.bottom
-              : targetRect.top;
-            bottom = alignToBottom ? targetRect.bottom : targetRect.top;
-
-            /* If responsive is true and the Drop doesn't have enough room 
-            to be fully visible and there is more room in the other 
-            direction, change the Drop to display above/below. If there is 
-            less room in the other direction leave the Drop in its current 
-            position. */
-            if (
-              responsive &&
-              (bottom === 0 ||
-                (bottom - containerRect.height < 0 &&
-                  0 + bottom > switchTarget))
-            ) {
-              bottom = '';
-              top = alignToBottom ? targetRect.top : targetRect.bottom;
-              maxHeight = top;
-              container.style.maxHeight = `${maxHeight}px`;
-            } else {
-              maxHeight = bottom;
-              container.style.maxHeight = `${maxHeight}px`;
-            }
-          } else {
-            // center
-            top =
-              targetRect.top + targetRect.height / 2 - containerRect.height / 2;
-            maxHeight = windowHeight - top;
-          }
-          // if we can't fit it all, or we're rather close,
-          // see if there's more room the other direction
           if (
             responsive &&
-            (containerRect.height > maxHeight || maxHeight < windowHeight / 10)
+            ((align.top === 'top' && targetRect.top < 0) ||
+              (align.bottom === 'top' &&
+                targetRect.top - containerRect.height <= 0 &&
+                targetRect.bottom + containerRect.height < windowHeight))
           ) {
-            // We need more room than we have.
-            if (align.top && top > windowHeight / 2) {
-              // We put it below, but there's more room above, put it above
-              top = '';
-              if (align.top === 'bottom') {
-                // top = Math.max(targetRect.top - containerRect.height, 0);
-                // maxHeight = targetRect.top - top;
-                bottom = targetRect.top;
-              } else {
-                // top = Math.max(targetRect.bottom - containerRect.height, 0);
-                // maxHeight = targetRect.bottom - top;
-                ({ bottom } = targetRect);
-              }
-              maxHeight = bottom;
-            } else if (align.bottom && maxHeight < windowHeight / 2) {
-              // We put it above but there's more room below, put it below
-              bottom = '';
-              if (align.bottom === 'bottom') {
-                ({ top } = targetRect);
-              } else {
-                top = targetRect.bottom;
-              }
-              maxHeight = windowHeight - top;
-            }
+            top = targetRect.bottom;
+            maxHeight = top;
+          } else if (
+            responsive &&
+            ((align.bottom === 'bottom' && targetRect.bottom > windowHeight) ||
+              (align.top === 'bottom' &&
+                targetRect.bottom + containerRect.height >= windowHeight &&
+                targetRect.top - containerRect.height > 0))
+          ) {
+            bottom = targetRect.top;
+            maxHeight = bottom;
+          } else if (align.top === 'top') {
+            top = targetRect.top;
+            maxHeight = windowHeight - top;
+          } else if (align.top === 'bottom') {
+            top = targetRect.bottom;
+            maxHeight = windowHeight - top;
+          } else if (align.bottom === 'top') {
+            bottom = targetRect.top;
+            maxHeight = bottom;
+          } else if (align.bottom === 'bottom') {
+            bottom = targetRect.bottom;
+            maxHeight = bottom;
+          } else {
+            top =
+              targetRect.top + targetRect.height / 2 - containerRect.height / 2;
           }
           container.style.left = `${left}px`;
           if (stretch) {

--- a/src/js/components/Drop/__tests__/__snapshots__/Drop-test.tsx.snap
+++ b/src/js/components/Drop/__tests__/__snapshots__/Drop-test.tsx.snap
@@ -58,7 +58,7 @@ exports[`Drop align left left 1`] = `
   class="c0 c1"
   data-g-portal-id="0"
   id="drop-node"
-  style="max-height: 768px; left: 0px; width: 0.1px; top: 0px;"
+  style="left: 0px; width: 0.1px; bottom: 768px; max-height: 0px;"
   tabindex="-1"
 >
   this is a test
@@ -366,7 +366,7 @@ exports[`Drop align right right 1`] = `
   class="c0 c1"
   data-g-portal-id="0"
   id="drop-node"
-  style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
+  style="left: 0px; width: 0.1px; top: 0px; max-height: 0px;"
   tabindex="-1"
 >
   this is a test
@@ -461,7 +461,7 @@ exports[`Drop align right right bottom top 1`] = `
   class="c0 c1"
   data-g-portal-id="0"
   id="drop-node"
-  style="max-height: 768px; left: 0px; width: 0.1px; top: 0px;"
+  style="left: 0px; width: 0.1px; top: 0px; max-height: 0px;"
   tabindex="-1"
 >
   this is a test
@@ -556,7 +556,7 @@ exports[`Drop align right right bottom top 3`] = `
   class="c0 c1"
   data-g-portal-id="0"
   id="drop-node"
-  style="max-height: 768px; left: 0px; width: 0.1px; top: 0px;"
+  style="left: 0px; width: 0.1px; top: 0px; max-height: 0px;"
   tabindex="-1"
 >
   this is a test
@@ -1165,7 +1165,7 @@ exports[`Drop invalid align 1`] = `
   class="c0 c1"
   data-g-portal-id="0"
   id="drop-node"
-  style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
+  style="left: 0px; width: 0.1px; top: 0px; max-height: 0px;"
   tabindex="-1"
 >
   this is a test
@@ -2051,7 +2051,7 @@ exports[`Drop should render correct margin depending on value of align:
   class="c0 c1"
   data-g-portal-id="0"
   id="margin-drop-test"
-  style="max-height: 1000px; left: 0px; width: 0.1px; top: 0px;"
+  style="left: 0px; width: 0.1px; bottom: 1000px; max-height: 0px;"
   tabindex="-1"
 >
   this is a test
@@ -2149,7 +2149,7 @@ exports[`Drop should render correct margin depending on value of align:
   class="c0 c1"
   data-g-portal-id="0"
   id="margin-drop-test"
-  style="max-height: 1000px; left: 0px; width: 0.1px; top: 0px;"
+  style="left: 0px; width: 0.1px; bottom: 1000px; max-height: 0px;"
   tabindex="-1"
 >
   this is a test
@@ -2247,7 +2247,7 @@ exports[`Drop should render correct margin depending on value of align:
   class="c0 c1"
   data-g-portal-id="0"
   id="margin-drop-test"
-  style="max-height: 1000px; left: 0px; width: 0.1px; top: 0px;"
+  style="left: 0px; width: 0.1px; top: 0px; max-height: 0px;"
   tabindex="-1"
 >
   this is a test
@@ -2346,7 +2346,7 @@ exports[`Drop should render correct margin depending on value of align:
   class="c0 c1"
   data-g-portal-id="0"
   id="margin-drop-test"
-  style="max-height: 1000px; left: 0px; width: 0.1px; top: 0px;"
+  style="left: 0px; width: 0.1px; top: 0px; max-height: 0px;"
   tabindex="-1"
 >
   this is a test
@@ -2445,7 +2445,7 @@ exports[`Drop should render correct margin depending on value of align:
   class="c0 c1"
   data-g-portal-id="0"
   id="margin-drop-test"
-  style="max-height: 1000px; left: 0px; width: 0.1px; top: 0px;"
+  style="left: 0px; width: 0.1px; top: 0px; max-height: 0px;"
   tabindex="-1"
 >
   this is a test
@@ -2544,7 +2544,7 @@ exports[`Drop should render correct margin depending on value of align:
   class="c0 c1"
   data-g-portal-id="0"
   id="margin-drop-test"
-  style="max-height: 1000px; left: 0px; width: 0.1px; top: 0px;"
+  style="left: 0px; width: 0.1px; top: 0px; max-height: 0px;"
   tabindex="-1"
 >
   this is a test
@@ -2642,7 +2642,7 @@ exports[`Drop should render correct margin depending on value of align:
   class="c0 c1"
   data-g-portal-id="0"
   id="margin-drop-test"
-  style="max-height: 1000px; left: 0px; width: 0.1px; top: 0px;"
+  style="left: 0px; width: 0.1px; top: 0px; max-height: 0px;"
   tabindex="-1"
 >
   this is a test

--- a/src/js/components/Drop/__tests__/__snapshots__/Drop-test.tsx.snap
+++ b/src/js/components/Drop/__tests__/__snapshots__/Drop-test.tsx.snap
@@ -58,7 +58,7 @@ exports[`Drop align left left 1`] = `
   class="c0 c1"
   data-g-portal-id="0"
   id="drop-node"
-  style="max-height: 0px; left: 0px; width: 0.1px; bottom: 768px;"
+  style="max-height: 768px; left: 0px; width: 0.1px; top: 0px;"
   tabindex="-1"
 >
   this is a test
@@ -461,7 +461,7 @@ exports[`Drop align right right bottom top 1`] = `
   class="c0 c1"
   data-g-portal-id="0"
   id="drop-node"
-  style="max-height: 0px; left: 0px; width: 0.1px; bottom: 768px;"
+  style="max-height: 768px; left: 0px; width: 0.1px; top: 0px;"
   tabindex="-1"
 >
   this is a test
@@ -556,7 +556,7 @@ exports[`Drop align right right bottom top 3`] = `
   class="c0 c1"
   data-g-portal-id="0"
   id="drop-node"
-  style="max-height: 0px; left: 0px; width: 0.1px; bottom: 768px;"
+  style="max-height: 768px; left: 0px; width: 0.1px; top: 0px;"
   tabindex="-1"
 >
   this is a test
@@ -2051,7 +2051,7 @@ exports[`Drop should render correct margin depending on value of align:
   class="c0 c1"
   data-g-portal-id="0"
   id="margin-drop-test"
-  style="max-height: 0px; left: 0px; width: 0.1px; bottom: 1000px;"
+  style="max-height: 1000px; left: 0px; width: 0.1px; top: 0px;"
   tabindex="-1"
 >
   this is a test
@@ -2149,7 +2149,7 @@ exports[`Drop should render correct margin depending on value of align:
   class="c0 c1"
   data-g-portal-id="0"
   id="margin-drop-test"
-  style="max-height: 0px; left: 0px; width: 0.1px; bottom: 1000px;"
+  style="max-height: 1000px; left: 0px; width: 0.1px; top: 0px;"
   tabindex="-1"
 >
   this is a test
@@ -2247,7 +2247,7 @@ exports[`Drop should render correct margin depending on value of align:
   class="c0 c1"
   data-g-portal-id="0"
   id="margin-drop-test"
-  style="max-height: 0px; left: 0px; width: 0.1px; bottom: 1000px;"
+  style="max-height: 1000px; left: 0px; width: 0.1px; top: 0px;"
   tabindex="-1"
 >
   this is a test
@@ -2346,7 +2346,7 @@ exports[`Drop should render correct margin depending on value of align:
   class="c0 c1"
   data-g-portal-id="0"
   id="margin-drop-test"
-  style="max-height: 0px; left: 0px; width: 0.1px; bottom: 1000px;"
+  style="max-height: 1000px; left: 0px; width: 0.1px; top: 0px;"
   tabindex="-1"
 >
   this is a test
@@ -2445,7 +2445,7 @@ exports[`Drop should render correct margin depending on value of align:
   class="c0 c1"
   data-g-portal-id="0"
   id="margin-drop-test"
-  style="max-height: 0px; left: 0px; width: 0.1px; bottom: 1000px;"
+  style="max-height: 1000px; left: 0px; width: 0.1px; top: 0px;"
   tabindex="-1"
 >
   this is a test
@@ -2544,7 +2544,7 @@ exports[`Drop should render correct margin depending on value of align:
   class="c0 c1"
   data-g-portal-id="0"
   id="margin-drop-test"
-  style="max-height: 0px; left: 0px; width: 0.1px; bottom: 1000px;"
+  style="max-height: 1000px; left: 0px; width: 0.1px; top: 0px;"
   tabindex="-1"
 >
   this is a test
@@ -2642,7 +2642,7 @@ exports[`Drop should render correct margin depending on value of align:
   class="c0 c1"
   data-g-portal-id="0"
   id="margin-drop-test"
-  style="max-height: 0px; left: 0px; width: 0.1px; bottom: 1000px;"
+  style="max-height: 1000px; left: 0px; width: 0.1px; top: 0px;"
   tabindex="-1"
 >
   this is a test

--- a/src/js/components/Drop/stories/Overflow.js
+++ b/src/js/components/Drop/stories/Overflow.js
@@ -34,6 +34,7 @@ const OverflowDrop = () => {
       </Box>
       {targetRef.current && (
         <Drop
+          responsive={false}
           overflow="unset"
           align={align}
           target={targetRef.current}

--- a/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
+++ b/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
@@ -6308,7 +6308,7 @@ exports[`Menu with dropAlign bottom renders 2`] = `
   class="c0 c1"
   data-g-portal-id="0"
   id="test-menu__drop"
-  style="max-height: 768px; left: 0px; width: 0.1px; top: 0px;"
+  style="left: 0px; width: 0.1px; bottom: 768px; max-height: 0px;"
   tabindex="-1"
 >
   <div

--- a/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
+++ b/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
@@ -6308,7 +6308,7 @@ exports[`Menu with dropAlign bottom renders 2`] = `
   class="c0 c1"
   data-g-portal-id="0"
   id="test-menu__drop"
-  style="max-height: 0px; left: 0px; width: 0.1px; bottom: 768px;"
+  style="max-height: 768px; left: 0px; width: 0.1px; top: 0px;"
   tabindex="-1"
 >
   <div


### PR DESCRIPTION
#### What does this PR do?
Changed Drop behavior to flip the drop if part of the drop isn't visible and there is more room in the opposite direction.

I also set the `responsive` prop to true by default. This aligns with what the documentation shows.

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes https://github.com/grommet/grommet/issues/6495

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Yes

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible