### PR TITLE
Fix DataTable size parameter to allow for css string

### DIFF
--- a/src/js/components/DataTable/StyledDataTable.js
+++ b/src/js/components/DataTable/StyledDataTable.js
@@ -94,7 +94,7 @@ const StyledDataTableBody = styled(TableBody)`
     `
     display: block;
     width: 100%;
-    max-height: ${props.theme.global.size[props.size]};
+    max-height: ${props.theme.global.size[props.size] || props.size};
     overflow: auto;
   `}
 

--- a/src/js/components/DataTable/__tests__/DataTable-test.tsx
+++ b/src/js/components/DataTable/__tests__/DataTable-test.tsx
@@ -1574,4 +1574,42 @@ describe('DataTable', () => {
 
     expect(asFragment()).toMatchSnapshot();
   });
+
+  test('should base table body max height on global size', () => {
+    const { container } = render(
+      <Grommet>
+        <DataTable
+          columns={[
+            { property: 'a', header: 'A' },
+            { property: 'b', header: 'B' },
+          ]}
+          data={[
+            { a: 'one', b: 1 },
+            { a: 'two', b: 2 },
+          ]}
+          size="small"
+        />
+      </Grommet>,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test('should base table body max height on css value', () => {
+    const { container } = render(
+      <Grommet>
+        <DataTable
+          columns={[
+            { property: 'a', header: 'A' },
+            { property: 'b', header: 'B' },
+          ]}
+          data={[
+            { a: 'one', b: 1 },
+            { a: 'two', b: 2 },
+          ]}
+          size="50px"
+        />
+      </Grommet>,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
 });

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.tsx.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.tsx.snap
@@ -23724,6 +23724,478 @@ exports[`DataTable should apply pagination styling 1`] = `
 </div>
 `;
 
+exports[`DataTable should base table body max height on css value 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c6 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c11 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c4 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c9 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c1 {
+  border-spacing: 0;
+  border-collapse: collapse;
+  width: inherit;
+}
+
+.c2 {
+  position: relative;
+  border-spacing: 0;
+  border-collapse: separate;
+}
+
+.c8 {
+  display: table;
+  width: 100%;
+  table-layout: fixed;
+}
+
+.c7 {
+  display: block;
+  width: 100%;
+  max-height: 50px;
+  overflow: auto;
+}
+
+.c7:focus {
+  outline: 2px solid #6FFFB0;
+}
+
+.c7:focus:not(:focus-visible) {
+  outline: none;
+}
+
+.c3 {
+  height: -webkit-fit-content;
+  height: -moz-fit-content;
+  height: fit-content;
+  display: table;
+  width: calc(100% - 0px);
+  table-layout: fixed;
+}
+
+<div
+  class="c0"
+>
+  <table
+    class="c1 c2"
+  >
+    <thead
+      class="StyledTable__StyledTableHeader-sc-1m3u5g-4 c3"
+    >
+      <tr
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+      >
+        <th
+          class="c4 "
+          scope="col"
+        >
+          <div
+            class="c5"
+          >
+            <span
+              class="c6"
+            >
+              A
+            </span>
+          </div>
+        </th>
+        <th
+          class="c4 "
+          scope="col"
+        >
+          <div
+            class="c5"
+          >
+            <span
+              class="c6"
+            >
+              B
+            </span>
+          </div>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 c7"
+    >
+      <tr
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 c8"
+      >
+        <th
+          class="c9 "
+          scope="row"
+        >
+          <div
+            class="c10"
+          >
+            <span
+              class="c11"
+            >
+              one
+            </span>
+          </div>
+        </th>
+        <td
+          class="c9 "
+        >
+          <div
+            class="c10"
+          >
+            <span
+              class="c6"
+            >
+              1
+            </span>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 c8"
+      >
+        <th
+          class="c9 "
+          scope="row"
+        >
+          <div
+            class="c10"
+          >
+            <span
+              class="c11"
+            >
+              two
+            </span>
+          </div>
+        </th>
+        <td
+          class="c9 "
+        >
+          <div
+            class="c10"
+          >
+            <span
+              class="c6"
+            >
+              2
+            </span>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
+exports[`DataTable should base table body max height on global size 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c6 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c11 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c4 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c9 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c1 {
+  border-spacing: 0;
+  border-collapse: collapse;
+  width: inherit;
+}
+
+.c2 {
+  position: relative;
+  border-spacing: 0;
+  border-collapse: separate;
+}
+
+.c8 {
+  display: table;
+  width: 100%;
+  table-layout: fixed;
+}
+
+.c7 {
+  display: block;
+  width: 100%;
+  max-height: 192px;
+  overflow: auto;
+}
+
+.c7:focus {
+  outline: 2px solid #6FFFB0;
+}
+
+.c7:focus:not(:focus-visible) {
+  outline: none;
+}
+
+.c3 {
+  height: -webkit-fit-content;
+  height: -moz-fit-content;
+  height: fit-content;
+  display: table;
+  width: calc(100% - 0px);
+  table-layout: fixed;
+}
+
+<div
+  class="c0"
+>
+  <table
+    class="c1 c2"
+  >
+    <thead
+      class="StyledTable__StyledTableHeader-sc-1m3u5g-4 c3"
+    >
+      <tr
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+      >
+        <th
+          class="c4 "
+          scope="col"
+        >
+          <div
+            class="c5"
+          >
+            <span
+              class="c6"
+            >
+              A
+            </span>
+          </div>
+        </th>
+        <th
+          class="c4 "
+          scope="col"
+        >
+          <div
+            class="c5"
+          >
+            <span
+              class="c6"
+            >
+              B
+            </span>
+          </div>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 c7"
+    >
+      <tr
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 c8"
+      >
+        <th
+          class="c9 "
+          scope="row"
+        >
+          <div
+            class="c10"
+          >
+            <span
+              class="c11"
+            >
+              one
+            </span>
+          </div>
+        </th>
+        <td
+          class="c9 "
+        >
+          <div
+            class="c10"
+          >
+            <span
+              class="c6"
+            >
+              1
+            </span>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 c8"
+      >
+        <th
+          class="c9 "
+          scope="row"
+        >
+          <div
+            class="c10"
+          >
+            <span
+              class="c11"
+            >
+              two
+            </span>
+          </div>
+        </th>
+        <td
+          class="c9 "
+        >
+          <div
+            class="c10"
+          >
+            <span
+              class="c6"
+            >
+              2
+            </span>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
 exports[`DataTable should not show paginate controls when data is empty array 1`] = `
 .c0 {
   font-size: 18px;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Currently, the DataTable size parameter only allows for a size that is defined in the theme (i.e. small, medium, large, etc.). This PR allows for a custom css string to be provided instead. 

#### Where should the reviewer start?

- Checkout the PR branch. 
- Run storybook
- Navigate to http://localhost:9001/?path=/story/visualizations-datatable-sized--sized-data-table
- Update to the [associated story](https://github.com/grommet/grommet/blob/master/src/js/components/DataTable/stories/Sized.js) to test a standard css value (i.e. '200px')

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

I have not developed test for this PR since it is a pretty simple change.  Let me know if you would like me to do so

#### Any background context you want to provide?

I have a use case in which I need to fill a container (Box) with a data table.  Without this PR, I haven't found another way to accomplish this. 

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

I don't think so. The docs already say that a 'string' can be provided. I'm not sure if 'Any CSS value' would be more accurate. 

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?

It it backward compatible. 