### PR TITLE
Button text color handle dark and transparent backgrounds

### DIFF
--- a/src/js/components/Accordion/__tests__/__snapshots__/Accordion-test.tsx.snap
+++ b/src/js/components/Accordion/__tests__/__snapshots__/Accordion-test.tsx.snap
@@ -4259,7 +4259,8 @@ exports[`Accordion custom accordion 1`] = `
 }
 
 .c3:hover {
-  background: #33333310;
+  background-color: #33333310;
+  color: #000000;
 }
 
 .c3:focus {
@@ -4572,7 +4573,8 @@ exports[`Accordion custom accordion 2`] = `
 }
 
 .c3:hover {
-  background: #33333310;
+  background-color: #33333310;
+  color: #000000;
 }
 
 .c3:focus {

--- a/src/js/components/Box/__tests__/__snapshots__/Box-style-test.tsx.snap
+++ b/src/js/components/Box/__tests__/__snapshots__/Box-style-test.tsx.snap
@@ -1739,7 +1739,8 @@ exports[`Box hoverIndicator 1`] = `
 }
 
 .c3:hover {
-  background: #33333310;
+  background-color: #33333310;
+  color: #000000;
 }
 
 .c4 {

--- a/src/js/components/Button/__tests__/Button-kind-test.js
+++ b/src/js/components/Button/__tests__/Button-kind-test.js
@@ -8,7 +8,9 @@ import { axe } from 'jest-axe';
 import { fireEvent, render } from '@testing-library/react';
 import { Add } from 'grommet-icons';
 
-import { Grommet, Button } from '../..';
+import { hpe } from 'grommet-theme-hpe';
+import { deepMerge } from '../../../utils';
+import { Grommet, Button, Box } from '../..';
 import { buttonKindTheme } from './theme/buttonKindTheme';
 
 describe('Button kind', () => {
@@ -725,6 +727,49 @@ describe('Button kind', () => {
         <Button label="Add" />
         <Button icon={<Add />} size="large" />
         <Button label="Add" size="large" />
+      </Grommet>,
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  test('button with transparent background', () => {
+    const { asFragment } = render(
+      <Grommet
+        theme={deepMerge(hpe, {
+          button: {
+            'background-contrast': {
+              background: 'background-contrast',
+              color: 'text-strong',
+            },
+            active: {
+              'background-contrast': {
+                color: 'text-strong',
+              },
+            },
+          },
+        })}
+      >
+        <Box
+          background={{ dark: true, color: 'background' }}
+          pad="large"
+          gap="medium"
+          align="start"
+        >
+          <Button label="Test button" kind="background-contrast" />
+          <Button
+            label="Active Test button"
+            kind="background-contrast"
+            active
+          />
+        </Box>
+        <Box pad="large" gap="medium" align="start">
+          <Button label="Test button" kind="background-contrast" />
+          <Button
+            label="Active Test button"
+            kind="background-contrast"
+            active
+          />
+        </Box>
       </Grommet>,
     );
     expect(asFragment()).toMatchSnapshot();

--- a/src/js/components/Button/__tests__/__snapshots__/Button-kind-test.js.snap
+++ b/src/js/components/Button/__tests__/__snapshots__/Button-kind-test.js.snap
@@ -1859,6 +1859,420 @@ exports[`Button kind button with icon and align 1`] = `
 </div>
 `;
 
+exports[`Button kind button with transparent background 1`] = `
+<DocumentFragment>
+  .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  background-color: rgba(28,28,28,1);
+  color: #FFFFFFE6;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 48px;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 48px;
+}
+
+.c3 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  height: 24px;
+}
+
+.c2 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 6px;
+  padding: 6px 12px;
+  font-size: 18px;
+  line-height: 24px;
+  background-color: #FFFFFF0F;
+  color: #FFFFFFF5;
+  text-align: center;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+  font-size: 19px;
+  line-height: 24px;
+}
+
+.c2:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #00E8CF;
+}
+
+.c2:focus > circle,
+.c2:focus > ellipse,
+.c2:focus > line,
+.c2:focus > path,
+.c2:focus > polygon,
+.c2:focus > polyline,
+.c2:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #00E8CF;
+}
+
+.c2:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c2:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c2:focus:not(:focus-visible) > circle,
+.c2:focus:not(:focus-visible) > ellipse,
+.c2:focus:not(:focus-visible) > line,
+.c2:focus:not(:focus-visible) > path,
+.c2:focus:not(:focus-visible) > polygon,
+.c2:focus:not(:focus-visible) > polyline,
+.c2:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c2:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c4 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  background-color: #FFFFFF0F;
+  color: #FFFFFFE6;
+  border: none;
+  border-radius: 6px;
+  padding: 6px 12px;
+  font-size: 18px;
+  line-height: 24px;
+  background-color: #FFFFFF0F;
+  color: #FFFFFFF5;
+  background-color: rgba(255,255,255,0.058823529411764705);
+  color: #FFFFFFF5;
+  color: #FFFFFFF5;
+  text-align: center;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+  font-size: 19px;
+  line-height: 24px;
+}
+
+.c4:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #00E8CF;
+}
+
+.c4:focus > circle,
+.c4:focus > ellipse,
+.c4:focus > line,
+.c4:focus > path,
+.c4:focus > polygon,
+.c4:focus > polyline,
+.c4:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #00E8CF;
+}
+
+.c4:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c4:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c4:focus:not(:focus-visible) > circle,
+.c4:focus:not(:focus-visible) > ellipse,
+.c4:focus:not(:focus-visible) > line,
+.c4:focus:not(:focus-visible) > path,
+.c4:focus:not(:focus-visible) > polygon,
+.c4:focus:not(:focus-visible) > polyline,
+.c4:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c4:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c6 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 6px;
+  padding: 6px 12px;
+  font-size: 18px;
+  line-height: 24px;
+  background-color: #0000000A;
+  color: #000000;
+  text-align: center;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+  font-size: 19px;
+  line-height: 24px;
+}
+
+.c6:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #00E8CF;
+}
+
+.c6:focus > circle,
+.c6:focus > ellipse,
+.c6:focus > line,
+.c6:focus > path,
+.c6:focus > polygon,
+.c6:focus > polyline,
+.c6:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #00E8CF;
+}
+
+.c6:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c6:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c6:focus:not(:focus-visible) > circle,
+.c6:focus:not(:focus-visible) > ellipse,
+.c6:focus:not(:focus-visible) > line,
+.c6:focus:not(:focus-visible) > path,
+.c6:focus:not(:focus-visible) > polygon,
+.c6:focus:not(:focus-visible) > polyline,
+.c6:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c6:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c7 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  background-color: #0000000A;
+  color: #444444;
+  border: none;
+  border-radius: 6px;
+  padding: 6px 12px;
+  font-size: 18px;
+  line-height: 24px;
+  background-color: #0000000A;
+  color: #000000;
+  background-color: rgba(0,0,0,0.0392156862745098);
+  color: #000000;
+  color: #000000;
+  text-align: center;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+  font-size: 19px;
+  line-height: 24px;
+}
+
+.c7:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #00E8CF;
+}
+
+.c7:focus > circle,
+.c7:focus > ellipse,
+.c7:focus > line,
+.c7:focus > path,
+.c7:focus > polygon,
+.c7:focus > polyline,
+.c7:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #00E8CF;
+}
+
+.c7:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c7:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c7:focus:not(:focus-visible) > circle,
+.c7:focus:not(:focus-visible) > ellipse,
+.c7:focus:not(:focus-visible) > line,
+.c7:focus:not(:focus-visible) > path,
+.c7:focus:not(:focus-visible) > polygon,
+.c7:focus:not(:focus-visible) > polyline,
+.c7:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c7:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c0 {
+  font-family: 'Metric',Arial,sans-serif;
+  font-size: 18px;
+  line-height: 24px;
+  background-color: #FFFFFF;
+  color: #444444;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    padding: 24px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c5 {
+    padding: 24px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c3 {
+    height: 12px;
+  }
+}
+
+<div
+    class="c0"
+  >
+    <div
+      class="c1"
+    >
+      <button
+        class="c2"
+        type="button"
+      >
+        Test button
+      </button>
+      <div
+        class="c3"
+      />
+      <button
+        class="c4"
+        type="button"
+      >
+        Active Test button
+      </button>
+    </div>
+    <div
+      class="c5"
+    >
+      <button
+        class="c6"
+        type="button"
+      >
+        Test button
+      </button>
+      <div
+        class="c3"
+      />
+      <button
+        class="c7"
+        type="button"
+      >
+        Active Test button
+      </button>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`Button kind default button 1`] = `
 .c1 {
   display: inline-block;

--- a/src/js/components/Card/__tests__/__snapshots__/Card-test.tsx.snap
+++ b/src/js/components/Card/__tests__/__snapshots__/Card-test.tsx.snap
@@ -78,7 +78,8 @@ exports[`Card Themed 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background: #FFFFFF27;
+  background-color: #FFFFFF27;
+  color: #f8f8f8;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;

--- a/src/js/components/Drop/__tests__/__snapshots__/Drop-test.tsx.snap
+++ b/src/js/components/Drop/__tests__/__snapshots__/Drop-test.tsx.snap
@@ -601,7 +601,8 @@ exports[`Drop background 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #33333310;
+  background-color: #33333310;
+  color: #444444;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -623,7 +624,8 @@ exports[`Drop background 1`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: #33333310;
+  background-color: #33333310;
+  color: #444444;
   opacity: 0;
   -webkit-transform-origin: top left;
   -ms-transform-origin: top left;
@@ -1056,7 +1058,8 @@ exports[`Drop elevation 1`] = `
   position: fixed;
   z-index: 15;
   outline: none;
-  background: #33333310;
+  background-color: #33333310;
+  color: #444444;
   margin: 6px;
   opacity: 0;
   -webkit-transform-origin: top left;
@@ -3515,7 +3518,8 @@ exports[`Drop theme elevation renders 1`] = `
   position: fixed;
   z-index: 15;
   outline: none;
-  background: #33333310;
+  background-color: #33333310;
+  color: #444444;
   margin: 6px;
   opacity: 0;
   -webkit-transform-origin: top left;

--- a/src/js/components/List/__tests__/__snapshots__/List-test.js.snap
+++ b/src/js/components/List/__tests__/__snapshots__/List-test.js.snap
@@ -14004,7 +14004,8 @@ exports[`List itemKey function 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background: #33333310;
+  background-color: #33333310;
+  color: #444444;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
   min-height: 0;
@@ -18074,7 +18075,8 @@ exports[`List pinned Pinned items should not be allowed to be re-ordered 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background: #33333310;
+  background-color: #33333310;
+  color: #444444;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
   min-height: 0;
@@ -18741,7 +18743,8 @@ exports[`List pinned Pinned items should not be allowed to be re-ordered 2`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background: #33333310;
+  background-color: #33333310;
+  color: #444444;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
   min-height: 0;
@@ -19454,7 +19457,8 @@ exports[`List pinned Should apply pinned styling to items 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background: #33333310;
+  background-color: #33333310;
+  color: #444444;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
   min-height: 0;
@@ -19802,7 +19806,8 @@ exports[`List pinned Should apply pinned styling to items when data are children
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background: #33333310;
+  background-color: #33333310;
+  color: #444444;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
   min-height: 0;
@@ -20182,7 +20187,8 @@ exports[`List pinned Should apply pinned styling to items when data are objects 
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background: #33333310;
+  background-color: #33333310;
+  color: #444444;
   border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
   min-height: 0;

--- a/src/js/components/Pagination/__tests__/__snapshots__/Pagination-test.tsx.snap
+++ b/src/js/components/Pagination/__tests__/__snapshots__/Pagination-test.tsx.snap
@@ -1596,7 +1596,8 @@ exports[`Pagination should apply button kind style when referenced by a string 1
   border-width: 2px;
   border-color: skyblue;
   padding: 2px 20px;
-  background: #33333310;
+  background-color: #33333310;
+  color: #000000;
   background-color: rgba(202,156,234,1);
   color: #444444;
   border-color: transparent;

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -349,7 +349,8 @@ exports[`Select Clear option renders - bottom 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background: #33333310;
+  background-color: #33333310;
+  color: #444444;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -1258,7 +1259,8 @@ exports[`Select Clear option renders- top 1`] = `
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
   align-items: flex-start;
-  background: #33333310;
+  background-color: #33333310;
+  color: #444444;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -3798,7 +3800,8 @@ exports[`Select default value clear 1`] = `
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
   align-items: flex-start;
-  background: #33333310;
+  background-color: #33333310;
+  color: #444444;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;

--- a/src/js/components/Tip/__tests__/__snapshots__/Tip-test.tsx.snap
+++ b/src/js/components/Tip/__tests__/__snapshots__/Tip-test.tsx.snap
@@ -27,7 +27,8 @@ exports[`Tip dropProps should pass props to Drop 1`] = `
   box-sizing: border-box;
   max-width: 100%;
   margin: 6px;
-  background: #33333310;
+  background-color: #33333310;
+  color: #444444;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -256,7 +257,8 @@ exports[`Tip mouseOver and mouseOut events on the Tip's child 1`] = `
   box-sizing: border-box;
   max-width: 100%;
   margin: 6px;
-  background: #33333310;
+  background-color: #33333310;
+  color: #444444;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -537,7 +539,8 @@ exports[`Tip themed 1`] = `
   box-sizing: border-box;
   max-width: 100%;
   margin: 6px;
-  background: #FFFFFF18;
+  background-color: #FFFFFF18;
+  color: #f8f8f8;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;

--- a/src/js/themes/__tests__/__snapshots__/theme-test.js.snap
+++ b/src/js/themes/__tests__/__snapshots__/theme-test.js.snap
@@ -1757,7 +1757,8 @@ exports[`Grommet hpe theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background: #0000000A;
+  background-color: #0000000A;
+  color: #444444;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;

--- a/src/js/utils/background.js
+++ b/src/js/utils/background.js
@@ -169,6 +169,7 @@ export const backgroundAndTextColors = (backgroundArg, textArg, theme) => {
 
     if (backgroundColor && canExtractRGBArray(backgroundColor)) {
       const colorArray = getRGBArray(backgroundColor);
+      // check if the alpha value is less than 0.5
       if (colorArray[3] < 0.5) transparent = true;
     }
     if (shade) {

--- a/src/js/utils/background.js
+++ b/src/js/utils/background.js
@@ -1,6 +1,12 @@
 import { css } from 'styled-components';
 
-import { colorIsDark, getRGBA, normalizeColor } from './colors';
+import {
+  colorIsDark,
+  getRGBA,
+  normalizeColor,
+  canExtractRGBArray,
+  getRGBArray,
+} from './colors';
 
 // evalStyle() converts a styled-components item into a string
 const evalStyle = (arg, theme) => {
@@ -159,8 +165,16 @@ export const backgroundAndTextColors = (backgroundArg, textArg, theme) => {
   } else {
     backgroundColor = normalizeBackgroundColor(background, theme);
     const shade = darkContext(backgroundColor, theme);
+    let transparent;
+
+    if (backgroundColor && canExtractRGBArray(backgroundColor)) {
+      const colorArray = getRGBArray(backgroundColor);
+      if (colorArray[3] < 0.5) transparent = true;
+    }
     if (shade) {
       textColor = normalizeColor(text[shade] || text, theme, shade === 'dark');
+    } else if (transparent && text) {
+      textColor = normalizeColor(text, theme);
     } else {
       // If we can't determine the shade, we assume this isn't a simple color.
       // It could be a gradient. backgroundStyle() will take care of that case.

--- a/src/js/utils/colors.js
+++ b/src/js/utils/colors.js
@@ -79,13 +79,13 @@ const rgbaExp =
 // e.g. hsl(240, 60%, 50%)
 const hslExp = /^hsla?\(\s?([0-9]*)\s?,\s?([0-9]*)%?\s?,\s?([0-9]*)%?\s?.*?\)/;
 
-const canExtractRGBArray = (color) =>
+export const canExtractRGBArray = (color) =>
   hexExp.test(color) ||
   rgbExp.test(color) ||
   rgbaExp.test(color) ||
   hslExp.test(color);
 
-const getRGBArray = (color) => {
+export const getRGBArray = (color) => {
   if (hexExp.test(color)) {
     const [red, green, blue, alpha] = parseHexToRGB(color);
     return [red, green, blue, alpha !== undefined ? alpha / 255.0 : undefined];


### PR DESCRIPTION
#### What does this PR do?
Fixes an issue on dark transparent background where the text is the wrong color.

Just a note about the snapshot changes: for background colors that are opaque the snapshots are changing to use the css property `background-color` instead of `background`. In addition the text color is added in the snapshot, note that in most cases the snapshot already includes the text color so the text color is being duplicated in some cases. I couldn't find a good way around this. Visually I didn't notice any problems from this change but since this code is used across so many components it would be good to get extra eyes here.

#### Where should the reviewer start?

#### What testing has been done on this PR?
Added a unit test and tested with the following story:
```javascript
import React from 'react';

import {
  Box,
  Grommet,
  Button,
} from 'grommet';
import { deepMerge } from 'grommet/utils';
import { hpe } from 'grommet-theme-hpe';

const myTheme = deepMerge(hpe, {
  button: {
    'background-contrast': {
      background: 'background-contrast',
      color: 'text-strong',
    },
    active: {
      'background-contrast': {
        color: 'text-strong',
      },
    },
  },
});

export const Test = () => (
  <Grommet theme={myTheme}>
    <Box
      background={{ dark: true, color: 'background' }}
      pad="large"
      gap="medium"
      align="start"
    >
      <Button label="Test button" kind="background-contrast" />
      <Button label="Active Test button" kind="background-contrast" active />
    </Box>
    <Box pad="large" gap="medium" align="start">
      <Button label="Test button" kind="background-contrast" />
      <Button label="Active Test button" kind="background-contrast" active />
    </Box>
  </Grommet>
);

export default {
  title: 'Controls/Button/Test',
};
```

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [x] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
closes https://github.com/grommet/grommet/issues/6301

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Maybe? Not sure if we should mention that we support `button.kind.background` and `button.kind.background.color`? Currently we just document `button.kind.background.color`.

#### Should this PR be mentioned in the release notes?
Yes

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible