### PR TITLE
Issue #6542 Updated form stories to use htmlFor and id.

### DIFF
--- a/src/js/components/Form/stories/Controlled.js
+++ b/src/js/components/Form/stories/Controlled.js
@@ -44,8 +44,8 @@ export const Controlled = () => {
             console.log('Submit', event.value, event.touched)
           }
         >
-          <FormField label="Name" name="name">
-            <TextInput name="name" suggestions={suggestions} />
+          <FormField label="Name" htmlFor="name" name="name">
+            <TextInput id="name" name="name" suggestions={suggestions} />
           </FormField>
           <FormField label="Email" htmlFor="email" name="email" required>
             <MaskedInput
@@ -66,14 +66,19 @@ export const Controlled = () => {
           <FormField name="ampm">
             <RadioButtonGroup name="ampm" options={['morning', 'evening']} />
           </FormField>
-          <FormField label="Size" name="size">
-            <Select name="size" options={['small', 'medium', 'large']} />
+          <FormField label="Size" htmlFor="size" name="size">
+            <Select
+              id="size"
+              aria-label="size"
+              name="size"
+              options={['small', 'medium', 'large']}
+            />
           </FormField>
-          <FormField label="Comments" name="comments">
-            <TextArea name="comments" />
+          <FormField label="Comments" htmlFor="comments" name="comments">
+            <TextArea id="comments" name="comments" />
           </FormField>
-          <FormField label="Age" name="age" pad>
-            <RangeInput name="age" min={15} max={75} />
+          <FormField label="Age" htmlFor="age" name="age" pad>
+            <RangeInput id="age" name="age" min={15} max={75} />
           </FormField>
           <Box direction="row" justify="between" margin={{ top: 'medium' }}>
             <Button label="Cancel" />

--- a/src/js/components/Form/stories/ControlledInput.js
+++ b/src/js/components/Form/stories/ControlledInput.js
@@ -42,15 +42,17 @@ export const ControlledInput = () => {
             console.log('Submit', event.value, event.touched)
           }
         >
-          <FormField label="Name" name="name">
+          <FormField label="Name" htmlFor="name" name="name">
             <TextInput
+              id="name"
               name="name"
               value={name}
               onChange={(event) => setName(event.target.value)}
             />
           </FormField>
-          <FormField label="Email" name="email" required>
+          <FormField label="Email" htmlFor="email" name="email" required>
             <MaskedInput
+              id="email"
               name="email"
               mask={[
                 { regexp: /^[\w\-_.]+$/, placeholder: 'example' },
@@ -79,23 +81,27 @@ export const ControlledInput = () => {
               onChange={(event) => setAmpm(event.target.value)}
             />
           </FormField>
-          <FormField label="Size" name="size">
+          <FormField label="Size" htmlFor="size" name="size">
             <Select
+              id="size"
+              aria-label="size"
               name="size"
               options={['small', 'medium', 'large']}
               value={size}
               onChange={(event) => setSize(event.option)}
             />
           </FormField>
-          <FormField label="Comments" name="comments">
+          <FormField label="Comments" htmlFor="comments" name="comments">
             <TextArea
+              id="comments"
               name="comments"
               value={comments}
               onChange={(event) => setComments(event.target.value)}
             />
           </FormField>
-          <FormField label="Age" name="age" pad>
+          <FormField label="Age" htmlFor="age" name="age" pad>
             <RangeInput
+              id="age"
               name="age"
               min={15}
               max={75}

--- a/src/js/components/Form/stories/ControlledInputLazy.js
+++ b/src/js/components/Form/stories/ControlledInputLazy.js
@@ -53,15 +53,17 @@ export const ControlledInputLazy = () => {
             console.log('Submit', event.value, event.touched)
           }
         >
-          <FormField label="Name" name="name">
+          <FormField label="Name" htmlFor="name" name="name">
             <TextInput
+              id="name"
               name="name"
               value={name}
               onChange={(event) => setName(event.target.value)}
             />
           </FormField>
-          <FormField label="Email" name="email" required>
+          <FormField label="Email" htmlFor="email" name="email" required>
             <MaskedInput
+              id="email"
               name="email"
               mask={[
                 { regexp: /^[\w\-_.]+$/, placeholder: 'example' },
@@ -90,23 +92,27 @@ export const ControlledInputLazy = () => {
               onChange={(event) => setAmpm(event.target.value)}
             />
           </FormField>
-          <FormField label="Size" name="size">
+          <FormField label="Size" htmlFor="size" name="size">
             <Select
+              id="size"
+              aria-label="size"
               name="size"
               options={['small', 'medium', 'large']}
               value={size}
               onChange={(event) => setSize(event.option)}
             />
           </FormField>
-          <FormField label="Comments" name="comments">
+          <FormField label="Comments" htmlFor="comments" name="comments">
             <TextArea
+              id="comments"
               name="comments"
               value={comments}
               onChange={(event) => setComments(event.target.value)}
             />
           </FormField>
-          <FormField label="Age" name="age" pad>
+          <FormField label="Age" htmlFor="age" name="age" pad>
             <RangeInput
+              id="age"
               name="age"
               min={15}
               max={75}

--- a/src/js/components/Form/stories/ControlledLazy.js
+++ b/src/js/components/Form/stories/ControlledLazy.js
@@ -56,11 +56,12 @@ export const ControlledLazy = () => {
             console.log('Submit', event.value, event.touched)
           }
         >
-          <FormField label="Name" name="name">
-            <TextInput name="name" />
+          <FormField label="Name" htmlFor="name" name="name">
+            <TextInput id="name" name="name" />
           </FormField>
-          <FormField label="Email" name="email" required>
+          <FormField label="Email" htmlFor="email" name="email" required>
             <MaskedInput
+              id="email"
               name="email"
               mask={[
                 { regexp: /^[\w\-_.]+$/, placeholder: 'example' },
@@ -77,14 +78,19 @@ export const ControlledLazy = () => {
           <FormField name="ampm">
             <RadioButtonGroup name="ampm" options={['morning', 'evening']} />
           </FormField>
-          <FormField label="Size" name="size">
-            <Select name="size" options={['small', 'medium', 'large']} />
+          <FormField label="Size" htmlFor="size" name="size">
+            <Select
+              id="size"
+              aria-label="size"
+              name="size"
+              options={['small', 'medium', 'large']}
+            />
           </FormField>
-          <FormField label="Comments" name="comments">
-            <TextArea name="comments" />
+          <FormField label="Comments" htmlFor="comments" name="comments">
+            <TextArea id="comments" name="comments" />
           </FormField>
-          <FormField label="Age" name="age" pad>
-            <RangeInput name="age" min={15} max={75} />
+          <FormField label="Age" htmlFor="age" name="age" pad>
+            <RangeInput id="age" name="age" min={15} max={75} />
           </FormField>
           <Box direction="row" justify="between" margin={{ top: 'medium' }}>
             <Button label="Cancel" />

--- a/src/js/components/Form/stories/FieldWithChildren.js
+++ b/src/js/components/Form/stories/FieldWithChildren.js
@@ -49,11 +49,12 @@ export const FieldWithChildren = () => (
           console.log('Validate', errors, infos)
         }
       >
-        <FormField label="Name" name="name" required>
-          <TextInput name="name" />
+        <FormField label="Name" htmlFor="name" name="name" required>
+          <TextInput id="name" name="name" />
         </FormField>
-        <FormField label="Email" name="email" required>
+        <FormField label="Email" htmlFor="email" name="email" required>
           <MaskedInput
+            id="email"
             name="email"
             mask={[
               { regexp: /^[\w\-_.]+$/, placeholder: 'example' },
@@ -81,14 +82,20 @@ export const FieldWithChildren = () => (
         <FormField name="ampm">
           <RadioButtonGroup name="ampm" options={['morning', 'evening']} />
         </FormField>
-        <FormField label="Size" name="size">
-          <Select name="size" multiple options={['small', 'medium', 'large']} />
+        <FormField label="Size" htmlFor="size" name="size">
+          <Select
+            id="size"
+            aria-label="size"
+            name="size"
+            multiple
+            options={['small', 'medium', 'large']}
+          />
         </FormField>
-        <FormField label="Comments" name="comments">
-          <TextArea name="comments" />
+        <FormField label="Comments" htmlFor="comments" name="comments">
+          <TextArea id="comments" name="comments" />
         </FormField>
-        <FormField label="Age" name="age" pad>
-          <RangeInput name="age" min={15} max={75} />
+        <FormField label="Age" htmlFor="age" name="age" pad>
+          <RangeInput id="age" name="age" min={15} max={75} />
         </FormField>
         <Box direction="row" justify="between" margin={{ top: 'medium' }}>
           <Button label="Cancel" />

--- a/src/js/components/Form/stories/FieldWithComponentProp.js
+++ b/src/js/components/Form/stories/FieldWithComponentProp.js
@@ -65,6 +65,8 @@ export const FieldWithComponentProp = () => (
         />
         <FormField
           label="Size"
+          htmlFor="size"
+          id="size"
           aria-label="size"
           name="size"
           component={Select}

--- a/src/js/components/Form/stories/FieldWithComponentProp.js
+++ b/src/js/components/Form/stories/FieldWithComponentProp.js
@@ -24,6 +24,8 @@ export const FieldWithComponentProp = () => (
       >
         <FormField
           label="Name"
+          htmlFor="name"
+          id="name"
           name="name"
           required
           validate={[
@@ -39,9 +41,18 @@ export const FieldWithComponentProp = () => (
             },
           ]}
         />
-        <FormField label="Email" name="email" type="email" required />
+        <FormField
+          label="Email"
+          htmlFor="email"
+          id="email"
+          name="email"
+          type="email"
+          required
+        />
         <FormField
           label="Employee ID"
+          htmlFor="employeeId"
+          id="employeeId"
           name="employeeId"
           required
           validate={{ regexp: /^[0-9]{4,6}$/, message: '4-6 digits' }}
@@ -54,23 +65,40 @@ export const FieldWithComponentProp = () => (
         />
         <FormField
           label="Size"
+          aria-label="size"
           name="size"
           component={Select}
           onChange={(event) => console.log(event)}
           options={['small', 'medium', 'large', 'xlarge']}
         />
-        <FormField label="Comments" name="comments" component={TextArea} />
+        <FormField
+          label="Comments"
+          htmlFor="comments"
+          id="comments"
+          name="comments"
+          component={TextArea}
+        />
         <FormField
           label="Age"
+          htmlFor="age"
+          id="age"
           name="age"
           component={RangeInput}
           pad
           min={15}
           max={75}
         />
-        <FormField label="File" name="file" component={FileInput} />
+        <FormField
+          label="File"
+          htmlFor="file"
+          id="file"
+          name="file"
+          component={FileInput}
+        />
         <FormField
           label="Custom"
+          htmlFor="custom"
+          id="custom"
           name="custom"
           component={(props) => <input {...props} />}
         />

--- a/src/js/components/Form/stories/Uncontrolled.js
+++ b/src/js/components/Form/stories/Uncontrolled.js
@@ -26,11 +26,12 @@ export const Uncontrolled = () => (
         onChange={(value) => console.log('Change', value)}
         onSubmit={(event) => console.log('Submit', event.value, event.touched)}
       >
-        <FormField label="Name" name="name">
-          <TextInput name="name" suggestions={suggestions} />
+        <FormField label="Name" htmlFor="name" name="name">
+          <TextInput id="name" name="name" suggestions={suggestions} />
         </FormField>
-        <FormField label="Email" name="email" required>
+        <FormField label="Email" htmlFor="email" name="email" required>
           <MaskedInput
+            id="id"
             name="email"
             mask={[
               { regexp: /^[\w\-_.]+$/, placeholder: 'example' },
@@ -47,17 +48,22 @@ export const Uncontrolled = () => (
         <FormField name="ampm">
           <RadioButtonGroup name="ampm" options={['morning', 'evening']} />
         </FormField>
-        <FormField label="Size" name="size">
-          <Select name="size" options={['small', 'medium', 'large']} />
+        <FormField label="Size" htmlFor="size" name="size">
+          <Select
+            id="size"
+            aria-label="size"
+            name="size"
+            options={['small', 'medium', 'large']}
+          />
         </FormField>
-        <FormField label="Comments" name="comments">
-          <TextArea name="comments" />
+        <FormField label="Comments" htmlFor="comments" name="comments">
+          <TextArea id="comments" name="comments" />
         </FormField>
-        <FormField label="Age" name="age" pad>
-          <RangeInput name="age" min={15} max={75} />
+        <FormField label="Age" htmlFor="age" name="age" pad>
+          <RangeInput id="age" name="age" min={15} max={75} />
         </FormField>
-        <FormField required label="Image" name="image">
-          <FileInput name="image" />
+        <FormField required label="Image" htmlFor="image" name="image">
+          <FileInput id="image" name="image" />
         </FormField>
         <Box direction="row" justify="between" margin={{ top: 'medium' }}>
           <Button label="Cancel" />

--- a/src/js/components/Form/stories/Uncontrolled.js
+++ b/src/js/components/Form/stories/Uncontrolled.js
@@ -31,7 +31,7 @@ export const Uncontrolled = () => (
         </FormField>
         <FormField label="Email" htmlFor="email" name="email" required>
           <MaskedInput
-            id="id"
+            id="email"
             name="email"
             mask={[
               { regexp: /^[\w\-_.]+$/, placeholder: 'example' },

--- a/src/js/components/Form/stories/ValidateOnChange.js
+++ b/src/js/components/Form/stories/ValidateOnChange.js
@@ -66,6 +66,8 @@ export const ValidateOnChange = () => {
               name="select-size"
               htmlFor="select-size"
               id="select-size"
+              htmlFor="select-size"
+              id="select-size"
               aria-label="select-size"
               options={['small', 'medium', 'large']}
             />

--- a/src/js/components/Form/stories/ValidateOnChange.js
+++ b/src/js/components/Form/stories/ValidateOnChange.js
@@ -21,6 +21,8 @@ export const ValidateOnChange = () => {
         >
           <FormField
             label="First Name"
+            htmlFor="firstName"
+            id="firstName"
             name="firstName"
             required
             validate={[
@@ -35,6 +37,8 @@ export const ValidateOnChange = () => {
 
           <FormField
             label="Last Name"
+            htmlFor="lastName"
+            id="lastName"
             name="lastName"
             required
             validate={[
@@ -61,6 +65,7 @@ export const ValidateOnChange = () => {
             <Select
               name="select-size"
               id="select-size"
+              aria-label="select-size"
               options={['small', 'medium', 'large']}
             />
           </FormField>

--- a/src/js/components/Form/stories/ValidateOnChange.js
+++ b/src/js/components/Form/stories/ValidateOnChange.js
@@ -66,7 +66,6 @@ export const ValidateOnChange = () => {
               name="select-size"
               htmlFor="select-size"
               id="select-size"
-              id="select-size"
               aria-label="select-size"
               options={['small', 'medium', 'large']}
             />

--- a/src/js/components/Form/stories/ValidateOnChange.js
+++ b/src/js/components/Form/stories/ValidateOnChange.js
@@ -64,6 +64,7 @@ export const ValidateOnChange = () => {
           >
             <Select
               name="select-size"
+              htmlFor="select-size"
               id="select-size"
               aria-label="select-size"
               options={['small', 'medium', 'large']}

--- a/src/js/components/Form/stories/ValidateOnChange.js
+++ b/src/js/components/Form/stories/ValidateOnChange.js
@@ -66,7 +66,6 @@ export const ValidateOnChange = () => {
               name="select-size"
               htmlFor="select-size"
               id="select-size"
-              htmlFor="select-size"
               id="select-size"
               aria-label="select-size"
               options={['small', 'medium', 'large']}

--- a/src/js/components/Form/stories/ValidateOnMount.js
+++ b/src/js/components/Form/stories/ValidateOnMount.js
@@ -31,6 +31,8 @@ export const ValidateOnMount = () => {
         >
           <FormField
             label="First Name"
+            htmlFor="firstName"
+            id="firstName"
             name="firstName"
             required
             validate={[
@@ -45,6 +47,8 @@ export const ValidateOnMount = () => {
 
           <FormField
             label="Last Name"
+            htmlFor="lastName"
+            id="lastName"
             name="lastName"
             required
             validate={[

--- a/src/js/components/Form/stories/typescript/TypedForm.tsx
+++ b/src/js/components/Form/stories/typescript/TypedForm.tsx
@@ -86,6 +86,8 @@ export const TypedForm = () => {
           />
           <FormField
             label="Size"
+            htmlFor="size"
+            id="size"
             aria-label="size"
             name="size"
             component={Select}

--- a/src/js/components/Form/stories/typescript/TypedForm.tsx
+++ b/src/js/components/Form/stories/typescript/TypedForm.tsx
@@ -88,7 +88,6 @@ export const TypedForm = () => {
             label="Size"
             htmlFor="size"
             id="size"
-            htmlFor="size"
             aria-label="size"
             name="size"
             component={Select}

--- a/src/js/components/Form/stories/typescript/TypedForm.tsx
+++ b/src/js/components/Form/stories/typescript/TypedForm.tsx
@@ -50,13 +50,24 @@ export const TypedForm = () => {
         >
           <FormField
             label="Name"
+            htmlFor="name"
+            id="name"
             name="name"
             required
             validate={{ regexp: /^[a-z]/i }}
           />
-          <FormField label="Email" name="email" type="email" required />
+          <FormField
+            label="Email"
+            htmlFor="email"
+            id="email"
+            name="email"
+            type="email"
+            required
+          />
           <FormField
             label="Employee ID"
+            htmlFor="employeeId"
+            id="employeeId"
             name="employeeId"
             required
             validate={{ regexp: /^[0-9]{4,6}$/, message: '4-6 digits' }}
@@ -75,14 +86,23 @@ export const TypedForm = () => {
           />
           <FormField
             label="Size"
+            aria-label="size"
             name="size"
             component={Select}
             onChange={(event) => console.log(event)}
             options={['small', 'medium', 'large', 'xlarge']}
           />
-          <FormField label="Comments" name="comments" component={TextArea} />
+          <FormField
+            label="Comments"
+            htmlFor="comments"
+            id="comments"
+            name="comments"
+            component={TextArea}
+          />
           <FormField
             label="Age"
+            htmlFor="age"
+            id="age"
             name="age"
             component={RangeInput}
             pad

--- a/src/js/components/Form/stories/typescript/TypedForm.tsx
+++ b/src/js/components/Form/stories/typescript/TypedForm.tsx
@@ -88,6 +88,8 @@ export const TypedForm = () => {
             label="Size"
             htmlFor="size"
             id="size"
+            htmlFor="size"
+            id="size"
             aria-label="size"
             name="size"
             component={Select}

--- a/src/js/components/Form/stories/typescript/TypedForm.tsx
+++ b/src/js/components/Form/stories/typescript/TypedForm.tsx
@@ -89,7 +89,6 @@ export const TypedForm = () => {
             htmlFor="size"
             id="size"
             htmlFor="size"
-            id="size"
             aria-label="size"
             name="size"
             component={Select}


### PR DESCRIPTION

#### What does this PR do?
This PR adds the htmlFor and id's for the form stories that caused the "Form elements must have labels" accessibility warnings. 
#### Where should the reviewer start?
Controlled.js
#### What testing has been done on this PR?
form-test-controlled and form-test-uncontrolled passed.
#### How should this be manually tested?
Storybook
#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
#6542 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No
#### Should this PR be mentioned in the release notes?
No
#### Is this change backwards compatible or is it a breaking change?
Backwards compatible