### PR TITLE
Changed DataTableColumns to fix an issue when Data doesn't have updateOn=change

### DIFF
--- a/src/js/components/DataTableColumns/DataTableColumns.js
+++ b/src/js/components/DataTableColumns/DataTableColumns.js
@@ -152,7 +152,12 @@ export const DataTableColumns = ({ drop, options, ...rest }) => {
   const [showContent, setShowContent] = useState();
 
   let content = <Content drop={drop} options={options} />;
-  if (noForm) content = <DataForm footer={false}>{content}</DataForm>;
+  if (noForm)
+    content = (
+      <DataForm footer={false} updateOn="change">
+        {content}
+      </DataForm>
+    );
 
   if (!drop) return content;
 

--- a/src/js/components/DataView/stories/Simple.js
+++ b/src/js/components/DataView/stories/Simple.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Box, Data } from 'grommet';
+import { Box, Data, DataTable } from 'grommet';
 
 import { DataView } from '../DataView';
 import { DATA } from '../../DataTable/stories/data';
@@ -17,6 +17,7 @@ export const Simple = () => (
       ]}
     >
       <DataView />
+      <DataTable />
     </Data>
   </Box>
   // </Grommet>


### PR DESCRIPTION
#### What does this PR do?

Changed DataTableColumns to fix an issue when Data doesn't have updateOn=change.

This aligns with DataFilters where the DataForm is set to have `updateOn="change"` when not already in a DataForm context.

#### Where should the reviewer start?

DataTableColumns.js

#### What testing has been done on this PR?

manually tested

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

no unit tests changed

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
