### PR TITLE
use `forwardref` and change `buttonref`

### DIFF
--- a/src/js/components/Drop/DropContainer.js
+++ b/src/js/components/Drop/DropContainer.js
@@ -96,7 +96,7 @@ const DropContainer = forwardRef(
 
     useEffect(() => {
       const notifyAlign = () => {
-        const styleCurrent = dropRef?.current.style;
+        const styleCurrent = dropRef.current.style;
         const alignControl = styleCurrent.top !== '' ? 'top' : 'bottom';
 
         onAlign(alignControl);
@@ -109,7 +109,7 @@ const DropContainer = forwardRef(
         const windowWidth = window.innerWidth;
         const windowHeight = window.innerHeight;
         const target = dropTarget?.current || dropTarget;
-        const container = dropRef?.current;
+        const container = dropRef.current;
         if (container && target) {
           // clear prior styling
           container.style.left = '';
@@ -306,7 +306,6 @@ const DropContainer = forwardRef(
       dropTarget,
       portalContext,
       portalId,
-      ref,
       responsive,
       restrictFocus,
       stretch,
@@ -316,9 +315,9 @@ const DropContainer = forwardRef(
 
     useEffect(() => {
       if (restrictFocus) {
-        dropRef?.current.focus();
+        dropRef.current.focus();
       }
-    }, [dropRef, ref, restrictFocus]);
+    }, [dropRef, restrictFocus]);
 
     let content = (
       <StyledDrop

--- a/src/js/components/Drop/DropContainer.js
+++ b/src/js/components/Drop/DropContainer.js
@@ -1,10 +1,4 @@
-import React, {
-  forwardRef,
-  useContext,
-  useEffect,
-  useMemo,
-  useRef,
-} from 'react';
+import React, { forwardRef, useContext, useEffect, useMemo } from 'react';
 import { ThemeContext } from 'styled-components';
 import { ContainerTargetContext } from '../../contexts/ContainerTargetContext';
 import { FocusedContainer } from '../FocusedContainer';
@@ -13,6 +7,7 @@ import {
   findScrollParents,
   parseMetricToNum,
   PortalContext,
+  useForwardedRef,
 } from '../../utils';
 import { defaultProps } from '../../default-props';
 import { Box } from '../Box';
@@ -64,7 +59,7 @@ const DropContainer = forwardRef(
       () => [...portalContext, portalId],
       [portalContext, portalId],
     );
-    const dropRef = useRef();
+    const dropRef = useForwardedRef(ref);
 
     useEffect(() => {
       const onClickDocument = (event) => {
@@ -101,7 +96,7 @@ const DropContainer = forwardRef(
 
     useEffect(() => {
       const notifyAlign = () => {
-        const styleCurrent = (ref || dropRef).current.style;
+        const styleCurrent = dropRef?.current.style;
         const alignControl = styleCurrent.top !== '' ? 'top' : 'bottom';
 
         onAlign(alignControl);
@@ -113,8 +108,8 @@ const DropContainer = forwardRef(
       const place = (preserveHeight) => {
         const windowWidth = window.innerWidth;
         const windowHeight = window.innerHeight;
-        const target = dropTarget;
-        const container = (ref || dropRef).current;
+        const target = dropTarget?.current || dropTarget;
+        const container = dropRef?.current;
         if (container && target) {
           // clear prior styling
           container.style.left = '';
@@ -316,18 +311,19 @@ const DropContainer = forwardRef(
       restrictFocus,
       stretch,
       theme.drop,
+      dropRef,
     ]);
 
     useEffect(() => {
       if (restrictFocus) {
-        (ref || dropRef).current.focus();
+        dropRef?.current.focus();
       }
-    }, [ref, restrictFocus]);
+    }, [dropRef, ref, restrictFocus]);
 
     let content = (
       <StyledDrop
         aria-label={a11yTitle || ariaLabel}
-        ref={ref || dropRef}
+        ref={dropRef}
         as={Box}
         background={background}
         plain={plain}

--- a/src/js/components/DropButton/DropButton.js
+++ b/src/js/components/DropButton/DropButton.js
@@ -80,7 +80,7 @@ const DropButton = forwardRef(
             onAlign={onAlign}
             restrictFocus
             align={dropAlign}
-            target={dropTarget || buttonRef.current}
+            target={dropTarget || buttonRef}
             onClickOutside={onDropClose}
             onEsc={onDropClose}
             {...dropProps}


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

#### Where should the reviewer start?
DropContainer.js
DropButton.js
#### What testing has been done on this PR?
storybook
#### How should this be manually tested?
```

      <Box margin={{ left: 'large', top: '200px' }} direction="row">
        <DropButton
          badge={badge}
          dropAlign={{ left: 'left', top: 'bottom' }}
          label='hello'
          icon={<Columns />}
          dropContent={
            <Box pad="medium">
              <Button
                label="Toggle badge"
                onClick={() => setBadge((prev) => !prev)}
              />
            </Box>
          }
        />
      </Box>

```
#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

Re-rendering the Button when adding a badge or tip causes the DropButton's `buttonRef.current` to change. DropButton passes the initial `buttonRef.current` to DropContainer but doesn't pass the new one when the Button re-renders for the badge.

more comments [here](https://github.com/grommet/grommet/issues/6539)

#### What are the relevant issues?
closes #6539 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible