### PR TITLE
Changed DataFilters to have overflow

### DIFF
--- a/src/js/components/Data/DataForm.js
+++ b/src/js/components/Data/DataForm.js
@@ -16,6 +16,7 @@ const HideableButton = styled(Button)`
 
 const MaxForm = styled(Form)`
   max-width: 100%;
+  ${(props) => props.fill && 'max-height: 100%;'}
 `;
 
 const hideButtonProps = {
@@ -232,10 +233,12 @@ export const DataForm = ({
       onSubmit={updateOn === 'submit' ? onSubmit : undefined}
       onChange={onChange}
     >
-      <Box flex={false} pad={pad} gap={gap}>
-        {children}
+      <Box fill="vertical">
+        <Box flex overflow="auto" pad={{ horizontal: pad, top: pad }} gap={gap}>
+          {children}
+        </Box>
         {footer !== false && updateOn === 'submit' && (
-          <Footer>
+          <Footer flex={false} pad={pad}>
             <Button
               label={format({
                 id: 'dataForm.submit',

--- a/src/js/components/Data/DataForm.js
+++ b/src/js/components/Data/DataForm.js
@@ -173,7 +173,6 @@ const normalizeValue = (nextValue, prevValue, views) => {
 export const DataForm = ({
   children,
   footer,
-  gap,
   onDone,
   onTouched,
   pad,
@@ -234,11 +233,16 @@ export const DataForm = ({
       onChange={onChange}
     >
       <Box fill="vertical">
-        <Box flex overflow="auto" pad={{ horizontal: pad, top: pad }} gap={gap}>
+        <Box flex overflow="auto" pad={{ horizontal: pad, top: pad }}>
           {children}
         </Box>
         {footer !== false && updateOn === 'submit' && (
-          <Footer flex={false} pad={pad}>
+          <Footer
+            flex={false}
+            margin={{ top: 'small' }}
+            pad={{ horizontal: pad, bottom: pad }}
+            gap="small"
+          >
             <Button
               label={format({
                 id: 'dataForm.submit',

--- a/src/js/components/Data/__tests__/__snapshots__/Data-test.tsx.snap
+++ b/src/js/components/Data/__tests__/__snapshots__/Data-test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Data controlled search 1`] = `
-.c8 {
+.c10 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -12,25 +12,25 @@ exports[`Data controlled search 1`] = `
   stroke: #666666;
 }
 
-.c8 g {
+.c10 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c8 *:not([stroke])[fill="none"] {
+.c10 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c8 *[stroke*="#"],
-.c8 *[STROKE*="#"] {
+.c10 *[stroke*="#"],
+.c10 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c8 *[fill-rule],
-.c8 *[FILL-RULE],
-.c8 *[fill*="#"],
-.c8 *[FILL*="#"] {
+.c10 *[fill-rule],
+.c10 *[FILL-RULE],
+.c10 *[fill*="#"],
+.c10 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -95,7 +95,40 @@ exports[`Data controlled search 1`] = `
   overflow: auto;
 }
 
-.c10 {
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-bottom: 12px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -112,7 +145,7 @@ exports[`Data controlled search 1`] = `
   flex: 0 0 auto;
 }
 
-.c16 {
+.c18 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -133,7 +166,7 @@ exports[`Data controlled search 1`] = `
   justify-content: center;
 }
 
-.c19 {
+.c21 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -174,20 +207,20 @@ exports[`Data controlled search 1`] = `
   row-gap: 12px;
 }
 
-.c12 {
+.c14 {
   margin-top: 6px;
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
 }
 
-.c20 {
+.c22 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
 }
 
-.c11 {
+.c13 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -207,52 +240,52 @@ exports[`Data controlled search 1`] = `
   padding: 12px;
 }
 
-.c11:hover {
+.c13:hover {
   background-color: rgba(221,221,221,0.4);
   color: #000000;
 }
 
-.c11:focus {
+.c13:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus > circle,
-.c11:focus > ellipse,
-.c11:focus > line,
-.c11:focus > path,
-.c11:focus > polygon,
-.c11:focus > polyline,
-.c11:focus > rect {
+.c13:focus > circle,
+.c13:focus > ellipse,
+.c13:focus > line,
+.c13:focus > path,
+.c13:focus > polygon,
+.c13:focus > polyline,
+.c13:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus::-moz-focus-inner {
+.c13:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c11:focus:not(:focus-visible) {
+.c13:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c11:focus:not(:focus-visible) > circle,
-.c11:focus:not(:focus-visible) > ellipse,
-.c11:focus:not(:focus-visible) > line,
-.c11:focus:not(:focus-visible) > path,
-.c11:focus:not(:focus-visible) > polygon,
-.c11:focus:not(:focus-visible) > polyline,
-.c11:focus:not(:focus-visible) > rect {
+.c13:focus:not(:focus-visible) > circle,
+.c13:focus:not(:focus-visible) > ellipse,
+.c13:focus:not(:focus-visible) > line,
+.c13:focus:not(:focus-visible) > path,
+.c13:focus:not(:focus-visible) > polygon,
+.c13:focus:not(:focus-visible) > polyline,
+.c13:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c11:focus:not(:focus-visible)::-moz-focus-inner {
+.c13:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c9 {
+.c11 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -266,61 +299,43 @@ exports[`Data controlled search 1`] = `
   margin: 0;
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
+  outline: none;
+  border: none;
   padding-left: 48px;
 }
 
-.c9:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c9:focus > circle,
-.c9:focus > ellipse,
-.c9:focus > line,
-.c9:focus > path,
-.c9:focus > polygon,
-.c9:focus > polyline,
-.c9:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c9:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c9::-webkit-input-placeholder {
+.c11::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c9::-moz-placeholder {
+.c11::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c9:-ms-input-placeholder {
+.c11:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c9::-webkit-search-decoration {
+.c11::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c9::-moz-focus-inner {
+.c11::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c9:-moz-placeholder,
-.c9::-moz-placeholder {
+.c11:-moz-placeholder,
+.c11::-moz-placeholder {
   opacity: 1;
 }
 
-.c6 {
+.c8 {
   position: relative;
   width: 100%;
 }
 
-.c7 {
+.c9 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -342,7 +357,7 @@ exports[`Data controlled search 1`] = `
   max-width: 100%;
 }
 
-.c15 {
+.c17 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -355,7 +370,7 @@ exports[`Data controlled search 1`] = `
   padding-bottom: 6px;
 }
 
-.c18 {
+.c20 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -367,28 +382,40 @@ exports[`Data controlled search 1`] = `
   padding-bottom: 6px;
 }
 
-.c13 {
+.c15 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
 }
 
-.c14 {
+.c16 {
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
 }
 
-.c17:focus {
+.c19:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c17:focus:not(:focus-visible) {
+.c19:focus:not(:focus-visible) {
   outline: none;
 }
 
 @media only screen and (max-width:768px) {
 
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    margin-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
 }
 
 @media only screen and (max-width:768px) {
@@ -418,49 +445,57 @@ exports[`Data controlled search 1`] = `
             class="c5"
           >
             <div
-              class="c6"
+              class="c6 "
             >
               <div
-                class="c7"
+                class="c7 FormField__FormFieldContentBox-sc-m9hood-1"
               >
-                <svg
-                  aria-label="Search"
+                <div
                   class="c8"
-                  viewBox="0 0 24 24"
                 >
-                  <path
-                    d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                    fill="none"
-                    stroke="#000"
-                    stroke-width="2"
+                  <div
+                    class="c9"
+                  >
+                    <svg
+                      aria-label="Search"
+                      class="c10"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                        fill="none"
+                        stroke="#000"
+                        stroke-width="2"
+                      />
+                    </svg>
+                  </div>
+                  <input
+                    aria-label="Search data"
+                    autocomplete="off"
+                    class="c11"
+                    id="data--search"
+                    name="_search"
+                    type="search"
+                    value=""
                   />
-                </svg>
+                </div>
               </div>
-              <input
-                aria-label="Search data"
-                autocomplete="off"
-                class="c9"
-                id="data--search"
-                name="_search"
-                type="search"
-                value=""
-              />
             </div>
           </div>
         </div>
       </form>
       <div
-        class="c10"
+        class="c12"
       >
         <button
           aria-label="Open filters"
-          class="c11"
+          class="c13"
           id="data--filters-control"
           type="button"
         >
           <svg
             aria-label="Filter"
-            class="c8"
+            class="c10"
             viewBox="0 0 24 24"
           >
             <path
@@ -474,12 +509,12 @@ exports[`Data controlled search 1`] = `
       </div>
     </div>
     <span
-      class="c12"
+      class="c14"
     >
       4 results of undefined items
     </span>
     <table
-      class="c13 c14"
+      class="c15 c16"
     >
       <thead
         class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -488,30 +523,30 @@ exports[`Data controlled search 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c15 "
+            class="c17 "
             scope="col"
           >
             <div
-              class="c16"
+              class="c18"
             />
           </th>
         </tr>
       </thead>
       <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c17"
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c19"
       >
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c18 "
+            class="c20 "
             scope="row"
           >
             <div
-              class="c19"
+              class="c21"
             >
               <span
-                class="c20"
+                class="c22"
               >
                 aa
               </span>
@@ -522,14 +557,14 @@ exports[`Data controlled search 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c18 "
+            class="c20 "
             scope="row"
           >
             <div
-              class="c19"
+              class="c21"
             >
               <span
-                class="c20"
+                class="c22"
               >
                 bb
               </span>
@@ -540,14 +575,14 @@ exports[`Data controlled search 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c18 "
+            class="c20 "
             scope="row"
           >
             <div
-              class="c19"
+              class="c21"
             >
               <span
-                class="c20"
+                class="c22"
               >
                 cc
               </span>
@@ -558,14 +593,14 @@ exports[`Data controlled search 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c18 "
+            class="c20 "
             scope="row"
           >
             <div
-              class="c19"
+              class="c21"
             >
               <span
-                class="c20"
+                class="c22"
               >
                 dd
               </span>
@@ -599,33 +634,41 @@ exports[`Data controlled search 2`] = `
             class="StyledBox-sc-13pk1d4-0 dePIJN"
           >
             <div
-              class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 edcgVv"
+              class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
             >
               <div
-                class="StyledTextInput__StyledIcon-sc-1x30a0s-3 cFBrkA"
+                class="StyledBox-sc-13pk1d4-0 cqRjpC FormField__FormFieldContentBox-sc-m9hood-1"
               >
-                <svg
-                  aria-label="Search"
-                  class="StyledIcon-sc-ofa7kd-0 jQvEgu"
-                  viewBox="0 0 24 24"
+                <div
+                  class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 edcgVv"
                 >
-                  <path
-                    d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                    fill="none"
-                    stroke="#000"
-                    stroke-width="2"
+                  <div
+                    class="StyledTextInput__StyledIcon-sc-1x30a0s-3 cFBrkA"
+                  >
+                    <svg
+                      aria-label="Search"
+                      class="StyledIcon-sc-ofa7kd-0 jQvEgu"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                        fill="none"
+                        stroke="#000"
+                        stroke-width="2"
+                      />
+                    </svg>
+                  </div>
+                  <input
+                    aria-label="Search data"
+                    autocomplete="off"
+                    class="StyledTextInput-sc-1x30a0s-0 kovfiL"
+                    id="data--search"
+                    name="_search"
+                    type="search"
+                    value="a"
                   />
-                </svg>
+                </div>
               </div>
-              <input
-                aria-label="Search data"
-                autocomplete="off"
-                class="StyledTextInput-sc-1x30a0s-0 bMqJAS"
-                id="data--search"
-                name="_search"
-                type="search"
-                value="a"
-              />
             </div>
           </div>
         </div>
@@ -760,7 +803,7 @@ exports[`Data controlled search 2`] = `
 `;
 
 exports[`Data messages 1`] = `
-.c8 {
+.c10 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -771,25 +814,25 @@ exports[`Data messages 1`] = `
   stroke: #666666;
 }
 
-.c8 g {
+.c10 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c8 *:not([stroke])[fill="none"] {
+.c10 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c8 *[stroke*="#"],
-.c8 *[STROKE*="#"] {
+.c10 *[stroke*="#"],
+.c10 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c8 *[fill-rule],
-.c8 *[FILL-RULE],
-.c8 *[fill*="#"],
-.c8 *[FILL*="#"] {
+.c10 *[fill-rule],
+.c10 *[FILL-RULE],
+.c10 *[fill*="#"],
+.c10 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -854,7 +897,40 @@ exports[`Data messages 1`] = `
   overflow: auto;
 }
 
-.c10 {
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-bottom: 12px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -871,7 +947,7 @@ exports[`Data messages 1`] = `
   flex: 0 0 auto;
 }
 
-.c16 {
+.c18 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -892,7 +968,7 @@ exports[`Data messages 1`] = `
   justify-content: center;
 }
 
-.c19 {
+.c21 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -933,25 +1009,25 @@ exports[`Data messages 1`] = `
   row-gap: 12px;
 }
 
-.c12 {
+.c14 {
   margin-top: 6px;
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
 }
 
-.c20 {
+.c22 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
 }
 
-.c21 {
+.c23 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c11 {
+.c13 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -971,52 +1047,52 @@ exports[`Data messages 1`] = `
   padding: 12px;
 }
 
-.c11:hover {
+.c13:hover {
   background-color: rgba(221,221,221,0.4);
   color: #000000;
 }
 
-.c11:focus {
+.c13:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus > circle,
-.c11:focus > ellipse,
-.c11:focus > line,
-.c11:focus > path,
-.c11:focus > polygon,
-.c11:focus > polyline,
-.c11:focus > rect {
+.c13:focus > circle,
+.c13:focus > ellipse,
+.c13:focus > line,
+.c13:focus > path,
+.c13:focus > polygon,
+.c13:focus > polyline,
+.c13:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus::-moz-focus-inner {
+.c13:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c11:focus:not(:focus-visible) {
+.c13:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c11:focus:not(:focus-visible) > circle,
-.c11:focus:not(:focus-visible) > ellipse,
-.c11:focus:not(:focus-visible) > line,
-.c11:focus:not(:focus-visible) > path,
-.c11:focus:not(:focus-visible) > polygon,
-.c11:focus:not(:focus-visible) > polyline,
-.c11:focus:not(:focus-visible) > rect {
+.c13:focus:not(:focus-visible) > circle,
+.c13:focus:not(:focus-visible) > ellipse,
+.c13:focus:not(:focus-visible) > line,
+.c13:focus:not(:focus-visible) > path,
+.c13:focus:not(:focus-visible) > polygon,
+.c13:focus:not(:focus-visible) > polyline,
+.c13:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c11:focus:not(:focus-visible)::-moz-focus-inner {
+.c13:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c9 {
+.c11 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -1030,61 +1106,43 @@ exports[`Data messages 1`] = `
   margin: 0;
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
+  outline: none;
+  border: none;
   padding-left: 48px;
 }
 
-.c9:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c9:focus > circle,
-.c9:focus > ellipse,
-.c9:focus > line,
-.c9:focus > path,
-.c9:focus > polygon,
-.c9:focus > polyline,
-.c9:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c9:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c9::-webkit-input-placeholder {
+.c11::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c9::-moz-placeholder {
+.c11::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c9:-ms-input-placeholder {
+.c11:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c9::-webkit-search-decoration {
+.c11::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c9::-moz-focus-inner {
+.c11::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c9:-moz-placeholder,
-.c9::-moz-placeholder {
+.c11:-moz-placeholder,
+.c11::-moz-placeholder {
   opacity: 1;
 }
 
-.c6 {
+.c8 {
   position: relative;
   width: 100%;
 }
 
-.c7 {
+.c9 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1106,7 +1164,7 @@ exports[`Data messages 1`] = `
   max-width: 100%;
 }
 
-.c15 {
+.c17 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -1119,7 +1177,7 @@ exports[`Data messages 1`] = `
   padding-bottom: 6px;
 }
 
-.c18 {
+.c20 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -1131,28 +1189,40 @@ exports[`Data messages 1`] = `
   padding-bottom: 6px;
 }
 
-.c13 {
+.c15 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
 }
 
-.c14 {
+.c16 {
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
 }
 
-.c17:focus {
+.c19:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c17:focus:not(:focus-visible) {
+.c19:focus:not(:focus-visible) {
   outline: none;
 }
 
 @media only screen and (max-width:768px) {
 
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    margin-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
 }
 
 @media only screen and (max-width:768px) {
@@ -1182,49 +1252,57 @@ exports[`Data messages 1`] = `
             class="c5"
           >
             <div
-              class="c6"
+              class="c6 "
             >
               <div
-                class="c7"
+                class="c7 FormField__FormFieldContentBox-sc-m9hood-1"
               >
-                <svg
-                  aria-label="Search"
+                <div
                   class="c8"
-                  viewBox="0 0 24 24"
                 >
-                  <path
-                    d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                    fill="none"
-                    stroke="#000"
-                    stroke-width="2"
+                  <div
+                    class="c9"
+                  >
+                    <svg
+                      aria-label="Search"
+                      class="c10"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                        fill="none"
+                        stroke="#000"
+                        stroke-width="2"
+                      />
+                    </svg>
+                  </div>
+                  <input
+                    aria-label="Search data"
+                    autocomplete="off"
+                    class="c11"
+                    id="data--search"
+                    name="_search"
+                    type="search"
+                    value=""
                   />
-                </svg>
+                </div>
               </div>
-              <input
-                aria-label="Search data"
-                autocomplete="off"
-                class="c9"
-                id="data--search"
-                name="_search"
-                type="search"
-                value=""
-              />
             </div>
           </div>
         </div>
       </form>
       <div
-        class="c10"
+        class="c12"
       >
         <button
           aria-label="Open filters"
-          class="c11"
+          class="c13"
           id="data--filters-control"
           type="button"
         >
           <svg
             aria-label="Filter"
-            class="c8"
+            class="c10"
             viewBox="0 0 24 24"
           >
             <path
@@ -1238,12 +1316,12 @@ exports[`Data messages 1`] = `
       </div>
     </div>
     <span
-      class="c12"
+      class="c14"
     >
       4 things
     </span>
     <table
-      class="c13 c14"
+      class="c15 c16"
     >
       <thead
         class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -1252,51 +1330,51 @@ exports[`Data messages 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c15 "
+            class="c17 "
             scope="col"
           >
             <div
-              class="c16"
+              class="c18"
             />
           </th>
           <th
-            class="c15 "
+            class="c17 "
             scope="col"
           >
             <div
-              class="c16"
+              class="c18"
             />
           </th>
         </tr>
       </thead>
       <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c17"
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c19"
       >
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c18 "
+            class="c20 "
             scope="row"
           >
             <div
-              class="c19"
+              class="c21"
             >
               <span
-                class="c20"
+                class="c22"
               >
                 aa
               </span>
             </div>
           </th>
           <td
-            class="c18 "
+            class="c20 "
           >
             <div
-              class="c19"
+              class="c21"
             >
               <span
-                class="c21"
+                class="c23"
               >
                 ZZ
               </span>
@@ -1307,27 +1385,27 @@ exports[`Data messages 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c18 "
+            class="c20 "
             scope="row"
           >
             <div
-              class="c19"
+              class="c21"
             >
               <span
-                class="c20"
+                class="c22"
               >
                 bb
               </span>
             </div>
           </th>
           <td
-            class="c18 "
+            class="c20 "
           >
             <div
-              class="c19"
+              class="c21"
             >
               <span
-                class="c21"
+                class="c23"
               >
                 YY
               </span>
@@ -1338,24 +1416,24 @@ exports[`Data messages 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c18 "
+            class="c20 "
             scope="row"
           >
             <div
-              class="c19"
+              class="c21"
             >
               <span
-                class="c20"
+                class="c22"
               >
                 cc
               </span>
             </div>
           </th>
           <td
-            class="c18 "
+            class="c20 "
           >
             <div
-              class="c19"
+              class="c21"
             />
           </td>
         </tr>
@@ -1363,24 +1441,24 @@ exports[`Data messages 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c18 "
+            class="c20 "
             scope="row"
           >
             <div
-              class="c19"
+              class="c21"
             >
               <span
-                class="c20"
+                class="c22"
               >
                 dd
               </span>
             </div>
           </th>
           <td
-            class="c18 "
+            class="c20 "
           >
             <div
-              class="c19"
+              class="c21"
             />
           </td>
         </tr>
@@ -1476,7 +1554,7 @@ exports[`Data onView 1`] = `
   justify-content: space-between;
 }
 
-.c8 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1494,7 +1572,7 @@ exports[`Data onView 1`] = `
   flex: 0 0 auto;
 }
 
-.c10 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1510,7 +1588,7 @@ exports[`Data onView 1`] = `
   padding: 12px;
 }
 
-.c11 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1524,7 +1602,7 @@ exports[`Data onView 1`] = `
   flex-direction: column;
 }
 
-.c13 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1547,7 +1625,7 @@ exports[`Data onView 1`] = `
   justify-content: center;
 }
 
-.c16 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1573,7 +1651,7 @@ exports[`Data onView 1`] = `
   border-radius: 4px;
 }
 
-.c18 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1593,7 +1671,7 @@ exports[`Data onView 1`] = `
   height: 100%;
 }
 
-.c20 {
+.c19 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1614,7 +1692,7 @@ exports[`Data onView 1`] = `
   cursor: pointer;
 }
 
-.c22 {
+.c21 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1633,7 +1711,7 @@ exports[`Data onView 1`] = `
   border-radius: 12px;
 }
 
-.c23 {
+.c22 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1659,7 +1737,7 @@ exports[`Data onView 1`] = `
   overflow: visible;
 }
 
-.c24 {
+.c23 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1684,7 +1762,7 @@ exports[`Data onView 1`] = `
   justify-content: center;
 }
 
-.c25 {
+.c24 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1703,7 +1781,7 @@ exports[`Data onView 1`] = `
   border-radius: 100%;
 }
 
-.c26 {
+.c25 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1722,6 +1800,32 @@ exports[`Data onView 1`] = `
   flex-direction: column;
   width: 100%;
   border-radius: 12px;
+}
+
+.c27 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-top: 12px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
 }
 
 .c35 {
@@ -1745,17 +1849,7 @@ exports[`Data onView 1`] = `
   justify-content: center;
 }
 
-.c7 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  -webkit-align-self: stretch;
-  -ms-flex-item-align: stretch;
-  align-self: stretch;
-  height: 6px;
-}
-
-.c17 {
+.c16 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -1772,10 +1866,10 @@ exports[`Data onView 1`] = `
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
   align-self: stretch;
-  width: 24px;
+  width: 12px;
 }
 
-.c9 {
+.c8 {
   margin-left: 12px;
   margin-right: 12px;
   margin-top: 6px;
@@ -1784,7 +1878,7 @@ exports[`Data onView 1`] = `
   line-height: 24px;
 }
 
-.c19 {
+.c18 {
   margin-left: 12px;
   margin-right: 12px;
   font-size: 14px;
@@ -1792,7 +1886,7 @@ exports[`Data onView 1`] = `
   text-align: right;
 }
 
-.c27 {
+.c26 {
   margin-left: 12px;
   margin-right: 12px;
   font-size: 14px;
@@ -1949,7 +2043,7 @@ exports[`Data onView 1`] = `
   border: 0;
 }
 
-.c12 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1971,12 +2065,12 @@ exports[`Data onView 1`] = `
   cursor: pointer;
 }
 
-.c12:hover input:not([disabled]) + div,
-.c12:hover input:not([disabled]) + span {
+.c11:hover input:not([disabled]) + div,
+.c11:hover input:not([disabled]) + span {
   border-color: #000000;
 }
 
-.c15 {
+.c14 {
   opacity: 0;
   -moz-appearance: none;
   width: 0;
@@ -1985,18 +2079,18 @@ exports[`Data onView 1`] = `
   cursor: pointer;
 }
 
-.c15:checked + span > span {
+.c14:checked + span > span {
   left: calc( 48px - 24px );
   background: #7D4CDB;
 }
 
-.c14 {
+.c13 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c21 {
+.c20 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -2066,62 +2160,62 @@ exports[`Data onView 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c7 {
     margin-bottom: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c10 {
+  .c9 {
     border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c10 {
+  .c9 {
     padding: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c13 {
+  .c12 {
     margin-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c16 {
+  .c15 {
     border: solid 2px rgba(0,0,0,0.15);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c22 {
+  .c21 {
     border-radius: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c26 {
+  .c25 {
     border-radius: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c7 {
-    height: 3px;
+  .c27 {
+    margin-top: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c17 {
+  .c16 {
     height: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c29 {
-    width: 12px;
+    width: 6px;
   }
 }
 
@@ -2165,38 +2259,35 @@ exports[`Data onView 1`] = `
             </h2>
           </header>
           <div
-            class="c7"
-          />
-          <div
-            class="c8 "
+            class="c7 "
           >
             <label
-              class="c9"
+              class="c8"
               for="data-name"
             >
               name
             </label>
             <div
-              class="c10 FormField__FormFieldContentBox-sc-m9hood-1"
+              class="c9 FormField__FormFieldContentBox-sc-m9hood-1"
             >
               <div
-                class="c11 StyledCheckBoxGroup-sc-2nhc5d-0"
+                class="c10 StyledCheckBoxGroup-sc-2nhc5d-0"
                 id="data-name"
                 role="group"
               >
                 <label
-                  class="c12"
+                  class="c11"
                   label="aa"
                 >
                   <div
-                    class="c13 c14"
+                    class="c12 c13"
                   >
                     <input
-                      class="c15"
+                      class="c14"
                       type="checkbox"
                     />
                     <div
-                      class="c16 "
+                      class="c15 "
                     />
                   </div>
                   <span>
@@ -2204,21 +2295,21 @@ exports[`Data onView 1`] = `
                   </span>
                 </label>
                 <div
-                  class="c17"
+                  class="c16"
                 />
                 <label
-                  class="c12"
+                  class="c11"
                   label="bb"
                 >
                   <div
-                    class="c13 c14"
+                    class="c12 c13"
                   >
                     <input
-                      class="c15"
+                      class="c14"
                       type="checkbox"
                     />
                     <div
-                      class="c16 "
+                      class="c15 "
                     />
                   </div>
                   <span>
@@ -2226,21 +2317,21 @@ exports[`Data onView 1`] = `
                   </span>
                 </label>
                 <div
-                  class="c17"
+                  class="c16"
                 />
                 <label
-                  class="c12"
+                  class="c11"
                   label="cc"
                 >
                   <div
-                    class="c13 c14"
+                    class="c12 c13"
                   >
                     <input
-                      class="c15"
+                      class="c14"
                       type="checkbox"
                     />
                     <div
-                      class="c16 "
+                      class="c15 "
                     />
                   </div>
                   <span>
@@ -2248,21 +2339,21 @@ exports[`Data onView 1`] = `
                   </span>
                 </label>
                 <div
-                  class="c17"
+                  class="c16"
                 />
                 <label
-                  class="c12"
+                  class="c11"
                   label="dd"
                 >
                   <div
-                    class="c13 c14"
+                    class="c12 c13"
                   >
                     <input
-                      class="c15"
+                      class="c14"
                       type="checkbox"
                     />
                     <div
-                      class="c16 "
+                      class="c15 "
                     />
                   </div>
                   <span>
@@ -2273,38 +2364,35 @@ exports[`Data onView 1`] = `
             </div>
           </div>
           <div
-            class="c7"
-          />
-          <div
-            class="c8 "
+            class="c7 "
           >
             <label
-              class="c9"
+              class="c8"
               for="data-enabled"
             >
               enabled
             </label>
             <div
-              class="c10 FormField__FormFieldContentBox-sc-m9hood-1"
+              class="c9 FormField__FormFieldContentBox-sc-m9hood-1"
             >
               <div
-                class="c11 StyledCheckBoxGroup-sc-2nhc5d-0"
+                class="c10 StyledCheckBoxGroup-sc-2nhc5d-0"
                 id="data-enabled"
                 role="group"
               >
                 <label
-                  class="c12"
+                  class="c11"
                   label="true"
                 >
                   <div
-                    class="c13 c14"
+                    class="c12 c13"
                   >
                     <input
-                      class="c15"
+                      class="c14"
                       type="checkbox"
                     />
                     <div
-                      class="c16 "
+                      class="c15 "
                     />
                   </div>
                   <span>
@@ -2312,21 +2400,21 @@ exports[`Data onView 1`] = `
                   </span>
                 </label>
                 <div
-                  class="c17"
+                  class="c16"
                 />
                 <label
-                  class="c12"
+                  class="c11"
                   label="false"
                 >
                   <div
-                    class="c13 c14"
+                    class="c12 c13"
                   >
                     <input
-                      class="c15"
+                      class="c14"
                       type="checkbox"
                     />
                     <div
-                      class="c16 "
+                      class="c15 "
                     />
                   </div>
                   <span>
@@ -2337,40 +2425,37 @@ exports[`Data onView 1`] = `
             </div>
           </div>
           <div
-            class="c7"
-          />
-          <div
-            class="c8 "
+            class="c7 "
           >
             <label
-              class="c9"
+              class="c8"
               for="data-rating"
             >
               rating
             </label>
             <div
-              class="c10 FormField__FormFieldContentBox-sc-m9hood-1"
+              class="c9 FormField__FormFieldContentBox-sc-m9hood-1"
             >
               <div
-                class="c18"
+                class="c17"
                 id="data-rating"
               >
                 <span
-                  class="c19"
+                  class="c18"
                   style="width: 0px;"
                 >
                   2.0999999999999996
                 </span>
                 <div
-                  class="c20 c21"
+                  class="c19 c20"
                   tabindex="-1"
                 >
                   <div
-                    class="c22"
+                    class="c21"
                     style="flex: 0 0 0px;"
                   />
                   <div
-                    class="c23"
+                    class="c22"
                     style="flex: 0 0 1px;"
                   >
                     <div
@@ -2378,22 +2463,22 @@ exports[`Data onView 1`] = `
                       aria-valuemax="4.8999999999999995"
                       aria-valuemin="2.0999999999999996"
                       aria-valuenow="2.0999999999999996"
-                      class="c24"
+                      class="c23"
                       role="slider"
                       style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 1;"
                       tabindex="0"
                     >
                       <div
-                        class="c25 EdgeControl__StyledBox-sc-1xo2yt9-0"
+                        class="c24 EdgeControl__StyledBox-sc-1xo2yt9-0"
                       />
                     </div>
                   </div>
                   <div
-                    class="c26"
+                    class="c25"
                     style="flex: 3.8 0 0px; cursor: ew-resize;"
                   />
                   <div
-                    class="c23"
+                    class="c22"
                     style="flex: 0 0 1px;"
                   >
                     <div
@@ -2401,23 +2486,23 @@ exports[`Data onView 1`] = `
                       aria-valuemax="4.8999999999999995"
                       aria-valuemin="2.0999999999999996"
                       aria-valuenow="4.8999999999999995"
-                      class="c24"
+                      class="c23"
                       role="slider"
                       style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 1;"
                       tabindex="0"
                     >
                       <div
-                        class="c25 EdgeControl__StyledBox-sc-1xo2yt9-0"
+                        class="c24 EdgeControl__StyledBox-sc-1xo2yt9-0"
                       />
                     </div>
                   </div>
                   <div
-                    class="c22"
+                    class="c21"
                     style="flex: 0 0 0px;"
                   />
                 </div>
                 <span
-                  class="c27"
+                  class="c26"
                   style="width: 0px;"
                 >
                   4.8999999999999995
@@ -2427,7 +2512,7 @@ exports[`Data onView 1`] = `
           </div>
         </div>
         <footer
-          class="c5"
+          class="c27"
         >
           <button
             class="c28"
@@ -2504,7 +2589,7 @@ exports[`Data onView 1`] = `
             scope="row"
           >
             <div
-              class="c11"
+              class="c10"
             >
               <span
                 class="c38"
@@ -2517,14 +2602,14 @@ exports[`Data onView 1`] = `
             class="c37 "
           >
             <div
-              class="c11"
+              class="c10"
             />
           </td>
           <td
             class="c37 "
           >
             <div
-              class="c11"
+              class="c10"
             >
               <span
                 class="c39"
@@ -2537,7 +2622,7 @@ exports[`Data onView 1`] = `
             class="c37 "
           >
             <div
-              class="c11"
+              class="c10"
             />
           </td>
         </tr>
@@ -2549,7 +2634,7 @@ exports[`Data onView 1`] = `
             scope="row"
           >
             <div
-              class="c11"
+              class="c10"
             >
               <span
                 class="c38"
@@ -2562,14 +2647,14 @@ exports[`Data onView 1`] = `
             class="c37 "
           >
             <div
-              class="c11"
+              class="c10"
             />
           </td>
           <td
             class="c37 "
           >
             <div
-              class="c11"
+              class="c10"
             >
               <span
                 class="c39"
@@ -2582,7 +2667,7 @@ exports[`Data onView 1`] = `
             class="c37 "
           >
             <div
-              class="c11"
+              class="c10"
             />
           </td>
         </tr>
@@ -2594,7 +2679,7 @@ exports[`Data onView 1`] = `
             scope="row"
           >
             <div
-              class="c11"
+              class="c10"
             >
               <span
                 class="c38"
@@ -2607,21 +2692,21 @@ exports[`Data onView 1`] = `
             class="c37 "
           >
             <div
-              class="c11"
+              class="c10"
             />
           </td>
           <td
             class="c37 "
           >
             <div
-              class="c11"
+              class="c10"
             />
           </td>
           <td
             class="c37 "
           >
             <div
-              class="c11"
+              class="c10"
             />
           </td>
         </tr>
@@ -2633,7 +2718,7 @@ exports[`Data onView 1`] = `
             scope="row"
           >
             <div
-              class="c11"
+              class="c10"
             >
               <span
                 class="c38"
@@ -2646,21 +2731,21 @@ exports[`Data onView 1`] = `
             class="c37 "
           >
             <div
-              class="c11"
+              class="c10"
             />
           </td>
           <td
             class="c37 "
           >
             <div
-              class="c11"
+              class="c10"
             />
           </td>
           <td
             class="c37 "
           >
             <div
-              class="c11"
+              class="c10"
             />
           </td>
         </tr>
@@ -3771,7 +3856,7 @@ exports[`Data renders 1`] = `
 `;
 
 exports[`Data toolbar 1`] = `
-.c8 {
+.c10 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -3782,25 +3867,25 @@ exports[`Data toolbar 1`] = `
   stroke: #666666;
 }
 
-.c8 g {
+.c10 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c8 *:not([stroke])[fill="none"] {
+.c10 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c8 *[stroke*="#"],
-.c8 *[STROKE*="#"] {
+.c10 *[stroke*="#"],
+.c10 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c8 *[fill-rule],
-.c8 *[FILL-RULE],
-.c8 *[fill*="#"],
-.c8 *[FILL*="#"] {
+.c10 *[fill-rule],
+.c10 *[FILL-RULE],
+.c10 *[fill*="#"],
+.c10 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -3865,7 +3950,40 @@ exports[`Data toolbar 1`] = `
   overflow: auto;
 }
 
-.c10 {
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-bottom: 12px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3882,7 +4000,7 @@ exports[`Data toolbar 1`] = `
   flex: 0 0 auto;
 }
 
-.c16 {
+.c18 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3903,7 +4021,7 @@ exports[`Data toolbar 1`] = `
   justify-content: center;
 }
 
-.c19 {
+.c21 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3944,25 +4062,25 @@ exports[`Data toolbar 1`] = `
   row-gap: 12px;
 }
 
-.c12 {
+.c14 {
   margin-top: 6px;
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
 }
 
-.c20 {
+.c22 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
 }
 
-.c21 {
+.c23 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c11 {
+.c13 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -3982,52 +4100,52 @@ exports[`Data toolbar 1`] = `
   padding: 12px;
 }
 
-.c11:hover {
+.c13:hover {
   background-color: rgba(221,221,221,0.4);
   color: #000000;
 }
 
-.c11:focus {
+.c13:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus > circle,
-.c11:focus > ellipse,
-.c11:focus > line,
-.c11:focus > path,
-.c11:focus > polygon,
-.c11:focus > polyline,
-.c11:focus > rect {
+.c13:focus > circle,
+.c13:focus > ellipse,
+.c13:focus > line,
+.c13:focus > path,
+.c13:focus > polygon,
+.c13:focus > polyline,
+.c13:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus::-moz-focus-inner {
+.c13:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c11:focus:not(:focus-visible) {
+.c13:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c11:focus:not(:focus-visible) > circle,
-.c11:focus:not(:focus-visible) > ellipse,
-.c11:focus:not(:focus-visible) > line,
-.c11:focus:not(:focus-visible) > path,
-.c11:focus:not(:focus-visible) > polygon,
-.c11:focus:not(:focus-visible) > polyline,
-.c11:focus:not(:focus-visible) > rect {
+.c13:focus:not(:focus-visible) > circle,
+.c13:focus:not(:focus-visible) > ellipse,
+.c13:focus:not(:focus-visible) > line,
+.c13:focus:not(:focus-visible) > path,
+.c13:focus:not(:focus-visible) > polygon,
+.c13:focus:not(:focus-visible) > polyline,
+.c13:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c11:focus:not(:focus-visible)::-moz-focus-inner {
+.c13:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c9 {
+.c11 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -4041,61 +4159,43 @@ exports[`Data toolbar 1`] = `
   margin: 0;
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
+  outline: none;
+  border: none;
   padding-left: 48px;
 }
 
-.c9:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c9:focus > circle,
-.c9:focus > ellipse,
-.c9:focus > line,
-.c9:focus > path,
-.c9:focus > polygon,
-.c9:focus > polyline,
-.c9:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c9:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c9::-webkit-input-placeholder {
+.c11::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c9::-moz-placeholder {
+.c11::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c9:-ms-input-placeholder {
+.c11:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c9::-webkit-search-decoration {
+.c11::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c9::-moz-focus-inner {
+.c11::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c9:-moz-placeholder,
-.c9::-moz-placeholder {
+.c11:-moz-placeholder,
+.c11::-moz-placeholder {
   opacity: 1;
 }
 
-.c6 {
+.c8 {
   position: relative;
   width: 100%;
 }
 
-.c7 {
+.c9 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -4117,7 +4217,7 @@ exports[`Data toolbar 1`] = `
   max-width: 100%;
 }
 
-.c15 {
+.c17 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -4130,7 +4230,7 @@ exports[`Data toolbar 1`] = `
   padding-bottom: 6px;
 }
 
-.c18 {
+.c20 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -4142,28 +4242,40 @@ exports[`Data toolbar 1`] = `
   padding-bottom: 6px;
 }
 
-.c13 {
+.c15 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
 }
 
-.c14 {
+.c16 {
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
 }
 
-.c17:focus {
+.c19:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c17:focus:not(:focus-visible) {
+.c19:focus:not(:focus-visible) {
   outline: none;
 }
 
 @media only screen and (max-width:768px) {
 
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    margin-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
 }
 
 @media only screen and (max-width:768px) {
@@ -4193,49 +4305,57 @@ exports[`Data toolbar 1`] = `
             class="c5"
           >
             <div
-              class="c6"
+              class="c6 "
             >
               <div
-                class="c7"
+                class="c7 FormField__FormFieldContentBox-sc-m9hood-1"
               >
-                <svg
-                  aria-label="Search"
+                <div
                   class="c8"
-                  viewBox="0 0 24 24"
                 >
-                  <path
-                    d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                    fill="none"
-                    stroke="#000"
-                    stroke-width="2"
+                  <div
+                    class="c9"
+                  >
+                    <svg
+                      aria-label="Search"
+                      class="c10"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                        fill="none"
+                        stroke="#000"
+                        stroke-width="2"
+                      />
+                    </svg>
+                  </div>
+                  <input
+                    aria-label="Search data"
+                    autocomplete="off"
+                    class="c11"
+                    id="data--search"
+                    name="_search"
+                    type="search"
+                    value=""
                   />
-                </svg>
+                </div>
               </div>
-              <input
-                aria-label="Search data"
-                autocomplete="off"
-                class="c9"
-                id="data--search"
-                name="_search"
-                type="search"
-                value=""
-              />
             </div>
           </div>
         </div>
       </form>
       <div
-        class="c10"
+        class="c12"
       >
         <button
           aria-label="Open filters"
-          class="c11"
+          class="c13"
           id="data--filters-control"
           type="button"
         >
           <svg
             aria-label="Filter"
-            class="c8"
+            class="c10"
             viewBox="0 0 24 24"
           >
             <path
@@ -4249,12 +4369,12 @@ exports[`Data toolbar 1`] = `
       </div>
     </div>
     <span
-      class="c12"
+      class="c14"
     >
       4 items
     </span>
     <table
-      class="c13 c14"
+      class="c15 c16"
     >
       <thead
         class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -4263,51 +4383,51 @@ exports[`Data toolbar 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c15 "
+            class="c17 "
             scope="col"
           >
             <div
-              class="c16"
+              class="c18"
             />
           </th>
           <th
-            class="c15 "
+            class="c17 "
             scope="col"
           >
             <div
-              class="c16"
+              class="c18"
             />
           </th>
         </tr>
       </thead>
       <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c17"
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c19"
       >
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c18 "
+            class="c20 "
             scope="row"
           >
             <div
-              class="c19"
+              class="c21"
             >
               <span
-                class="c20"
+                class="c22"
               >
                 aa
               </span>
             </div>
           </th>
           <td
-            class="c18 "
+            class="c20 "
           >
             <div
-              class="c19"
+              class="c21"
             >
               <span
-                class="c21"
+                class="c23"
               >
                 ZZ
               </span>
@@ -4318,27 +4438,27 @@ exports[`Data toolbar 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c18 "
+            class="c20 "
             scope="row"
           >
             <div
-              class="c19"
+              class="c21"
             >
               <span
-                class="c20"
+                class="c22"
               >
                 bb
               </span>
             </div>
           </th>
           <td
-            class="c18 "
+            class="c20 "
           >
             <div
-              class="c19"
+              class="c21"
             >
               <span
-                class="c21"
+                class="c23"
               >
                 YY
               </span>
@@ -4349,24 +4469,24 @@ exports[`Data toolbar 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c18 "
+            class="c20 "
             scope="row"
           >
             <div
-              class="c19"
+              class="c21"
             >
               <span
-                class="c20"
+                class="c22"
               >
                 cc
               </span>
             </div>
           </th>
           <td
-            class="c18 "
+            class="c20 "
           >
             <div
-              class="c19"
+              class="c21"
             />
           </td>
         </tr>
@@ -4374,24 +4494,24 @@ exports[`Data toolbar 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c18 "
+            class="c20 "
             scope="row"
           >
             <div
-              class="c19"
+              class="c21"
             >
               <span
-                class="c20"
+                class="c22"
               >
                 dd
               </span>
             </div>
           </th>
           <td
-            class="c18 "
+            class="c20 "
           >
             <div
-              class="c19"
+              class="c21"
             />
           </td>
         </tr>
@@ -4816,7 +4936,7 @@ exports[`Data toolbar filters 1`] = `
 `;
 
 exports[`Data toolbar search 1`] = `
-.c8 {
+.c10 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -4827,25 +4947,25 @@ exports[`Data toolbar search 1`] = `
   stroke: #666666;
 }
 
-.c8 g {
+.c10 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c8 *:not([stroke])[fill="none"] {
+.c10 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c8 *[stroke*="#"],
-.c8 *[STROKE*="#"] {
+.c10 *[stroke*="#"],
+.c10 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c8 *[fill-rule],
-.c8 *[FILL-RULE],
-.c8 *[fill*="#"],
-.c8 *[FILL*="#"] {
+.c10 *[fill-rule],
+.c10 *[FILL-RULE],
+.c10 *[fill*="#"],
+.c10 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -4908,496 +5028,39 @@ exports[`Data toolbar search 1`] = `
   -ms-flex: 1 1;
   flex: 1 1;
   overflow: auto;
-}
-
-.c14 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-}
-
-.c17 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-column-gap: 12px;
-  column-gap: 12px;
-  row-gap: 12px;
-}
-
-.c10 {
-  margin-top: 6px;
-  margin-bottom: 6px;
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c18 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c9 {
-  box-sizing: border-box;
-  font-size: inherit;
-  font-family: inherit;
-  border: none;
-  -webkit-appearance: none;
-  background: transparent;
-  color: inherit;
-  width: 100%;
-  padding: 11px;
-  font-weight: 600;
-  margin: 0;
-  border: 1px solid rgba(0,0,0,0.33);
-  border-radius: 4px;
-  padding-left: 48px;
-}
-
-.c9:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c9:focus > circle,
-.c9:focus > ellipse,
-.c9:focus > line,
-.c9:focus > path,
-.c9:focus > polygon,
-.c9:focus > polyline,
-.c9:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c9:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c9::-webkit-input-placeholder {
-  color: #AAAAAA;
-}
-
-.c9::-moz-placeholder {
-  color: #AAAAAA;
-}
-
-.c9:-ms-input-placeholder {
-  color: #AAAAAA;
-}
-
-.c9::-webkit-search-decoration {
-  -webkit-appearance: none;
-}
-
-.c9::-moz-focus-inner {
-  border: none;
-  outline: none;
-}
-
-.c9:-moz-placeholder,
-.c9::-moz-placeholder {
-  opacity: 1;
 }
 
 .c6 {
-  position: relative;
-  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-bottom: 12px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c7 {
-  position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-box-packjustify: center;
-  -webkit-justify: center;
-  -ms-flex-packjustify: center;
-  justify: center;
-  top: 50%;
-  -webkit-transform: translateY(-50%);
-  -ms-transform: translateY(-50%);
-  transform: translateY(-50%);
-  pointer-events: none;
-  left: 12px;
-}
-
-.c3 {
+  box-sizing: border-box;
   max-width: 100%;
-}
-
-.c13 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
   border-bottom: solid 1px rgba(0,0,0,0.33);
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-.c16 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-.c11 {
-  border-spacing: 0;
-  border-collapse: collapse;
-  width: inherit;
-}
-
-.c12 {
-  position: relative;
-  border-spacing: 0;
-  border-collapse: separate;
-}
-
-.c15:focus {
-  outline: 2px solid #6FFFB0;
-}
-
-.c15:focus:not(:focus-visible) {
-  outline: none;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-  .c2 {
-    -webkit-column-gap: 6px;
-    column-gap: 6px;
-  }
-}
-
-<div
-  class="c0"
->
-  <div
-    class="c1"
-    id="data"
-  >
-    <div
-      class="c2"
-    >
-      <form
-        class="c3"
-      >
-        <div
-          class="c4"
-        >
-          <div
-            class="c5"
-          >
-            <div
-              class="c6"
-            >
-              <div
-                class="c7"
-              >
-                <svg
-                  aria-label="Search"
-                  class="c8"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                    fill="none"
-                    stroke="#000"
-                    stroke-width="2"
-                  />
-                </svg>
-              </div>
-              <input
-                aria-label="Search data"
-                autocomplete="off"
-                class="c9"
-                id="data--search"
-                name="_search"
-                type="search"
-                value=""
-              />
-            </div>
-          </div>
-        </div>
-      </form>
-    </div>
-    <span
-      class="c10"
-    >
-      4 items
-    </span>
-    <table
-      class="c11 c12"
-    >
-      <thead
-        class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
-      >
-        <tr
-          class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
-        >
-          <th
-            class="c13 "
-            scope="col"
-          >
-            <div
-              class="c14"
-            />
-          </th>
-        </tr>
-      </thead>
-      <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c15"
-      >
-        <tr
-          class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
-        >
-          <th
-            class="c16 "
-            scope="row"
-          >
-            <div
-              class="c17"
-            >
-              <span
-                class="c18"
-              >
-                aa
-              </span>
-            </div>
-          </th>
-        </tr>
-        <tr
-          class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
-        >
-          <th
-            class="c16 "
-            scope="row"
-          >
-            <div
-              class="c17"
-            >
-              <span
-                class="c18"
-              >
-                bb
-              </span>
-            </div>
-          </th>
-        </tr>
-        <tr
-          class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
-        >
-          <th
-            class="c16 "
-            scope="row"
-          >
-            <div
-              class="c17"
-            >
-              <span
-                class="c18"
-              >
-                cc
-              </span>
-            </div>
-          </th>
-        </tr>
-        <tr
-          class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
-        >
-          <th
-            class="c16 "
-            scope="row"
-          >
-            <div
-              class="c17"
-            >
-              <span
-                class="c18"
-              >
-                dd
-              </span>
-            </div>
-          </th>
-        </tr>
-      </tbody>
-    </table>
-  </div>
-</div>
-`;
-
-exports[`Data uncontrolled search 1`] = `
-.c8 {
-  display: inline-block;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
-  fill: #666666;
-  stroke: #666666;
-}
-
-.c8 g {
-  fill: inherit;
-  stroke: inherit;
-}
-
-.c8 *:not([stroke])[fill="none"] {
-  stroke-width: 0;
-}
-
-.c8 *[stroke*="#"],
-.c8 *[STROKE*="#"] {
-  stroke: inherit;
-  fill: none;
-}
-
-.c8 *[fill-rule],
-.c8 *[FILL-RULE],
-.c8 *[fill*="#"],
-.c8 *[FILL*="#"] {
-  fill: inherit;
-  stroke: none;
-}
-
-.c0 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-}
-
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  height: 100%;
-}
-
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 1 1;
-  -ms-flex: 1 1;
-  flex: 1 1;
-  overflow: auto;
-}
-
-.c10 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c16 {
@@ -5476,71 +5139,6 @@ exports[`Data uncontrolled search 1`] = `
 }
 
 .c11 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  color: inherit;
-  outline: none;
-  border: none;
-  padding: 0;
-  text-align: inherit;
-  line-height: 0;
-  padding: 12px;
-}
-
-.c11:hover {
-  background-color: rgba(221,221,221,0.4);
-  color: #000000;
-}
-
-.c11:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c11:focus > circle,
-.c11:focus > ellipse,
-.c11:focus > line,
-.c11:focus > path,
-.c11:focus > polygon,
-.c11:focus > polyline,
-.c11:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c11:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c11:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c11:focus:not(:focus-visible) > circle,
-.c11:focus:not(:focus-visible) > ellipse,
-.c11:focus:not(:focus-visible) > line,
-.c11:focus:not(:focus-visible) > path,
-.c11:focus:not(:focus-visible) > polygon,
-.c11:focus:not(:focus-visible) > polyline,
-.c11:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c11:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c9 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -5554,61 +5152,43 @@ exports[`Data uncontrolled search 1`] = `
   margin: 0;
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
+  outline: none;
+  border: none;
   padding-left: 48px;
 }
 
-.c9:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c9:focus > circle,
-.c9:focus > ellipse,
-.c9:focus > line,
-.c9:focus > path,
-.c9:focus > polygon,
-.c9:focus > polyline,
-.c9:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c9:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c9::-webkit-input-placeholder {
+.c11::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c9::-moz-placeholder {
+.c11::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c9:-ms-input-placeholder {
+.c11:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c9::-webkit-search-decoration {
+.c11::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c9::-moz-focus-inner {
+.c11::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c9:-moz-placeholder,
-.c9::-moz-placeholder {
+.c11:-moz-placeholder,
+.c11::-moz-placeholder {
   opacity: 1;
 }
 
-.c6 {
+.c8 {
   position: relative;
   width: 100%;
 }
 
-.c7 {
+.c9 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -5680,6 +5260,18 @@ exports[`Data uncontrolled search 1`] = `
 }
 
 @media only screen and (max-width:768px) {
+  .c6 {
+    margin-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
   .c2 {
     -webkit-column-gap: 6px;
     column-gap: 6px;
@@ -5706,60 +5298,45 @@ exports[`Data uncontrolled search 1`] = `
             class="c5"
           >
             <div
-              class="c6"
+              class="c6 "
             >
               <div
-                class="c7"
+                class="c7 FormField__FormFieldContentBox-sc-m9hood-1"
               >
-                <svg
-                  aria-label="Search"
+                <div
                   class="c8"
-                  viewBox="0 0 24 24"
                 >
-                  <path
-                    d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                    fill="none"
-                    stroke="#000"
-                    stroke-width="2"
+                  <div
+                    class="c9"
+                  >
+                    <svg
+                      aria-label="Search"
+                      class="c10"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                        fill="none"
+                        stroke="#000"
+                        stroke-width="2"
+                      />
+                    </svg>
+                  </div>
+                  <input
+                    aria-label="Search data"
+                    autocomplete="off"
+                    class="c11"
+                    id="data--search"
+                    name="_search"
+                    type="search"
+                    value=""
                   />
-                </svg>
+                </div>
               </div>
-              <input
-                aria-label="Search data"
-                autocomplete="off"
-                class="c9"
-                id="data--search"
-                name="_search"
-                type="search"
-                value=""
-              />
             </div>
           </div>
         </div>
       </form>
-      <div
-        class="c10"
-      >
-        <button
-          aria-label="Open filters"
-          class="c11"
-          id="data--filters-control"
-          type="button"
-        >
-          <svg
-            aria-label="Filter"
-            class="c8"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="m3 6 7 7v8h4v-8l7-7V3H3z"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-      </div>
     </div>
     <span
       class="c12"
@@ -5866,6 +5443,619 @@ exports[`Data uncontrolled search 1`] = `
 </div>
 `;
 
+exports[`Data uncontrolled search 1`] = `
+.c10 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #666666;
+  stroke: #666666;
+}
+
+.c10 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c10 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c10 *[stroke*="#"],
+.c10 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c10 *[fill-rule],
+.c10 *[FILL-RULE],
+.c10 *[fill*="#"],
+.c10 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 100%;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  overflow: auto;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-bottom: 12px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c12 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c18 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c21 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-column-gap: 12px;
+  column-gap: 12px;
+  row-gap: 12px;
+}
+
+.c14 {
+  margin-top: 6px;
+  margin-bottom: 6px;
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c22 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c13 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  line-height: 0;
+  padding: 12px;
+}
+
+.c13:hover {
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
+}
+
+.c13:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c13:focus > circle,
+.c13:focus > ellipse,
+.c13:focus > line,
+.c13:focus > path,
+.c13:focus > polygon,
+.c13:focus > polyline,
+.c13:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c13:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c13:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c13:focus:not(:focus-visible) > circle,
+.c13:focus:not(:focus-visible) > ellipse,
+.c13:focus:not(:focus-visible) > line,
+.c13:focus:not(:focus-visible) > path,
+.c13:focus:not(:focus-visible) > polygon,
+.c13:focus:not(:focus-visible) > polyline,
+.c13:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c13:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c11 {
+  box-sizing: border-box;
+  font-size: inherit;
+  font-family: inherit;
+  border: none;
+  -webkit-appearance: none;
+  background: transparent;
+  color: inherit;
+  width: 100%;
+  padding: 11px;
+  font-weight: 600;
+  margin: 0;
+  border: 1px solid rgba(0,0,0,0.33);
+  border-radius: 4px;
+  outline: none;
+  border: none;
+  padding-left: 48px;
+}
+
+.c11::-webkit-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c11::-moz-placeholder {
+  color: #AAAAAA;
+}
+
+.c11:-ms-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c11::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+.c11::-moz-focus-inner {
+  border: none;
+  outline: none;
+}
+
+.c11:-moz-placeholder,
+.c11::-moz-placeholder {
+  opacity: 1;
+}
+
+.c8 {
+  position: relative;
+  width: 100%;
+}
+
+.c9 {
+  position: absolute;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-packjustify: center;
+  -webkit-justify: center;
+  -ms-flex-packjustify: center;
+  justify: center;
+  top: 50%;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  pointer-events: none;
+  left: 12px;
+}
+
+.c3 {
+  max-width: 100%;
+}
+
+.c17 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c20 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c15 {
+  border-spacing: 0;
+  border-collapse: collapse;
+  width: inherit;
+}
+
+.c16 {
+  position: relative;
+  border-spacing: 0;
+  border-collapse: separate;
+}
+
+.c19:focus {
+  outline: 2px solid #6FFFB0;
+}
+
+.c19:focus:not(:focus-visible) {
+  outline: none;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    margin-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    -webkit-column-gap: 6px;
+    column-gap: 6px;
+  }
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+    id="data"
+  >
+    <div
+      class="c2"
+    >
+      <form
+        class="c3"
+      >
+        <div
+          class="c4"
+        >
+          <div
+            class="c5"
+          >
+            <div
+              class="c6 "
+            >
+              <div
+                class="c7 FormField__FormFieldContentBox-sc-m9hood-1"
+              >
+                <div
+                  class="c8"
+                >
+                  <div
+                    class="c9"
+                  >
+                    <svg
+                      aria-label="Search"
+                      class="c10"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                        fill="none"
+                        stroke="#000"
+                        stroke-width="2"
+                      />
+                    </svg>
+                  </div>
+                  <input
+                    aria-label="Search data"
+                    autocomplete="off"
+                    class="c11"
+                    id="data--search"
+                    name="_search"
+                    type="search"
+                    value=""
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </form>
+      <div
+        class="c12"
+      >
+        <button
+          aria-label="Open filters"
+          class="c13"
+          id="data--filters-control"
+          type="button"
+        >
+          <svg
+            aria-label="Filter"
+            class="c10"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="m3 6 7 7v8h4v-8l7-7V3H3z"
+              fill="none"
+              stroke="#000"
+              stroke-width="2"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+    <span
+      class="c14"
+    >
+      4 items
+    </span>
+    <table
+      class="c15 c16"
+    >
+      <thead
+        class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
+      >
+        <tr
+          class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+        >
+          <th
+            class="c17 "
+            scope="col"
+          >
+            <div
+              class="c18"
+            />
+          </th>
+        </tr>
+      </thead>
+      <tbody
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c19"
+      >
+        <tr
+          class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+        >
+          <th
+            class="c20 "
+            scope="row"
+          >
+            <div
+              class="c21"
+            >
+              <span
+                class="c22"
+              >
+                aa
+              </span>
+            </div>
+          </th>
+        </tr>
+        <tr
+          class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+        >
+          <th
+            class="c20 "
+            scope="row"
+          >
+            <div
+              class="c21"
+            >
+              <span
+                class="c22"
+              >
+                bb
+              </span>
+            </div>
+          </th>
+        </tr>
+        <tr
+          class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+        >
+          <th
+            class="c20 "
+            scope="row"
+          >
+            <div
+              class="c21"
+            >
+              <span
+                class="c22"
+              >
+                cc
+              </span>
+            </div>
+          </th>
+        </tr>
+        <tr
+          class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+        >
+          <th
+            class="c20 "
+            scope="row"
+          >
+            <div
+              class="c21"
+            >
+              <span
+                class="c22"
+              >
+                dd
+              </span>
+            </div>
+          </th>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+`;
+
 exports[`Data uncontrolled search 2`] = `
 <div
   class="StyledGrommet-sc-19lkkz7-0 ioQEen"
@@ -5887,33 +6077,41 @@ exports[`Data uncontrolled search 2`] = `
             class="StyledBox-sc-13pk1d4-0 dePIJN"
           >
             <div
-              class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 edcgVv"
+              class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
             >
               <div
-                class="StyledTextInput__StyledIcon-sc-1x30a0s-3 cFBrkA"
+                class="StyledBox-sc-13pk1d4-0 cqRjpC FormField__FormFieldContentBox-sc-m9hood-1"
               >
-                <svg
-                  aria-label="Search"
-                  class="StyledIcon-sc-ofa7kd-0 jQvEgu"
-                  viewBox="0 0 24 24"
+                <div
+                  class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 edcgVv"
                 >
-                  <path
-                    d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                    fill="none"
-                    stroke="#000"
-                    stroke-width="2"
+                  <div
+                    class="StyledTextInput__StyledIcon-sc-1x30a0s-3 cFBrkA"
+                  >
+                    <svg
+                      aria-label="Search"
+                      class="StyledIcon-sc-ofa7kd-0 jQvEgu"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                        fill="none"
+                        stroke="#000"
+                        stroke-width="2"
+                      />
+                    </svg>
+                  </div>
+                  <input
+                    aria-label="Search data"
+                    autocomplete="off"
+                    class="StyledTextInput-sc-1x30a0s-0 kovfiL"
+                    id="data--search"
+                    name="_search"
+                    type="search"
+                    value="a"
                   />
-                </svg>
+                </div>
               </div>
-              <input
-                aria-label="Search data"
-                autocomplete="off"
-                class="StyledTextInput-sc-1x30a0s-0 bMqJAS"
-                id="data--search"
-                name="_search"
-                type="search"
-                value="a"
-              />
             </div>
           </div>
         </div>
@@ -6268,7 +6466,7 @@ exports[`Data view 1`] = `
 `;
 
 exports[`Data view all 1`] = `
-.c8 {
+.c10 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -6279,25 +6477,25 @@ exports[`Data view all 1`] = `
   stroke: #666666;
 }
 
-.c8 g {
+.c10 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c8 *:not([stroke])[fill="none"] {
+.c10 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c8 *[stroke*="#"],
-.c8 *[STROKE*="#"] {
+.c10 *[stroke*="#"],
+.c10 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c8 *[fill-rule],
-.c8 *[FILL-RULE],
-.c8 *[fill*="#"],
-.c8 *[FILL*="#"] {
+.c10 *[fill-rule],
+.c10 *[FILL-RULE],
+.c10 *[fill*="#"],
+.c10 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -6362,7 +6560,40 @@ exports[`Data view all 1`] = `
   overflow: auto;
 }
 
-.c10 {
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-bottom: 12px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6379,7 +6610,7 @@ exports[`Data view all 1`] = `
   flex: 0 0 auto;
 }
 
-.c16 {
+.c18 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6400,7 +6631,7 @@ exports[`Data view all 1`] = `
   justify-content: center;
 }
 
-.c19 {
+.c21 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6441,25 +6672,25 @@ exports[`Data view all 1`] = `
   row-gap: 12px;
 }
 
-.c12 {
+.c14 {
   margin-top: 6px;
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
 }
 
-.c20 {
+.c22 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
 }
 
-.c21 {
+.c23 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c11 {
+.c13 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -6479,52 +6710,52 @@ exports[`Data view all 1`] = `
   padding: 12px;
 }
 
-.c11:hover {
+.c13:hover {
   background-color: rgba(221,221,221,0.4);
   color: #000000;
 }
 
-.c11:focus {
+.c13:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus > circle,
-.c11:focus > ellipse,
-.c11:focus > line,
-.c11:focus > path,
-.c11:focus > polygon,
-.c11:focus > polyline,
-.c11:focus > rect {
+.c13:focus > circle,
+.c13:focus > ellipse,
+.c13:focus > line,
+.c13:focus > path,
+.c13:focus > polygon,
+.c13:focus > polyline,
+.c13:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus::-moz-focus-inner {
+.c13:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c11:focus:not(:focus-visible) {
+.c13:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c11:focus:not(:focus-visible) > circle,
-.c11:focus:not(:focus-visible) > ellipse,
-.c11:focus:not(:focus-visible) > line,
-.c11:focus:not(:focus-visible) > path,
-.c11:focus:not(:focus-visible) > polygon,
-.c11:focus:not(:focus-visible) > polyline,
-.c11:focus:not(:focus-visible) > rect {
+.c13:focus:not(:focus-visible) > circle,
+.c13:focus:not(:focus-visible) > ellipse,
+.c13:focus:not(:focus-visible) > line,
+.c13:focus:not(:focus-visible) > path,
+.c13:focus:not(:focus-visible) > polygon,
+.c13:focus:not(:focus-visible) > polyline,
+.c13:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c11:focus:not(:focus-visible)::-moz-focus-inner {
+.c13:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c9 {
+.c11 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -6538,61 +6769,43 @@ exports[`Data view all 1`] = `
   margin: 0;
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
+  outline: none;
+  border: none;
   padding-left: 48px;
 }
 
-.c9:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c9:focus > circle,
-.c9:focus > ellipse,
-.c9:focus > line,
-.c9:focus > path,
-.c9:focus > polygon,
-.c9:focus > polyline,
-.c9:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c9:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c9::-webkit-input-placeholder {
+.c11::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c9::-moz-placeholder {
+.c11::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c9:-ms-input-placeholder {
+.c11:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c9::-webkit-search-decoration {
+.c11::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c9::-moz-focus-inner {
+.c11::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c9:-moz-placeholder,
-.c9::-moz-placeholder {
+.c11:-moz-placeholder,
+.c11::-moz-placeholder {
   opacity: 1;
 }
 
-.c6 {
+.c8 {
   position: relative;
   width: 100%;
 }
 
-.c7 {
+.c9 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -6614,7 +6827,7 @@ exports[`Data view all 1`] = `
   max-width: 100%;
 }
 
-.c15 {
+.c17 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -6627,7 +6840,7 @@ exports[`Data view all 1`] = `
   padding-bottom: 6px;
 }
 
-.c18 {
+.c20 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -6639,28 +6852,40 @@ exports[`Data view all 1`] = `
   padding-bottom: 6px;
 }
 
-.c13 {
+.c15 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
 }
 
-.c14 {
+.c16 {
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
 }
 
-.c17:focus {
+.c19:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c17:focus:not(:focus-visible) {
+.c19:focus:not(:focus-visible) {
   outline: none;
 }
 
 @media only screen and (max-width:768px) {
 
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    margin-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
 }
 
 @media only screen and (max-width:768px) {
@@ -6690,49 +6915,57 @@ exports[`Data view all 1`] = `
             class="c5"
           >
             <div
-              class="c6"
+              class="c6 "
             >
               <div
-                class="c7"
+                class="c7 FormField__FormFieldContentBox-sc-m9hood-1"
               >
-                <svg
-                  aria-label="Search"
+                <div
                   class="c8"
-                  viewBox="0 0 24 24"
                 >
-                  <path
-                    d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                    fill="none"
-                    stroke="#000"
-                    stroke-width="2"
+                  <div
+                    class="c9"
+                  >
+                    <svg
+                      aria-label="Search"
+                      class="c10"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                        fill="none"
+                        stroke="#000"
+                        stroke-width="2"
+                      />
+                    </svg>
+                  </div>
+                  <input
+                    aria-label="Search data"
+                    autocomplete="off"
+                    class="c11"
+                    id="data--search"
+                    name="_search"
+                    type="search"
+                    value="a"
                   />
-                </svg>
+                </div>
               </div>
-              <input
-                aria-label="Search data"
-                autocomplete="off"
-                class="c9"
-                id="data--search"
-                name="_search"
-                type="search"
-                value="a"
-              />
             </div>
           </div>
         </div>
       </form>
       <div
-        class="c10"
+        class="c12"
       >
         <button
           aria-label="Open filters"
-          class="c11"
+          class="c13"
           id="data--filters-control"
           type="button"
         >
           <svg
             aria-label="Filter"
-            class="c8"
+            class="c10"
             viewBox="0 0 24 24"
           >
             <path
@@ -6746,12 +6979,12 @@ exports[`Data view all 1`] = `
       </div>
     </div>
     <span
-      class="c12"
+      class="c14"
     >
       1 result of 4 items
     </span>
     <table
-      class="c13 c14"
+      class="c15 c16"
     >
       <thead
         class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -6760,51 +6993,51 @@ exports[`Data view all 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c15 "
+            class="c17 "
             scope="col"
           >
             <div
-              class="c16"
+              class="c18"
             />
           </th>
           <th
-            class="c15 "
+            class="c17 "
             scope="col"
           >
             <div
-              class="c16"
+              class="c18"
             />
           </th>
         </tr>
       </thead>
       <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c17"
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c19"
       >
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c18 "
+            class="c20 "
             scope="row"
           >
             <div
-              class="c19"
+              class="c21"
             >
               <span
-                class="c20"
+                class="c22"
               >
                 aa
               </span>
             </div>
           </th>
           <td
-            class="c18 "
+            class="c20 "
           >
             <div
-              class="c19"
+              class="c21"
             >
               <span
-                class="c21"
+                class="c23"
               >
                 ZZ
               </span>
@@ -6818,7 +7051,7 @@ exports[`Data view all 1`] = `
 `;
 
 exports[`Data view property option 1`] = `
-.c8 {
+.c10 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -6829,25 +7062,25 @@ exports[`Data view property option 1`] = `
   stroke: #666666;
 }
 
-.c8 g {
+.c10 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c8 *:not([stroke])[fill="none"] {
+.c10 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c8 *[stroke*="#"],
-.c8 *[STROKE*="#"] {
+.c10 *[stroke*="#"],
+.c10 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c8 *[fill-rule],
-.c8 *[FILL-RULE],
-.c8 *[fill*="#"],
-.c8 *[FILL*="#"] {
+.c10 *[fill-rule],
+.c10 *[FILL-RULE],
+.c10 *[fill*="#"],
+.c10 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -6912,7 +7145,40 @@ exports[`Data view property option 1`] = `
   overflow: auto;
 }
 
-.c10 {
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-bottom: 12px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6929,7 +7195,7 @@ exports[`Data view property option 1`] = `
   flex: 0 0 auto;
 }
 
-.c16 {
+.c18 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6950,7 +7216,7 @@ exports[`Data view property option 1`] = `
   justify-content: center;
 }
 
-.c19 {
+.c21 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6991,25 +7257,25 @@ exports[`Data view property option 1`] = `
   row-gap: 12px;
 }
 
-.c12 {
+.c14 {
   margin-top: 6px;
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
 }
 
-.c20 {
+.c22 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
 }
 
-.c21 {
+.c23 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c11 {
+.c13 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -7029,52 +7295,52 @@ exports[`Data view property option 1`] = `
   padding: 12px;
 }
 
-.c11:hover {
+.c13:hover {
   background-color: rgba(221,221,221,0.4);
   color: #000000;
 }
 
-.c11:focus {
+.c13:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus > circle,
-.c11:focus > ellipse,
-.c11:focus > line,
-.c11:focus > path,
-.c11:focus > polygon,
-.c11:focus > polyline,
-.c11:focus > rect {
+.c13:focus > circle,
+.c13:focus > ellipse,
+.c13:focus > line,
+.c13:focus > path,
+.c13:focus > polygon,
+.c13:focus > polyline,
+.c13:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus::-moz-focus-inner {
+.c13:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c11:focus:not(:focus-visible) {
+.c13:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c11:focus:not(:focus-visible) > circle,
-.c11:focus:not(:focus-visible) > ellipse,
-.c11:focus:not(:focus-visible) > line,
-.c11:focus:not(:focus-visible) > path,
-.c11:focus:not(:focus-visible) > polygon,
-.c11:focus:not(:focus-visible) > polyline,
-.c11:focus:not(:focus-visible) > rect {
+.c13:focus:not(:focus-visible) > circle,
+.c13:focus:not(:focus-visible) > ellipse,
+.c13:focus:not(:focus-visible) > line,
+.c13:focus:not(:focus-visible) > path,
+.c13:focus:not(:focus-visible) > polygon,
+.c13:focus:not(:focus-visible) > polyline,
+.c13:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c11:focus:not(:focus-visible)::-moz-focus-inner {
+.c13:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c9 {
+.c11 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -7088,61 +7354,43 @@ exports[`Data view property option 1`] = `
   margin: 0;
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
+  outline: none;
+  border: none;
   padding-left: 48px;
 }
 
-.c9:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c9:focus > circle,
-.c9:focus > ellipse,
-.c9:focus > line,
-.c9:focus > path,
-.c9:focus > polygon,
-.c9:focus > polyline,
-.c9:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c9:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c9::-webkit-input-placeholder {
+.c11::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c9::-moz-placeholder {
+.c11::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c9:-ms-input-placeholder {
+.c11:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c9::-webkit-search-decoration {
+.c11::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c9::-moz-focus-inner {
+.c11::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c9:-moz-placeholder,
-.c9::-moz-placeholder {
+.c11:-moz-placeholder,
+.c11::-moz-placeholder {
   opacity: 1;
 }
 
-.c6 {
+.c8 {
   position: relative;
   width: 100%;
 }
 
-.c7 {
+.c9 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -7164,7 +7412,7 @@ exports[`Data view property option 1`] = `
   max-width: 100%;
 }
 
-.c15 {
+.c17 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -7177,7 +7425,7 @@ exports[`Data view property option 1`] = `
   padding-bottom: 6px;
 }
 
-.c18 {
+.c20 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -7189,28 +7437,40 @@ exports[`Data view property option 1`] = `
   padding-bottom: 6px;
 }
 
-.c13 {
+.c15 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
 }
 
-.c14 {
+.c16 {
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
 }
 
-.c17:focus {
+.c19:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c17:focus:not(:focus-visible) {
+.c19:focus:not(:focus-visible) {
   outline: none;
 }
 
 @media only screen and (max-width:768px) {
 
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    margin-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
 }
 
 @media only screen and (max-width:768px) {
@@ -7240,49 +7500,57 @@ exports[`Data view property option 1`] = `
             class="c5"
           >
             <div
-              class="c6"
+              class="c6 "
             >
               <div
-                class="c7"
+                class="c7 FormField__FormFieldContentBox-sc-m9hood-1"
               >
-                <svg
-                  aria-label="Search"
+                <div
                   class="c8"
-                  viewBox="0 0 24 24"
                 >
-                  <path
-                    d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                    fill="none"
-                    stroke="#000"
-                    stroke-width="2"
+                  <div
+                    class="c9"
+                  >
+                    <svg
+                      aria-label="Search"
+                      class="c10"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                        fill="none"
+                        stroke="#000"
+                        stroke-width="2"
+                      />
+                    </svg>
+                  </div>
+                  <input
+                    aria-label="Search data"
+                    autocomplete="off"
+                    class="c11"
+                    id="data--search"
+                    name="_search"
+                    type="search"
+                    value=""
                   />
-                </svg>
+                </div>
               </div>
-              <input
-                aria-label="Search data"
-                autocomplete="off"
-                class="c9"
-                id="data--search"
-                name="_search"
-                type="search"
-                value=""
-              />
             </div>
           </div>
         </div>
       </form>
       <div
-        class="c10"
+        class="c12"
       >
         <button
           aria-label="Open filters"
-          class="c11"
+          class="c13"
           id="data--filters-control"
           type="button"
         >
           <svg
             aria-label="Filter"
-            class="c8"
+            class="c10"
             viewBox="0 0 24 24"
           >
             <path
@@ -7296,12 +7564,12 @@ exports[`Data view property option 1`] = `
       </div>
     </div>
     <span
-      class="c12"
+      class="c14"
     >
       1 result of 4 items
     </span>
     <table
-      class="c13 c14"
+      class="c15 c16"
     >
       <thead
         class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -7310,51 +7578,51 @@ exports[`Data view property option 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c15 "
+            class="c17 "
             scope="col"
           >
             <div
-              class="c16"
+              class="c18"
             />
           </th>
           <th
-            class="c15 "
+            class="c17 "
             scope="col"
           >
             <div
-              class="c16"
+              class="c18"
             />
           </th>
         </tr>
       </thead>
       <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c17"
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c19"
       >
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c18 "
+            class="c20 "
             scope="row"
           >
             <div
-              class="c19"
+              class="c21"
             >
               <span
-                class="c20"
+                class="c22"
               >
                 aa
               </span>
             </div>
           </th>
           <td
-            class="c18 "
+            class="c20 "
           >
             <div
-              class="c19"
+              class="c21"
             >
               <span
-                class="c21"
+                class="c23"
               >
                 ZZ
               </span>
@@ -7368,7 +7636,7 @@ exports[`Data view property option 1`] = `
 `;
 
 exports[`Data view property range 1`] = `
-.c8 {
+.c10 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -7379,25 +7647,25 @@ exports[`Data view property range 1`] = `
   stroke: #666666;
 }
 
-.c8 g {
+.c10 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c8 *:not([stroke])[fill="none"] {
+.c10 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c8 *[stroke*="#"],
-.c8 *[STROKE*="#"] {
+.c10 *[stroke*="#"],
+.c10 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c8 *[fill-rule],
-.c8 *[FILL-RULE],
-.c8 *[fill*="#"],
-.c8 *[FILL*="#"] {
+.c10 *[fill-rule],
+.c10 *[FILL-RULE],
+.c10 *[fill*="#"],
+.c10 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -7462,7 +7730,40 @@ exports[`Data view property range 1`] = `
   overflow: auto;
 }
 
-.c10 {
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-bottom: 12px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7479,7 +7780,7 @@ exports[`Data view property range 1`] = `
   flex: 0 0 auto;
 }
 
-.c16 {
+.c18 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7500,7 +7801,7 @@ exports[`Data view property range 1`] = `
   justify-content: center;
 }
 
-.c19 {
+.c21 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7541,25 +7842,25 @@ exports[`Data view property range 1`] = `
   row-gap: 12px;
 }
 
-.c12 {
+.c14 {
   margin-top: 6px;
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
 }
 
-.c20 {
+.c22 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
 }
 
-.c21 {
+.c23 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c11 {
+.c13 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -7579,52 +7880,52 @@ exports[`Data view property range 1`] = `
   padding: 12px;
 }
 
-.c11:hover {
+.c13:hover {
   background-color: rgba(221,221,221,0.4);
   color: #000000;
 }
 
-.c11:focus {
+.c13:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus > circle,
-.c11:focus > ellipse,
-.c11:focus > line,
-.c11:focus > path,
-.c11:focus > polygon,
-.c11:focus > polyline,
-.c11:focus > rect {
+.c13:focus > circle,
+.c13:focus > ellipse,
+.c13:focus > line,
+.c13:focus > path,
+.c13:focus > polygon,
+.c13:focus > polyline,
+.c13:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus::-moz-focus-inner {
+.c13:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c11:focus:not(:focus-visible) {
+.c13:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c11:focus:not(:focus-visible) > circle,
-.c11:focus:not(:focus-visible) > ellipse,
-.c11:focus:not(:focus-visible) > line,
-.c11:focus:not(:focus-visible) > path,
-.c11:focus:not(:focus-visible) > polygon,
-.c11:focus:not(:focus-visible) > polyline,
-.c11:focus:not(:focus-visible) > rect {
+.c13:focus:not(:focus-visible) > circle,
+.c13:focus:not(:focus-visible) > ellipse,
+.c13:focus:not(:focus-visible) > line,
+.c13:focus:not(:focus-visible) > path,
+.c13:focus:not(:focus-visible) > polygon,
+.c13:focus:not(:focus-visible) > polyline,
+.c13:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c11:focus:not(:focus-visible)::-moz-focus-inner {
+.c13:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c9 {
+.c11 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -7638,61 +7939,43 @@ exports[`Data view property range 1`] = `
   margin: 0;
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
+  outline: none;
+  border: none;
   padding-left: 48px;
 }
 
-.c9:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c9:focus > circle,
-.c9:focus > ellipse,
-.c9:focus > line,
-.c9:focus > path,
-.c9:focus > polygon,
-.c9:focus > polyline,
-.c9:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c9:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c9::-webkit-input-placeholder {
+.c11::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c9::-moz-placeholder {
+.c11::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c9:-ms-input-placeholder {
+.c11:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c9::-webkit-search-decoration {
+.c11::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c9::-moz-focus-inner {
+.c11::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c9:-moz-placeholder,
-.c9::-moz-placeholder {
+.c11:-moz-placeholder,
+.c11::-moz-placeholder {
   opacity: 1;
 }
 
-.c6 {
+.c8 {
   position: relative;
   width: 100%;
 }
 
-.c7 {
+.c9 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -7714,7 +7997,7 @@ exports[`Data view property range 1`] = `
   max-width: 100%;
 }
 
-.c15 {
+.c17 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -7727,7 +8010,7 @@ exports[`Data view property range 1`] = `
   padding-bottom: 6px;
 }
 
-.c18 {
+.c20 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -7739,28 +8022,40 @@ exports[`Data view property range 1`] = `
   padding-bottom: 6px;
 }
 
-.c13 {
+.c15 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
 }
 
-.c14 {
+.c16 {
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
 }
 
-.c17:focus {
+.c19:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c17:focus:not(:focus-visible) {
+.c19:focus:not(:focus-visible) {
   outline: none;
 }
 
 @media only screen and (max-width:768px) {
 
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    margin-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
 }
 
 @media only screen and (max-width:768px) {
@@ -7790,49 +8085,57 @@ exports[`Data view property range 1`] = `
             class="c5"
           >
             <div
-              class="c6"
+              class="c6 "
             >
               <div
-                class="c7"
+                class="c7 FormField__FormFieldContentBox-sc-m9hood-1"
               >
-                <svg
-                  aria-label="Search"
+                <div
                   class="c8"
-                  viewBox="0 0 24 24"
                 >
-                  <path
-                    d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                    fill="none"
-                    stroke="#000"
-                    stroke-width="2"
+                  <div
+                    class="c9"
+                  >
+                    <svg
+                      aria-label="Search"
+                      class="c10"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                        fill="none"
+                        stroke="#000"
+                        stroke-width="2"
+                      />
+                    </svg>
+                  </div>
+                  <input
+                    aria-label="Search data"
+                    autocomplete="off"
+                    class="c11"
+                    id="data--search"
+                    name="_search"
+                    type="search"
+                    value=""
                   />
-                </svg>
+                </div>
               </div>
-              <input
-                aria-label="Search data"
-                autocomplete="off"
-                class="c9"
-                id="data--search"
-                name="_search"
-                type="search"
-                value=""
-              />
             </div>
           </div>
         </div>
       </form>
       <div
-        class="c10"
+        class="c12"
       >
         <button
           aria-label="Open filters"
-          class="c11"
+          class="c13"
           id="data--filters-control"
           type="button"
         >
           <svg
             aria-label="Filter"
-            class="c8"
+            class="c10"
             viewBox="0 0 24 24"
           >
             <path
@@ -7846,12 +8149,12 @@ exports[`Data view property range 1`] = `
       </div>
     </div>
     <span
-      class="c12"
+      class="c14"
     >
       1 result of 4 items
     </span>
     <table
-      class="c13 c14"
+      class="c15 c16"
     >
       <thead
         class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -7860,72 +8163,72 @@ exports[`Data view property range 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c15 "
+            class="c17 "
             scope="col"
           >
             <div
-              class="c16"
+              class="c18"
             />
           </th>
           <th
-            class="c15 "
+            class="c17 "
             scope="col"
           >
             <div
-              class="c16"
+              class="c18"
             />
           </th>
           <th
-            class="c15 "
+            class="c17 "
             scope="col"
           >
             <div
-              class="c16"
+              class="c18"
             />
           </th>
         </tr>
       </thead>
       <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c17"
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c19"
       >
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c18 "
+            class="c20 "
             scope="row"
           >
             <div
-              class="c19"
+              class="c21"
             >
               <span
-                class="c20"
+                class="c22"
               >
                 bb
               </span>
             </div>
           </th>
           <td
-            class="c18 "
+            class="c20 "
           >
             <div
-              class="c19"
+              class="c21"
             >
               <span
-                class="c21"
+                class="c23"
               >
                 YY
               </span>
             </div>
           </td>
           <td
-            class="c18 "
+            class="c20 "
           >
             <div
-              class="c19"
+              class="c21"
             >
               <span
-                class="c21"
+                class="c23"
               >
                 4.3
               </span>
@@ -7939,7 +8242,7 @@ exports[`Data view property range 1`] = `
 `;
 
 exports[`Data view search 1`] = `
-.c8 {
+.c10 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -7950,25 +8253,25 @@ exports[`Data view search 1`] = `
   stroke: #666666;
 }
 
-.c8 g {
+.c10 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c8 *:not([stroke])[fill="none"] {
+.c10 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c8 *[stroke*="#"],
-.c8 *[STROKE*="#"] {
+.c10 *[stroke*="#"],
+.c10 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c8 *[fill-rule],
-.c8 *[FILL-RULE],
-.c8 *[fill*="#"],
-.c8 *[FILL*="#"] {
+.c10 *[fill-rule],
+.c10 *[FILL-RULE],
+.c10 *[fill*="#"],
+.c10 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -8033,7 +8336,40 @@ exports[`Data view search 1`] = `
   overflow: auto;
 }
 
-.c10 {
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-bottom: 12px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8050,7 +8386,7 @@ exports[`Data view search 1`] = `
   flex: 0 0 auto;
 }
 
-.c16 {
+.c18 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8071,7 +8407,7 @@ exports[`Data view search 1`] = `
   justify-content: center;
 }
 
-.c19 {
+.c21 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8112,25 +8448,25 @@ exports[`Data view search 1`] = `
   row-gap: 12px;
 }
 
-.c12 {
+.c14 {
   margin-top: 6px;
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
 }
 
-.c20 {
+.c22 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
 }
 
-.c21 {
+.c23 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c11 {
+.c13 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -8150,52 +8486,52 @@ exports[`Data view search 1`] = `
   padding: 12px;
 }
 
-.c11:hover {
+.c13:hover {
   background-color: rgba(221,221,221,0.4);
   color: #000000;
 }
 
-.c11:focus {
+.c13:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus > circle,
-.c11:focus > ellipse,
-.c11:focus > line,
-.c11:focus > path,
-.c11:focus > polygon,
-.c11:focus > polyline,
-.c11:focus > rect {
+.c13:focus > circle,
+.c13:focus > ellipse,
+.c13:focus > line,
+.c13:focus > path,
+.c13:focus > polygon,
+.c13:focus > polyline,
+.c13:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus::-moz-focus-inner {
+.c13:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c11:focus:not(:focus-visible) {
+.c13:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c11:focus:not(:focus-visible) > circle,
-.c11:focus:not(:focus-visible) > ellipse,
-.c11:focus:not(:focus-visible) > line,
-.c11:focus:not(:focus-visible) > path,
-.c11:focus:not(:focus-visible) > polygon,
-.c11:focus:not(:focus-visible) > polyline,
-.c11:focus:not(:focus-visible) > rect {
+.c13:focus:not(:focus-visible) > circle,
+.c13:focus:not(:focus-visible) > ellipse,
+.c13:focus:not(:focus-visible) > line,
+.c13:focus:not(:focus-visible) > path,
+.c13:focus:not(:focus-visible) > polygon,
+.c13:focus:not(:focus-visible) > polyline,
+.c13:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c11:focus:not(:focus-visible)::-moz-focus-inner {
+.c13:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c9 {
+.c11 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -8209,61 +8545,43 @@ exports[`Data view search 1`] = `
   margin: 0;
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
+  outline: none;
+  border: none;
   padding-left: 48px;
 }
 
-.c9:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c9:focus > circle,
-.c9:focus > ellipse,
-.c9:focus > line,
-.c9:focus > path,
-.c9:focus > polygon,
-.c9:focus > polyline,
-.c9:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c9:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c9::-webkit-input-placeholder {
+.c11::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c9::-moz-placeholder {
+.c11::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c9:-ms-input-placeholder {
+.c11:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c9::-webkit-search-decoration {
+.c11::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c9::-moz-focus-inner {
+.c11::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c9:-moz-placeholder,
-.c9::-moz-placeholder {
+.c11:-moz-placeholder,
+.c11::-moz-placeholder {
   opacity: 1;
 }
 
-.c6 {
+.c8 {
   position: relative;
   width: 100%;
 }
 
-.c7 {
+.c9 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -8285,7 +8603,7 @@ exports[`Data view search 1`] = `
   max-width: 100%;
 }
 
-.c15 {
+.c17 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -8298,7 +8616,7 @@ exports[`Data view search 1`] = `
   padding-bottom: 6px;
 }
 
-.c18 {
+.c20 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -8310,28 +8628,40 @@ exports[`Data view search 1`] = `
   padding-bottom: 6px;
 }
 
-.c13 {
+.c15 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
 }
 
-.c14 {
+.c16 {
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
 }
 
-.c17:focus {
+.c19:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c17:focus:not(:focus-visible) {
+.c19:focus:not(:focus-visible) {
   outline: none;
 }
 
 @media only screen and (max-width:768px) {
 
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    margin-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
 }
 
 @media only screen and (max-width:768px) {
@@ -8361,49 +8691,57 @@ exports[`Data view search 1`] = `
             class="c5"
           >
             <div
-              class="c6"
+              class="c6 "
             >
               <div
-                class="c7"
+                class="c7 FormField__FormFieldContentBox-sc-m9hood-1"
               >
-                <svg
-                  aria-label="Search"
+                <div
                   class="c8"
-                  viewBox="0 0 24 24"
                 >
-                  <path
-                    d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                    fill="none"
-                    stroke="#000"
-                    stroke-width="2"
+                  <div
+                    class="c9"
+                  >
+                    <svg
+                      aria-label="Search"
+                      class="c10"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                        fill="none"
+                        stroke="#000"
+                        stroke-width="2"
+                      />
+                    </svg>
+                  </div>
+                  <input
+                    aria-label="Search data"
+                    autocomplete="off"
+                    class="c11"
+                    id="data--search"
+                    name="_search"
+                    type="search"
+                    value="a"
                   />
-                </svg>
+                </div>
               </div>
-              <input
-                aria-label="Search data"
-                autocomplete="off"
-                class="c9"
-                id="data--search"
-                name="_search"
-                type="search"
-                value="a"
-              />
             </div>
           </div>
         </div>
       </form>
       <div
-        class="c10"
+        class="c12"
       >
         <button
           aria-label="Open filters"
-          class="c11"
+          class="c13"
           id="data--filters-control"
           type="button"
         >
           <svg
             aria-label="Filter"
-            class="c8"
+            class="c10"
             viewBox="0 0 24 24"
           >
             <path
@@ -8417,12 +8755,12 @@ exports[`Data view search 1`] = `
       </div>
     </div>
     <span
-      class="c12"
+      class="c14"
     >
       1 result of 4 items
     </span>
     <table
-      class="c13 c14"
+      class="c15 c16"
     >
       <thead
         class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -8431,51 +8769,51 @@ exports[`Data view search 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c15 "
+            class="c17 "
             scope="col"
           >
             <div
-              class="c16"
+              class="c18"
             />
           </th>
           <th
-            class="c15 "
+            class="c17 "
             scope="col"
           >
             <div
-              class="c16"
+              class="c18"
             />
           </th>
         </tr>
       </thead>
       <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c17"
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c19"
       >
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c18 "
+            class="c20 "
             scope="row"
           >
             <div
-              class="c19"
+              class="c21"
             >
               <span
-                class="c20"
+                class="c22"
               >
                 aa
               </span>
             </div>
           </th>
           <td
-            class="c18 "
+            class="c20 "
           >
             <div
-              class="c19"
+              class="c21"
             >
               <span
-                class="c21"
+                class="c23"
               >
                 ZZ
               </span>
@@ -8489,7 +8827,7 @@ exports[`Data view search 1`] = `
 `;
 
 exports[`Data view sort 1`] = `
-.c8 {
+.c10 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -8500,25 +8838,25 @@ exports[`Data view sort 1`] = `
   stroke: #666666;
 }
 
-.c8 g {
+.c10 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c8 *:not([stroke])[fill="none"] {
+.c10 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c8 *[stroke*="#"],
-.c8 *[STROKE*="#"] {
+.c10 *[stroke*="#"],
+.c10 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c8 *[fill-rule],
-.c8 *[FILL-RULE],
-.c8 *[fill*="#"],
-.c8 *[FILL*="#"] {
+.c10 *[fill-rule],
+.c10 *[FILL-RULE],
+.c10 *[fill*="#"],
+.c10 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -8583,7 +8921,40 @@ exports[`Data view sort 1`] = `
   overflow: auto;
 }
 
-.c10 {
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-bottom: 12px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8600,7 +8971,7 @@ exports[`Data view sort 1`] = `
   flex: 0 0 auto;
 }
 
-.c16 {
+.c18 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8621,7 +8992,7 @@ exports[`Data view sort 1`] = `
   justify-content: center;
 }
 
-.c19 {
+.c21 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8662,25 +9033,25 @@ exports[`Data view sort 1`] = `
   row-gap: 12px;
 }
 
-.c12 {
+.c14 {
   margin-top: 6px;
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
 }
 
-.c20 {
+.c22 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
 }
 
-.c21 {
+.c23 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c11 {
+.c13 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -8700,52 +9071,52 @@ exports[`Data view sort 1`] = `
   padding: 12px;
 }
 
-.c11:hover {
+.c13:hover {
   background-color: rgba(221,221,221,0.4);
   color: #000000;
 }
 
-.c11:focus {
+.c13:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus > circle,
-.c11:focus > ellipse,
-.c11:focus > line,
-.c11:focus > path,
-.c11:focus > polygon,
-.c11:focus > polyline,
-.c11:focus > rect {
+.c13:focus > circle,
+.c13:focus > ellipse,
+.c13:focus > line,
+.c13:focus > path,
+.c13:focus > polygon,
+.c13:focus > polyline,
+.c13:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus::-moz-focus-inner {
+.c13:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c11:focus:not(:focus-visible) {
+.c13:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c11:focus:not(:focus-visible) > circle,
-.c11:focus:not(:focus-visible) > ellipse,
-.c11:focus:not(:focus-visible) > line,
-.c11:focus:not(:focus-visible) > path,
-.c11:focus:not(:focus-visible) > polygon,
-.c11:focus:not(:focus-visible) > polyline,
-.c11:focus:not(:focus-visible) > rect {
+.c13:focus:not(:focus-visible) > circle,
+.c13:focus:not(:focus-visible) > ellipse,
+.c13:focus:not(:focus-visible) > line,
+.c13:focus:not(:focus-visible) > path,
+.c13:focus:not(:focus-visible) > polygon,
+.c13:focus:not(:focus-visible) > polyline,
+.c13:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c11:focus:not(:focus-visible)::-moz-focus-inner {
+.c13:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c9 {
+.c11 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -8759,61 +9130,43 @@ exports[`Data view sort 1`] = `
   margin: 0;
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
+  outline: none;
+  border: none;
   padding-left: 48px;
 }
 
-.c9:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c9:focus > circle,
-.c9:focus > ellipse,
-.c9:focus > line,
-.c9:focus > path,
-.c9:focus > polygon,
-.c9:focus > polyline,
-.c9:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c9:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c9::-webkit-input-placeholder {
+.c11::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c9::-moz-placeholder {
+.c11::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c9:-ms-input-placeholder {
+.c11:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c9::-webkit-search-decoration {
+.c11::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c9::-moz-focus-inner {
+.c11::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c9:-moz-placeholder,
-.c9::-moz-placeholder {
+.c11:-moz-placeholder,
+.c11::-moz-placeholder {
   opacity: 1;
 }
 
-.c6 {
+.c8 {
   position: relative;
   width: 100%;
 }
 
-.c7 {
+.c9 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -8835,7 +9188,7 @@ exports[`Data view sort 1`] = `
   max-width: 100%;
 }
 
-.c15 {
+.c17 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -8848,7 +9201,7 @@ exports[`Data view sort 1`] = `
   padding-bottom: 6px;
 }
 
-.c18 {
+.c20 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -8860,28 +9213,40 @@ exports[`Data view sort 1`] = `
   padding-bottom: 6px;
 }
 
-.c13 {
+.c15 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
 }
 
-.c14 {
+.c16 {
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
 }
 
-.c17:focus {
+.c19:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c17:focus:not(:focus-visible) {
+.c19:focus:not(:focus-visible) {
   outline: none;
 }
 
 @media only screen and (max-width:768px) {
 
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    margin-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
 }
 
 @media only screen and (max-width:768px) {
@@ -8911,49 +9276,57 @@ exports[`Data view sort 1`] = `
             class="c5"
           >
             <div
-              class="c6"
+              class="c6 "
             >
               <div
-                class="c7"
+                class="c7 FormField__FormFieldContentBox-sc-m9hood-1"
               >
-                <svg
-                  aria-label="Search"
+                <div
                   class="c8"
-                  viewBox="0 0 24 24"
                 >
-                  <path
-                    d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                    fill="none"
-                    stroke="#000"
-                    stroke-width="2"
+                  <div
+                    class="c9"
+                  >
+                    <svg
+                      aria-label="Search"
+                      class="c10"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                        fill="none"
+                        stroke="#000"
+                        stroke-width="2"
+                      />
+                    </svg>
+                  </div>
+                  <input
+                    aria-label="Search data"
+                    autocomplete="off"
+                    class="c11"
+                    id="data--search"
+                    name="_search"
+                    type="search"
+                    value=""
                   />
-                </svg>
+                </div>
               </div>
-              <input
-                aria-label="Search data"
-                autocomplete="off"
-                class="c9"
-                id="data--search"
-                name="_search"
-                type="search"
-                value=""
-              />
             </div>
           </div>
         </div>
       </form>
       <div
-        class="c10"
+        class="c12"
       >
         <button
           aria-label="Open filters"
-          class="c11"
+          class="c13"
           id="data--filters-control"
           type="button"
         >
           <svg
             aria-label="Filter"
-            class="c8"
+            class="c10"
             viewBox="0 0 24 24"
           >
             <path
@@ -8967,12 +9340,12 @@ exports[`Data view sort 1`] = `
       </div>
     </div>
     <span
-      class="c12"
+      class="c14"
     >
       4 items
     </span>
     <table
-      class="c13 c14"
+      class="c15 c16"
     >
       <thead
         class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -8981,51 +9354,51 @@ exports[`Data view sort 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c15 "
+            class="c17 "
             scope="col"
           >
             <div
-              class="c16"
+              class="c18"
             />
           </th>
           <th
-            class="c15 "
+            class="c17 "
             scope="col"
           >
             <div
-              class="c16"
+              class="c18"
             />
           </th>
         </tr>
       </thead>
       <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c17"
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c19"
       >
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c18 "
+            class="c20 "
             scope="row"
           >
             <div
-              class="c19"
+              class="c21"
             >
               <span
-                class="c20"
+                class="c22"
               >
                 aa
               </span>
             </div>
           </th>
           <td
-            class="c18 "
+            class="c20 "
           >
             <div
-              class="c19"
+              class="c21"
             >
               <span
-                class="c21"
+                class="c23"
               >
                 ZZ
               </span>
@@ -9036,27 +9409,27 @@ exports[`Data view sort 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c18 "
+            class="c20 "
             scope="row"
           >
             <div
-              class="c19"
+              class="c21"
             >
               <span
-                class="c20"
+                class="c22"
               >
                 bb
               </span>
             </div>
           </th>
           <td
-            class="c18 "
+            class="c20 "
           >
             <div
-              class="c19"
+              class="c21"
             >
               <span
-                class="c21"
+                class="c23"
               >
                 YY
               </span>
@@ -9067,24 +9440,24 @@ exports[`Data view sort 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c18 "
+            class="c20 "
             scope="row"
           >
             <div
-              class="c19"
+              class="c21"
             >
               <span
-                class="c20"
+                class="c22"
               >
                 cc
               </span>
             </div>
           </th>
           <td
-            class="c18 "
+            class="c20 "
           >
             <div
-              class="c19"
+              class="c21"
             />
           </td>
         </tr>
@@ -9092,24 +9465,24 @@ exports[`Data view sort 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c18 "
+            class="c20 "
             scope="row"
           >
             <div
-              class="c19"
+              class="c21"
             >
               <span
-                class="c20"
+                class="c22"
               >
                 dd
               </span>
             </div>
           </th>
           <td
-            class="c18 "
+            class="c20 "
           >
             <div
-              class="c19"
+              class="c21"
             />
           </td>
         </tr>

--- a/src/js/components/Data/__tests__/__snapshots__/Data-test.tsx.snap
+++ b/src/js/components/Data/__tests__/__snapshots__/Data-test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Data controlled search 1`] = `
-.c6 {
+.c8 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -12,25 +12,25 @@ exports[`Data controlled search 1`] = `
   stroke: #666666;
 }
 
-.c6 g {
+.c8 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c6 *:not([stroke])[fill="none"] {
+.c8 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c6 *[stroke*="#"],
-.c6 *[STROKE*="#"] {
+.c8 *[stroke*="#"],
+.c8 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c6 *[fill-rule],
-.c6 *[FILL-RULE],
-.c6 *[fill*="#"],
-.c6 *[FILL*="#"] {
+.c8 *[fill-rule],
+.c8 *[FILL-RULE],
+.c8 *[fill*="#"],
+.c8 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -62,7 +62,40 @@ exports[`Data controlled search 1`] = `
   flex: 0 0 auto;
 }
 
-.c8 {
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 100%;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  overflow: auto;
+}
+
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -79,7 +112,7 @@ exports[`Data controlled search 1`] = `
   flex: 0 0 auto;
 }
 
-.c14 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -100,7 +133,7 @@ exports[`Data controlled search 1`] = `
   justify-content: center;
 }
 
-.c17 {
+.c19 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -141,20 +174,20 @@ exports[`Data controlled search 1`] = `
   row-gap: 12px;
 }
 
-.c10 {
+.c12 {
   margin-top: 6px;
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
 }
 
-.c18 {
+.c20 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
 }
 
-.c9 {
+.c11 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -174,9 +207,66 @@ exports[`Data controlled search 1`] = `
   padding: 12px;
 }
 
-.c9:hover {
+.c11:hover {
   background-color: rgba(221,221,221,0.4);
   color: #000000;
+}
+
+.c11:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus > circle,
+.c11:focus > ellipse,
+.c11:focus > line,
+.c11:focus > path,
+.c11:focus > polygon,
+.c11:focus > polyline,
+.c11:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c11:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c11:focus:not(:focus-visible) > circle,
+.c11:focus:not(:focus-visible) > ellipse,
+.c11:focus:not(:focus-visible) > line,
+.c11:focus:not(:focus-visible) > path,
+.c11:focus:not(:focus-visible) > polygon,
+.c11:focus:not(:focus-visible) > polyline,
+.c11:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c11:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c9 {
+  box-sizing: border-box;
+  font-size: inherit;
+  font-family: inherit;
+  border: none;
+  -webkit-appearance: none;
+  background: transparent;
+  color: inherit;
+  width: 100%;
+  padding: 11px;
+  font-weight: 600;
+  margin: 0;
+  border: 1px solid rgba(0,0,0,0.33);
+  border-radius: 4px;
+  padding-left: 48px;
 }
 
 .c9:focus {
@@ -199,95 +289,38 @@ exports[`Data controlled search 1`] = `
   border: 0;
 }
 
-.c9:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c9:focus:not(:focus-visible) > circle,
-.c9:focus:not(:focus-visible) > ellipse,
-.c9:focus:not(:focus-visible) > line,
-.c9:focus:not(:focus-visible) > path,
-.c9:focus:not(:focus-visible) > polygon,
-.c9:focus:not(:focus-visible) > polyline,
-.c9:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c9:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c7 {
-  box-sizing: border-box;
-  font-size: inherit;
-  font-family: inherit;
-  border: none;
-  -webkit-appearance: none;
-  background: transparent;
-  color: inherit;
-  width: 100%;
-  padding: 11px;
-  font-weight: 600;
-  margin: 0;
-  border: 1px solid rgba(0,0,0,0.33);
-  border-radius: 4px;
-  padding-left: 48px;
-}
-
-.c7:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c7:focus > circle,
-.c7:focus > ellipse,
-.c7:focus > line,
-.c7:focus > path,
-.c7:focus > polygon,
-.c7:focus > polyline,
-.c7:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c7:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c7::-webkit-input-placeholder {
+.c9::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-moz-placeholder {
+.c9::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c7:-ms-input-placeholder {
+.c9:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-webkit-search-decoration {
+.c9::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c7::-moz-focus-inner {
+.c9::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c7:-moz-placeholder,
-.c7::-moz-placeholder {
+.c9:-moz-placeholder,
+.c9::-moz-placeholder {
   opacity: 1;
 }
 
-.c4 {
+.c6 {
   position: relative;
   width: 100%;
 }
 
-.c5 {
+.c7 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -309,7 +342,7 @@ exports[`Data controlled search 1`] = `
   max-width: 100%;
 }
 
-.c13 {
+.c15 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -322,7 +355,7 @@ exports[`Data controlled search 1`] = `
   padding-bottom: 6px;
 }
 
-.c16 {
+.c18 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -334,23 +367,23 @@ exports[`Data controlled search 1`] = `
   padding-bottom: 6px;
 }
 
-.c11 {
+.c13 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
 }
 
-.c12 {
+.c14 {
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
 }
 
-.c15:focus {
+.c17:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c15:focus:not(:focus-visible) {
+.c17:focus:not(:focus-visible) {
   outline: none;
 }
 
@@ -379,51 +412,55 @@ exports[`Data controlled search 1`] = `
         class="c3"
       >
         <div
-          class="c1"
+          class="c4"
         >
           <div
-            class="c4"
+            class="c5"
           >
             <div
-              class="c5"
+              class="c6"
             >
-              <svg
-                aria-label="Search"
-                class="c6"
-                viewBox="0 0 24 24"
+              <div
+                class="c7"
               >
-                <path
-                  d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                  fill="none"
-                  stroke="#000"
-                  stroke-width="2"
-                />
-              </svg>
+                <svg
+                  aria-label="Search"
+                  class="c8"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                    fill="none"
+                    stroke="#000"
+                    stroke-width="2"
+                  />
+                </svg>
+              </div>
+              <input
+                aria-label="Search data"
+                autocomplete="off"
+                class="c9"
+                id="data--search"
+                name="_search"
+                type="search"
+                value=""
+              />
             </div>
-            <input
-              aria-label="Search data"
-              autocomplete="off"
-              class="c7"
-              id="data--search"
-              name="_search"
-              type="search"
-              value=""
-            />
           </div>
         </div>
       </form>
       <div
-        class="c8"
+        class="c10"
       >
         <button
           aria-label="Open filters"
-          class="c9"
+          class="c11"
           id="data--filters-control"
           type="button"
         >
           <svg
             aria-label="Filter"
-            class="c6"
+            class="c8"
             viewBox="0 0 24 24"
           >
             <path
@@ -437,12 +474,12 @@ exports[`Data controlled search 1`] = `
       </div>
     </div>
     <span
-      class="c10"
+      class="c12"
     >
       4 results of undefined items
     </span>
     <table
-      class="c11 c12"
+      class="c13 c14"
     >
       <thead
         class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -451,30 +488,30 @@ exports[`Data controlled search 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c13 "
+            class="c15 "
             scope="col"
           >
             <div
-              class="c14"
+              class="c16"
             />
           </th>
         </tr>
       </thead>
       <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c15"
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c17"
       >
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c16 "
+            class="c18 "
             scope="row"
           >
             <div
-              class="c17"
+              class="c19"
             >
               <span
-                class="c18"
+                class="c20"
               >
                 aa
               </span>
@@ -485,14 +522,14 @@ exports[`Data controlled search 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c16 "
+            class="c18 "
             scope="row"
           >
             <div
-              class="c17"
+              class="c19"
             >
               <span
-                class="c18"
+                class="c20"
               >
                 bb
               </span>
@@ -503,14 +540,14 @@ exports[`Data controlled search 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c16 "
+            class="c18 "
             scope="row"
           >
             <div
-              class="c17"
+              class="c19"
             >
               <span
-                class="c18"
+                class="c20"
               >
                 cc
               </span>
@@ -521,14 +558,14 @@ exports[`Data controlled search 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c16 "
+            class="c18 "
             scope="row"
           >
             <div
-              class="c17"
+              class="c19"
             >
               <span
-                class="c18"
+                class="c20"
               >
                 dd
               </span>
@@ -553,39 +590,43 @@ exports[`Data controlled search 2`] = `
       class="StyledBox-sc-13pk1d4-0 cA-DryL"
     >
       <form
-        class="DataForm__MaxForm-sc-v64e1r-1 hpHcfX"
+        class="DataForm__MaxForm-sc-v64e1r-1 dKlaJO"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 hoPFxc"
+          class="StyledBox-sc-13pk1d4-0 eMuiZr"
         >
           <div
-            class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 edcgVv"
+            class="StyledBox-sc-13pk1d4-0 dePIJN"
           >
             <div
-              class="StyledTextInput__StyledIcon-sc-1x30a0s-3 cFBrkA"
+              class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 edcgVv"
             >
-              <svg
-                aria-label="Search"
-                class="StyledIcon-sc-ofa7kd-0 jQvEgu"
-                viewBox="0 0 24 24"
+              <div
+                class="StyledTextInput__StyledIcon-sc-1x30a0s-3 cFBrkA"
               >
-                <path
-                  d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                  fill="none"
-                  stroke="#000"
-                  stroke-width="2"
-                />
-              </svg>
+                <svg
+                  aria-label="Search"
+                  class="StyledIcon-sc-ofa7kd-0 jQvEgu"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                    fill="none"
+                    stroke="#000"
+                    stroke-width="2"
+                  />
+                </svg>
+              </div>
+              <input
+                aria-label="Search data"
+                autocomplete="off"
+                class="StyledTextInput-sc-1x30a0s-0 bMqJAS"
+                id="data--search"
+                name="_search"
+                type="search"
+                value="a"
+              />
             </div>
-            <input
-              aria-label="Search data"
-              autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 bMqJAS"
-              id="data--search"
-              name="_search"
-              type="search"
-              value="a"
-            />
           </div>
         </div>
       </form>
@@ -719,7 +760,7 @@ exports[`Data controlled search 2`] = `
 `;
 
 exports[`Data messages 1`] = `
-.c6 {
+.c8 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -730,25 +771,25 @@ exports[`Data messages 1`] = `
   stroke: #666666;
 }
 
-.c6 g {
+.c8 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c6 *:not([stroke])[fill="none"] {
+.c8 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c6 *[stroke*="#"],
-.c6 *[STROKE*="#"] {
+.c8 *[stroke*="#"],
+.c8 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c6 *[fill-rule],
-.c6 *[FILL-RULE],
-.c6 *[fill*="#"],
-.c6 *[FILL*="#"] {
+.c8 *[fill-rule],
+.c8 *[FILL-RULE],
+.c8 *[fill*="#"],
+.c8 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -780,7 +821,40 @@ exports[`Data messages 1`] = `
   flex: 0 0 auto;
 }
 
-.c8 {
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 100%;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  overflow: auto;
+}
+
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -797,7 +871,7 @@ exports[`Data messages 1`] = `
   flex: 0 0 auto;
 }
 
-.c14 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -818,7 +892,7 @@ exports[`Data messages 1`] = `
   justify-content: center;
 }
 
-.c17 {
+.c19 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -859,25 +933,25 @@ exports[`Data messages 1`] = `
   row-gap: 12px;
 }
 
-.c10 {
+.c12 {
   margin-top: 6px;
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
 }
 
-.c18 {
+.c20 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
 }
 
-.c19 {
+.c21 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c9 {
+.c11 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -897,9 +971,66 @@ exports[`Data messages 1`] = `
   padding: 12px;
 }
 
-.c9:hover {
+.c11:hover {
   background-color: rgba(221,221,221,0.4);
   color: #000000;
+}
+
+.c11:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus > circle,
+.c11:focus > ellipse,
+.c11:focus > line,
+.c11:focus > path,
+.c11:focus > polygon,
+.c11:focus > polyline,
+.c11:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c11:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c11:focus:not(:focus-visible) > circle,
+.c11:focus:not(:focus-visible) > ellipse,
+.c11:focus:not(:focus-visible) > line,
+.c11:focus:not(:focus-visible) > path,
+.c11:focus:not(:focus-visible) > polygon,
+.c11:focus:not(:focus-visible) > polyline,
+.c11:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c11:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c9 {
+  box-sizing: border-box;
+  font-size: inherit;
+  font-family: inherit;
+  border: none;
+  -webkit-appearance: none;
+  background: transparent;
+  color: inherit;
+  width: 100%;
+  padding: 11px;
+  font-weight: 600;
+  margin: 0;
+  border: 1px solid rgba(0,0,0,0.33);
+  border-radius: 4px;
+  padding-left: 48px;
 }
 
 .c9:focus {
@@ -922,95 +1053,38 @@ exports[`Data messages 1`] = `
   border: 0;
 }
 
-.c9:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c9:focus:not(:focus-visible) > circle,
-.c9:focus:not(:focus-visible) > ellipse,
-.c9:focus:not(:focus-visible) > line,
-.c9:focus:not(:focus-visible) > path,
-.c9:focus:not(:focus-visible) > polygon,
-.c9:focus:not(:focus-visible) > polyline,
-.c9:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c9:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c7 {
-  box-sizing: border-box;
-  font-size: inherit;
-  font-family: inherit;
-  border: none;
-  -webkit-appearance: none;
-  background: transparent;
-  color: inherit;
-  width: 100%;
-  padding: 11px;
-  font-weight: 600;
-  margin: 0;
-  border: 1px solid rgba(0,0,0,0.33);
-  border-radius: 4px;
-  padding-left: 48px;
-}
-
-.c7:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c7:focus > circle,
-.c7:focus > ellipse,
-.c7:focus > line,
-.c7:focus > path,
-.c7:focus > polygon,
-.c7:focus > polyline,
-.c7:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c7:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c7::-webkit-input-placeholder {
+.c9::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-moz-placeholder {
+.c9::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c7:-ms-input-placeholder {
+.c9:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-webkit-search-decoration {
+.c9::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c7::-moz-focus-inner {
+.c9::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c7:-moz-placeholder,
-.c7::-moz-placeholder {
+.c9:-moz-placeholder,
+.c9::-moz-placeholder {
   opacity: 1;
 }
 
-.c4 {
+.c6 {
   position: relative;
   width: 100%;
 }
 
-.c5 {
+.c7 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1032,7 +1106,7 @@ exports[`Data messages 1`] = `
   max-width: 100%;
 }
 
-.c13 {
+.c15 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -1045,7 +1119,7 @@ exports[`Data messages 1`] = `
   padding-bottom: 6px;
 }
 
-.c16 {
+.c18 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -1057,23 +1131,23 @@ exports[`Data messages 1`] = `
   padding-bottom: 6px;
 }
 
-.c11 {
+.c13 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
 }
 
-.c12 {
+.c14 {
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
 }
 
-.c15:focus {
+.c17:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c15:focus:not(:focus-visible) {
+.c17:focus:not(:focus-visible) {
   outline: none;
 }
 
@@ -1102,51 +1176,55 @@ exports[`Data messages 1`] = `
         class="c3"
       >
         <div
-          class="c1"
+          class="c4"
         >
           <div
-            class="c4"
+            class="c5"
           >
             <div
-              class="c5"
+              class="c6"
             >
-              <svg
-                aria-label="Search"
-                class="c6"
-                viewBox="0 0 24 24"
+              <div
+                class="c7"
               >
-                <path
-                  d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                  fill="none"
-                  stroke="#000"
-                  stroke-width="2"
-                />
-              </svg>
+                <svg
+                  aria-label="Search"
+                  class="c8"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                    fill="none"
+                    stroke="#000"
+                    stroke-width="2"
+                  />
+                </svg>
+              </div>
+              <input
+                aria-label="Search data"
+                autocomplete="off"
+                class="c9"
+                id="data--search"
+                name="_search"
+                type="search"
+                value=""
+              />
             </div>
-            <input
-              aria-label="Search data"
-              autocomplete="off"
-              class="c7"
-              id="data--search"
-              name="_search"
-              type="search"
-              value=""
-            />
           </div>
         </div>
       </form>
       <div
-        class="c8"
+        class="c10"
       >
         <button
           aria-label="Open filters"
-          class="c9"
+          class="c11"
           id="data--filters-control"
           type="button"
         >
           <svg
             aria-label="Filter"
-            class="c6"
+            class="c8"
             viewBox="0 0 24 24"
           >
             <path
@@ -1160,12 +1238,12 @@ exports[`Data messages 1`] = `
       </div>
     </div>
     <span
-      class="c10"
+      class="c12"
     >
       4 things
     </span>
     <table
-      class="c11 c12"
+      class="c13 c14"
     >
       <thead
         class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -1174,51 +1252,51 @@ exports[`Data messages 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c13 "
+            class="c15 "
             scope="col"
           >
             <div
-              class="c14"
+              class="c16"
             />
           </th>
           <th
-            class="c13 "
+            class="c15 "
             scope="col"
           >
             <div
-              class="c14"
+              class="c16"
             />
           </th>
         </tr>
       </thead>
       <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c15"
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c17"
       >
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c16 "
+            class="c18 "
             scope="row"
           >
             <div
-              class="c17"
+              class="c19"
             >
               <span
-                class="c18"
+                class="c20"
               >
                 aa
               </span>
             </div>
           </th>
           <td
-            class="c16 "
+            class="c18 "
           >
             <div
-              class="c17"
+              class="c19"
             >
               <span
-                class="c19"
+                class="c21"
               >
                 ZZ
               </span>
@@ -1229,27 +1307,27 @@ exports[`Data messages 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c16 "
+            class="c18 "
             scope="row"
           >
             <div
-              class="c17"
+              class="c19"
             >
               <span
-                class="c18"
+                class="c20"
               >
                 bb
               </span>
             </div>
           </th>
           <td
-            class="c16 "
+            class="c18 "
           >
             <div
-              class="c17"
+              class="c19"
             >
               <span
-                class="c19"
+                class="c21"
               >
                 YY
               </span>
@@ -1260,24 +1338,24 @@ exports[`Data messages 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c16 "
+            class="c18 "
             scope="row"
           >
             <div
-              class="c17"
+              class="c19"
             >
               <span
-                class="c18"
+                class="c20"
               >
                 cc
               </span>
             </div>
           </th>
           <td
-            class="c16 "
+            class="c18 "
           >
             <div
-              class="c17"
+              class="c19"
             />
           </td>
         </tr>
@@ -1285,24 +1363,24 @@ exports[`Data messages 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c16 "
+            class="c18 "
             scope="row"
           >
             <div
-              class="c17"
+              class="c19"
             >
               <span
-                class="c18"
+                class="c20"
               >
                 dd
               </span>
             </div>
           </th>
           <td
-            class="c16 "
+            class="c18 "
           >
             <div
-              class="c17"
+              class="c19"
             />
           </td>
         </tr>
@@ -1347,6 +1425,39 @@ exports[`Data onView 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 100%;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  overflow: auto;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1365,7 +1476,7 @@ exports[`Data onView 1`] = `
   justify-content: space-between;
 }
 
-.c6 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1378,9 +1489,12 @@ exports[`Data onView 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
-.c8 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1396,7 +1510,7 @@ exports[`Data onView 1`] = `
   padding: 12px;
 }
 
-.c9 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1410,7 +1524,7 @@ exports[`Data onView 1`] = `
   flex-direction: column;
 }
 
-.c11 {
+.c13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1433,7 +1547,7 @@ exports[`Data onView 1`] = `
   justify-content: center;
 }
 
-.c14 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1459,7 +1573,7 @@ exports[`Data onView 1`] = `
   border-radius: 4px;
 }
 
-.c15 {
+.c18 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1479,7 +1593,7 @@ exports[`Data onView 1`] = `
   height: 100%;
 }
 
-.c17 {
+.c20 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1500,7 +1614,7 @@ exports[`Data onView 1`] = `
   cursor: pointer;
 }
 
-.c19 {
+.c22 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1519,7 +1633,7 @@ exports[`Data onView 1`] = `
   border-radius: 12px;
 }
 
-.c20 {
+.c23 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1545,7 +1659,7 @@ exports[`Data onView 1`] = `
   overflow: visible;
 }
 
-.c21 {
+.c24 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1570,7 +1684,7 @@ exports[`Data onView 1`] = `
   justify-content: center;
 }
 
-.c22 {
+.c25 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1589,7 +1703,7 @@ exports[`Data onView 1`] = `
   border-radius: 100%;
 }
 
-.c23 {
+.c26 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1610,7 +1724,7 @@ exports[`Data onView 1`] = `
   border-radius: 12px;
 }
 
-.c32 {
+.c35 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1631,7 +1745,17 @@ exports[`Data onView 1`] = `
   justify-content: center;
 }
 
-.c5 {
+.c7 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  height: 6px;
+}
+
+.c17 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -1641,7 +1765,7 @@ exports[`Data onView 1`] = `
   height: 12px;
 }
 
-.c26 {
+.c29 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -1651,7 +1775,7 @@ exports[`Data onView 1`] = `
   width: 24px;
 }
 
-.c7 {
+.c9 {
   margin-left: 12px;
   margin-right: 12px;
   margin-top: 6px;
@@ -1660,7 +1784,7 @@ exports[`Data onView 1`] = `
   line-height: 24px;
 }
 
-.c16 {
+.c19 {
   margin-left: 12px;
   margin-right: 12px;
   font-size: 14px;
@@ -1668,25 +1792,25 @@ exports[`Data onView 1`] = `
   text-align: right;
 }
 
-.c24 {
+.c27 {
   margin-left: 12px;
   margin-right: 12px;
   font-size: 14px;
   line-height: 20px;
 }
 
-.c35 {
+.c38 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
 }
 
-.c36 {
+.c39 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c25 {
+.c28 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -1714,51 +1838,51 @@ exports[`Data onView 1`] = `
   transition-timing-function: ease-in-out;
 }
 
-.c25:hover {
+.c28:hover {
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c25:focus {
+.c28:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c25:focus > circle,
-.c25:focus > ellipse,
-.c25:focus > line,
-.c25:focus > path,
-.c25:focus > polygon,
-.c25:focus > polyline,
-.c25:focus > rect {
+.c28:focus > circle,
+.c28:focus > ellipse,
+.c28:focus > line,
+.c28:focus > path,
+.c28:focus > polygon,
+.c28:focus > polyline,
+.c28:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c25:focus::-moz-focus-inner {
+.c28:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c25:focus:not(:focus-visible) {
+.c28:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c25:focus:not(:focus-visible) > circle,
-.c25:focus:not(:focus-visible) > ellipse,
-.c25:focus:not(:focus-visible) > line,
-.c25:focus:not(:focus-visible) > path,
-.c25:focus:not(:focus-visible) > polygon,
-.c25:focus:not(:focus-visible) > polyline,
-.c25:focus:not(:focus-visible) > rect {
+.c28:focus:not(:focus-visible) > circle,
+.c28:focus:not(:focus-visible) > ellipse,
+.c28:focus:not(:focus-visible) > line,
+.c28:focus:not(:focus-visible) > path,
+.c28:focus:not(:focus-visible) > polygon,
+.c28:focus:not(:focus-visible) > polyline,
+.c28:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c25:focus:not(:focus-visible)::-moz-focus-inner {
+.c28:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c27 {
+.c30 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -1785,47 +1909,47 @@ exports[`Data onView 1`] = `
   transition-timing-function: ease-in-out;
 }
 
-.c27:focus {
+.c30:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c27:focus > circle,
-.c27:focus > ellipse,
-.c27:focus > line,
-.c27:focus > path,
-.c27:focus > polygon,
-.c27:focus > polyline,
-.c27:focus > rect {
+.c30:focus > circle,
+.c30:focus > ellipse,
+.c30:focus > line,
+.c30:focus > path,
+.c30:focus > polygon,
+.c30:focus > polyline,
+.c30:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c27:focus::-moz-focus-inner {
+.c30:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c27:focus:not(:focus-visible) {
+.c30:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c27:focus:not(:focus-visible) > circle,
-.c27:focus:not(:focus-visible) > ellipse,
-.c27:focus:not(:focus-visible) > line,
-.c27:focus:not(:focus-visible) > path,
-.c27:focus:not(:focus-visible) > polygon,
-.c27:focus:not(:focus-visible) > polyline,
-.c27:focus:not(:focus-visible) > rect {
+.c30:focus:not(:focus-visible) > circle,
+.c30:focus:not(:focus-visible) > ellipse,
+.c30:focus:not(:focus-visible) > line,
+.c30:focus:not(:focus-visible) > path,
+.c30:focus:not(:focus-visible) > polygon,
+.c30:focus:not(:focus-visible) > polyline,
+.c30:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c27:focus:not(:focus-visible)::-moz-focus-inner {
+.c30:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c10 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1847,12 +1971,12 @@ exports[`Data onView 1`] = `
   cursor: pointer;
 }
 
-.c10:hover input:not([disabled]) + div,
-.c10:hover input:not([disabled]) + span {
+.c12:hover input:not([disabled]) + div,
+.c12:hover input:not([disabled]) + span {
   border-color: #000000;
 }
 
-.c13 {
+.c15 {
   opacity: 0;
   -moz-appearance: none;
   width: 0;
@@ -1861,25 +1985,25 @@ exports[`Data onView 1`] = `
   cursor: pointer;
 }
 
-.c13:checked + span > span {
+.c15:checked + span > span {
   left: calc( 48px - 24px );
   background: #7D4CDB;
 }
 
-.c12 {
+.c14 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c18 {
+.c21 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
 }
 
-.c28 {
+.c31 {
   opacity: 0;
 }
 
@@ -1887,7 +2011,7 @@ exports[`Data onView 1`] = `
   max-width: 100%;
 }
 
-.c4 {
+.c6 {
   margin: 0px;
   font-size: 26px;
   line-height: 32px;
@@ -1896,7 +2020,7 @@ exports[`Data onView 1`] = `
   overflow-wrap: break-word;
 }
 
-.c31 {
+.c34 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -1909,7 +2033,7 @@ exports[`Data onView 1`] = `
   padding-bottom: 6px;
 }
 
-.c34 {
+.c37 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -1921,88 +2045,94 @@ exports[`Data onView 1`] = `
   padding-bottom: 6px;
 }
 
-.c29 {
+.c32 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
 }
 
-.c30 {
+.c33 {
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
 }
 
-.c33:focus {
+.c36:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c33:focus:not(:focus-visible) {
+.c36:focus:not(:focus-visible) {
   outline: none;
 }
 
 @media only screen and (max-width:768px) {
-  .c6 {
+  .c8 {
     margin-bottom: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c10 {
     border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c10 {
     padding: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c11 {
+  .c13 {
     margin-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c14 {
+  .c16 {
     border: solid 2px rgba(0,0,0,0.15);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c19 {
+  .c22 {
     border-radius: 6px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c23 {
-    border-radius: 6px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c5 {
-    height: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c26 {
+    border-radius: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    height: 3px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c17 {
+    height: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c29 {
     width: 12px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c6 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c6 {
     font-size: 22px;
     line-height: 28px;
     max-width: 528px;
@@ -2020,296 +2150,297 @@ exports[`Data onView 1`] = `
       class="c2"
     >
       <div
-        class="c1"
+        class="c3"
       >
-        <header
-          class="c3"
-        >
-          <h2
-            class="c4"
-          >
-            Filters
-          </h2>
-        </header>
         <div
-          class="c5"
-        />
-        <div
-          class="c6 "
+          class="c4"
         >
-          <label
-            class="c7"
-            for="data-name"
+          <header
+            class="c5"
           >
-            name
-          </label>
-          <div
-            class="c8 FormField__FormFieldContentBox-sc-m9hood-1"
-          >
-            <div
-              class="c9 StyledCheckBoxGroup-sc-2nhc5d-0"
-              id="data-name"
-              role="group"
+            <h2
+              class="c6"
             >
-              <label
-                class="c10"
-                label="aa"
-              >
-                <div
-                  class="c11 c12"
-                >
-                  <input
-                    class="c13"
-                    type="checkbox"
-                  />
-                  <div
-                    class="c14 "
-                  />
-                </div>
-                <span>
-                  aa
-                </span>
-              </label>
-              <div
-                class="c5"
-              />
-              <label
-                class="c10"
-                label="bb"
-              >
-                <div
-                  class="c11 c12"
-                >
-                  <input
-                    class="c13"
-                    type="checkbox"
-                  />
-                  <div
-                    class="c14 "
-                  />
-                </div>
-                <span>
-                  bb
-                </span>
-              </label>
-              <div
-                class="c5"
-              />
-              <label
-                class="c10"
-                label="cc"
-              >
-                <div
-                  class="c11 c12"
-                >
-                  <input
-                    class="c13"
-                    type="checkbox"
-                  />
-                  <div
-                    class="c14 "
-                  />
-                </div>
-                <span>
-                  cc
-                </span>
-              </label>
-              <div
-                class="c5"
-              />
-              <label
-                class="c10"
-                label="dd"
-              >
-                <div
-                  class="c11 c12"
-                >
-                  <input
-                    class="c13"
-                    type="checkbox"
-                  />
-                  <div
-                    class="c14 "
-                  />
-                </div>
-                <span>
-                  dd
-                </span>
-              </label>
-            </div>
-          </div>
-        </div>
-        <div
-          class="c5"
-        />
-        <div
-          class="c6 "
-        >
-          <label
-            class="c7"
-            for="data-enabled"
-          >
-            enabled
-          </label>
+              Filters
+            </h2>
+          </header>
           <div
-            class="c8 FormField__FormFieldContentBox-sc-m9hood-1"
-          >
-            <div
-              class="c9 StyledCheckBoxGroup-sc-2nhc5d-0"
-              id="data-enabled"
-              role="group"
-            >
-              <label
-                class="c10"
-                label="true"
-              >
-                <div
-                  class="c11 c12"
-                >
-                  <input
-                    class="c13"
-                    type="checkbox"
-                  />
-                  <div
-                    class="c14 "
-                  />
-                </div>
-                <span>
-                  true
-                </span>
-              </label>
-              <div
-                class="c5"
-              />
-              <label
-                class="c10"
-                label="false"
-              >
-                <div
-                  class="c11 c12"
-                >
-                  <input
-                    class="c13"
-                    type="checkbox"
-                  />
-                  <div
-                    class="c14 "
-                  />
-                </div>
-                <span>
-                  false
-                </span>
-              </label>
-            </div>
-          </div>
-        </div>
-        <div
-          class="c5"
-        />
-        <div
-          class="c6 "
-        >
-          <label
             class="c7"
-            for="data-rating"
-          >
-            rating
-          </label>
+          />
           <div
-            class="c8 FormField__FormFieldContentBox-sc-m9hood-1"
+            class="c8 "
           >
-            <div
-              class="c15"
-              id="data-rating"
+            <label
+              class="c9"
+              for="data-name"
             >
-              <span
-                class="c16"
-                style="width: 0px;"
-              >
-                2.0999999999999996
-              </span>
+              name
+            </label>
+            <div
+              class="c10 FormField__FormFieldContentBox-sc-m9hood-1"
+            >
               <div
-                class="c17 c18"
-                tabindex="-1"
+                class="c11 StyledCheckBoxGroup-sc-2nhc5d-0"
+                id="data-name"
+                role="group"
               >
-                <div
-                  class="c19"
-                  style="flex: 0 0 0px;"
-                />
-                <div
-                  class="c20"
-                  style="flex: 0 0 1px;"
+                <label
+                  class="c12"
+                  label="aa"
                 >
                   <div
-                    aria-label="Lower Bounds"
-                    aria-valuemax="4.8999999999999995"
-                    aria-valuemin="2.0999999999999996"
-                    aria-valuenow="2.0999999999999996"
-                    class="c21"
-                    role="slider"
-                    style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 1;"
-                    tabindex="0"
+                    class="c13 c14"
                   >
+                    <input
+                      class="c15"
+                      type="checkbox"
+                    />
                     <div
-                      class="c22 EdgeControl__StyledBox-sc-1xo2yt9-0"
+                      class="c16 "
                     />
                   </div>
-                </div>
+                  <span>
+                    aa
+                  </span>
+                </label>
                 <div
-                  class="c23"
-                  style="flex: 3.8 0 0px; cursor: ew-resize;"
+                  class="c17"
                 />
-                <div
-                  class="c20"
-                  style="flex: 0 0 1px;"
+                <label
+                  class="c12"
+                  label="bb"
                 >
                   <div
-                    aria-label="Upper Bounds"
-                    aria-valuemax="4.8999999999999995"
-                    aria-valuemin="2.0999999999999996"
-                    aria-valuenow="4.8999999999999995"
-                    class="c21"
-                    role="slider"
-                    style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 1;"
-                    tabindex="0"
+                    class="c13 c14"
                   >
+                    <input
+                      class="c15"
+                      type="checkbox"
+                    />
                     <div
-                      class="c22 EdgeControl__StyledBox-sc-1xo2yt9-0"
+                      class="c16 "
                     />
                   </div>
-                </div>
+                  <span>
+                    bb
+                  </span>
+                </label>
                 <div
-                  class="c19"
-                  style="flex: 0 0 0px;"
+                  class="c17"
                 />
+                <label
+                  class="c12"
+                  label="cc"
+                >
+                  <div
+                    class="c13 c14"
+                  >
+                    <input
+                      class="c15"
+                      type="checkbox"
+                    />
+                    <div
+                      class="c16 "
+                    />
+                  </div>
+                  <span>
+                    cc
+                  </span>
+                </label>
+                <div
+                  class="c17"
+                />
+                <label
+                  class="c12"
+                  label="dd"
+                >
+                  <div
+                    class="c13 c14"
+                  >
+                    <input
+                      class="c15"
+                      type="checkbox"
+                    />
+                    <div
+                      class="c16 "
+                    />
+                  </div>
+                  <span>
+                    dd
+                  </span>
+                </label>
               </div>
-              <span
-                class="c24"
-                style="width: 0px;"
+            </div>
+          </div>
+          <div
+            class="c7"
+          />
+          <div
+            class="c8 "
+          >
+            <label
+              class="c9"
+              for="data-enabled"
+            >
+              enabled
+            </label>
+            <div
+              class="c10 FormField__FormFieldContentBox-sc-m9hood-1"
+            >
+              <div
+                class="c11 StyledCheckBoxGroup-sc-2nhc5d-0"
+                id="data-enabled"
+                role="group"
               >
-                4.8999999999999995
-              </span>
+                <label
+                  class="c12"
+                  label="true"
+                >
+                  <div
+                    class="c13 c14"
+                  >
+                    <input
+                      class="c15"
+                      type="checkbox"
+                    />
+                    <div
+                      class="c16 "
+                    />
+                  </div>
+                  <span>
+                    true
+                  </span>
+                </label>
+                <div
+                  class="c17"
+                />
+                <label
+                  class="c12"
+                  label="false"
+                >
+                  <div
+                    class="c13 c14"
+                  >
+                    <input
+                      class="c15"
+                      type="checkbox"
+                    />
+                    <div
+                      class="c16 "
+                    />
+                  </div>
+                  <span>
+                    false
+                  </span>
+                </label>
+              </div>
+            </div>
+          </div>
+          <div
+            class="c7"
+          />
+          <div
+            class="c8 "
+          >
+            <label
+              class="c9"
+              for="data-rating"
+            >
+              rating
+            </label>
+            <div
+              class="c10 FormField__FormFieldContentBox-sc-m9hood-1"
+            >
+              <div
+                class="c18"
+                id="data-rating"
+              >
+                <span
+                  class="c19"
+                  style="width: 0px;"
+                >
+                  2.0999999999999996
+                </span>
+                <div
+                  class="c20 c21"
+                  tabindex="-1"
+                >
+                  <div
+                    class="c22"
+                    style="flex: 0 0 0px;"
+                  />
+                  <div
+                    class="c23"
+                    style="flex: 0 0 1px;"
+                  >
+                    <div
+                      aria-label="Lower Bounds"
+                      aria-valuemax="4.8999999999999995"
+                      aria-valuemin="2.0999999999999996"
+                      aria-valuenow="2.0999999999999996"
+                      class="c24"
+                      role="slider"
+                      style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 1;"
+                      tabindex="0"
+                    >
+                      <div
+                        class="c25 EdgeControl__StyledBox-sc-1xo2yt9-0"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="c26"
+                    style="flex: 3.8 0 0px; cursor: ew-resize;"
+                  />
+                  <div
+                    class="c23"
+                    style="flex: 0 0 1px;"
+                  >
+                    <div
+                      aria-label="Upper Bounds"
+                      aria-valuemax="4.8999999999999995"
+                      aria-valuemin="2.0999999999999996"
+                      aria-valuenow="4.8999999999999995"
+                      class="c24"
+                      role="slider"
+                      style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 1;"
+                      tabindex="0"
+                    >
+                      <div
+                        class="c25 EdgeControl__StyledBox-sc-1xo2yt9-0"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="c22"
+                    style="flex: 0 0 0px;"
+                  />
+                </div>
+                <span
+                  class="c27"
+                  style="width: 0px;"
+                >
+                  4.8999999999999995
+                </span>
+              </div>
             </div>
           </div>
         </div>
-        <div
-          class="c5"
-        />
         <footer
-          class="c3"
+          class="c5"
         >
           <button
-            class="c25"
+            class="c28"
             type="submit"
           >
             Apply filters
           </button>
           <div
-            class="c26"
+            class="c29"
           />
           <button
             aria-hidden="true"
-            class="c27 c28"
+            class="c30 c31"
             disabled=""
             tabindex="-1"
             type="reset"
@@ -2320,7 +2451,7 @@ exports[`Data onView 1`] = `
       </div>
     </form>
     <table
-      class="c29 c30"
+      class="c32 c33"
     >
       <thead
         class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -2329,84 +2460,84 @@ exports[`Data onView 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c31 "
+            class="c34 "
             scope="col"
           >
             <div
-              class="c32"
+              class="c35"
             />
           </th>
           <th
-            class="c31 "
+            class="c34 "
             scope="col"
           >
             <div
-              class="c32"
+              class="c35"
             />
           </th>
           <th
-            class="c31 "
+            class="c34 "
             scope="col"
           >
             <div
-              class="c32"
+              class="c35"
             />
           </th>
           <th
-            class="c31 "
+            class="c34 "
             scope="col"
           >
             <div
-              class="c32"
+              class="c35"
             />
           </th>
         </tr>
       </thead>
       <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c33"
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c36"
       >
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c34 "
+            class="c37 "
             scope="row"
           >
             <div
-              class="c9"
+              class="c11"
             >
               <span
-                class="c35"
+                class="c38"
               >
                 aa
               </span>
             </div>
           </th>
           <td
-            class="c34 "
+            class="c37 "
           >
             <div
-              class="c9"
+              class="c11"
             />
           </td>
           <td
-            class="c34 "
+            class="c37 "
           >
             <div
-              class="c9"
+              class="c11"
             >
               <span
-                class="c36"
+                class="c39"
               >
                 2.3
               </span>
             </div>
           </td>
           <td
-            class="c34 "
+            class="c37 "
           >
             <div
-              class="c9"
+              class="c11"
             />
           </td>
         </tr>
@@ -2414,44 +2545,44 @@ exports[`Data onView 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c34 "
+            class="c37 "
             scope="row"
           >
             <div
-              class="c9"
+              class="c11"
             >
               <span
-                class="c35"
+                class="c38"
               >
                 bb
               </span>
             </div>
           </th>
           <td
-            class="c34 "
+            class="c37 "
           >
             <div
-              class="c9"
+              class="c11"
             />
           </td>
           <td
-            class="c34 "
+            class="c37 "
           >
             <div
-              class="c9"
+              class="c11"
             >
               <span
-                class="c36"
+                class="c39"
               >
                 4.3
               </span>
             </div>
           </td>
           <td
-            class="c34 "
+            class="c37 "
           >
             <div
-              class="c9"
+              class="c11"
             />
           </td>
         </tr>
@@ -2459,38 +2590,38 @@ exports[`Data onView 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c34 "
+            class="c37 "
             scope="row"
           >
             <div
-              class="c9"
+              class="c11"
             >
               <span
-                class="c35"
+                class="c38"
               >
                 cc
               </span>
             </div>
           </th>
           <td
-            class="c34 "
+            class="c37 "
           >
             <div
-              class="c9"
+              class="c11"
             />
           </td>
           <td
-            class="c34 "
+            class="c37 "
           >
             <div
-              class="c9"
+              class="c11"
             />
           </td>
           <td
-            class="c34 "
+            class="c37 "
           >
             <div
-              class="c9"
+              class="c11"
             />
           </td>
         </tr>
@@ -2498,38 +2629,38 @@ exports[`Data onView 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c34 "
+            class="c37 "
             scope="row"
           >
             <div
-              class="c9"
+              class="c11"
             >
               <span
-                class="c35"
+                class="c38"
               >
                 dd
               </span>
             </div>
           </th>
           <td
-            class="c34 "
+            class="c37 "
           >
             <div
-              class="c9"
+              class="c11"
             />
           </td>
           <td
-            class="c34 "
+            class="c37 "
           >
             <div
-              class="c9"
+              class="c11"
             />
           </td>
           <td
-            class="c34 "
+            class="c37 "
           >
             <div
-              class="c9"
+              class="c11"
             />
           </td>
         </tr>
@@ -3640,7 +3771,7 @@ exports[`Data renders 1`] = `
 `;
 
 exports[`Data toolbar 1`] = `
-.c6 {
+.c8 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -3651,25 +3782,25 @@ exports[`Data toolbar 1`] = `
   stroke: #666666;
 }
 
-.c6 g {
+.c8 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c6 *:not([stroke])[fill="none"] {
+.c8 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c6 *[stroke*="#"],
-.c6 *[STROKE*="#"] {
+.c8 *[stroke*="#"],
+.c8 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c6 *[fill-rule],
-.c6 *[FILL-RULE],
-.c6 *[fill*="#"],
-.c6 *[FILL*="#"] {
+.c8 *[fill-rule],
+.c8 *[FILL-RULE],
+.c8 *[fill*="#"],
+.c8 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -3701,7 +3832,40 @@ exports[`Data toolbar 1`] = `
   flex: 0 0 auto;
 }
 
-.c8 {
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 100%;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  overflow: auto;
+}
+
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3718,7 +3882,7 @@ exports[`Data toolbar 1`] = `
   flex: 0 0 auto;
 }
 
-.c14 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3739,7 +3903,7 @@ exports[`Data toolbar 1`] = `
   justify-content: center;
 }
 
-.c17 {
+.c19 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3780,25 +3944,25 @@ exports[`Data toolbar 1`] = `
   row-gap: 12px;
 }
 
-.c10 {
+.c12 {
   margin-top: 6px;
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
 }
 
-.c18 {
+.c20 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
 }
 
-.c19 {
+.c21 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c9 {
+.c11 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -3818,9 +3982,66 @@ exports[`Data toolbar 1`] = `
   padding: 12px;
 }
 
-.c9:hover {
+.c11:hover {
   background-color: rgba(221,221,221,0.4);
   color: #000000;
+}
+
+.c11:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus > circle,
+.c11:focus > ellipse,
+.c11:focus > line,
+.c11:focus > path,
+.c11:focus > polygon,
+.c11:focus > polyline,
+.c11:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c11:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c11:focus:not(:focus-visible) > circle,
+.c11:focus:not(:focus-visible) > ellipse,
+.c11:focus:not(:focus-visible) > line,
+.c11:focus:not(:focus-visible) > path,
+.c11:focus:not(:focus-visible) > polygon,
+.c11:focus:not(:focus-visible) > polyline,
+.c11:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c11:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c9 {
+  box-sizing: border-box;
+  font-size: inherit;
+  font-family: inherit;
+  border: none;
+  -webkit-appearance: none;
+  background: transparent;
+  color: inherit;
+  width: 100%;
+  padding: 11px;
+  font-weight: 600;
+  margin: 0;
+  border: 1px solid rgba(0,0,0,0.33);
+  border-radius: 4px;
+  padding-left: 48px;
 }
 
 .c9:focus {
@@ -3843,95 +4064,38 @@ exports[`Data toolbar 1`] = `
   border: 0;
 }
 
-.c9:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c9:focus:not(:focus-visible) > circle,
-.c9:focus:not(:focus-visible) > ellipse,
-.c9:focus:not(:focus-visible) > line,
-.c9:focus:not(:focus-visible) > path,
-.c9:focus:not(:focus-visible) > polygon,
-.c9:focus:not(:focus-visible) > polyline,
-.c9:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c9:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c7 {
-  box-sizing: border-box;
-  font-size: inherit;
-  font-family: inherit;
-  border: none;
-  -webkit-appearance: none;
-  background: transparent;
-  color: inherit;
-  width: 100%;
-  padding: 11px;
-  font-weight: 600;
-  margin: 0;
-  border: 1px solid rgba(0,0,0,0.33);
-  border-radius: 4px;
-  padding-left: 48px;
-}
-
-.c7:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c7:focus > circle,
-.c7:focus > ellipse,
-.c7:focus > line,
-.c7:focus > path,
-.c7:focus > polygon,
-.c7:focus > polyline,
-.c7:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c7:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c7::-webkit-input-placeholder {
+.c9::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-moz-placeholder {
+.c9::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c7:-ms-input-placeholder {
+.c9:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-webkit-search-decoration {
+.c9::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c7::-moz-focus-inner {
+.c9::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c7:-moz-placeholder,
-.c7::-moz-placeholder {
+.c9:-moz-placeholder,
+.c9::-moz-placeholder {
   opacity: 1;
 }
 
-.c4 {
+.c6 {
   position: relative;
   width: 100%;
 }
 
-.c5 {
+.c7 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -3953,7 +4117,7 @@ exports[`Data toolbar 1`] = `
   max-width: 100%;
 }
 
-.c13 {
+.c15 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -3966,7 +4130,7 @@ exports[`Data toolbar 1`] = `
   padding-bottom: 6px;
 }
 
-.c16 {
+.c18 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -3978,23 +4142,23 @@ exports[`Data toolbar 1`] = `
   padding-bottom: 6px;
 }
 
-.c11 {
+.c13 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
 }
 
-.c12 {
+.c14 {
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
 }
 
-.c15:focus {
+.c17:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c15:focus:not(:focus-visible) {
+.c17:focus:not(:focus-visible) {
   outline: none;
 }
 
@@ -4023,51 +4187,55 @@ exports[`Data toolbar 1`] = `
         class="c3"
       >
         <div
-          class="c1"
+          class="c4"
         >
           <div
-            class="c4"
+            class="c5"
           >
             <div
-              class="c5"
+              class="c6"
             >
-              <svg
-                aria-label="Search"
-                class="c6"
-                viewBox="0 0 24 24"
+              <div
+                class="c7"
               >
-                <path
-                  d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                  fill="none"
-                  stroke="#000"
-                  stroke-width="2"
-                />
-              </svg>
+                <svg
+                  aria-label="Search"
+                  class="c8"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                    fill="none"
+                    stroke="#000"
+                    stroke-width="2"
+                  />
+                </svg>
+              </div>
+              <input
+                aria-label="Search data"
+                autocomplete="off"
+                class="c9"
+                id="data--search"
+                name="_search"
+                type="search"
+                value=""
+              />
             </div>
-            <input
-              aria-label="Search data"
-              autocomplete="off"
-              class="c7"
-              id="data--search"
-              name="_search"
-              type="search"
-              value=""
-            />
           </div>
         </div>
       </form>
       <div
-        class="c8"
+        class="c10"
       >
         <button
           aria-label="Open filters"
-          class="c9"
+          class="c11"
           id="data--filters-control"
           type="button"
         >
           <svg
             aria-label="Filter"
-            class="c6"
+            class="c8"
             viewBox="0 0 24 24"
           >
             <path
@@ -4081,12 +4249,12 @@ exports[`Data toolbar 1`] = `
       </div>
     </div>
     <span
-      class="c10"
+      class="c12"
     >
       4 items
     </span>
     <table
-      class="c11 c12"
+      class="c13 c14"
     >
       <thead
         class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -4095,51 +4263,51 @@ exports[`Data toolbar 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c13 "
+            class="c15 "
             scope="col"
           >
             <div
-              class="c14"
+              class="c16"
             />
           </th>
           <th
-            class="c13 "
+            class="c15 "
             scope="col"
           >
             <div
-              class="c14"
+              class="c16"
             />
           </th>
         </tr>
       </thead>
       <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c15"
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c17"
       >
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c16 "
+            class="c18 "
             scope="row"
           >
             <div
-              class="c17"
+              class="c19"
             >
               <span
-                class="c18"
+                class="c20"
               >
                 aa
               </span>
             </div>
           </th>
           <td
-            class="c16 "
+            class="c18 "
           >
             <div
-              class="c17"
+              class="c19"
             >
               <span
-                class="c19"
+                class="c21"
               >
                 ZZ
               </span>
@@ -4150,27 +4318,27 @@ exports[`Data toolbar 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c16 "
+            class="c18 "
             scope="row"
           >
             <div
-              class="c17"
+              class="c19"
             >
               <span
-                class="c18"
+                class="c20"
               >
                 bb
               </span>
             </div>
           </th>
           <td
-            class="c16 "
+            class="c18 "
           >
             <div
-              class="c17"
+              class="c19"
             >
               <span
-                class="c19"
+                class="c21"
               >
                 YY
               </span>
@@ -4181,24 +4349,24 @@ exports[`Data toolbar 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c16 "
+            class="c18 "
             scope="row"
           >
             <div
-              class="c17"
+              class="c19"
             >
               <span
-                class="c18"
+                class="c20"
               >
                 cc
               </span>
             </div>
           </th>
           <td
-            class="c16 "
+            class="c18 "
           >
             <div
-              class="c17"
+              class="c19"
             />
           </td>
         </tr>
@@ -4206,24 +4374,24 @@ exports[`Data toolbar 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c16 "
+            class="c18 "
             scope="row"
           >
             <div
-              class="c17"
+              class="c19"
             >
               <span
-                class="c18"
+                class="c20"
               >
                 dd
               </span>
             </div>
           </th>
           <td
-            class="c16 "
+            class="c18 "
           >
             <div
-              class="c17"
+              class="c19"
             />
           </td>
         </tr>
@@ -4648,7 +4816,7 @@ exports[`Data toolbar filters 1`] = `
 `;
 
 exports[`Data toolbar search 1`] = `
-.c6 {
+.c8 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -4659,25 +4827,25 @@ exports[`Data toolbar search 1`] = `
   stroke: #666666;
 }
 
-.c6 g {
+.c8 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c6 *:not([stroke])[fill="none"] {
+.c8 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c6 *[stroke*="#"],
-.c6 *[STROKE*="#"] {
+.c8 *[stroke*="#"],
+.c8 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c6 *[fill-rule],
-.c6 *[FILL-RULE],
-.c6 *[fill*="#"],
-.c6 *[FILL*="#"] {
+.c8 *[fill-rule],
+.c8 *[FILL-RULE],
+.c8 *[fill*="#"],
+.c8 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -4707,428 +4875,9 @@ exports[`Data toolbar search 1`] = `
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-}
-
-.c12 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-}
-
-.c15 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-column-gap: 12px;
-  column-gap: 12px;
-  row-gap: 12px;
-}
-
-.c8 {
-  margin-top: 6px;
-  margin-bottom: 6px;
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c16 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c7 {
-  box-sizing: border-box;
-  font-size: inherit;
-  font-family: inherit;
-  border: none;
-  -webkit-appearance: none;
-  background: transparent;
-  color: inherit;
-  width: 100%;
-  padding: 11px;
-  font-weight: 600;
-  margin: 0;
-  border: 1px solid rgba(0,0,0,0.33);
-  border-radius: 4px;
-  padding-left: 48px;
-}
-
-.c7:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c7:focus > circle,
-.c7:focus > ellipse,
-.c7:focus > line,
-.c7:focus > path,
-.c7:focus > polygon,
-.c7:focus > polyline,
-.c7:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c7:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c7::-webkit-input-placeholder {
-  color: #AAAAAA;
-}
-
-.c7::-moz-placeholder {
-  color: #AAAAAA;
-}
-
-.c7:-ms-input-placeholder {
-  color: #AAAAAA;
-}
-
-.c7::-webkit-search-decoration {
-  -webkit-appearance: none;
-}
-
-.c7::-moz-focus-inner {
-  border: none;
-  outline: none;
-}
-
-.c7:-moz-placeholder,
-.c7::-moz-placeholder {
-  opacity: 1;
 }
 
 .c4 {
-  position: relative;
-  width: 100%;
-}
-
-.c5 {
-  position: absolute;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-packjustify: center;
-  -webkit-justify: center;
-  -ms-flex-packjustify: center;
-  justify: center;
-  top: 50%;
-  -webkit-transform: translateY(-50%);
-  -ms-transform: translateY(-50%);
-  transform: translateY(-50%);
-  pointer-events: none;
-  left: 12px;
-}
-
-.c3 {
-  max-width: 100%;
-}
-
-.c11 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-.c14 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-.c9 {
-  border-spacing: 0;
-  border-collapse: collapse;
-  width: inherit;
-}
-
-.c10 {
-  position: relative;
-  border-spacing: 0;
-  border-collapse: separate;
-}
-
-.c13:focus {
-  outline: 2px solid #6FFFB0;
-}
-
-.c13:focus:not(:focus-visible) {
-  outline: none;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-  .c2 {
-    -webkit-column-gap: 6px;
-    column-gap: 6px;
-  }
-}
-
-<div
-  class="c0"
->
-  <div
-    class="c1"
-    id="data"
-  >
-    <div
-      class="c2"
-    >
-      <form
-        class="c3"
-      >
-        <div
-          class="c1"
-        >
-          <div
-            class="c4"
-          >
-            <div
-              class="c5"
-            >
-              <svg
-                aria-label="Search"
-                class="c6"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                  fill="none"
-                  stroke="#000"
-                  stroke-width="2"
-                />
-              </svg>
-            </div>
-            <input
-              aria-label="Search data"
-              autocomplete="off"
-              class="c7"
-              id="data--search"
-              name="_search"
-              type="search"
-              value=""
-            />
-          </div>
-        </div>
-      </form>
-    </div>
-    <span
-      class="c8"
-    >
-      4 items
-    </span>
-    <table
-      class="c9 c10"
-    >
-      <thead
-        class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
-      >
-        <tr
-          class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
-        >
-          <th
-            class="c11 "
-            scope="col"
-          >
-            <div
-              class="c12"
-            />
-          </th>
-        </tr>
-      </thead>
-      <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c13"
-      >
-        <tr
-          class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
-        >
-          <th
-            class="c14 "
-            scope="row"
-          >
-            <div
-              class="c15"
-            >
-              <span
-                class="c16"
-              >
-                aa
-              </span>
-            </div>
-          </th>
-        </tr>
-        <tr
-          class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
-        >
-          <th
-            class="c14 "
-            scope="row"
-          >
-            <div
-              class="c15"
-            >
-              <span
-                class="c16"
-              >
-                bb
-              </span>
-            </div>
-          </th>
-        </tr>
-        <tr
-          class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
-        >
-          <th
-            class="c14 "
-            scope="row"
-          >
-            <div
-              class="c15"
-            >
-              <span
-                class="c16"
-              >
-                cc
-              </span>
-            </div>
-          </th>
-        </tr>
-        <tr
-          class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
-        >
-          <th
-            class="c14 "
-            scope="row"
-          >
-            <div
-              class="c15"
-            >
-              <span
-                class="c16"
-              >
-                dd
-              </span>
-            </div>
-          </th>
-        </tr>
-      </tbody>
-    </table>
-  </div>
-</div>
-`;
-
-exports[`Data uncontrolled search 1`] = `
-.c6 {
-  display: inline-block;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
-  fill: #666666;
-  stroke: #666666;
-}
-
-.c6 g {
-  fill: inherit;
-  stroke: inherit;
-}
-
-.c6 *:not([stroke])[fill="none"] {
-  stroke-width: 0;
-}
-
-.c6 *[stroke*="#"],
-.c6 *[STROKE*="#"] {
-  stroke: inherit;
-  fill: none;
-}
-
-.c6 *[fill-rule],
-.c6 *[FILL-RULE],
-.c6 *[fill*="#"],
-.c6 *[FILL*="#"] {
-  fill: inherit;
-  stroke: none;
-}
-
-.c0 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
-.c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5140,12 +4889,10 @@ exports[`Data uncontrolled search 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
+  height: 100%;
 }
 
-.c8 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5154,12 +4901,13 @@ exports[`Data uncontrolled search 1`] = `
   max-width: 100%;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  overflow: auto;
 }
 
 .c14 {
@@ -5238,28 +4986,20 @@ exports[`Data uncontrolled search 1`] = `
 }
 
 .c9 {
-  display: inline-block;
   box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  color: inherit;
-  outline: none;
+  font-size: inherit;
+  font-family: inherit;
   border: none;
-  padding: 0;
-  text-align: inherit;
-  line-height: 0;
-  padding: 12px;
-}
-
-.c9:hover {
-  background-color: rgba(221,221,221,0.4);
-  color: #000000;
+  -webkit-appearance: none;
+  background: transparent;
+  color: inherit;
+  width: 100%;
+  padding: 11px;
+  font-weight: 600;
+  margin: 0;
+  border: 1px solid rgba(0,0,0,0.33);
+  border-radius: 4px;
+  padding-left: 48px;
 }
 
 .c9:focus {
@@ -5282,95 +5022,38 @@ exports[`Data uncontrolled search 1`] = `
   border: 0;
 }
 
-.c9:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c9:focus:not(:focus-visible) > circle,
-.c9:focus:not(:focus-visible) > ellipse,
-.c9:focus:not(:focus-visible) > line,
-.c9:focus:not(:focus-visible) > path,
-.c9:focus:not(:focus-visible) > polygon,
-.c9:focus:not(:focus-visible) > polyline,
-.c9:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c9:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c7 {
-  box-sizing: border-box;
-  font-size: inherit;
-  font-family: inherit;
-  border: none;
-  -webkit-appearance: none;
-  background: transparent;
-  color: inherit;
-  width: 100%;
-  padding: 11px;
-  font-weight: 600;
-  margin: 0;
-  border: 1px solid rgba(0,0,0,0.33);
-  border-radius: 4px;
-  padding-left: 48px;
-}
-
-.c7:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c7:focus > circle,
-.c7:focus > ellipse,
-.c7:focus > line,
-.c7:focus > path,
-.c7:focus > polygon,
-.c7:focus > polyline,
-.c7:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c7:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c7::-webkit-input-placeholder {
+.c9::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-moz-placeholder {
+.c9::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c7:-ms-input-placeholder {
+.c9:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-webkit-search-decoration {
+.c9::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c7::-moz-focus-inner {
+.c9::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c7:-moz-placeholder,
-.c7::-moz-placeholder {
+.c9:-moz-placeholder,
+.c9::-moz-placeholder {
   opacity: 1;
 }
 
-.c4 {
+.c6 {
   position: relative;
   width: 100%;
 }
 
-.c5 {
+.c7 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -5462,62 +5145,43 @@ exports[`Data uncontrolled search 1`] = `
         class="c3"
       >
         <div
-          class="c1"
+          class="c4"
         >
           <div
-            class="c4"
+            class="c5"
           >
             <div
-              class="c5"
+              class="c6"
             >
-              <svg
-                aria-label="Search"
-                class="c6"
-                viewBox="0 0 24 24"
+              <div
+                class="c7"
               >
-                <path
-                  d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                  fill="none"
-                  stroke="#000"
-                  stroke-width="2"
-                />
-              </svg>
+                <svg
+                  aria-label="Search"
+                  class="c8"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                    fill="none"
+                    stroke="#000"
+                    stroke-width="2"
+                  />
+                </svg>
+              </div>
+              <input
+                aria-label="Search data"
+                autocomplete="off"
+                class="c9"
+                id="data--search"
+                name="_search"
+                type="search"
+                value=""
+              />
             </div>
-            <input
-              aria-label="Search data"
-              autocomplete="off"
-              class="c7"
-              id="data--search"
-              name="_search"
-              type="search"
-              value=""
-            />
           </div>
         </div>
       </form>
-      <div
-        class="c8"
-      >
-        <button
-          aria-label="Open filters"
-          class="c9"
-          id="data--filters-control"
-          type="button"
-        >
-          <svg
-            aria-label="Filter"
-            class="c6"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="m3 6 7 7v8h4v-8l7-7V3H3z"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-      </div>
     </div>
     <span
       class="c10"
@@ -5624,6 +5288,584 @@ exports[`Data uncontrolled search 1`] = `
 </div>
 `;
 
+exports[`Data uncontrolled search 1`] = `
+.c8 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #666666;
+  stroke: #666666;
+}
+
+.c8 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c8 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c8 *[stroke*="#"],
+.c8 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c8 *[fill-rule],
+.c8 *[FILL-RULE],
+.c8 *[fill*="#"],
+.c8 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 100%;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  overflow: auto;
+}
+
+.c10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c16 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c19 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-column-gap: 12px;
+  column-gap: 12px;
+  row-gap: 12px;
+}
+
+.c12 {
+  margin-top: 6px;
+  margin-bottom: 6px;
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c20 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c11 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  line-height: 0;
+  padding: 12px;
+}
+
+.c11:hover {
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
+}
+
+.c11:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus > circle,
+.c11:focus > ellipse,
+.c11:focus > line,
+.c11:focus > path,
+.c11:focus > polygon,
+.c11:focus > polyline,
+.c11:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c11:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c11:focus:not(:focus-visible) > circle,
+.c11:focus:not(:focus-visible) > ellipse,
+.c11:focus:not(:focus-visible) > line,
+.c11:focus:not(:focus-visible) > path,
+.c11:focus:not(:focus-visible) > polygon,
+.c11:focus:not(:focus-visible) > polyline,
+.c11:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c11:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c9 {
+  box-sizing: border-box;
+  font-size: inherit;
+  font-family: inherit;
+  border: none;
+  -webkit-appearance: none;
+  background: transparent;
+  color: inherit;
+  width: 100%;
+  padding: 11px;
+  font-weight: 600;
+  margin: 0;
+  border: 1px solid rgba(0,0,0,0.33);
+  border-radius: 4px;
+  padding-left: 48px;
+}
+
+.c9:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9:focus > circle,
+.c9:focus > ellipse,
+.c9:focus > line,
+.c9:focus > path,
+.c9:focus > polygon,
+.c9:focus > polyline,
+.c9:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c9::-webkit-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c9::-moz-placeholder {
+  color: #AAAAAA;
+}
+
+.c9:-ms-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c9::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+.c9::-moz-focus-inner {
+  border: none;
+  outline: none;
+}
+
+.c9:-moz-placeholder,
+.c9::-moz-placeholder {
+  opacity: 1;
+}
+
+.c6 {
+  position: relative;
+  width: 100%;
+}
+
+.c7 {
+  position: absolute;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-packjustify: center;
+  -webkit-justify: center;
+  -ms-flex-packjustify: center;
+  justify: center;
+  top: 50%;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  pointer-events: none;
+  left: 12px;
+}
+
+.c3 {
+  max-width: 100%;
+}
+
+.c15 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c18 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c13 {
+  border-spacing: 0;
+  border-collapse: collapse;
+  width: inherit;
+}
+
+.c14 {
+  position: relative;
+  border-spacing: 0;
+  border-collapse: separate;
+}
+
+.c17:focus {
+  outline: 2px solid #6FFFB0;
+}
+
+.c17:focus:not(:focus-visible) {
+  outline: none;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    -webkit-column-gap: 6px;
+    column-gap: 6px;
+  }
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+    id="data"
+  >
+    <div
+      class="c2"
+    >
+      <form
+        class="c3"
+      >
+        <div
+          class="c4"
+        >
+          <div
+            class="c5"
+          >
+            <div
+              class="c6"
+            >
+              <div
+                class="c7"
+              >
+                <svg
+                  aria-label="Search"
+                  class="c8"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                    fill="none"
+                    stroke="#000"
+                    stroke-width="2"
+                  />
+                </svg>
+              </div>
+              <input
+                aria-label="Search data"
+                autocomplete="off"
+                class="c9"
+                id="data--search"
+                name="_search"
+                type="search"
+                value=""
+              />
+            </div>
+          </div>
+        </div>
+      </form>
+      <div
+        class="c10"
+      >
+        <button
+          aria-label="Open filters"
+          class="c11"
+          id="data--filters-control"
+          type="button"
+        >
+          <svg
+            aria-label="Filter"
+            class="c8"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="m3 6 7 7v8h4v-8l7-7V3H3z"
+              fill="none"
+              stroke="#000"
+              stroke-width="2"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+    <span
+      class="c12"
+    >
+      4 items
+    </span>
+    <table
+      class="c13 c14"
+    >
+      <thead
+        class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
+      >
+        <tr
+          class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+        >
+          <th
+            class="c15 "
+            scope="col"
+          >
+            <div
+              class="c16"
+            />
+          </th>
+        </tr>
+      </thead>
+      <tbody
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c17"
+      >
+        <tr
+          class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+        >
+          <th
+            class="c18 "
+            scope="row"
+          >
+            <div
+              class="c19"
+            >
+              <span
+                class="c20"
+              >
+                aa
+              </span>
+            </div>
+          </th>
+        </tr>
+        <tr
+          class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+        >
+          <th
+            class="c18 "
+            scope="row"
+          >
+            <div
+              class="c19"
+            >
+              <span
+                class="c20"
+              >
+                bb
+              </span>
+            </div>
+          </th>
+        </tr>
+        <tr
+          class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+        >
+          <th
+            class="c18 "
+            scope="row"
+          >
+            <div
+              class="c19"
+            >
+              <span
+                class="c20"
+              >
+                cc
+              </span>
+            </div>
+          </th>
+        </tr>
+        <tr
+          class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+        >
+          <th
+            class="c18 "
+            scope="row"
+          >
+            <div
+              class="c19"
+            >
+              <span
+                class="c20"
+              >
+                dd
+              </span>
+            </div>
+          </th>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+`;
+
 exports[`Data uncontrolled search 2`] = `
 <div
   class="StyledGrommet-sc-19lkkz7-0 ioQEen"
@@ -5636,39 +5878,43 @@ exports[`Data uncontrolled search 2`] = `
       class="StyledBox-sc-13pk1d4-0 cA-DryL"
     >
       <form
-        class="DataForm__MaxForm-sc-v64e1r-1 hpHcfX"
+        class="DataForm__MaxForm-sc-v64e1r-1 dKlaJO"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 hoPFxc"
+          class="StyledBox-sc-13pk1d4-0 eMuiZr"
         >
           <div
-            class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 edcgVv"
+            class="StyledBox-sc-13pk1d4-0 dePIJN"
           >
             <div
-              class="StyledTextInput__StyledIcon-sc-1x30a0s-3 cFBrkA"
+              class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 edcgVv"
             >
-              <svg
-                aria-label="Search"
-                class="StyledIcon-sc-ofa7kd-0 jQvEgu"
-                viewBox="0 0 24 24"
+              <div
+                class="StyledTextInput__StyledIcon-sc-1x30a0s-3 cFBrkA"
               >
-                <path
-                  d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                  fill="none"
-                  stroke="#000"
-                  stroke-width="2"
-                />
-              </svg>
+                <svg
+                  aria-label="Search"
+                  class="StyledIcon-sc-ofa7kd-0 jQvEgu"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                    fill="none"
+                    stroke="#000"
+                    stroke-width="2"
+                  />
+                </svg>
+              </div>
+              <input
+                aria-label="Search data"
+                autocomplete="off"
+                class="StyledTextInput-sc-1x30a0s-0 bMqJAS"
+                id="data--search"
+                name="_search"
+                type="search"
+                value="a"
+              />
             </div>
-            <input
-              aria-label="Search data"
-              autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 bMqJAS"
-              id="data--search"
-              name="_search"
-              type="search"
-              value="a"
-            />
           </div>
         </div>
       </form>
@@ -6022,7 +6268,7 @@ exports[`Data view 1`] = `
 `;
 
 exports[`Data view all 1`] = `
-.c6 {
+.c8 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -6033,25 +6279,25 @@ exports[`Data view all 1`] = `
   stroke: #666666;
 }
 
-.c6 g {
+.c8 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c6 *:not([stroke])[fill="none"] {
+.c8 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c6 *[stroke*="#"],
-.c6 *[STROKE*="#"] {
+.c8 *[stroke*="#"],
+.c8 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c6 *[fill-rule],
-.c6 *[FILL-RULE],
-.c6 *[fill*="#"],
-.c6 *[FILL*="#"] {
+.c8 *[fill-rule],
+.c8 *[FILL-RULE],
+.c8 *[fill*="#"],
+.c8 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -6083,7 +6329,40 @@ exports[`Data view all 1`] = `
   flex: 0 0 auto;
 }
 
-.c8 {
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 100%;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  overflow: auto;
+}
+
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6100,7 +6379,7 @@ exports[`Data view all 1`] = `
   flex: 0 0 auto;
 }
 
-.c14 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6121,7 +6400,7 @@ exports[`Data view all 1`] = `
   justify-content: center;
 }
 
-.c17 {
+.c19 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6162,25 +6441,25 @@ exports[`Data view all 1`] = `
   row-gap: 12px;
 }
 
-.c10 {
+.c12 {
   margin-top: 6px;
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
 }
 
-.c18 {
+.c20 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
 }
 
-.c19 {
+.c21 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c9 {
+.c11 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -6200,9 +6479,66 @@ exports[`Data view all 1`] = `
   padding: 12px;
 }
 
-.c9:hover {
+.c11:hover {
   background-color: rgba(221,221,221,0.4);
   color: #000000;
+}
+
+.c11:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus > circle,
+.c11:focus > ellipse,
+.c11:focus > line,
+.c11:focus > path,
+.c11:focus > polygon,
+.c11:focus > polyline,
+.c11:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c11:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c11:focus:not(:focus-visible) > circle,
+.c11:focus:not(:focus-visible) > ellipse,
+.c11:focus:not(:focus-visible) > line,
+.c11:focus:not(:focus-visible) > path,
+.c11:focus:not(:focus-visible) > polygon,
+.c11:focus:not(:focus-visible) > polyline,
+.c11:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c11:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c9 {
+  box-sizing: border-box;
+  font-size: inherit;
+  font-family: inherit;
+  border: none;
+  -webkit-appearance: none;
+  background: transparent;
+  color: inherit;
+  width: 100%;
+  padding: 11px;
+  font-weight: 600;
+  margin: 0;
+  border: 1px solid rgba(0,0,0,0.33);
+  border-radius: 4px;
+  padding-left: 48px;
 }
 
 .c9:focus {
@@ -6225,95 +6561,38 @@ exports[`Data view all 1`] = `
   border: 0;
 }
 
-.c9:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c9:focus:not(:focus-visible) > circle,
-.c9:focus:not(:focus-visible) > ellipse,
-.c9:focus:not(:focus-visible) > line,
-.c9:focus:not(:focus-visible) > path,
-.c9:focus:not(:focus-visible) > polygon,
-.c9:focus:not(:focus-visible) > polyline,
-.c9:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c9:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c7 {
-  box-sizing: border-box;
-  font-size: inherit;
-  font-family: inherit;
-  border: none;
-  -webkit-appearance: none;
-  background: transparent;
-  color: inherit;
-  width: 100%;
-  padding: 11px;
-  font-weight: 600;
-  margin: 0;
-  border: 1px solid rgba(0,0,0,0.33);
-  border-radius: 4px;
-  padding-left: 48px;
-}
-
-.c7:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c7:focus > circle,
-.c7:focus > ellipse,
-.c7:focus > line,
-.c7:focus > path,
-.c7:focus > polygon,
-.c7:focus > polyline,
-.c7:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c7:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c7::-webkit-input-placeholder {
+.c9::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-moz-placeholder {
+.c9::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c7:-ms-input-placeholder {
+.c9:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-webkit-search-decoration {
+.c9::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c7::-moz-focus-inner {
+.c9::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c7:-moz-placeholder,
-.c7::-moz-placeholder {
+.c9:-moz-placeholder,
+.c9::-moz-placeholder {
   opacity: 1;
 }
 
-.c4 {
+.c6 {
   position: relative;
   width: 100%;
 }
 
-.c5 {
+.c7 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -6335,7 +6614,7 @@ exports[`Data view all 1`] = `
   max-width: 100%;
 }
 
-.c13 {
+.c15 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -6348,7 +6627,7 @@ exports[`Data view all 1`] = `
   padding-bottom: 6px;
 }
 
-.c16 {
+.c18 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -6360,23 +6639,23 @@ exports[`Data view all 1`] = `
   padding-bottom: 6px;
 }
 
-.c11 {
+.c13 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
 }
 
-.c12 {
+.c14 {
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
 }
 
-.c15:focus {
+.c17:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c15:focus:not(:focus-visible) {
+.c17:focus:not(:focus-visible) {
   outline: none;
 }
 
@@ -6405,51 +6684,55 @@ exports[`Data view all 1`] = `
         class="c3"
       >
         <div
-          class="c1"
+          class="c4"
         >
           <div
-            class="c4"
+            class="c5"
           >
             <div
-              class="c5"
+              class="c6"
             >
-              <svg
-                aria-label="Search"
-                class="c6"
-                viewBox="0 0 24 24"
+              <div
+                class="c7"
               >
-                <path
-                  d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                  fill="none"
-                  stroke="#000"
-                  stroke-width="2"
-                />
-              </svg>
+                <svg
+                  aria-label="Search"
+                  class="c8"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                    fill="none"
+                    stroke="#000"
+                    stroke-width="2"
+                  />
+                </svg>
+              </div>
+              <input
+                aria-label="Search data"
+                autocomplete="off"
+                class="c9"
+                id="data--search"
+                name="_search"
+                type="search"
+                value="a"
+              />
             </div>
-            <input
-              aria-label="Search data"
-              autocomplete="off"
-              class="c7"
-              id="data--search"
-              name="_search"
-              type="search"
-              value="a"
-            />
           </div>
         </div>
       </form>
       <div
-        class="c8"
+        class="c10"
       >
         <button
           aria-label="Open filters"
-          class="c9"
+          class="c11"
           id="data--filters-control"
           type="button"
         >
           <svg
             aria-label="Filter"
-            class="c6"
+            class="c8"
             viewBox="0 0 24 24"
           >
             <path
@@ -6463,12 +6746,12 @@ exports[`Data view all 1`] = `
       </div>
     </div>
     <span
-      class="c10"
+      class="c12"
     >
       1 result of 4 items
     </span>
     <table
-      class="c11 c12"
+      class="c13 c14"
     >
       <thead
         class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -6477,51 +6760,51 @@ exports[`Data view all 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c13 "
+            class="c15 "
             scope="col"
           >
             <div
-              class="c14"
+              class="c16"
             />
           </th>
           <th
-            class="c13 "
+            class="c15 "
             scope="col"
           >
             <div
-              class="c14"
+              class="c16"
             />
           </th>
         </tr>
       </thead>
       <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c15"
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c17"
       >
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c16 "
+            class="c18 "
             scope="row"
           >
             <div
-              class="c17"
+              class="c19"
             >
               <span
-                class="c18"
+                class="c20"
               >
                 aa
               </span>
             </div>
           </th>
           <td
-            class="c16 "
+            class="c18 "
           >
             <div
-              class="c17"
+              class="c19"
             >
               <span
-                class="c19"
+                class="c21"
               >
                 ZZ
               </span>
@@ -6535,7 +6818,7 @@ exports[`Data view all 1`] = `
 `;
 
 exports[`Data view property option 1`] = `
-.c6 {
+.c8 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -6546,25 +6829,25 @@ exports[`Data view property option 1`] = `
   stroke: #666666;
 }
 
-.c6 g {
+.c8 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c6 *:not([stroke])[fill="none"] {
+.c8 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c6 *[stroke*="#"],
-.c6 *[STROKE*="#"] {
+.c8 *[stroke*="#"],
+.c8 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c6 *[fill-rule],
-.c6 *[FILL-RULE],
-.c6 *[fill*="#"],
-.c6 *[FILL*="#"] {
+.c8 *[fill-rule],
+.c8 *[FILL-RULE],
+.c8 *[fill*="#"],
+.c8 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -6596,7 +6879,40 @@ exports[`Data view property option 1`] = `
   flex: 0 0 auto;
 }
 
-.c8 {
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 100%;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  overflow: auto;
+}
+
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6613,7 +6929,7 @@ exports[`Data view property option 1`] = `
   flex: 0 0 auto;
 }
 
-.c14 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6634,7 +6950,7 @@ exports[`Data view property option 1`] = `
   justify-content: center;
 }
 
-.c17 {
+.c19 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6675,25 +6991,25 @@ exports[`Data view property option 1`] = `
   row-gap: 12px;
 }
 
-.c10 {
+.c12 {
   margin-top: 6px;
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
 }
 
-.c18 {
+.c20 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
 }
 
-.c19 {
+.c21 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c9 {
+.c11 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -6713,9 +7029,66 @@ exports[`Data view property option 1`] = `
   padding: 12px;
 }
 
-.c9:hover {
+.c11:hover {
   background-color: rgba(221,221,221,0.4);
   color: #000000;
+}
+
+.c11:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus > circle,
+.c11:focus > ellipse,
+.c11:focus > line,
+.c11:focus > path,
+.c11:focus > polygon,
+.c11:focus > polyline,
+.c11:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c11:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c11:focus:not(:focus-visible) > circle,
+.c11:focus:not(:focus-visible) > ellipse,
+.c11:focus:not(:focus-visible) > line,
+.c11:focus:not(:focus-visible) > path,
+.c11:focus:not(:focus-visible) > polygon,
+.c11:focus:not(:focus-visible) > polyline,
+.c11:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c11:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c9 {
+  box-sizing: border-box;
+  font-size: inherit;
+  font-family: inherit;
+  border: none;
+  -webkit-appearance: none;
+  background: transparent;
+  color: inherit;
+  width: 100%;
+  padding: 11px;
+  font-weight: 600;
+  margin: 0;
+  border: 1px solid rgba(0,0,0,0.33);
+  border-radius: 4px;
+  padding-left: 48px;
 }
 
 .c9:focus {
@@ -6738,95 +7111,38 @@ exports[`Data view property option 1`] = `
   border: 0;
 }
 
-.c9:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c9:focus:not(:focus-visible) > circle,
-.c9:focus:not(:focus-visible) > ellipse,
-.c9:focus:not(:focus-visible) > line,
-.c9:focus:not(:focus-visible) > path,
-.c9:focus:not(:focus-visible) > polygon,
-.c9:focus:not(:focus-visible) > polyline,
-.c9:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c9:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c7 {
-  box-sizing: border-box;
-  font-size: inherit;
-  font-family: inherit;
-  border: none;
-  -webkit-appearance: none;
-  background: transparent;
-  color: inherit;
-  width: 100%;
-  padding: 11px;
-  font-weight: 600;
-  margin: 0;
-  border: 1px solid rgba(0,0,0,0.33);
-  border-radius: 4px;
-  padding-left: 48px;
-}
-
-.c7:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c7:focus > circle,
-.c7:focus > ellipse,
-.c7:focus > line,
-.c7:focus > path,
-.c7:focus > polygon,
-.c7:focus > polyline,
-.c7:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c7:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c7::-webkit-input-placeholder {
+.c9::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-moz-placeholder {
+.c9::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c7:-ms-input-placeholder {
+.c9:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-webkit-search-decoration {
+.c9::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c7::-moz-focus-inner {
+.c9::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c7:-moz-placeholder,
-.c7::-moz-placeholder {
+.c9:-moz-placeholder,
+.c9::-moz-placeholder {
   opacity: 1;
 }
 
-.c4 {
+.c6 {
   position: relative;
   width: 100%;
 }
 
-.c5 {
+.c7 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -6848,7 +7164,7 @@ exports[`Data view property option 1`] = `
   max-width: 100%;
 }
 
-.c13 {
+.c15 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -6861,7 +7177,7 @@ exports[`Data view property option 1`] = `
   padding-bottom: 6px;
 }
 
-.c16 {
+.c18 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -6873,23 +7189,23 @@ exports[`Data view property option 1`] = `
   padding-bottom: 6px;
 }
 
-.c11 {
+.c13 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
 }
 
-.c12 {
+.c14 {
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
 }
 
-.c15:focus {
+.c17:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c15:focus:not(:focus-visible) {
+.c17:focus:not(:focus-visible) {
   outline: none;
 }
 
@@ -6918,51 +7234,55 @@ exports[`Data view property option 1`] = `
         class="c3"
       >
         <div
-          class="c1"
+          class="c4"
         >
           <div
-            class="c4"
+            class="c5"
           >
             <div
-              class="c5"
+              class="c6"
             >
-              <svg
-                aria-label="Search"
-                class="c6"
-                viewBox="0 0 24 24"
+              <div
+                class="c7"
               >
-                <path
-                  d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                  fill="none"
-                  stroke="#000"
-                  stroke-width="2"
-                />
-              </svg>
+                <svg
+                  aria-label="Search"
+                  class="c8"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                    fill="none"
+                    stroke="#000"
+                    stroke-width="2"
+                  />
+                </svg>
+              </div>
+              <input
+                aria-label="Search data"
+                autocomplete="off"
+                class="c9"
+                id="data--search"
+                name="_search"
+                type="search"
+                value=""
+              />
             </div>
-            <input
-              aria-label="Search data"
-              autocomplete="off"
-              class="c7"
-              id="data--search"
-              name="_search"
-              type="search"
-              value=""
-            />
           </div>
         </div>
       </form>
       <div
-        class="c8"
+        class="c10"
       >
         <button
           aria-label="Open filters"
-          class="c9"
+          class="c11"
           id="data--filters-control"
           type="button"
         >
           <svg
             aria-label="Filter"
-            class="c6"
+            class="c8"
             viewBox="0 0 24 24"
           >
             <path
@@ -6976,12 +7296,12 @@ exports[`Data view property option 1`] = `
       </div>
     </div>
     <span
-      class="c10"
+      class="c12"
     >
       1 result of 4 items
     </span>
     <table
-      class="c11 c12"
+      class="c13 c14"
     >
       <thead
         class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -6990,51 +7310,51 @@ exports[`Data view property option 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c13 "
+            class="c15 "
             scope="col"
           >
             <div
-              class="c14"
+              class="c16"
             />
           </th>
           <th
-            class="c13 "
+            class="c15 "
             scope="col"
           >
             <div
-              class="c14"
+              class="c16"
             />
           </th>
         </tr>
       </thead>
       <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c15"
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c17"
       >
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c16 "
+            class="c18 "
             scope="row"
           >
             <div
-              class="c17"
+              class="c19"
             >
               <span
-                class="c18"
+                class="c20"
               >
                 aa
               </span>
             </div>
           </th>
           <td
-            class="c16 "
+            class="c18 "
           >
             <div
-              class="c17"
+              class="c19"
             >
               <span
-                class="c19"
+                class="c21"
               >
                 ZZ
               </span>
@@ -7048,7 +7368,7 @@ exports[`Data view property option 1`] = `
 `;
 
 exports[`Data view property range 1`] = `
-.c6 {
+.c8 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -7059,25 +7379,25 @@ exports[`Data view property range 1`] = `
   stroke: #666666;
 }
 
-.c6 g {
+.c8 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c6 *:not([stroke])[fill="none"] {
+.c8 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c6 *[stroke*="#"],
-.c6 *[STROKE*="#"] {
+.c8 *[stroke*="#"],
+.c8 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c6 *[fill-rule],
-.c6 *[FILL-RULE],
-.c6 *[fill*="#"],
-.c6 *[FILL*="#"] {
+.c8 *[fill-rule],
+.c8 *[FILL-RULE],
+.c8 *[fill*="#"],
+.c8 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -7109,7 +7429,40 @@ exports[`Data view property range 1`] = `
   flex: 0 0 auto;
 }
 
-.c8 {
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 100%;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  overflow: auto;
+}
+
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7126,7 +7479,7 @@ exports[`Data view property range 1`] = `
   flex: 0 0 auto;
 }
 
-.c14 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7147,7 +7500,7 @@ exports[`Data view property range 1`] = `
   justify-content: center;
 }
 
-.c17 {
+.c19 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7188,25 +7541,25 @@ exports[`Data view property range 1`] = `
   row-gap: 12px;
 }
 
-.c10 {
+.c12 {
   margin-top: 6px;
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
 }
 
-.c18 {
+.c20 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
 }
 
-.c19 {
+.c21 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c9 {
+.c11 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -7226,9 +7579,66 @@ exports[`Data view property range 1`] = `
   padding: 12px;
 }
 
-.c9:hover {
+.c11:hover {
   background-color: rgba(221,221,221,0.4);
   color: #000000;
+}
+
+.c11:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus > circle,
+.c11:focus > ellipse,
+.c11:focus > line,
+.c11:focus > path,
+.c11:focus > polygon,
+.c11:focus > polyline,
+.c11:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c11:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c11:focus:not(:focus-visible) > circle,
+.c11:focus:not(:focus-visible) > ellipse,
+.c11:focus:not(:focus-visible) > line,
+.c11:focus:not(:focus-visible) > path,
+.c11:focus:not(:focus-visible) > polygon,
+.c11:focus:not(:focus-visible) > polyline,
+.c11:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c11:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c9 {
+  box-sizing: border-box;
+  font-size: inherit;
+  font-family: inherit;
+  border: none;
+  -webkit-appearance: none;
+  background: transparent;
+  color: inherit;
+  width: 100%;
+  padding: 11px;
+  font-weight: 600;
+  margin: 0;
+  border: 1px solid rgba(0,0,0,0.33);
+  border-radius: 4px;
+  padding-left: 48px;
 }
 
 .c9:focus {
@@ -7251,95 +7661,38 @@ exports[`Data view property range 1`] = `
   border: 0;
 }
 
-.c9:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c9:focus:not(:focus-visible) > circle,
-.c9:focus:not(:focus-visible) > ellipse,
-.c9:focus:not(:focus-visible) > line,
-.c9:focus:not(:focus-visible) > path,
-.c9:focus:not(:focus-visible) > polygon,
-.c9:focus:not(:focus-visible) > polyline,
-.c9:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c9:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c7 {
-  box-sizing: border-box;
-  font-size: inherit;
-  font-family: inherit;
-  border: none;
-  -webkit-appearance: none;
-  background: transparent;
-  color: inherit;
-  width: 100%;
-  padding: 11px;
-  font-weight: 600;
-  margin: 0;
-  border: 1px solid rgba(0,0,0,0.33);
-  border-radius: 4px;
-  padding-left: 48px;
-}
-
-.c7:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c7:focus > circle,
-.c7:focus > ellipse,
-.c7:focus > line,
-.c7:focus > path,
-.c7:focus > polygon,
-.c7:focus > polyline,
-.c7:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c7:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c7::-webkit-input-placeholder {
+.c9::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-moz-placeholder {
+.c9::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c7:-ms-input-placeholder {
+.c9:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-webkit-search-decoration {
+.c9::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c7::-moz-focus-inner {
+.c9::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c7:-moz-placeholder,
-.c7::-moz-placeholder {
+.c9:-moz-placeholder,
+.c9::-moz-placeholder {
   opacity: 1;
 }
 
-.c4 {
+.c6 {
   position: relative;
   width: 100%;
 }
 
-.c5 {
+.c7 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -7361,7 +7714,7 @@ exports[`Data view property range 1`] = `
   max-width: 100%;
 }
 
-.c13 {
+.c15 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -7374,7 +7727,7 @@ exports[`Data view property range 1`] = `
   padding-bottom: 6px;
 }
 
-.c16 {
+.c18 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -7386,23 +7739,23 @@ exports[`Data view property range 1`] = `
   padding-bottom: 6px;
 }
 
-.c11 {
+.c13 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
 }
 
-.c12 {
+.c14 {
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
 }
 
-.c15:focus {
+.c17:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c15:focus:not(:focus-visible) {
+.c17:focus:not(:focus-visible) {
   outline: none;
 }
 
@@ -7431,51 +7784,55 @@ exports[`Data view property range 1`] = `
         class="c3"
       >
         <div
-          class="c1"
+          class="c4"
         >
           <div
-            class="c4"
+            class="c5"
           >
             <div
-              class="c5"
+              class="c6"
             >
-              <svg
-                aria-label="Search"
-                class="c6"
-                viewBox="0 0 24 24"
+              <div
+                class="c7"
               >
-                <path
-                  d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                  fill="none"
-                  stroke="#000"
-                  stroke-width="2"
-                />
-              </svg>
+                <svg
+                  aria-label="Search"
+                  class="c8"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                    fill="none"
+                    stroke="#000"
+                    stroke-width="2"
+                  />
+                </svg>
+              </div>
+              <input
+                aria-label="Search data"
+                autocomplete="off"
+                class="c9"
+                id="data--search"
+                name="_search"
+                type="search"
+                value=""
+              />
             </div>
-            <input
-              aria-label="Search data"
-              autocomplete="off"
-              class="c7"
-              id="data--search"
-              name="_search"
-              type="search"
-              value=""
-            />
           </div>
         </div>
       </form>
       <div
-        class="c8"
+        class="c10"
       >
         <button
           aria-label="Open filters"
-          class="c9"
+          class="c11"
           id="data--filters-control"
           type="button"
         >
           <svg
             aria-label="Filter"
-            class="c6"
+            class="c8"
             viewBox="0 0 24 24"
           >
             <path
@@ -7489,12 +7846,12 @@ exports[`Data view property range 1`] = `
       </div>
     </div>
     <span
-      class="c10"
+      class="c12"
     >
       1 result of 4 items
     </span>
     <table
-      class="c11 c12"
+      class="c13 c14"
     >
       <thead
         class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -7503,72 +7860,72 @@ exports[`Data view property range 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c13 "
+            class="c15 "
             scope="col"
           >
             <div
-              class="c14"
+              class="c16"
             />
           </th>
           <th
-            class="c13 "
+            class="c15 "
             scope="col"
           >
             <div
-              class="c14"
+              class="c16"
             />
           </th>
           <th
-            class="c13 "
+            class="c15 "
             scope="col"
           >
             <div
-              class="c14"
+              class="c16"
             />
           </th>
         </tr>
       </thead>
       <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c15"
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c17"
       >
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c16 "
+            class="c18 "
             scope="row"
           >
             <div
-              class="c17"
+              class="c19"
             >
               <span
-                class="c18"
+                class="c20"
               >
                 bb
               </span>
             </div>
           </th>
           <td
-            class="c16 "
+            class="c18 "
           >
             <div
-              class="c17"
+              class="c19"
             >
               <span
-                class="c19"
+                class="c21"
               >
                 YY
               </span>
             </div>
           </td>
           <td
-            class="c16 "
+            class="c18 "
           >
             <div
-              class="c17"
+              class="c19"
             >
               <span
-                class="c19"
+                class="c21"
               >
                 4.3
               </span>
@@ -7582,7 +7939,7 @@ exports[`Data view property range 1`] = `
 `;
 
 exports[`Data view search 1`] = `
-.c6 {
+.c8 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -7593,25 +7950,25 @@ exports[`Data view search 1`] = `
   stroke: #666666;
 }
 
-.c6 g {
+.c8 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c6 *:not([stroke])[fill="none"] {
+.c8 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c6 *[stroke*="#"],
-.c6 *[STROKE*="#"] {
+.c8 *[stroke*="#"],
+.c8 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c6 *[fill-rule],
-.c6 *[FILL-RULE],
-.c6 *[fill*="#"],
-.c6 *[FILL*="#"] {
+.c8 *[fill-rule],
+.c8 *[FILL-RULE],
+.c8 *[fill*="#"],
+.c8 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -7643,7 +8000,40 @@ exports[`Data view search 1`] = `
   flex: 0 0 auto;
 }
 
-.c8 {
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 100%;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  overflow: auto;
+}
+
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7660,7 +8050,7 @@ exports[`Data view search 1`] = `
   flex: 0 0 auto;
 }
 
-.c14 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7681,7 +8071,7 @@ exports[`Data view search 1`] = `
   justify-content: center;
 }
 
-.c17 {
+.c19 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7722,25 +8112,25 @@ exports[`Data view search 1`] = `
   row-gap: 12px;
 }
 
-.c10 {
+.c12 {
   margin-top: 6px;
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
 }
 
-.c18 {
+.c20 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
 }
 
-.c19 {
+.c21 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c9 {
+.c11 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -7760,9 +8150,66 @@ exports[`Data view search 1`] = `
   padding: 12px;
 }
 
-.c9:hover {
+.c11:hover {
   background-color: rgba(221,221,221,0.4);
   color: #000000;
+}
+
+.c11:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus > circle,
+.c11:focus > ellipse,
+.c11:focus > line,
+.c11:focus > path,
+.c11:focus > polygon,
+.c11:focus > polyline,
+.c11:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c11:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c11:focus:not(:focus-visible) > circle,
+.c11:focus:not(:focus-visible) > ellipse,
+.c11:focus:not(:focus-visible) > line,
+.c11:focus:not(:focus-visible) > path,
+.c11:focus:not(:focus-visible) > polygon,
+.c11:focus:not(:focus-visible) > polyline,
+.c11:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c11:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c9 {
+  box-sizing: border-box;
+  font-size: inherit;
+  font-family: inherit;
+  border: none;
+  -webkit-appearance: none;
+  background: transparent;
+  color: inherit;
+  width: 100%;
+  padding: 11px;
+  font-weight: 600;
+  margin: 0;
+  border: 1px solid rgba(0,0,0,0.33);
+  border-radius: 4px;
+  padding-left: 48px;
 }
 
 .c9:focus {
@@ -7785,95 +8232,38 @@ exports[`Data view search 1`] = `
   border: 0;
 }
 
-.c9:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c9:focus:not(:focus-visible) > circle,
-.c9:focus:not(:focus-visible) > ellipse,
-.c9:focus:not(:focus-visible) > line,
-.c9:focus:not(:focus-visible) > path,
-.c9:focus:not(:focus-visible) > polygon,
-.c9:focus:not(:focus-visible) > polyline,
-.c9:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c9:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c7 {
-  box-sizing: border-box;
-  font-size: inherit;
-  font-family: inherit;
-  border: none;
-  -webkit-appearance: none;
-  background: transparent;
-  color: inherit;
-  width: 100%;
-  padding: 11px;
-  font-weight: 600;
-  margin: 0;
-  border: 1px solid rgba(0,0,0,0.33);
-  border-radius: 4px;
-  padding-left: 48px;
-}
-
-.c7:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c7:focus > circle,
-.c7:focus > ellipse,
-.c7:focus > line,
-.c7:focus > path,
-.c7:focus > polygon,
-.c7:focus > polyline,
-.c7:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c7:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c7::-webkit-input-placeholder {
+.c9::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-moz-placeholder {
+.c9::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c7:-ms-input-placeholder {
+.c9:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-webkit-search-decoration {
+.c9::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c7::-moz-focus-inner {
+.c9::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c7:-moz-placeholder,
-.c7::-moz-placeholder {
+.c9:-moz-placeholder,
+.c9::-moz-placeholder {
   opacity: 1;
 }
 
-.c4 {
+.c6 {
   position: relative;
   width: 100%;
 }
 
-.c5 {
+.c7 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -7895,7 +8285,7 @@ exports[`Data view search 1`] = `
   max-width: 100%;
 }
 
-.c13 {
+.c15 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -7908,7 +8298,7 @@ exports[`Data view search 1`] = `
   padding-bottom: 6px;
 }
 
-.c16 {
+.c18 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -7920,23 +8310,23 @@ exports[`Data view search 1`] = `
   padding-bottom: 6px;
 }
 
-.c11 {
+.c13 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
 }
 
-.c12 {
+.c14 {
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
 }
 
-.c15:focus {
+.c17:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c15:focus:not(:focus-visible) {
+.c17:focus:not(:focus-visible) {
   outline: none;
 }
 
@@ -7965,51 +8355,55 @@ exports[`Data view search 1`] = `
         class="c3"
       >
         <div
-          class="c1"
+          class="c4"
         >
           <div
-            class="c4"
+            class="c5"
           >
             <div
-              class="c5"
+              class="c6"
             >
-              <svg
-                aria-label="Search"
-                class="c6"
-                viewBox="0 0 24 24"
+              <div
+                class="c7"
               >
-                <path
-                  d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                  fill="none"
-                  stroke="#000"
-                  stroke-width="2"
-                />
-              </svg>
+                <svg
+                  aria-label="Search"
+                  class="c8"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                    fill="none"
+                    stroke="#000"
+                    stroke-width="2"
+                  />
+                </svg>
+              </div>
+              <input
+                aria-label="Search data"
+                autocomplete="off"
+                class="c9"
+                id="data--search"
+                name="_search"
+                type="search"
+                value="a"
+              />
             </div>
-            <input
-              aria-label="Search data"
-              autocomplete="off"
-              class="c7"
-              id="data--search"
-              name="_search"
-              type="search"
-              value="a"
-            />
           </div>
         </div>
       </form>
       <div
-        class="c8"
+        class="c10"
       >
         <button
           aria-label="Open filters"
-          class="c9"
+          class="c11"
           id="data--filters-control"
           type="button"
         >
           <svg
             aria-label="Filter"
-            class="c6"
+            class="c8"
             viewBox="0 0 24 24"
           >
             <path
@@ -8023,12 +8417,12 @@ exports[`Data view search 1`] = `
       </div>
     </div>
     <span
-      class="c10"
+      class="c12"
     >
       1 result of 4 items
     </span>
     <table
-      class="c11 c12"
+      class="c13 c14"
     >
       <thead
         class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -8037,51 +8431,51 @@ exports[`Data view search 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c13 "
+            class="c15 "
             scope="col"
           >
             <div
-              class="c14"
+              class="c16"
             />
           </th>
           <th
-            class="c13 "
+            class="c15 "
             scope="col"
           >
             <div
-              class="c14"
+              class="c16"
             />
           </th>
         </tr>
       </thead>
       <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c15"
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c17"
       >
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c16 "
+            class="c18 "
             scope="row"
           >
             <div
-              class="c17"
+              class="c19"
             >
               <span
-                class="c18"
+                class="c20"
               >
                 aa
               </span>
             </div>
           </th>
           <td
-            class="c16 "
+            class="c18 "
           >
             <div
-              class="c17"
+              class="c19"
             >
               <span
-                class="c19"
+                class="c21"
               >
                 ZZ
               </span>
@@ -8095,7 +8489,7 @@ exports[`Data view search 1`] = `
 `;
 
 exports[`Data view sort 1`] = `
-.c6 {
+.c8 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -8106,25 +8500,25 @@ exports[`Data view sort 1`] = `
   stroke: #666666;
 }
 
-.c6 g {
+.c8 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c6 *:not([stroke])[fill="none"] {
+.c8 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c6 *[stroke*="#"],
-.c6 *[STROKE*="#"] {
+.c8 *[stroke*="#"],
+.c8 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c6 *[fill-rule],
-.c6 *[FILL-RULE],
-.c6 *[fill*="#"],
-.c6 *[FILL*="#"] {
+.c8 *[fill-rule],
+.c8 *[FILL-RULE],
+.c8 *[fill*="#"],
+.c8 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -8156,7 +8550,40 @@ exports[`Data view sort 1`] = `
   flex: 0 0 auto;
 }
 
-.c8 {
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 100%;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  overflow: auto;
+}
+
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8173,7 +8600,7 @@ exports[`Data view sort 1`] = `
   flex: 0 0 auto;
 }
 
-.c14 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8194,7 +8621,7 @@ exports[`Data view sort 1`] = `
   justify-content: center;
 }
 
-.c17 {
+.c19 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8235,25 +8662,25 @@ exports[`Data view sort 1`] = `
   row-gap: 12px;
 }
 
-.c10 {
+.c12 {
   margin-top: 6px;
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
 }
 
-.c18 {
+.c20 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
 }
 
-.c19 {
+.c21 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c9 {
+.c11 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -8273,9 +8700,66 @@ exports[`Data view sort 1`] = `
   padding: 12px;
 }
 
-.c9:hover {
+.c11:hover {
   background-color: rgba(221,221,221,0.4);
   color: #000000;
+}
+
+.c11:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus > circle,
+.c11:focus > ellipse,
+.c11:focus > line,
+.c11:focus > path,
+.c11:focus > polygon,
+.c11:focus > polyline,
+.c11:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c11:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c11:focus:not(:focus-visible) > circle,
+.c11:focus:not(:focus-visible) > ellipse,
+.c11:focus:not(:focus-visible) > line,
+.c11:focus:not(:focus-visible) > path,
+.c11:focus:not(:focus-visible) > polygon,
+.c11:focus:not(:focus-visible) > polyline,
+.c11:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c11:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c9 {
+  box-sizing: border-box;
+  font-size: inherit;
+  font-family: inherit;
+  border: none;
+  -webkit-appearance: none;
+  background: transparent;
+  color: inherit;
+  width: 100%;
+  padding: 11px;
+  font-weight: 600;
+  margin: 0;
+  border: 1px solid rgba(0,0,0,0.33);
+  border-radius: 4px;
+  padding-left: 48px;
 }
 
 .c9:focus {
@@ -8298,95 +8782,38 @@ exports[`Data view sort 1`] = `
   border: 0;
 }
 
-.c9:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c9:focus:not(:focus-visible) > circle,
-.c9:focus:not(:focus-visible) > ellipse,
-.c9:focus:not(:focus-visible) > line,
-.c9:focus:not(:focus-visible) > path,
-.c9:focus:not(:focus-visible) > polygon,
-.c9:focus:not(:focus-visible) > polyline,
-.c9:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c9:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c7 {
-  box-sizing: border-box;
-  font-size: inherit;
-  font-family: inherit;
-  border: none;
-  -webkit-appearance: none;
-  background: transparent;
-  color: inherit;
-  width: 100%;
-  padding: 11px;
-  font-weight: 600;
-  margin: 0;
-  border: 1px solid rgba(0,0,0,0.33);
-  border-radius: 4px;
-  padding-left: 48px;
-}
-
-.c7:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c7:focus > circle,
-.c7:focus > ellipse,
-.c7:focus > line,
-.c7:focus > path,
-.c7:focus > polygon,
-.c7:focus > polyline,
-.c7:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c7:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c7::-webkit-input-placeholder {
+.c9::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-moz-placeholder {
+.c9::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c7:-ms-input-placeholder {
+.c9:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-webkit-search-decoration {
+.c9::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c7::-moz-focus-inner {
+.c9::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c7:-moz-placeholder,
-.c7::-moz-placeholder {
+.c9:-moz-placeholder,
+.c9::-moz-placeholder {
   opacity: 1;
 }
 
-.c4 {
+.c6 {
   position: relative;
   width: 100%;
 }
 
-.c5 {
+.c7 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -8408,7 +8835,7 @@ exports[`Data view sort 1`] = `
   max-width: 100%;
 }
 
-.c13 {
+.c15 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -8421,7 +8848,7 @@ exports[`Data view sort 1`] = `
   padding-bottom: 6px;
 }
 
-.c16 {
+.c18 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -8433,23 +8860,23 @@ exports[`Data view sort 1`] = `
   padding-bottom: 6px;
 }
 
-.c11 {
+.c13 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
 }
 
-.c12 {
+.c14 {
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
 }
 
-.c15:focus {
+.c17:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c15:focus:not(:focus-visible) {
+.c17:focus:not(:focus-visible) {
   outline: none;
 }
 
@@ -8478,51 +8905,55 @@ exports[`Data view sort 1`] = `
         class="c3"
       >
         <div
-          class="c1"
+          class="c4"
         >
           <div
-            class="c4"
+            class="c5"
           >
             <div
-              class="c5"
+              class="c6"
             >
-              <svg
-                aria-label="Search"
-                class="c6"
-                viewBox="0 0 24 24"
+              <div
+                class="c7"
               >
-                <path
-                  d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                  fill="none"
-                  stroke="#000"
-                  stroke-width="2"
-                />
-              </svg>
+                <svg
+                  aria-label="Search"
+                  class="c8"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                    fill="none"
+                    stroke="#000"
+                    stroke-width="2"
+                  />
+                </svg>
+              </div>
+              <input
+                aria-label="Search data"
+                autocomplete="off"
+                class="c9"
+                id="data--search"
+                name="_search"
+                type="search"
+                value=""
+              />
             </div>
-            <input
-              aria-label="Search data"
-              autocomplete="off"
-              class="c7"
-              id="data--search"
-              name="_search"
-              type="search"
-              value=""
-            />
           </div>
         </div>
       </form>
       <div
-        class="c8"
+        class="c10"
       >
         <button
           aria-label="Open filters"
-          class="c9"
+          class="c11"
           id="data--filters-control"
           type="button"
         >
           <svg
             aria-label="Filter"
-            class="c6"
+            class="c8"
             viewBox="0 0 24 24"
           >
             <path
@@ -8536,12 +8967,12 @@ exports[`Data view sort 1`] = `
       </div>
     </div>
     <span
-      class="c10"
+      class="c12"
     >
       4 items
     </span>
     <table
-      class="c11 c12"
+      class="c13 c14"
     >
       <thead
         class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -8550,51 +8981,51 @@ exports[`Data view sort 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c13 "
+            class="c15 "
             scope="col"
           >
             <div
-              class="c14"
+              class="c16"
             />
           </th>
           <th
-            class="c13 "
+            class="c15 "
             scope="col"
           >
             <div
-              class="c14"
+              class="c16"
             />
           </th>
         </tr>
       </thead>
       <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c15"
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c17"
       >
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c16 "
+            class="c18 "
             scope="row"
           >
             <div
-              class="c17"
+              class="c19"
             >
               <span
-                class="c18"
+                class="c20"
               >
                 aa
               </span>
             </div>
           </th>
           <td
-            class="c16 "
+            class="c18 "
           >
             <div
-              class="c17"
+              class="c19"
             >
               <span
-                class="c19"
+                class="c21"
               >
                 ZZ
               </span>
@@ -8605,27 +9036,27 @@ exports[`Data view sort 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c16 "
+            class="c18 "
             scope="row"
           >
             <div
-              class="c17"
+              class="c19"
             >
               <span
-                class="c18"
+                class="c20"
               >
                 bb
               </span>
             </div>
           </th>
           <td
-            class="c16 "
+            class="c18 "
           >
             <div
-              class="c17"
+              class="c19"
             >
               <span
-                class="c19"
+                class="c21"
               >
                 YY
               </span>
@@ -8636,24 +9067,24 @@ exports[`Data view sort 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c16 "
+            class="c18 "
             scope="row"
           >
             <div
-              class="c17"
+              class="c19"
             >
               <span
-                class="c18"
+                class="c20"
               >
                 cc
               </span>
             </div>
           </th>
           <td
-            class="c16 "
+            class="c18 "
           >
             <div
-              class="c17"
+              class="c19"
             />
           </td>
         </tr>
@@ -8661,24 +9092,24 @@ exports[`Data view sort 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c16 "
+            class="c18 "
             scope="row"
           >
             <div
-              class="c17"
+              class="c19"
             >
               <span
-                class="c18"
+                class="c20"
               >
                 dd
               </span>
             </div>
           </th>
           <td
-            class="c16 "
+            class="c18 "
           >
             <div
-              class="c17"
+              class="c19"
             />
           </td>
         </tr>

--- a/src/js/components/Data/__tests__/__snapshots__/Data-test.tsx.snap
+++ b/src/js/components/Data/__tests__/__snapshots__/Data-test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Data controlled search 1`] = `
-.c10 {
+.c8 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -12,25 +12,25 @@ exports[`Data controlled search 1`] = `
   stroke: #666666;
 }
 
-.c10 g {
+.c8 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c10 *:not([stroke])[fill="none"] {
+.c8 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c10 *[stroke*="#"],
-.c10 *[STROKE*="#"] {
+.c8 *[stroke*="#"],
+.c8 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c10 *[fill-rule],
-.c10 *[FILL-RULE],
-.c10 *[fill*="#"],
-.c10 *[FILL*="#"] {
+.c8 *[fill-rule],
+.c8 *[FILL-RULE],
+.c8 *[fill*="#"],
+.c8 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -95,40 +95,7 @@ exports[`Data controlled search 1`] = `
   overflow: auto;
 }
 
-.c6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  margin-bottom: 12px;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-}
-
-.c7 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c12 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -145,7 +112,7 @@ exports[`Data controlled search 1`] = `
   flex: 0 0 auto;
 }
 
-.c18 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -166,7 +133,7 @@ exports[`Data controlled search 1`] = `
   justify-content: center;
 }
 
-.c21 {
+.c19 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -207,20 +174,20 @@ exports[`Data controlled search 1`] = `
   row-gap: 12px;
 }
 
-.c14 {
+.c12 {
   margin-top: 6px;
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
 }
 
-.c22 {
+.c20 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
 }
 
-.c13 {
+.c11 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -240,52 +207,52 @@ exports[`Data controlled search 1`] = `
   padding: 12px;
 }
 
-.c13:hover {
+.c11:hover {
   background-color: rgba(221,221,221,0.4);
   color: #000000;
 }
 
-.c13:focus {
+.c11:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus > circle,
-.c13:focus > ellipse,
-.c13:focus > line,
-.c13:focus > path,
-.c13:focus > polygon,
-.c13:focus > polyline,
-.c13:focus > rect {
+.c11:focus > circle,
+.c11:focus > ellipse,
+.c11:focus > line,
+.c11:focus > path,
+.c11:focus > polygon,
+.c11:focus > polyline,
+.c11:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus::-moz-focus-inner {
+.c11:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c13:focus:not(:focus-visible) {
+.c11:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible) > circle,
-.c13:focus:not(:focus-visible) > ellipse,
-.c13:focus:not(:focus-visible) > line,
-.c13:focus:not(:focus-visible) > path,
-.c13:focus:not(:focus-visible) > polygon,
-.c13:focus:not(:focus-visible) > polyline,
-.c13:focus:not(:focus-visible) > rect {
+.c11:focus:not(:focus-visible) > circle,
+.c11:focus:not(:focus-visible) > ellipse,
+.c11:focus:not(:focus-visible) > line,
+.c11:focus:not(:focus-visible) > path,
+.c11:focus:not(:focus-visible) > polygon,
+.c11:focus:not(:focus-visible) > polyline,
+.c11:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible)::-moz-focus-inner {
+.c11:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c11 {
+.c9 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -299,43 +266,61 @@ exports[`Data controlled search 1`] = `
   margin: 0;
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
-  outline: none;
-  border: none;
   padding-left: 48px;
 }
 
-.c11::-webkit-input-placeholder {
+.c9:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9:focus > circle,
+.c9:focus > ellipse,
+.c9:focus > line,
+.c9:focus > path,
+.c9:focus > polygon,
+.c9:focus > polyline,
+.c9:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c9::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c11::-moz-placeholder {
+.c9::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c11:-ms-input-placeholder {
+.c9:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c11::-webkit-search-decoration {
+.c9::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c11::-moz-focus-inner {
+.c9::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c11:-moz-placeholder,
-.c11::-moz-placeholder {
+.c9:-moz-placeholder,
+.c9::-moz-placeholder {
   opacity: 1;
 }
 
-.c8 {
+.c6 {
   position: relative;
   width: 100%;
 }
 
-.c9 {
+.c7 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -357,7 +342,7 @@ exports[`Data controlled search 1`] = `
   max-width: 100%;
 }
 
-.c17 {
+.c15 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -370,7 +355,7 @@ exports[`Data controlled search 1`] = `
   padding-bottom: 6px;
 }
 
-.c20 {
+.c18 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -382,40 +367,28 @@ exports[`Data controlled search 1`] = `
   padding-bottom: 6px;
 }
 
-.c15 {
+.c13 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
 }
 
-.c16 {
+.c14 {
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
 }
 
-.c19:focus {
+.c17:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c19:focus:not(:focus-visible) {
+.c17:focus:not(:focus-visible) {
   outline: none;
 }
 
 @media only screen and (max-width:768px) {
 
-}
-
-@media only screen and (max-width:768px) {
-  .c6 {
-    margin-bottom: 6px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c7 {
-    border-bottom: solid 1px rgba(0,0,0,0.33);
-  }
 }
 
 @media only screen and (max-width:768px) {
@@ -445,57 +418,49 @@ exports[`Data controlled search 1`] = `
             class="c5"
           >
             <div
-              class="c6 "
+              class="c6"
             >
               <div
-                class="c7 FormField__FormFieldContentBox-sc-m9hood-1"
+                class="c7"
               >
-                <div
+                <svg
+                  aria-label="Search"
                   class="c8"
+                  viewBox="0 0 24 24"
                 >
-                  <div
-                    class="c9"
-                  >
-                    <svg
-                      aria-label="Search"
-                      class="c10"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                        fill="none"
-                        stroke="#000"
-                        stroke-width="2"
-                      />
-                    </svg>
-                  </div>
-                  <input
-                    aria-label="Search data"
-                    autocomplete="off"
-                    class="c11"
-                    id="data--search"
-                    name="_search"
-                    type="search"
-                    value=""
+                  <path
+                    d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                    fill="none"
+                    stroke="#000"
+                    stroke-width="2"
                   />
-                </div>
+                </svg>
               </div>
+              <input
+                aria-label="Search"
+                autocomplete="off"
+                class="c9"
+                id="data--search"
+                name="_search"
+                type="search"
+                value=""
+              />
             </div>
           </div>
         </div>
       </form>
       <div
-        class="c12"
+        class="c10"
       >
         <button
           aria-label="Open filters"
-          class="c13"
+          class="c11"
           id="data--filters-control"
           type="button"
         >
           <svg
             aria-label="Filter"
-            class="c10"
+            class="c8"
             viewBox="0 0 24 24"
           >
             <path
@@ -509,12 +474,12 @@ exports[`Data controlled search 1`] = `
       </div>
     </div>
     <span
-      class="c14"
+      class="c12"
     >
       4 results of undefined items
     </span>
     <table
-      class="c15 c16"
+      class="c13 c14"
     >
       <thead
         class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -523,30 +488,30 @@ exports[`Data controlled search 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c17 "
+            class="c15 "
             scope="col"
           >
             <div
-              class="c18"
+              class="c16"
             />
           </th>
         </tr>
       </thead>
       <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c19"
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c17"
       >
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c20 "
+            class="c18 "
             scope="row"
           >
             <div
-              class="c21"
+              class="c19"
             >
               <span
-                class="c22"
+                class="c20"
               >
                 aa
               </span>
@@ -557,14 +522,14 @@ exports[`Data controlled search 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c20 "
+            class="c18 "
             scope="row"
           >
             <div
-              class="c21"
+              class="c19"
             >
               <span
-                class="c22"
+                class="c20"
               >
                 bb
               </span>
@@ -575,14 +540,14 @@ exports[`Data controlled search 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c20 "
+            class="c18 "
             scope="row"
           >
             <div
-              class="c21"
+              class="c19"
             >
               <span
-                class="c22"
+                class="c20"
               >
                 cc
               </span>
@@ -593,14 +558,14 @@ exports[`Data controlled search 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c20 "
+            class="c18 "
             scope="row"
           >
             <div
-              class="c21"
+              class="c19"
             >
               <span
-                class="c22"
+                class="c20"
               >
                 dd
               </span>
@@ -634,41 +599,33 @@ exports[`Data controlled search 2`] = `
             class="StyledBox-sc-13pk1d4-0 dePIJN"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
+              class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 edcgVv"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 cqRjpC FormField__FormFieldContentBox-sc-m9hood-1"
+                class="StyledTextInput__StyledIcon-sc-1x30a0s-3 cFBrkA"
               >
-                <div
-                  class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 edcgVv"
+                <svg
+                  aria-label="Search"
+                  class="StyledIcon-sc-ofa7kd-0 jQvEgu"
+                  viewBox="0 0 24 24"
                 >
-                  <div
-                    class="StyledTextInput__StyledIcon-sc-1x30a0s-3 cFBrkA"
-                  >
-                    <svg
-                      aria-label="Search"
-                      class="StyledIcon-sc-ofa7kd-0 jQvEgu"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                        fill="none"
-                        stroke="#000"
-                        stroke-width="2"
-                      />
-                    </svg>
-                  </div>
-                  <input
-                    aria-label="Search data"
-                    autocomplete="off"
-                    class="StyledTextInput-sc-1x30a0s-0 kovfiL"
-                    id="data--search"
-                    name="_search"
-                    type="search"
-                    value="a"
+                  <path
+                    d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                    fill="none"
+                    stroke="#000"
+                    stroke-width="2"
                   />
-                </div>
+                </svg>
               </div>
+              <input
+                aria-label="Search"
+                autocomplete="off"
+                class="StyledTextInput-sc-1x30a0s-0 bMqJAS"
+                id="data--search"
+                name="_search"
+                type="search"
+                value="a"
+              />
             </div>
           </div>
         </div>
@@ -803,7 +760,7 @@ exports[`Data controlled search 2`] = `
 `;
 
 exports[`Data messages 1`] = `
-.c10 {
+.c8 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -814,25 +771,25 @@ exports[`Data messages 1`] = `
   stroke: #666666;
 }
 
-.c10 g {
+.c8 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c10 *:not([stroke])[fill="none"] {
+.c8 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c10 *[stroke*="#"],
-.c10 *[STROKE*="#"] {
+.c8 *[stroke*="#"],
+.c8 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c10 *[fill-rule],
-.c10 *[FILL-RULE],
-.c10 *[fill*="#"],
-.c10 *[FILL*="#"] {
+.c8 *[fill-rule],
+.c8 *[FILL-RULE],
+.c8 *[fill*="#"],
+.c8 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -897,40 +854,7 @@ exports[`Data messages 1`] = `
   overflow: auto;
 }
 
-.c6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  margin-bottom: 12px;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-}
-
-.c7 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c12 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -947,7 +871,7 @@ exports[`Data messages 1`] = `
   flex: 0 0 auto;
 }
 
-.c18 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -968,7 +892,7 @@ exports[`Data messages 1`] = `
   justify-content: center;
 }
 
-.c21 {
+.c19 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1009,25 +933,25 @@ exports[`Data messages 1`] = `
   row-gap: 12px;
 }
 
-.c14 {
+.c12 {
   margin-top: 6px;
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
 }
 
-.c22 {
+.c20 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
 }
 
-.c23 {
+.c21 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c13 {
+.c11 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -1047,52 +971,52 @@ exports[`Data messages 1`] = `
   padding: 12px;
 }
 
-.c13:hover {
+.c11:hover {
   background-color: rgba(221,221,221,0.4);
   color: #000000;
 }
 
-.c13:focus {
+.c11:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus > circle,
-.c13:focus > ellipse,
-.c13:focus > line,
-.c13:focus > path,
-.c13:focus > polygon,
-.c13:focus > polyline,
-.c13:focus > rect {
+.c11:focus > circle,
+.c11:focus > ellipse,
+.c11:focus > line,
+.c11:focus > path,
+.c11:focus > polygon,
+.c11:focus > polyline,
+.c11:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus::-moz-focus-inner {
+.c11:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c13:focus:not(:focus-visible) {
+.c11:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible) > circle,
-.c13:focus:not(:focus-visible) > ellipse,
-.c13:focus:not(:focus-visible) > line,
-.c13:focus:not(:focus-visible) > path,
-.c13:focus:not(:focus-visible) > polygon,
-.c13:focus:not(:focus-visible) > polyline,
-.c13:focus:not(:focus-visible) > rect {
+.c11:focus:not(:focus-visible) > circle,
+.c11:focus:not(:focus-visible) > ellipse,
+.c11:focus:not(:focus-visible) > line,
+.c11:focus:not(:focus-visible) > path,
+.c11:focus:not(:focus-visible) > polygon,
+.c11:focus:not(:focus-visible) > polyline,
+.c11:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible)::-moz-focus-inner {
+.c11:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c11 {
+.c9 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -1106,43 +1030,61 @@ exports[`Data messages 1`] = `
   margin: 0;
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
-  outline: none;
-  border: none;
   padding-left: 48px;
 }
 
-.c11::-webkit-input-placeholder {
+.c9:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9:focus > circle,
+.c9:focus > ellipse,
+.c9:focus > line,
+.c9:focus > path,
+.c9:focus > polygon,
+.c9:focus > polyline,
+.c9:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c9::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c11::-moz-placeholder {
+.c9::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c11:-ms-input-placeholder {
+.c9:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c11::-webkit-search-decoration {
+.c9::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c11::-moz-focus-inner {
+.c9::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c11:-moz-placeholder,
-.c11::-moz-placeholder {
+.c9:-moz-placeholder,
+.c9::-moz-placeholder {
   opacity: 1;
 }
 
-.c8 {
+.c6 {
   position: relative;
   width: 100%;
 }
 
-.c9 {
+.c7 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1164,7 +1106,7 @@ exports[`Data messages 1`] = `
   max-width: 100%;
 }
 
-.c17 {
+.c15 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -1177,7 +1119,7 @@ exports[`Data messages 1`] = `
   padding-bottom: 6px;
 }
 
-.c20 {
+.c18 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -1189,40 +1131,28 @@ exports[`Data messages 1`] = `
   padding-bottom: 6px;
 }
 
-.c15 {
+.c13 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
 }
 
-.c16 {
+.c14 {
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
 }
 
-.c19:focus {
+.c17:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c19:focus:not(:focus-visible) {
+.c17:focus:not(:focus-visible) {
   outline: none;
 }
 
 @media only screen and (max-width:768px) {
 
-}
-
-@media only screen and (max-width:768px) {
-  .c6 {
-    margin-bottom: 6px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c7 {
-    border-bottom: solid 1px rgba(0,0,0,0.33);
-  }
 }
 
 @media only screen and (max-width:768px) {
@@ -1252,57 +1182,49 @@ exports[`Data messages 1`] = `
             class="c5"
           >
             <div
-              class="c6 "
+              class="c6"
             >
               <div
-                class="c7 FormField__FormFieldContentBox-sc-m9hood-1"
+                class="c7"
               >
-                <div
+                <svg
+                  aria-label="Search"
                   class="c8"
+                  viewBox="0 0 24 24"
                 >
-                  <div
-                    class="c9"
-                  >
-                    <svg
-                      aria-label="Search"
-                      class="c10"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                        fill="none"
-                        stroke="#000"
-                        stroke-width="2"
-                      />
-                    </svg>
-                  </div>
-                  <input
-                    aria-label="Search data"
-                    autocomplete="off"
-                    class="c11"
-                    id="data--search"
-                    name="_search"
-                    type="search"
-                    value=""
+                  <path
+                    d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                    fill="none"
+                    stroke="#000"
+                    stroke-width="2"
                   />
-                </div>
+                </svg>
               </div>
+              <input
+                aria-label="Search"
+                autocomplete="off"
+                class="c9"
+                id="data--search"
+                name="_search"
+                type="search"
+                value=""
+              />
             </div>
           </div>
         </div>
       </form>
       <div
-        class="c12"
+        class="c10"
       >
         <button
           aria-label="Open filters"
-          class="c13"
+          class="c11"
           id="data--filters-control"
           type="button"
         >
           <svg
             aria-label="Filter"
-            class="c10"
+            class="c8"
             viewBox="0 0 24 24"
           >
             <path
@@ -1316,12 +1238,12 @@ exports[`Data messages 1`] = `
       </div>
     </div>
     <span
-      class="c14"
+      class="c12"
     >
       4 things
     </span>
     <table
-      class="c15 c16"
+      class="c13 c14"
     >
       <thead
         class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -1330,51 +1252,51 @@ exports[`Data messages 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c17 "
+            class="c15 "
             scope="col"
           >
             <div
-              class="c18"
+              class="c16"
             />
           </th>
           <th
-            class="c17 "
+            class="c15 "
             scope="col"
           >
             <div
-              class="c18"
+              class="c16"
             />
           </th>
         </tr>
       </thead>
       <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c19"
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c17"
       >
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c20 "
+            class="c18 "
             scope="row"
           >
             <div
-              class="c21"
+              class="c19"
             >
               <span
-                class="c22"
+                class="c20"
               >
                 aa
               </span>
             </div>
           </th>
           <td
-            class="c20 "
+            class="c18 "
           >
             <div
-              class="c21"
+              class="c19"
             >
               <span
-                class="c23"
+                class="c21"
               >
                 ZZ
               </span>
@@ -1385,27 +1307,27 @@ exports[`Data messages 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c20 "
+            class="c18 "
             scope="row"
           >
             <div
-              class="c21"
+              class="c19"
             >
               <span
-                class="c22"
+                class="c20"
               >
                 bb
               </span>
             </div>
           </th>
           <td
-            class="c20 "
+            class="c18 "
           >
             <div
-              class="c21"
+              class="c19"
             >
               <span
-                class="c23"
+                class="c21"
               >
                 YY
               </span>
@@ -1416,24 +1338,24 @@ exports[`Data messages 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c20 "
+            class="c18 "
             scope="row"
           >
             <div
-              class="c21"
+              class="c19"
             >
               <span
-                class="c22"
+                class="c20"
               >
                 cc
               </span>
             </div>
           </th>
           <td
-            class="c20 "
+            class="c18 "
           >
             <div
-              class="c21"
+              class="c19"
             />
           </td>
         </tr>
@@ -1441,24 +1363,24 @@ exports[`Data messages 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c20 "
+            class="c18 "
             scope="row"
           >
             <div
-              class="c21"
+              class="c19"
             >
               <span
-                class="c22"
+                class="c20"
               >
                 dd
               </span>
             </div>
           </th>
           <td
-            class="c20 "
+            class="c18 "
           >
             <div
-              class="c21"
+              class="c19"
             />
           </td>
         </tr>
@@ -3856,7 +3778,7 @@ exports[`Data renders 1`] = `
 `;
 
 exports[`Data toolbar 1`] = `
-.c10 {
+.c8 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -3867,25 +3789,25 @@ exports[`Data toolbar 1`] = `
   stroke: #666666;
 }
 
-.c10 g {
+.c8 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c10 *:not([stroke])[fill="none"] {
+.c8 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c10 *[stroke*="#"],
-.c10 *[STROKE*="#"] {
+.c8 *[stroke*="#"],
+.c8 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c10 *[fill-rule],
-.c10 *[FILL-RULE],
-.c10 *[fill*="#"],
-.c10 *[FILL*="#"] {
+.c8 *[fill-rule],
+.c8 *[FILL-RULE],
+.c8 *[fill*="#"],
+.c8 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -3950,40 +3872,7 @@ exports[`Data toolbar 1`] = `
   overflow: auto;
 }
 
-.c6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  margin-bottom: 12px;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-}
-
-.c7 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c12 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4000,7 +3889,7 @@ exports[`Data toolbar 1`] = `
   flex: 0 0 auto;
 }
 
-.c18 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4021,7 +3910,7 @@ exports[`Data toolbar 1`] = `
   justify-content: center;
 }
 
-.c21 {
+.c19 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4062,25 +3951,25 @@ exports[`Data toolbar 1`] = `
   row-gap: 12px;
 }
 
-.c14 {
+.c12 {
   margin-top: 6px;
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
 }
 
-.c22 {
+.c20 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
 }
 
-.c23 {
+.c21 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c13 {
+.c11 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -4100,52 +3989,52 @@ exports[`Data toolbar 1`] = `
   padding: 12px;
 }
 
-.c13:hover {
+.c11:hover {
   background-color: rgba(221,221,221,0.4);
   color: #000000;
 }
 
-.c13:focus {
+.c11:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus > circle,
-.c13:focus > ellipse,
-.c13:focus > line,
-.c13:focus > path,
-.c13:focus > polygon,
-.c13:focus > polyline,
-.c13:focus > rect {
+.c11:focus > circle,
+.c11:focus > ellipse,
+.c11:focus > line,
+.c11:focus > path,
+.c11:focus > polygon,
+.c11:focus > polyline,
+.c11:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus::-moz-focus-inner {
+.c11:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c13:focus:not(:focus-visible) {
+.c11:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible) > circle,
-.c13:focus:not(:focus-visible) > ellipse,
-.c13:focus:not(:focus-visible) > line,
-.c13:focus:not(:focus-visible) > path,
-.c13:focus:not(:focus-visible) > polygon,
-.c13:focus:not(:focus-visible) > polyline,
-.c13:focus:not(:focus-visible) > rect {
+.c11:focus:not(:focus-visible) > circle,
+.c11:focus:not(:focus-visible) > ellipse,
+.c11:focus:not(:focus-visible) > line,
+.c11:focus:not(:focus-visible) > path,
+.c11:focus:not(:focus-visible) > polygon,
+.c11:focus:not(:focus-visible) > polyline,
+.c11:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible)::-moz-focus-inner {
+.c11:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c11 {
+.c9 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -4159,43 +4048,61 @@ exports[`Data toolbar 1`] = `
   margin: 0;
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
-  outline: none;
-  border: none;
   padding-left: 48px;
 }
 
-.c11::-webkit-input-placeholder {
+.c9:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9:focus > circle,
+.c9:focus > ellipse,
+.c9:focus > line,
+.c9:focus > path,
+.c9:focus > polygon,
+.c9:focus > polyline,
+.c9:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c9::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c11::-moz-placeholder {
+.c9::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c11:-ms-input-placeholder {
+.c9:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c11::-webkit-search-decoration {
+.c9::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c11::-moz-focus-inner {
+.c9::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c11:-moz-placeholder,
-.c11::-moz-placeholder {
+.c9:-moz-placeholder,
+.c9::-moz-placeholder {
   opacity: 1;
 }
 
-.c8 {
+.c6 {
   position: relative;
   width: 100%;
 }
 
-.c9 {
+.c7 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -4217,7 +4124,7 @@ exports[`Data toolbar 1`] = `
   max-width: 100%;
 }
 
-.c17 {
+.c15 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -4230,7 +4137,7 @@ exports[`Data toolbar 1`] = `
   padding-bottom: 6px;
 }
 
-.c20 {
+.c18 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -4242,40 +4149,28 @@ exports[`Data toolbar 1`] = `
   padding-bottom: 6px;
 }
 
-.c15 {
+.c13 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
 }
 
-.c16 {
+.c14 {
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
 }
 
-.c19:focus {
+.c17:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c19:focus:not(:focus-visible) {
+.c17:focus:not(:focus-visible) {
   outline: none;
 }
 
 @media only screen and (max-width:768px) {
 
-}
-
-@media only screen and (max-width:768px) {
-  .c6 {
-    margin-bottom: 6px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c7 {
-    border-bottom: solid 1px rgba(0,0,0,0.33);
-  }
 }
 
 @media only screen and (max-width:768px) {
@@ -4305,57 +4200,49 @@ exports[`Data toolbar 1`] = `
             class="c5"
           >
             <div
-              class="c6 "
+              class="c6"
             >
               <div
-                class="c7 FormField__FormFieldContentBox-sc-m9hood-1"
+                class="c7"
               >
-                <div
+                <svg
+                  aria-label="Search"
                   class="c8"
+                  viewBox="0 0 24 24"
                 >
-                  <div
-                    class="c9"
-                  >
-                    <svg
-                      aria-label="Search"
-                      class="c10"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                        fill="none"
-                        stroke="#000"
-                        stroke-width="2"
-                      />
-                    </svg>
-                  </div>
-                  <input
-                    aria-label="Search data"
-                    autocomplete="off"
-                    class="c11"
-                    id="data--search"
-                    name="_search"
-                    type="search"
-                    value=""
+                  <path
+                    d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                    fill="none"
+                    stroke="#000"
+                    stroke-width="2"
                   />
-                </div>
+                </svg>
               </div>
+              <input
+                aria-label="Search"
+                autocomplete="off"
+                class="c9"
+                id="data--search"
+                name="_search"
+                type="search"
+                value=""
+              />
             </div>
           </div>
         </div>
       </form>
       <div
-        class="c12"
+        class="c10"
       >
         <button
           aria-label="Open filters"
-          class="c13"
+          class="c11"
           id="data--filters-control"
           type="button"
         >
           <svg
             aria-label="Filter"
-            class="c10"
+            class="c8"
             viewBox="0 0 24 24"
           >
             <path
@@ -4369,12 +4256,12 @@ exports[`Data toolbar 1`] = `
       </div>
     </div>
     <span
-      class="c14"
+      class="c12"
     >
       4 items
     </span>
     <table
-      class="c15 c16"
+      class="c13 c14"
     >
       <thead
         class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -4383,51 +4270,51 @@ exports[`Data toolbar 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c17 "
+            class="c15 "
             scope="col"
           >
             <div
-              class="c18"
+              class="c16"
             />
           </th>
           <th
-            class="c17 "
+            class="c15 "
             scope="col"
           >
             <div
-              class="c18"
+              class="c16"
             />
           </th>
         </tr>
       </thead>
       <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c19"
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c17"
       >
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c20 "
+            class="c18 "
             scope="row"
           >
             <div
-              class="c21"
+              class="c19"
             >
               <span
-                class="c22"
+                class="c20"
               >
                 aa
               </span>
             </div>
           </th>
           <td
-            class="c20 "
+            class="c18 "
           >
             <div
-              class="c21"
+              class="c19"
             >
               <span
-                class="c23"
+                class="c21"
               >
                 ZZ
               </span>
@@ -4438,27 +4325,27 @@ exports[`Data toolbar 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c20 "
+            class="c18 "
             scope="row"
           >
             <div
-              class="c21"
+              class="c19"
             >
               <span
-                class="c22"
+                class="c20"
               >
                 bb
               </span>
             </div>
           </th>
           <td
-            class="c20 "
+            class="c18 "
           >
             <div
-              class="c21"
+              class="c19"
             >
               <span
-                class="c23"
+                class="c21"
               >
                 YY
               </span>
@@ -4469,24 +4356,24 @@ exports[`Data toolbar 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c20 "
+            class="c18 "
             scope="row"
           >
             <div
-              class="c21"
+              class="c19"
             >
               <span
-                class="c22"
+                class="c20"
               >
                 cc
               </span>
             </div>
           </th>
           <td
-            class="c20 "
+            class="c18 "
           >
             <div
-              class="c21"
+              class="c19"
             />
           </td>
         </tr>
@@ -4494,24 +4381,24 @@ exports[`Data toolbar 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c20 "
+            class="c18 "
             scope="row"
           >
             <div
-              class="c21"
+              class="c19"
             >
               <span
-                class="c22"
+                class="c20"
               >
                 dd
               </span>
             </div>
           </th>
           <td
-            class="c20 "
+            class="c18 "
           >
             <div
-              class="c21"
+              class="c19"
             />
           </td>
         </tr>
@@ -4936,7 +4823,7 @@ exports[`Data toolbar filters 1`] = `
 `;
 
 exports[`Data toolbar search 1`] = `
-.c10 {
+.c8 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -4947,25 +4834,25 @@ exports[`Data toolbar search 1`] = `
   stroke: #666666;
 }
 
-.c10 g {
+.c8 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c10 *:not([stroke])[fill="none"] {
+.c8 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c10 *[stroke*="#"],
-.c10 *[STROKE*="#"] {
+.c8 *[stroke*="#"],
+.c8 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c10 *[fill-rule],
-.c10 *[FILL-RULE],
-.c10 *[fill*="#"],
-.c10 *[FILL*="#"] {
+.c8 *[fill-rule],
+.c8 *[FILL-RULE],
+.c8 *[fill*="#"],
+.c8 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -5030,14 +4917,436 @@ exports[`Data toolbar search 1`] = `
   overflow: auto;
 }
 
-.c6 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  margin-bottom: 12px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c17 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-column-gap: 12px;
+  column-gap: 12px;
+  row-gap: 12px;
+}
+
+.c10 {
+  margin-top: 6px;
+  margin-bottom: 6px;
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c18 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c9 {
+  box-sizing: border-box;
+  font-size: inherit;
+  font-family: inherit;
+  border: none;
+  -webkit-appearance: none;
+  background: transparent;
+  color: inherit;
+  width: 100%;
+  padding: 11px;
+  font-weight: 600;
+  margin: 0;
+  border: 1px solid rgba(0,0,0,0.33);
+  border-radius: 4px;
+  padding-left: 48px;
+}
+
+.c9:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9:focus > circle,
+.c9:focus > ellipse,
+.c9:focus > line,
+.c9:focus > path,
+.c9:focus > polygon,
+.c9:focus > polyline,
+.c9:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c9::-webkit-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c9::-moz-placeholder {
+  color: #AAAAAA;
+}
+
+.c9:-ms-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c9::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+.c9::-moz-focus-inner {
+  border: none;
+  outline: none;
+}
+
+.c9:-moz-placeholder,
+.c9::-moz-placeholder {
+  opacity: 1;
+}
+
+.c6 {
+  position: relative;
+  width: 100%;
+}
+
+.c7 {
+  position: absolute;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-packjustify: center;
+  -webkit-justify: center;
+  -ms-flex-packjustify: center;
+  justify: center;
+  top: 50%;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  pointer-events: none;
+  left: 12px;
+}
+
+.c3 {
+  max-width: 100%;
+}
+
+.c13 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c16 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c11 {
+  border-spacing: 0;
+  border-collapse: collapse;
+  width: inherit;
+}
+
+.c12 {
+  position: relative;
+  border-spacing: 0;
+  border-collapse: separate;
+}
+
+.c15:focus {
+  outline: 2px solid #6FFFB0;
+}
+
+.c15:focus:not(:focus-visible) {
+  outline: none;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    -webkit-column-gap: 6px;
+    column-gap: 6px;
+  }
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+    id="data"
+  >
+    <div
+      class="c2"
+    >
+      <form
+        class="c3"
+      >
+        <div
+          class="c4"
+        >
+          <div
+            class="c5"
+          >
+            <div
+              class="c6"
+            >
+              <div
+                class="c7"
+              >
+                <svg
+                  aria-label="Search"
+                  class="c8"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                    fill="none"
+                    stroke="#000"
+                    stroke-width="2"
+                  />
+                </svg>
+              </div>
+              <input
+                aria-label="Search"
+                autocomplete="off"
+                class="c9"
+                id="data--search"
+                name="_search"
+                type="search"
+                value=""
+              />
+            </div>
+          </div>
+        </div>
+      </form>
+    </div>
+    <span
+      class="c10"
+    >
+      4 items
+    </span>
+    <table
+      class="c11 c12"
+    >
+      <thead
+        class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
+      >
+        <tr
+          class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+        >
+          <th
+            class="c13 "
+            scope="col"
+          >
+            <div
+              class="c14"
+            />
+          </th>
+        </tr>
+      </thead>
+      <tbody
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c15"
+      >
+        <tr
+          class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+        >
+          <th
+            class="c16 "
+            scope="row"
+          >
+            <div
+              class="c17"
+            >
+              <span
+                class="c18"
+              >
+                aa
+              </span>
+            </div>
+          </th>
+        </tr>
+        <tr
+          class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+        >
+          <th
+            class="c16 "
+            scope="row"
+          >
+            <div
+              class="c17"
+            >
+              <span
+                class="c18"
+              >
+                bb
+              </span>
+            </div>
+          </th>
+        </tr>
+        <tr
+          class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+        >
+          <th
+            class="c16 "
+            scope="row"
+          >
+            <div
+              class="c17"
+            >
+              <span
+                class="c18"
+              >
+                cc
+              </span>
+            </div>
+          </th>
+        </tr>
+        <tr
+          class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+        >
+          <th
+            class="c16 "
+            scope="row"
+          >
+            <div
+              class="c17"
+            >
+              <span
+                class="c18"
+              >
+                dd
+              </span>
+            </div>
+          </th>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+`;
+
+exports[`Data uncontrolled search 1`] = `
+.c8 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #666666;
+  stroke: #666666;
+}
+
+.c8 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c8 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c8 *[stroke*="#"],
+.c8 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c8 *[fill-rule],
+.c8 *[FILL-RULE],
+.c8 *[fill*="#"],
+.c8 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -5048,19 +5357,54 @@ exports[`Data toolbar search 1`] = `
   flex: 0 0 auto;
 }
 
-.c7 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  height: 100%;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  overflow: auto;
+}
+
+.c10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c16 {
@@ -5139,6 +5483,71 @@ exports[`Data toolbar search 1`] = `
 }
 
 .c11 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  line-height: 0;
+  padding: 12px;
+}
+
+.c11:hover {
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
+}
+
+.c11:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus > circle,
+.c11:focus > ellipse,
+.c11:focus > line,
+.c11:focus > path,
+.c11:focus > polygon,
+.c11:focus > polyline,
+.c11:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c11:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c11:focus:not(:focus-visible) > circle,
+.c11:focus:not(:focus-visible) > ellipse,
+.c11:focus:not(:focus-visible) > line,
+.c11:focus:not(:focus-visible) > path,
+.c11:focus:not(:focus-visible) > polygon,
+.c11:focus:not(:focus-visible) > polyline,
+.c11:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c11:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c9 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -5152,43 +5561,61 @@ exports[`Data toolbar search 1`] = `
   margin: 0;
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
-  outline: none;
-  border: none;
   padding-left: 48px;
 }
 
-.c11::-webkit-input-placeholder {
+.c9:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9:focus > circle,
+.c9:focus > ellipse,
+.c9:focus > line,
+.c9:focus > path,
+.c9:focus > polygon,
+.c9:focus > polyline,
+.c9:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c9::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c11::-moz-placeholder {
+.c9::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c11:-ms-input-placeholder {
+.c9:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c11::-webkit-search-decoration {
+.c9::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c11::-moz-focus-inner {
+.c9::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c11:-moz-placeholder,
-.c11::-moz-placeholder {
+.c9:-moz-placeholder,
+.c9::-moz-placeholder {
   opacity: 1;
 }
 
-.c8 {
+.c6 {
   position: relative;
   width: 100%;
 }
 
-.c9 {
+.c7 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -5260,18 +5687,6 @@ exports[`Data toolbar search 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c6 {
-    margin-bottom: 6px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c7 {
-    border-bottom: solid 1px rgba(0,0,0,0.33);
-  }
-}
-
-@media only screen and (max-width:768px) {
   .c2 {
     -webkit-column-gap: 6px;
     column-gap: 6px;
@@ -5298,45 +5713,60 @@ exports[`Data toolbar search 1`] = `
             class="c5"
           >
             <div
-              class="c6 "
+              class="c6"
             >
               <div
-                class="c7 FormField__FormFieldContentBox-sc-m9hood-1"
+                class="c7"
               >
-                <div
+                <svg
+                  aria-label="Search"
                   class="c8"
+                  viewBox="0 0 24 24"
                 >
-                  <div
-                    class="c9"
-                  >
-                    <svg
-                      aria-label="Search"
-                      class="c10"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                        fill="none"
-                        stroke="#000"
-                        stroke-width="2"
-                      />
-                    </svg>
-                  </div>
-                  <input
-                    aria-label="Search data"
-                    autocomplete="off"
-                    class="c11"
-                    id="data--search"
-                    name="_search"
-                    type="search"
-                    value=""
+                  <path
+                    d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                    fill="none"
+                    stroke="#000"
+                    stroke-width="2"
                   />
-                </div>
+                </svg>
               </div>
+              <input
+                aria-label="Search"
+                autocomplete="off"
+                class="c9"
+                id="data--search"
+                name="_search"
+                type="search"
+                value=""
+              />
             </div>
           </div>
         </div>
       </form>
+      <div
+        class="c10"
+      >
+        <button
+          aria-label="Open filters"
+          class="c11"
+          id="data--filters-control"
+          type="button"
+        >
+          <svg
+            aria-label="Filter"
+            class="c8"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="m3 6 7 7v8h4v-8l7-7V3H3z"
+              fill="none"
+              stroke="#000"
+              stroke-width="2"
+            />
+          </svg>
+        </button>
+      </div>
     </div>
     <span
       class="c12"
@@ -5443,619 +5873,6 @@ exports[`Data toolbar search 1`] = `
 </div>
 `;
 
-exports[`Data uncontrolled search 1`] = `
-.c10 {
-  display: inline-block;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
-  fill: #666666;
-  stroke: #666666;
-}
-
-.c10 g {
-  fill: inherit;
-  stroke: inherit;
-}
-
-.c10 *:not([stroke])[fill="none"] {
-  stroke-width: 0;
-}
-
-.c10 *[stroke*="#"],
-.c10 *[STROKE*="#"] {
-  stroke: inherit;
-  fill: none;
-}
-
-.c10 *[fill-rule],
-.c10 *[FILL-RULE],
-.c10 *[fill*="#"],
-.c10 *[FILL*="#"] {
-  fill: inherit;
-  stroke: none;
-}
-
-.c0 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-}
-
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  height: 100%;
-}
-
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 1 1;
-  -ms-flex: 1 1;
-  flex: 1 1;
-  overflow: auto;
-}
-
-.c6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  margin-bottom: 12px;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-}
-
-.c7 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c12 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-}
-
-.c18 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-}
-
-.c21 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-column-gap: 12px;
-  column-gap: 12px;
-  row-gap: 12px;
-}
-
-.c14 {
-  margin-top: 6px;
-  margin-bottom: 6px;
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c22 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-.c13 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  color: inherit;
-  outline: none;
-  border: none;
-  padding: 0;
-  text-align: inherit;
-  line-height: 0;
-  padding: 12px;
-}
-
-.c13:hover {
-  background-color: rgba(221,221,221,0.4);
-  color: #000000;
-}
-
-.c13:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c13:focus > circle,
-.c13:focus > ellipse,
-.c13:focus > line,
-.c13:focus > path,
-.c13:focus > polygon,
-.c13:focus > polyline,
-.c13:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c13:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c13:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c13:focus:not(:focus-visible) > circle,
-.c13:focus:not(:focus-visible) > ellipse,
-.c13:focus:not(:focus-visible) > line,
-.c13:focus:not(:focus-visible) > path,
-.c13:focus:not(:focus-visible) > polygon,
-.c13:focus:not(:focus-visible) > polyline,
-.c13:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c13:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c11 {
-  box-sizing: border-box;
-  font-size: inherit;
-  font-family: inherit;
-  border: none;
-  -webkit-appearance: none;
-  background: transparent;
-  color: inherit;
-  width: 100%;
-  padding: 11px;
-  font-weight: 600;
-  margin: 0;
-  border: 1px solid rgba(0,0,0,0.33);
-  border-radius: 4px;
-  outline: none;
-  border: none;
-  padding-left: 48px;
-}
-
-.c11::-webkit-input-placeholder {
-  color: #AAAAAA;
-}
-
-.c11::-moz-placeholder {
-  color: #AAAAAA;
-}
-
-.c11:-ms-input-placeholder {
-  color: #AAAAAA;
-}
-
-.c11::-webkit-search-decoration {
-  -webkit-appearance: none;
-}
-
-.c11::-moz-focus-inner {
-  border: none;
-  outline: none;
-}
-
-.c11:-moz-placeholder,
-.c11::-moz-placeholder {
-  opacity: 1;
-}
-
-.c8 {
-  position: relative;
-  width: 100%;
-}
-
-.c9 {
-  position: absolute;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-packjustify: center;
-  -webkit-justify: center;
-  -ms-flex-packjustify: center;
-  justify: center;
-  top: 50%;
-  -webkit-transform: translateY(-50%);
-  -ms-transform: translateY(-50%);
-  transform: translateY(-50%);
-  pointer-events: none;
-  left: 12px;
-}
-
-.c3 {
-  max-width: 100%;
-}
-
-.c17 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-.c20 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-.c15 {
-  border-spacing: 0;
-  border-collapse: collapse;
-  width: inherit;
-}
-
-.c16 {
-  position: relative;
-  border-spacing: 0;
-  border-collapse: separate;
-}
-
-.c19:focus {
-  outline: 2px solid #6FFFB0;
-}
-
-.c19:focus:not(:focus-visible) {
-  outline: none;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-  .c6 {
-    margin-bottom: 6px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c7 {
-    border-bottom: solid 1px rgba(0,0,0,0.33);
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c2 {
-    -webkit-column-gap: 6px;
-    column-gap: 6px;
-  }
-}
-
-<div
-  class="c0"
->
-  <div
-    class="c1"
-    id="data"
-  >
-    <div
-      class="c2"
-    >
-      <form
-        class="c3"
-      >
-        <div
-          class="c4"
-        >
-          <div
-            class="c5"
-          >
-            <div
-              class="c6 "
-            >
-              <div
-                class="c7 FormField__FormFieldContentBox-sc-m9hood-1"
-              >
-                <div
-                  class="c8"
-                >
-                  <div
-                    class="c9"
-                  >
-                    <svg
-                      aria-label="Search"
-                      class="c10"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                        fill="none"
-                        stroke="#000"
-                        stroke-width="2"
-                      />
-                    </svg>
-                  </div>
-                  <input
-                    aria-label="Search data"
-                    autocomplete="off"
-                    class="c11"
-                    id="data--search"
-                    name="_search"
-                    type="search"
-                    value=""
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </form>
-      <div
-        class="c12"
-      >
-        <button
-          aria-label="Open filters"
-          class="c13"
-          id="data--filters-control"
-          type="button"
-        >
-          <svg
-            aria-label="Filter"
-            class="c10"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="m3 6 7 7v8h4v-8l7-7V3H3z"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-      </div>
-    </div>
-    <span
-      class="c14"
-    >
-      4 items
-    </span>
-    <table
-      class="c15 c16"
-    >
-      <thead
-        class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
-      >
-        <tr
-          class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
-        >
-          <th
-            class="c17 "
-            scope="col"
-          >
-            <div
-              class="c18"
-            />
-          </th>
-        </tr>
-      </thead>
-      <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c19"
-      >
-        <tr
-          class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
-        >
-          <th
-            class="c20 "
-            scope="row"
-          >
-            <div
-              class="c21"
-            >
-              <span
-                class="c22"
-              >
-                aa
-              </span>
-            </div>
-          </th>
-        </tr>
-        <tr
-          class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
-        >
-          <th
-            class="c20 "
-            scope="row"
-          >
-            <div
-              class="c21"
-            >
-              <span
-                class="c22"
-              >
-                bb
-              </span>
-            </div>
-          </th>
-        </tr>
-        <tr
-          class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
-        >
-          <th
-            class="c20 "
-            scope="row"
-          >
-            <div
-              class="c21"
-            >
-              <span
-                class="c22"
-              >
-                cc
-              </span>
-            </div>
-          </th>
-        </tr>
-        <tr
-          class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
-        >
-          <th
-            class="c20 "
-            scope="row"
-          >
-            <div
-              class="c21"
-            >
-              <span
-                class="c22"
-              >
-                dd
-              </span>
-            </div>
-          </th>
-        </tr>
-      </tbody>
-    </table>
-  </div>
-</div>
-`;
-
 exports[`Data uncontrolled search 2`] = `
 <div
   class="StyledGrommet-sc-19lkkz7-0 ioQEen"
@@ -6077,41 +5894,33 @@ exports[`Data uncontrolled search 2`] = `
             class="StyledBox-sc-13pk1d4-0 dePIJN"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
+              class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 edcgVv"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 cqRjpC FormField__FormFieldContentBox-sc-m9hood-1"
+                class="StyledTextInput__StyledIcon-sc-1x30a0s-3 cFBrkA"
               >
-                <div
-                  class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 edcgVv"
+                <svg
+                  aria-label="Search"
+                  class="StyledIcon-sc-ofa7kd-0 jQvEgu"
+                  viewBox="0 0 24 24"
                 >
-                  <div
-                    class="StyledTextInput__StyledIcon-sc-1x30a0s-3 cFBrkA"
-                  >
-                    <svg
-                      aria-label="Search"
-                      class="StyledIcon-sc-ofa7kd-0 jQvEgu"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                        fill="none"
-                        stroke="#000"
-                        stroke-width="2"
-                      />
-                    </svg>
-                  </div>
-                  <input
-                    aria-label="Search data"
-                    autocomplete="off"
-                    class="StyledTextInput-sc-1x30a0s-0 kovfiL"
-                    id="data--search"
-                    name="_search"
-                    type="search"
-                    value="a"
+                  <path
+                    d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                    fill="none"
+                    stroke="#000"
+                    stroke-width="2"
                   />
-                </div>
+                </svg>
               </div>
+              <input
+                aria-label="Search"
+                autocomplete="off"
+                class="StyledTextInput-sc-1x30a0s-0 bMqJAS"
+                id="data--search"
+                name="_search"
+                type="search"
+                value="a"
+              />
             </div>
           </div>
         </div>
@@ -6466,7 +6275,7 @@ exports[`Data view 1`] = `
 `;
 
 exports[`Data view all 1`] = `
-.c10 {
+.c8 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -6477,25 +6286,25 @@ exports[`Data view all 1`] = `
   stroke: #666666;
 }
 
-.c10 g {
+.c8 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c10 *:not([stroke])[fill="none"] {
+.c8 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c10 *[stroke*="#"],
-.c10 *[STROKE*="#"] {
+.c8 *[stroke*="#"],
+.c8 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c10 *[fill-rule],
-.c10 *[FILL-RULE],
-.c10 *[fill*="#"],
-.c10 *[FILL*="#"] {
+.c8 *[fill-rule],
+.c8 *[FILL-RULE],
+.c8 *[fill*="#"],
+.c8 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -6560,40 +6369,7 @@ exports[`Data view all 1`] = `
   overflow: auto;
 }
 
-.c6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  margin-bottom: 12px;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-}
-
-.c7 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c12 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6610,7 +6386,7 @@ exports[`Data view all 1`] = `
   flex: 0 0 auto;
 }
 
-.c18 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6631,7 +6407,7 @@ exports[`Data view all 1`] = `
   justify-content: center;
 }
 
-.c21 {
+.c19 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6672,25 +6448,25 @@ exports[`Data view all 1`] = `
   row-gap: 12px;
 }
 
-.c14 {
+.c12 {
   margin-top: 6px;
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
 }
 
-.c22 {
+.c20 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
 }
 
-.c23 {
+.c21 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c13 {
+.c11 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -6710,52 +6486,52 @@ exports[`Data view all 1`] = `
   padding: 12px;
 }
 
-.c13:hover {
+.c11:hover {
   background-color: rgba(221,221,221,0.4);
   color: #000000;
 }
 
-.c13:focus {
+.c11:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus > circle,
-.c13:focus > ellipse,
-.c13:focus > line,
-.c13:focus > path,
-.c13:focus > polygon,
-.c13:focus > polyline,
-.c13:focus > rect {
+.c11:focus > circle,
+.c11:focus > ellipse,
+.c11:focus > line,
+.c11:focus > path,
+.c11:focus > polygon,
+.c11:focus > polyline,
+.c11:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus::-moz-focus-inner {
+.c11:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c13:focus:not(:focus-visible) {
+.c11:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible) > circle,
-.c13:focus:not(:focus-visible) > ellipse,
-.c13:focus:not(:focus-visible) > line,
-.c13:focus:not(:focus-visible) > path,
-.c13:focus:not(:focus-visible) > polygon,
-.c13:focus:not(:focus-visible) > polyline,
-.c13:focus:not(:focus-visible) > rect {
+.c11:focus:not(:focus-visible) > circle,
+.c11:focus:not(:focus-visible) > ellipse,
+.c11:focus:not(:focus-visible) > line,
+.c11:focus:not(:focus-visible) > path,
+.c11:focus:not(:focus-visible) > polygon,
+.c11:focus:not(:focus-visible) > polyline,
+.c11:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible)::-moz-focus-inner {
+.c11:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c11 {
+.c9 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -6769,43 +6545,61 @@ exports[`Data view all 1`] = `
   margin: 0;
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
-  outline: none;
-  border: none;
   padding-left: 48px;
 }
 
-.c11::-webkit-input-placeholder {
+.c9:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9:focus > circle,
+.c9:focus > ellipse,
+.c9:focus > line,
+.c9:focus > path,
+.c9:focus > polygon,
+.c9:focus > polyline,
+.c9:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c9::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c11::-moz-placeholder {
+.c9::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c11:-ms-input-placeholder {
+.c9:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c11::-webkit-search-decoration {
+.c9::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c11::-moz-focus-inner {
+.c9::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c11:-moz-placeholder,
-.c11::-moz-placeholder {
+.c9:-moz-placeholder,
+.c9::-moz-placeholder {
   opacity: 1;
 }
 
-.c8 {
+.c6 {
   position: relative;
   width: 100%;
 }
 
-.c9 {
+.c7 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -6827,7 +6621,7 @@ exports[`Data view all 1`] = `
   max-width: 100%;
 }
 
-.c17 {
+.c15 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -6840,7 +6634,7 @@ exports[`Data view all 1`] = `
   padding-bottom: 6px;
 }
 
-.c20 {
+.c18 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -6852,40 +6646,28 @@ exports[`Data view all 1`] = `
   padding-bottom: 6px;
 }
 
-.c15 {
+.c13 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
 }
 
-.c16 {
+.c14 {
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
 }
 
-.c19:focus {
+.c17:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c19:focus:not(:focus-visible) {
+.c17:focus:not(:focus-visible) {
   outline: none;
 }
 
 @media only screen and (max-width:768px) {
 
-}
-
-@media only screen and (max-width:768px) {
-  .c6 {
-    margin-bottom: 6px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c7 {
-    border-bottom: solid 1px rgba(0,0,0,0.33);
-  }
 }
 
 @media only screen and (max-width:768px) {
@@ -6915,57 +6697,49 @@ exports[`Data view all 1`] = `
             class="c5"
           >
             <div
-              class="c6 "
+              class="c6"
             >
               <div
-                class="c7 FormField__FormFieldContentBox-sc-m9hood-1"
+                class="c7"
               >
-                <div
+                <svg
+                  aria-label="Search"
                   class="c8"
+                  viewBox="0 0 24 24"
                 >
-                  <div
-                    class="c9"
-                  >
-                    <svg
-                      aria-label="Search"
-                      class="c10"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                        fill="none"
-                        stroke="#000"
-                        stroke-width="2"
-                      />
-                    </svg>
-                  </div>
-                  <input
-                    aria-label="Search data"
-                    autocomplete="off"
-                    class="c11"
-                    id="data--search"
-                    name="_search"
-                    type="search"
-                    value="a"
+                  <path
+                    d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                    fill="none"
+                    stroke="#000"
+                    stroke-width="2"
                   />
-                </div>
+                </svg>
               </div>
+              <input
+                aria-label="Search"
+                autocomplete="off"
+                class="c9"
+                id="data--search"
+                name="_search"
+                type="search"
+                value="a"
+              />
             </div>
           </div>
         </div>
       </form>
       <div
-        class="c12"
+        class="c10"
       >
         <button
           aria-label="Open filters"
-          class="c13"
+          class="c11"
           id="data--filters-control"
           type="button"
         >
           <svg
             aria-label="Filter"
-            class="c10"
+            class="c8"
             viewBox="0 0 24 24"
           >
             <path
@@ -6979,12 +6753,12 @@ exports[`Data view all 1`] = `
       </div>
     </div>
     <span
-      class="c14"
+      class="c12"
     >
       1 result of 4 items
     </span>
     <table
-      class="c15 c16"
+      class="c13 c14"
     >
       <thead
         class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -6993,51 +6767,51 @@ exports[`Data view all 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c17 "
+            class="c15 "
             scope="col"
           >
             <div
-              class="c18"
+              class="c16"
             />
           </th>
           <th
-            class="c17 "
+            class="c15 "
             scope="col"
           >
             <div
-              class="c18"
+              class="c16"
             />
           </th>
         </tr>
       </thead>
       <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c19"
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c17"
       >
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c20 "
+            class="c18 "
             scope="row"
           >
             <div
-              class="c21"
+              class="c19"
             >
               <span
-                class="c22"
+                class="c20"
               >
                 aa
               </span>
             </div>
           </th>
           <td
-            class="c20 "
+            class="c18 "
           >
             <div
-              class="c21"
+              class="c19"
             >
               <span
-                class="c23"
+                class="c21"
               >
                 ZZ
               </span>
@@ -7051,7 +6825,7 @@ exports[`Data view all 1`] = `
 `;
 
 exports[`Data view property option 1`] = `
-.c10 {
+.c8 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -7062,25 +6836,25 @@ exports[`Data view property option 1`] = `
   stroke: #666666;
 }
 
-.c10 g {
+.c8 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c10 *:not([stroke])[fill="none"] {
+.c8 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c10 *[stroke*="#"],
-.c10 *[STROKE*="#"] {
+.c8 *[stroke*="#"],
+.c8 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c10 *[fill-rule],
-.c10 *[FILL-RULE],
-.c10 *[fill*="#"],
-.c10 *[FILL*="#"] {
+.c8 *[fill-rule],
+.c8 *[FILL-RULE],
+.c8 *[fill*="#"],
+.c8 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -7145,40 +6919,7 @@ exports[`Data view property option 1`] = `
   overflow: auto;
 }
 
-.c6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  margin-bottom: 12px;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-}
-
-.c7 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c12 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7195,7 +6936,7 @@ exports[`Data view property option 1`] = `
   flex: 0 0 auto;
 }
 
-.c18 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7216,7 +6957,7 @@ exports[`Data view property option 1`] = `
   justify-content: center;
 }
 
-.c21 {
+.c19 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7257,25 +6998,25 @@ exports[`Data view property option 1`] = `
   row-gap: 12px;
 }
 
-.c14 {
+.c12 {
   margin-top: 6px;
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
 }
 
-.c22 {
+.c20 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
 }
 
-.c23 {
+.c21 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c13 {
+.c11 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -7295,52 +7036,52 @@ exports[`Data view property option 1`] = `
   padding: 12px;
 }
 
-.c13:hover {
+.c11:hover {
   background-color: rgba(221,221,221,0.4);
   color: #000000;
 }
 
-.c13:focus {
+.c11:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus > circle,
-.c13:focus > ellipse,
-.c13:focus > line,
-.c13:focus > path,
-.c13:focus > polygon,
-.c13:focus > polyline,
-.c13:focus > rect {
+.c11:focus > circle,
+.c11:focus > ellipse,
+.c11:focus > line,
+.c11:focus > path,
+.c11:focus > polygon,
+.c11:focus > polyline,
+.c11:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus::-moz-focus-inner {
+.c11:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c13:focus:not(:focus-visible) {
+.c11:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible) > circle,
-.c13:focus:not(:focus-visible) > ellipse,
-.c13:focus:not(:focus-visible) > line,
-.c13:focus:not(:focus-visible) > path,
-.c13:focus:not(:focus-visible) > polygon,
-.c13:focus:not(:focus-visible) > polyline,
-.c13:focus:not(:focus-visible) > rect {
+.c11:focus:not(:focus-visible) > circle,
+.c11:focus:not(:focus-visible) > ellipse,
+.c11:focus:not(:focus-visible) > line,
+.c11:focus:not(:focus-visible) > path,
+.c11:focus:not(:focus-visible) > polygon,
+.c11:focus:not(:focus-visible) > polyline,
+.c11:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible)::-moz-focus-inner {
+.c11:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c11 {
+.c9 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -7354,43 +7095,61 @@ exports[`Data view property option 1`] = `
   margin: 0;
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
-  outline: none;
-  border: none;
   padding-left: 48px;
 }
 
-.c11::-webkit-input-placeholder {
+.c9:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9:focus > circle,
+.c9:focus > ellipse,
+.c9:focus > line,
+.c9:focus > path,
+.c9:focus > polygon,
+.c9:focus > polyline,
+.c9:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c9::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c11::-moz-placeholder {
+.c9::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c11:-ms-input-placeholder {
+.c9:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c11::-webkit-search-decoration {
+.c9::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c11::-moz-focus-inner {
+.c9::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c11:-moz-placeholder,
-.c11::-moz-placeholder {
+.c9:-moz-placeholder,
+.c9::-moz-placeholder {
   opacity: 1;
 }
 
-.c8 {
+.c6 {
   position: relative;
   width: 100%;
 }
 
-.c9 {
+.c7 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -7412,7 +7171,7 @@ exports[`Data view property option 1`] = `
   max-width: 100%;
 }
 
-.c17 {
+.c15 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -7425,7 +7184,7 @@ exports[`Data view property option 1`] = `
   padding-bottom: 6px;
 }
 
-.c20 {
+.c18 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -7437,40 +7196,28 @@ exports[`Data view property option 1`] = `
   padding-bottom: 6px;
 }
 
-.c15 {
+.c13 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
 }
 
-.c16 {
+.c14 {
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
 }
 
-.c19:focus {
+.c17:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c19:focus:not(:focus-visible) {
+.c17:focus:not(:focus-visible) {
   outline: none;
 }
 
 @media only screen and (max-width:768px) {
 
-}
-
-@media only screen and (max-width:768px) {
-  .c6 {
-    margin-bottom: 6px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c7 {
-    border-bottom: solid 1px rgba(0,0,0,0.33);
-  }
 }
 
 @media only screen and (max-width:768px) {
@@ -7500,57 +7247,49 @@ exports[`Data view property option 1`] = `
             class="c5"
           >
             <div
-              class="c6 "
+              class="c6"
             >
               <div
-                class="c7 FormField__FormFieldContentBox-sc-m9hood-1"
+                class="c7"
               >
-                <div
+                <svg
+                  aria-label="Search"
                   class="c8"
+                  viewBox="0 0 24 24"
                 >
-                  <div
-                    class="c9"
-                  >
-                    <svg
-                      aria-label="Search"
-                      class="c10"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                        fill="none"
-                        stroke="#000"
-                        stroke-width="2"
-                      />
-                    </svg>
-                  </div>
-                  <input
-                    aria-label="Search data"
-                    autocomplete="off"
-                    class="c11"
-                    id="data--search"
-                    name="_search"
-                    type="search"
-                    value=""
+                  <path
+                    d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                    fill="none"
+                    stroke="#000"
+                    stroke-width="2"
                   />
-                </div>
+                </svg>
               </div>
+              <input
+                aria-label="Search"
+                autocomplete="off"
+                class="c9"
+                id="data--search"
+                name="_search"
+                type="search"
+                value=""
+              />
             </div>
           </div>
         </div>
       </form>
       <div
-        class="c12"
+        class="c10"
       >
         <button
           aria-label="Open filters"
-          class="c13"
+          class="c11"
           id="data--filters-control"
           type="button"
         >
           <svg
             aria-label="Filter"
-            class="c10"
+            class="c8"
             viewBox="0 0 24 24"
           >
             <path
@@ -7564,12 +7303,12 @@ exports[`Data view property option 1`] = `
       </div>
     </div>
     <span
-      class="c14"
+      class="c12"
     >
       1 result of 4 items
     </span>
     <table
-      class="c15 c16"
+      class="c13 c14"
     >
       <thead
         class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -7578,51 +7317,51 @@ exports[`Data view property option 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c17 "
+            class="c15 "
             scope="col"
           >
             <div
-              class="c18"
+              class="c16"
             />
           </th>
           <th
-            class="c17 "
+            class="c15 "
             scope="col"
           >
             <div
-              class="c18"
+              class="c16"
             />
           </th>
         </tr>
       </thead>
       <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c19"
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c17"
       >
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c20 "
+            class="c18 "
             scope="row"
           >
             <div
-              class="c21"
+              class="c19"
             >
               <span
-                class="c22"
+                class="c20"
               >
                 aa
               </span>
             </div>
           </th>
           <td
-            class="c20 "
+            class="c18 "
           >
             <div
-              class="c21"
+              class="c19"
             >
               <span
-                class="c23"
+                class="c21"
               >
                 ZZ
               </span>
@@ -7636,7 +7375,7 @@ exports[`Data view property option 1`] = `
 `;
 
 exports[`Data view property range 1`] = `
-.c10 {
+.c8 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -7647,25 +7386,25 @@ exports[`Data view property range 1`] = `
   stroke: #666666;
 }
 
-.c10 g {
+.c8 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c10 *:not([stroke])[fill="none"] {
+.c8 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c10 *[stroke*="#"],
-.c10 *[STROKE*="#"] {
+.c8 *[stroke*="#"],
+.c8 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c10 *[fill-rule],
-.c10 *[FILL-RULE],
-.c10 *[fill*="#"],
-.c10 *[FILL*="#"] {
+.c8 *[fill-rule],
+.c8 *[FILL-RULE],
+.c8 *[fill*="#"],
+.c8 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -7730,40 +7469,7 @@ exports[`Data view property range 1`] = `
   overflow: auto;
 }
 
-.c6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  margin-bottom: 12px;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-}
-
-.c7 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c12 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7780,7 +7486,7 @@ exports[`Data view property range 1`] = `
   flex: 0 0 auto;
 }
 
-.c18 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7801,7 +7507,7 @@ exports[`Data view property range 1`] = `
   justify-content: center;
 }
 
-.c21 {
+.c19 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7842,25 +7548,25 @@ exports[`Data view property range 1`] = `
   row-gap: 12px;
 }
 
-.c14 {
+.c12 {
   margin-top: 6px;
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
 }
 
-.c22 {
+.c20 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
 }
 
-.c23 {
+.c21 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c13 {
+.c11 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -7880,52 +7586,52 @@ exports[`Data view property range 1`] = `
   padding: 12px;
 }
 
-.c13:hover {
+.c11:hover {
   background-color: rgba(221,221,221,0.4);
   color: #000000;
 }
 
-.c13:focus {
+.c11:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus > circle,
-.c13:focus > ellipse,
-.c13:focus > line,
-.c13:focus > path,
-.c13:focus > polygon,
-.c13:focus > polyline,
-.c13:focus > rect {
+.c11:focus > circle,
+.c11:focus > ellipse,
+.c11:focus > line,
+.c11:focus > path,
+.c11:focus > polygon,
+.c11:focus > polyline,
+.c11:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus::-moz-focus-inner {
+.c11:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c13:focus:not(:focus-visible) {
+.c11:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible) > circle,
-.c13:focus:not(:focus-visible) > ellipse,
-.c13:focus:not(:focus-visible) > line,
-.c13:focus:not(:focus-visible) > path,
-.c13:focus:not(:focus-visible) > polygon,
-.c13:focus:not(:focus-visible) > polyline,
-.c13:focus:not(:focus-visible) > rect {
+.c11:focus:not(:focus-visible) > circle,
+.c11:focus:not(:focus-visible) > ellipse,
+.c11:focus:not(:focus-visible) > line,
+.c11:focus:not(:focus-visible) > path,
+.c11:focus:not(:focus-visible) > polygon,
+.c11:focus:not(:focus-visible) > polyline,
+.c11:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible)::-moz-focus-inner {
+.c11:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c11 {
+.c9 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -7939,43 +7645,61 @@ exports[`Data view property range 1`] = `
   margin: 0;
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
-  outline: none;
-  border: none;
   padding-left: 48px;
 }
 
-.c11::-webkit-input-placeholder {
+.c9:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9:focus > circle,
+.c9:focus > ellipse,
+.c9:focus > line,
+.c9:focus > path,
+.c9:focus > polygon,
+.c9:focus > polyline,
+.c9:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c9::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c11::-moz-placeholder {
+.c9::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c11:-ms-input-placeholder {
+.c9:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c11::-webkit-search-decoration {
+.c9::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c11::-moz-focus-inner {
+.c9::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c11:-moz-placeholder,
-.c11::-moz-placeholder {
+.c9:-moz-placeholder,
+.c9::-moz-placeholder {
   opacity: 1;
 }
 
-.c8 {
+.c6 {
   position: relative;
   width: 100%;
 }
 
-.c9 {
+.c7 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -7997,7 +7721,7 @@ exports[`Data view property range 1`] = `
   max-width: 100%;
 }
 
-.c17 {
+.c15 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -8010,7 +7734,7 @@ exports[`Data view property range 1`] = `
   padding-bottom: 6px;
 }
 
-.c20 {
+.c18 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -8022,40 +7746,28 @@ exports[`Data view property range 1`] = `
   padding-bottom: 6px;
 }
 
-.c15 {
+.c13 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
 }
 
-.c16 {
+.c14 {
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
 }
 
-.c19:focus {
+.c17:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c19:focus:not(:focus-visible) {
+.c17:focus:not(:focus-visible) {
   outline: none;
 }
 
 @media only screen and (max-width:768px) {
 
-}
-
-@media only screen and (max-width:768px) {
-  .c6 {
-    margin-bottom: 6px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c7 {
-    border-bottom: solid 1px rgba(0,0,0,0.33);
-  }
 }
 
 @media only screen and (max-width:768px) {
@@ -8085,57 +7797,49 @@ exports[`Data view property range 1`] = `
             class="c5"
           >
             <div
-              class="c6 "
+              class="c6"
             >
               <div
-                class="c7 FormField__FormFieldContentBox-sc-m9hood-1"
+                class="c7"
               >
-                <div
+                <svg
+                  aria-label="Search"
                   class="c8"
+                  viewBox="0 0 24 24"
                 >
-                  <div
-                    class="c9"
-                  >
-                    <svg
-                      aria-label="Search"
-                      class="c10"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                        fill="none"
-                        stroke="#000"
-                        stroke-width="2"
-                      />
-                    </svg>
-                  </div>
-                  <input
-                    aria-label="Search data"
-                    autocomplete="off"
-                    class="c11"
-                    id="data--search"
-                    name="_search"
-                    type="search"
-                    value=""
+                  <path
+                    d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                    fill="none"
+                    stroke="#000"
+                    stroke-width="2"
                   />
-                </div>
+                </svg>
               </div>
+              <input
+                aria-label="Search"
+                autocomplete="off"
+                class="c9"
+                id="data--search"
+                name="_search"
+                type="search"
+                value=""
+              />
             </div>
           </div>
         </div>
       </form>
       <div
-        class="c12"
+        class="c10"
       >
         <button
           aria-label="Open filters"
-          class="c13"
+          class="c11"
           id="data--filters-control"
           type="button"
         >
           <svg
             aria-label="Filter"
-            class="c10"
+            class="c8"
             viewBox="0 0 24 24"
           >
             <path
@@ -8149,12 +7853,12 @@ exports[`Data view property range 1`] = `
       </div>
     </div>
     <span
-      class="c14"
+      class="c12"
     >
       1 result of 4 items
     </span>
     <table
-      class="c15 c16"
+      class="c13 c14"
     >
       <thead
         class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -8163,72 +7867,72 @@ exports[`Data view property range 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c17 "
+            class="c15 "
             scope="col"
           >
             <div
-              class="c18"
+              class="c16"
             />
           </th>
           <th
-            class="c17 "
+            class="c15 "
             scope="col"
           >
             <div
-              class="c18"
+              class="c16"
             />
           </th>
           <th
-            class="c17 "
+            class="c15 "
             scope="col"
           >
             <div
-              class="c18"
+              class="c16"
             />
           </th>
         </tr>
       </thead>
       <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c19"
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c17"
       >
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c20 "
+            class="c18 "
             scope="row"
           >
             <div
-              class="c21"
+              class="c19"
             >
               <span
-                class="c22"
+                class="c20"
               >
                 bb
               </span>
             </div>
           </th>
           <td
-            class="c20 "
+            class="c18 "
           >
             <div
-              class="c21"
+              class="c19"
             >
               <span
-                class="c23"
+                class="c21"
               >
                 YY
               </span>
             </div>
           </td>
           <td
-            class="c20 "
+            class="c18 "
           >
             <div
-              class="c21"
+              class="c19"
             >
               <span
-                class="c23"
+                class="c21"
               >
                 4.3
               </span>
@@ -8242,7 +7946,7 @@ exports[`Data view property range 1`] = `
 `;
 
 exports[`Data view search 1`] = `
-.c10 {
+.c8 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -8253,25 +7957,25 @@ exports[`Data view search 1`] = `
   stroke: #666666;
 }
 
-.c10 g {
+.c8 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c10 *:not([stroke])[fill="none"] {
+.c8 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c10 *[stroke*="#"],
-.c10 *[STROKE*="#"] {
+.c8 *[stroke*="#"],
+.c8 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c10 *[fill-rule],
-.c10 *[FILL-RULE],
-.c10 *[fill*="#"],
-.c10 *[FILL*="#"] {
+.c8 *[fill-rule],
+.c8 *[FILL-RULE],
+.c8 *[fill*="#"],
+.c8 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -8336,40 +8040,7 @@ exports[`Data view search 1`] = `
   overflow: auto;
 }
 
-.c6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  margin-bottom: 12px;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-}
-
-.c7 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c12 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8386,7 +8057,7 @@ exports[`Data view search 1`] = `
   flex: 0 0 auto;
 }
 
-.c18 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8407,7 +8078,7 @@ exports[`Data view search 1`] = `
   justify-content: center;
 }
 
-.c21 {
+.c19 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8448,25 +8119,25 @@ exports[`Data view search 1`] = `
   row-gap: 12px;
 }
 
-.c14 {
+.c12 {
   margin-top: 6px;
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
 }
 
-.c22 {
+.c20 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
 }
 
-.c23 {
+.c21 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c13 {
+.c11 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -8486,52 +8157,52 @@ exports[`Data view search 1`] = `
   padding: 12px;
 }
 
-.c13:hover {
+.c11:hover {
   background-color: rgba(221,221,221,0.4);
   color: #000000;
 }
 
-.c13:focus {
+.c11:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus > circle,
-.c13:focus > ellipse,
-.c13:focus > line,
-.c13:focus > path,
-.c13:focus > polygon,
-.c13:focus > polyline,
-.c13:focus > rect {
+.c11:focus > circle,
+.c11:focus > ellipse,
+.c11:focus > line,
+.c11:focus > path,
+.c11:focus > polygon,
+.c11:focus > polyline,
+.c11:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus::-moz-focus-inner {
+.c11:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c13:focus:not(:focus-visible) {
+.c11:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible) > circle,
-.c13:focus:not(:focus-visible) > ellipse,
-.c13:focus:not(:focus-visible) > line,
-.c13:focus:not(:focus-visible) > path,
-.c13:focus:not(:focus-visible) > polygon,
-.c13:focus:not(:focus-visible) > polyline,
-.c13:focus:not(:focus-visible) > rect {
+.c11:focus:not(:focus-visible) > circle,
+.c11:focus:not(:focus-visible) > ellipse,
+.c11:focus:not(:focus-visible) > line,
+.c11:focus:not(:focus-visible) > path,
+.c11:focus:not(:focus-visible) > polygon,
+.c11:focus:not(:focus-visible) > polyline,
+.c11:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible)::-moz-focus-inner {
+.c11:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c11 {
+.c9 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -8545,43 +8216,61 @@ exports[`Data view search 1`] = `
   margin: 0;
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
-  outline: none;
-  border: none;
   padding-left: 48px;
 }
 
-.c11::-webkit-input-placeholder {
+.c9:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9:focus > circle,
+.c9:focus > ellipse,
+.c9:focus > line,
+.c9:focus > path,
+.c9:focus > polygon,
+.c9:focus > polyline,
+.c9:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c9::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c11::-moz-placeholder {
+.c9::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c11:-ms-input-placeholder {
+.c9:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c11::-webkit-search-decoration {
+.c9::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c11::-moz-focus-inner {
+.c9::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c11:-moz-placeholder,
-.c11::-moz-placeholder {
+.c9:-moz-placeholder,
+.c9::-moz-placeholder {
   opacity: 1;
 }
 
-.c8 {
+.c6 {
   position: relative;
   width: 100%;
 }
 
-.c9 {
+.c7 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -8603,7 +8292,7 @@ exports[`Data view search 1`] = `
   max-width: 100%;
 }
 
-.c17 {
+.c15 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -8616,7 +8305,7 @@ exports[`Data view search 1`] = `
   padding-bottom: 6px;
 }
 
-.c20 {
+.c18 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -8628,40 +8317,28 @@ exports[`Data view search 1`] = `
   padding-bottom: 6px;
 }
 
-.c15 {
+.c13 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
 }
 
-.c16 {
+.c14 {
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
 }
 
-.c19:focus {
+.c17:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c19:focus:not(:focus-visible) {
+.c17:focus:not(:focus-visible) {
   outline: none;
 }
 
 @media only screen and (max-width:768px) {
 
-}
-
-@media only screen and (max-width:768px) {
-  .c6 {
-    margin-bottom: 6px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c7 {
-    border-bottom: solid 1px rgba(0,0,0,0.33);
-  }
 }
 
 @media only screen and (max-width:768px) {
@@ -8691,57 +8368,49 @@ exports[`Data view search 1`] = `
             class="c5"
           >
             <div
-              class="c6 "
+              class="c6"
             >
               <div
-                class="c7 FormField__FormFieldContentBox-sc-m9hood-1"
+                class="c7"
               >
-                <div
+                <svg
+                  aria-label="Search"
                   class="c8"
+                  viewBox="0 0 24 24"
                 >
-                  <div
-                    class="c9"
-                  >
-                    <svg
-                      aria-label="Search"
-                      class="c10"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                        fill="none"
-                        stroke="#000"
-                        stroke-width="2"
-                      />
-                    </svg>
-                  </div>
-                  <input
-                    aria-label="Search data"
-                    autocomplete="off"
-                    class="c11"
-                    id="data--search"
-                    name="_search"
-                    type="search"
-                    value="a"
+                  <path
+                    d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                    fill="none"
+                    stroke="#000"
+                    stroke-width="2"
                   />
-                </div>
+                </svg>
               </div>
+              <input
+                aria-label="Search"
+                autocomplete="off"
+                class="c9"
+                id="data--search"
+                name="_search"
+                type="search"
+                value="a"
+              />
             </div>
           </div>
         </div>
       </form>
       <div
-        class="c12"
+        class="c10"
       >
         <button
           aria-label="Open filters"
-          class="c13"
+          class="c11"
           id="data--filters-control"
           type="button"
         >
           <svg
             aria-label="Filter"
-            class="c10"
+            class="c8"
             viewBox="0 0 24 24"
           >
             <path
@@ -8755,12 +8424,12 @@ exports[`Data view search 1`] = `
       </div>
     </div>
     <span
-      class="c14"
+      class="c12"
     >
       1 result of 4 items
     </span>
     <table
-      class="c15 c16"
+      class="c13 c14"
     >
       <thead
         class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -8769,51 +8438,51 @@ exports[`Data view search 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c17 "
+            class="c15 "
             scope="col"
           >
             <div
-              class="c18"
+              class="c16"
             />
           </th>
           <th
-            class="c17 "
+            class="c15 "
             scope="col"
           >
             <div
-              class="c18"
+              class="c16"
             />
           </th>
         </tr>
       </thead>
       <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c19"
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c17"
       >
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c20 "
+            class="c18 "
             scope="row"
           >
             <div
-              class="c21"
+              class="c19"
             >
               <span
-                class="c22"
+                class="c20"
               >
                 aa
               </span>
             </div>
           </th>
           <td
-            class="c20 "
+            class="c18 "
           >
             <div
-              class="c21"
+              class="c19"
             >
               <span
-                class="c23"
+                class="c21"
               >
                 ZZ
               </span>
@@ -8827,7 +8496,7 @@ exports[`Data view search 1`] = `
 `;
 
 exports[`Data view sort 1`] = `
-.c10 {
+.c8 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -8838,25 +8507,25 @@ exports[`Data view sort 1`] = `
   stroke: #666666;
 }
 
-.c10 g {
+.c8 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c10 *:not([stroke])[fill="none"] {
+.c8 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c10 *[stroke*="#"],
-.c10 *[STROKE*="#"] {
+.c8 *[stroke*="#"],
+.c8 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c10 *[fill-rule],
-.c10 *[FILL-RULE],
-.c10 *[fill*="#"],
-.c10 *[FILL*="#"] {
+.c8 *[fill-rule],
+.c8 *[FILL-RULE],
+.c8 *[fill*="#"],
+.c8 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -8921,40 +8590,7 @@ exports[`Data view sort 1`] = `
   overflow: auto;
 }
 
-.c6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  margin-bottom: 12px;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-}
-
-.c7 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c12 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8971,7 +8607,7 @@ exports[`Data view sort 1`] = `
   flex: 0 0 auto;
 }
 
-.c18 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8992,7 +8628,7 @@ exports[`Data view sort 1`] = `
   justify-content: center;
 }
 
-.c21 {
+.c19 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -9033,25 +8669,25 @@ exports[`Data view sort 1`] = `
   row-gap: 12px;
 }
 
-.c14 {
+.c12 {
   margin-top: 6px;
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
 }
 
-.c22 {
+.c20 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
 }
 
-.c23 {
+.c21 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c13 {
+.c11 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -9071,52 +8707,52 @@ exports[`Data view sort 1`] = `
   padding: 12px;
 }
 
-.c13:hover {
+.c11:hover {
   background-color: rgba(221,221,221,0.4);
   color: #000000;
 }
 
-.c13:focus {
+.c11:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus > circle,
-.c13:focus > ellipse,
-.c13:focus > line,
-.c13:focus > path,
-.c13:focus > polygon,
-.c13:focus > polyline,
-.c13:focus > rect {
+.c11:focus > circle,
+.c11:focus > ellipse,
+.c11:focus > line,
+.c11:focus > path,
+.c11:focus > polygon,
+.c11:focus > polyline,
+.c11:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c13:focus::-moz-focus-inner {
+.c11:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c13:focus:not(:focus-visible) {
+.c11:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible) > circle,
-.c13:focus:not(:focus-visible) > ellipse,
-.c13:focus:not(:focus-visible) > line,
-.c13:focus:not(:focus-visible) > path,
-.c13:focus:not(:focus-visible) > polygon,
-.c13:focus:not(:focus-visible) > polyline,
-.c13:focus:not(:focus-visible) > rect {
+.c11:focus:not(:focus-visible) > circle,
+.c11:focus:not(:focus-visible) > ellipse,
+.c11:focus:not(:focus-visible) > line,
+.c11:focus:not(:focus-visible) > path,
+.c11:focus:not(:focus-visible) > polygon,
+.c11:focus:not(:focus-visible) > polyline,
+.c11:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c13:focus:not(:focus-visible)::-moz-focus-inner {
+.c11:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c11 {
+.c9 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -9130,43 +8766,61 @@ exports[`Data view sort 1`] = `
   margin: 0;
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
-  outline: none;
-  border: none;
   padding-left: 48px;
 }
 
-.c11::-webkit-input-placeholder {
+.c9:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9:focus > circle,
+.c9:focus > ellipse,
+.c9:focus > line,
+.c9:focus > path,
+.c9:focus > polygon,
+.c9:focus > polyline,
+.c9:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c9::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c11::-moz-placeholder {
+.c9::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c11:-ms-input-placeholder {
+.c9:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c11::-webkit-search-decoration {
+.c9::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c11::-moz-focus-inner {
+.c9::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c11:-moz-placeholder,
-.c11::-moz-placeholder {
+.c9:-moz-placeholder,
+.c9::-moz-placeholder {
   opacity: 1;
 }
 
-.c8 {
+.c6 {
   position: relative;
   width: 100%;
 }
 
-.c9 {
+.c7 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -9188,7 +8842,7 @@ exports[`Data view sort 1`] = `
   max-width: 100%;
 }
 
-.c17 {
+.c15 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -9201,7 +8855,7 @@ exports[`Data view sort 1`] = `
   padding-bottom: 6px;
 }
 
-.c20 {
+.c18 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -9213,40 +8867,28 @@ exports[`Data view sort 1`] = `
   padding-bottom: 6px;
 }
 
-.c15 {
+.c13 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
 }
 
-.c16 {
+.c14 {
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
 }
 
-.c19:focus {
+.c17:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c19:focus:not(:focus-visible) {
+.c17:focus:not(:focus-visible) {
   outline: none;
 }
 
 @media only screen and (max-width:768px) {
 
-}
-
-@media only screen and (max-width:768px) {
-  .c6 {
-    margin-bottom: 6px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c7 {
-    border-bottom: solid 1px rgba(0,0,0,0.33);
-  }
 }
 
 @media only screen and (max-width:768px) {
@@ -9276,57 +8918,49 @@ exports[`Data view sort 1`] = `
             class="c5"
           >
             <div
-              class="c6 "
+              class="c6"
             >
               <div
-                class="c7 FormField__FormFieldContentBox-sc-m9hood-1"
+                class="c7"
               >
-                <div
+                <svg
+                  aria-label="Search"
                   class="c8"
+                  viewBox="0 0 24 24"
                 >
-                  <div
-                    class="c9"
-                  >
-                    <svg
-                      aria-label="Search"
-                      class="c10"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                        fill="none"
-                        stroke="#000"
-                        stroke-width="2"
-                      />
-                    </svg>
-                  </div>
-                  <input
-                    aria-label="Search data"
-                    autocomplete="off"
-                    class="c11"
-                    id="data--search"
-                    name="_search"
-                    type="search"
-                    value=""
+                  <path
+                    d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                    fill="none"
+                    stroke="#000"
+                    stroke-width="2"
                   />
-                </div>
+                </svg>
               </div>
+              <input
+                aria-label="Search"
+                autocomplete="off"
+                class="c9"
+                id="data--search"
+                name="_search"
+                type="search"
+                value=""
+              />
             </div>
           </div>
         </div>
       </form>
       <div
-        class="c12"
+        class="c10"
       >
         <button
           aria-label="Open filters"
-          class="c13"
+          class="c11"
           id="data--filters-control"
           type="button"
         >
           <svg
             aria-label="Filter"
-            class="c10"
+            class="c8"
             viewBox="0 0 24 24"
           >
             <path
@@ -9340,12 +8974,12 @@ exports[`Data view sort 1`] = `
       </div>
     </div>
     <span
-      class="c14"
+      class="c12"
     >
       4 items
     </span>
     <table
-      class="c15 c16"
+      class="c13 c14"
     >
       <thead
         class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -9354,51 +8988,51 @@ exports[`Data view sort 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c17 "
+            class="c15 "
             scope="col"
           >
             <div
-              class="c18"
+              class="c16"
             />
           </th>
           <th
-            class="c17 "
+            class="c15 "
             scope="col"
           >
             <div
-              class="c18"
+              class="c16"
             />
           </th>
         </tr>
       </thead>
       <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c19"
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c17"
       >
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c20 "
+            class="c18 "
             scope="row"
           >
             <div
-              class="c21"
+              class="c19"
             >
               <span
-                class="c22"
+                class="c20"
               >
                 aa
               </span>
             </div>
           </th>
           <td
-            class="c20 "
+            class="c18 "
           >
             <div
-              class="c21"
+              class="c19"
             >
               <span
-                class="c23"
+                class="c21"
               >
                 ZZ
               </span>
@@ -9409,27 +9043,27 @@ exports[`Data view sort 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c20 "
+            class="c18 "
             scope="row"
           >
             <div
-              class="c21"
+              class="c19"
             >
               <span
-                class="c22"
+                class="c20"
               >
                 bb
               </span>
             </div>
           </th>
           <td
-            class="c20 "
+            class="c18 "
           >
             <div
-              class="c21"
+              class="c19"
             >
               <span
-                class="c23"
+                class="c21"
               >
                 YY
               </span>
@@ -9440,24 +9074,24 @@ exports[`Data view sort 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c20 "
+            class="c18 "
             scope="row"
           >
             <div
-              class="c21"
+              class="c19"
             >
               <span
-                class="c22"
+                class="c20"
               >
                 cc
               </span>
             </div>
           </th>
           <td
-            class="c20 "
+            class="c18 "
           >
             <div
-              class="c21"
+              class="c19"
             />
           </td>
         </tr>
@@ -9465,24 +9099,24 @@ exports[`Data view sort 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c20 "
+            class="c18 "
             scope="row"
           >
             <div
-              class="c21"
+              class="c19"
             >
               <span
-                class="c22"
+                class="c20"
               >
                 dd
               </span>
             </div>
           </th>
           <td
-            class="c20 "
+            class="c18 "
           >
             <div
-              class="c21"
+              class="c19"
             />
           </td>
         </tr>

--- a/src/js/components/DataFilter/__tests__/__snapshots__/DataFilter-test.tsx.snap
+++ b/src/js/components/DataFilter/__tests__/__snapshots__/DataFilter-test.tsx.snap
@@ -76,7 +76,7 @@ exports[`DataFilter children 1`] = `
   justify-content: space-between;
 }
 
-.c8 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -94,7 +94,7 @@ exports[`DataFilter children 1`] = `
   flex: 0 0 auto;
 }
 
-.c10 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -109,14 +109,30 @@ exports[`DataFilter children 1`] = `
   flex-direction: column;
 }
 
-.c7 {
+.c12 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-top: 12px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  -webkit-align-self: stretch;
-  -ms-flex-item-align: stretch;
-  align-self: stretch;
-  height: 6px;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
 }
 
 .c14 {
@@ -126,10 +142,10 @@ exports[`DataFilter children 1`] = `
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
   align-self: stretch;
-  width: 24px;
+  width: 12px;
 }
 
-.c9 {
+.c8 {
   margin-left: 12px;
   margin-right: 12px;
   margin-top: 6px;
@@ -277,7 +293,7 @@ exports[`DataFilter children 1`] = `
   border: 0;
 }
 
-.c12 {
+.c11 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -295,33 +311,33 @@ exports[`DataFilter children 1`] = `
   border: none;
 }
 
-.c12::-webkit-input-placeholder {
+.c11::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c12::-moz-placeholder {
+.c11::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c12:-ms-input-placeholder {
+.c11:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c12::-webkit-search-decoration {
+.c11::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c12::-moz-focus-inner {
+.c11::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c12:-moz-placeholder,
-.c12::-moz-placeholder {
+.c11:-moz-placeholder,
+.c11::-moz-placeholder {
   opacity: 1;
 }
 
-.c11 {
+.c10 {
   position: relative;
   width: 100%;
 }
@@ -354,26 +370,26 @@ exports[`DataFilter children 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c7 {
     margin-bottom: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c10 {
+  .c9 {
     border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c7 {
-    height: 3px;
+  .c12 {
+    margin-top: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c14 {
-    width: 12px;
+    width: 6px;
   }
 }
 
@@ -417,26 +433,23 @@ exports[`DataFilter children 1`] = `
             </h2>
           </header>
           <div
-            class="c7"
-          />
-          <div
-            class="c8 "
+            class="c7 "
           >
             <label
-              class="c9"
+              class="c8"
               for="data-name"
             >
               name
             </label>
             <div
-              class="c10 FormField__FormFieldContentBox-sc-m9hood-1"
+              class="c9 FormField__FormFieldContentBox-sc-m9hood-1"
             >
               <div
-                class="c11"
+                class="c10"
               >
                 <input
                   autocomplete="off"
-                  class="c12"
+                  class="c11"
                   value=""
                 />
               </div>
@@ -444,7 +457,7 @@ exports[`DataFilter children 1`] = `
           </div>
         </div>
         <footer
-          class="c5"
+          class="c12"
         >
           <button
             class="c13"
@@ -547,7 +560,7 @@ exports[`DataFilter options 1`] = `
   justify-content: space-between;
 }
 
-.c8 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -565,7 +578,7 @@ exports[`DataFilter options 1`] = `
   flex: 0 0 auto;
 }
 
-.c10 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -581,7 +594,7 @@ exports[`DataFilter options 1`] = `
   padding: 12px;
 }
 
-.c11 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -595,7 +608,7 @@ exports[`DataFilter options 1`] = `
   flex-direction: column;
 }
 
-.c13 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -618,7 +631,7 @@ exports[`DataFilter options 1`] = `
   justify-content: center;
 }
 
-.c16 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -644,17 +657,33 @@ exports[`DataFilter options 1`] = `
   border-radius: 4px;
 }
 
-.c7 {
+.c17 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-top: 12px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  -webkit-align-self: stretch;
-  -ms-flex-item-align: stretch;
-  align-self: stretch;
-  height: 6px;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
 }
 
-.c17 {
+.c16 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -671,10 +700,10 @@ exports[`DataFilter options 1`] = `
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
   align-self: stretch;
-  width: 24px;
+  width: 12px;
 }
 
-.c9 {
+.c8 {
   margin-left: 12px;
   margin-right: 12px;
   margin-top: 6px;
@@ -822,7 +851,7 @@ exports[`DataFilter options 1`] = `
   border: 0;
 }
 
-.c12 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -844,12 +873,12 @@ exports[`DataFilter options 1`] = `
   cursor: pointer;
 }
 
-.c12:hover input:not([disabled]) + div,
-.c12:hover input:not([disabled]) + span {
+.c11:hover input:not([disabled]) + div,
+.c11:hover input:not([disabled]) + span {
   border-color: #000000;
 }
 
-.c15 {
+.c14 {
   opacity: 0;
   -moz-appearance: none;
   width: 0;
@@ -858,12 +887,12 @@ exports[`DataFilter options 1`] = `
   cursor: pointer;
 }
 
-.c15:checked + span > span {
+.c14:checked + span > span {
   left: calc( 48px - 24px );
   background: #7D4CDB;
 }
 
-.c14 {
+.c13 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -897,50 +926,50 @@ exports[`DataFilter options 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c7 {
     margin-bottom: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c10 {
+  .c9 {
     border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c10 {
+  .c9 {
     padding: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c13 {
+  .c12 {
     margin-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c16 {
+  .c15 {
     border: solid 2px rgba(0,0,0,0.15);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c7 {
-    height: 3px;
+  .c17 {
+    margin-top: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c17 {
+  .c16 {
     height: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c19 {
-    width: 12px;
+    width: 6px;
   }
 }
 
@@ -984,38 +1013,35 @@ exports[`DataFilter options 1`] = `
             </h2>
           </header>
           <div
-            class="c7"
-          />
-          <div
-            class="c8 "
+            class="c7 "
           >
             <label
-              class="c9"
+              class="c8"
               for="data-name"
             >
               name
             </label>
             <div
-              class="c10 FormField__FormFieldContentBox-sc-m9hood-1"
+              class="c9 FormField__FormFieldContentBox-sc-m9hood-1"
             >
               <div
-                class="c11 StyledCheckBoxGroup-sc-2nhc5d-0"
+                class="c10 StyledCheckBoxGroup-sc-2nhc5d-0"
                 id="data-name"
                 role="group"
               >
                 <label
-                  class="c12"
+                  class="c11"
                   label="aa"
                 >
                   <div
-                    class="c13 c14"
+                    class="c12 c13"
                   >
                     <input
-                      class="c15"
+                      class="c14"
                       type="checkbox"
                     />
                     <div
-                      class="c16 "
+                      class="c15 "
                     />
                   </div>
                   <span>
@@ -1023,21 +1049,21 @@ exports[`DataFilter options 1`] = `
                   </span>
                 </label>
                 <div
-                  class="c17"
+                  class="c16"
                 />
                 <label
-                  class="c12"
+                  class="c11"
                   label="bb"
                 >
                   <div
-                    class="c13 c14"
+                    class="c12 c13"
                   >
                     <input
-                      class="c15"
+                      class="c14"
                       type="checkbox"
                     />
                     <div
-                      class="c16 "
+                      class="c15 "
                     />
                   </div>
                   <span>
@@ -1045,21 +1071,21 @@ exports[`DataFilter options 1`] = `
                   </span>
                 </label>
                 <div
-                  class="c17"
+                  class="c16"
                 />
                 <label
-                  class="c12"
+                  class="c11"
                   label="cc"
                 >
                   <div
-                    class="c13 c14"
+                    class="c12 c13"
                   >
                     <input
-                      class="c15"
+                      class="c14"
                       type="checkbox"
                     />
                     <div
-                      class="c16 "
+                      class="c15 "
                     />
                   </div>
                   <span>
@@ -1070,38 +1096,35 @@ exports[`DataFilter options 1`] = `
             </div>
           </div>
           <div
-            class="c7"
-          />
-          <div
-            class="c8 "
+            class="c7 "
           >
             <label
-              class="c9"
+              class="c8"
               for="data-enabled"
             >
               Enabled
             </label>
             <div
-              class="c10 FormField__FormFieldContentBox-sc-m9hood-1"
+              class="c9 FormField__FormFieldContentBox-sc-m9hood-1"
             >
               <div
-                class="c11 StyledCheckBoxGroup-sc-2nhc5d-0"
+                class="c10 StyledCheckBoxGroup-sc-2nhc5d-0"
                 id="data-enabled"
                 role="group"
               >
                 <label
-                  class="c12"
+                  class="c11"
                   label="Enabled"
                 >
                   <div
-                    class="c13 c14"
+                    class="c12 c13"
                   >
                     <input
-                      class="c15"
+                      class="c14"
                       type="checkbox"
                     />
                     <div
-                      class="c16 "
+                      class="c15 "
                     />
                   </div>
                   <span>
@@ -1109,21 +1132,21 @@ exports[`DataFilter options 1`] = `
                   </span>
                 </label>
                 <div
-                  class="c17"
+                  class="c16"
                 />
                 <label
-                  class="c12"
+                  class="c11"
                   label="Disabled"
                 >
                   <div
-                    class="c13 c14"
+                    class="c12 c13"
                   >
                     <input
-                      class="c15"
+                      class="c14"
                       type="checkbox"
                     />
                     <div
-                      class="c16 "
+                      class="c15 "
                     />
                   </div>
                   <span>
@@ -1134,38 +1157,35 @@ exports[`DataFilter options 1`] = `
             </div>
           </div>
           <div
-            class="c7"
-          />
-          <div
-            class="c8 "
+            class="c7 "
           >
             <label
-              class="c9"
+              class="c8"
               for="data-type.name"
             >
               Type
             </label>
             <div
-              class="c10 FormField__FormFieldContentBox-sc-m9hood-1"
+              class="c9 FormField__FormFieldContentBox-sc-m9hood-1"
             >
               <div
-                class="c11 StyledCheckBoxGroup-sc-2nhc5d-0"
+                class="c10 StyledCheckBoxGroup-sc-2nhc5d-0"
                 id="data-type.name"
                 role="group"
               >
                 <label
-                  class="c12"
+                  class="c11"
                   label="ZZ"
                 >
                   <div
-                    class="c13 c14"
+                    class="c12 c13"
                   >
                     <input
-                      class="c15"
+                      class="c14"
                       type="checkbox"
                     />
                     <div
-                      class="c16 "
+                      class="c15 "
                     />
                   </div>
                   <span>
@@ -1173,21 +1193,21 @@ exports[`DataFilter options 1`] = `
                   </span>
                 </label>
                 <div
-                  class="c17"
+                  class="c16"
                 />
                 <label
-                  class="c12"
+                  class="c11"
                   label="YY"
                 >
                   <div
-                    class="c13 c14"
+                    class="c12 c13"
                   >
                     <input
-                      class="c15"
+                      class="c14"
                       type="checkbox"
                     />
                     <div
-                      class="c16 "
+                      class="c15 "
                     />
                   </div>
                   <span>
@@ -1199,7 +1219,7 @@ exports[`DataFilter options 1`] = `
           </div>
         </div>
         <footer
-          class="c5"
+          class="c17"
         >
           <button
             class="c18"
@@ -1302,7 +1322,7 @@ exports[`DataFilter range Data 1`] = `
   justify-content: space-between;
 }
 
-.c8 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1320,7 +1340,7 @@ exports[`DataFilter range Data 1`] = `
   flex: 0 0 auto;
 }
 
-.c10 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1336,7 +1356,7 @@ exports[`DataFilter range Data 1`] = `
   padding: 12px;
 }
 
-.c11 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1356,7 +1376,7 @@ exports[`DataFilter range Data 1`] = `
   height: 100%;
 }
 
-.c13 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1377,7 +1397,7 @@ exports[`DataFilter range Data 1`] = `
   cursor: pointer;
 }
 
-.c15 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1396,7 +1416,7 @@ exports[`DataFilter range Data 1`] = `
   border-radius: 12px;
 }
 
-.c16 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1422,7 +1442,7 @@ exports[`DataFilter range Data 1`] = `
   overflow: visible;
 }
 
-.c17 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1447,7 +1467,7 @@ exports[`DataFilter range Data 1`] = `
   justify-content: center;
 }
 
-.c18 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1466,7 +1486,7 @@ exports[`DataFilter range Data 1`] = `
   border-radius: 100%;
 }
 
-.c19 {
+.c18 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1487,14 +1507,30 @@ exports[`DataFilter range Data 1`] = `
   border-radius: 12px;
 }
 
-.c7 {
+.c20 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-top: 12px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  -webkit-align-self: stretch;
-  -ms-flex-item-align: stretch;
-  align-self: stretch;
-  height: 6px;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
 }
 
 .c22 {
@@ -1504,10 +1540,10 @@ exports[`DataFilter range Data 1`] = `
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
   align-self: stretch;
-  width: 24px;
+  width: 12px;
 }
 
-.c9 {
+.c8 {
   margin-left: 12px;
   margin-right: 12px;
   margin-top: 6px;
@@ -1516,7 +1552,7 @@ exports[`DataFilter range Data 1`] = `
   line-height: 24px;
 }
 
-.c12 {
+.c11 {
   margin-left: 12px;
   margin-right: 12px;
   font-size: 14px;
@@ -1524,7 +1560,7 @@ exports[`DataFilter range Data 1`] = `
   text-align: right;
 }
 
-.c20 {
+.c19 {
   margin-left: 12px;
   margin-right: 12px;
   font-size: 14px;
@@ -1670,7 +1706,7 @@ exports[`DataFilter range Data 1`] = `
   border: 0;
 }
 
-.c14 {
+.c13 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -1705,44 +1741,44 @@ exports[`DataFilter range Data 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c7 {
     margin-bottom: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c10 {
+  .c9 {
     border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c10 {
+  .c9 {
     padding: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c15 {
+  .c14 {
     border-radius: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c19 {
+  .c18 {
     border-radius: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c7 {
-    height: 3px;
+  .c20 {
+    margin-top: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c22 {
-    width: 12px;
+    width: 6px;
   }
 }
 
@@ -1786,40 +1822,37 @@ exports[`DataFilter range Data 1`] = `
             </h2>
           </header>
           <div
-            class="c7"
-          />
-          <div
-            class="c8 "
+            class="c7 "
           >
             <label
-              class="c9"
+              class="c8"
               for="data-rating"
             >
               Rating
             </label>
             <div
-              class="c10 FormField__FormFieldContentBox-sc-m9hood-1"
+              class="c9 FormField__FormFieldContentBox-sc-m9hood-1"
             >
               <div
-                class="c11"
+                class="c10"
                 id="data-rating"
               >
                 <span
-                  class="c12"
+                  class="c11"
                   style="width: 0px;"
                 >
                   0
                 </span>
                 <div
-                  class="c13 c14"
+                  class="c12 c13"
                   tabindex="-1"
                 >
                   <div
-                    class="c15"
+                    class="c14"
                     style="flex: 0 0 0px;"
                   />
                   <div
-                    class="c16"
+                    class="c15"
                     style="flex: 0 0 1px;"
                   >
                     <div
@@ -1827,22 +1860,22 @@ exports[`DataFilter range Data 1`] = `
                       aria-valuemax="5"
                       aria-valuemin="0"
                       aria-valuenow="0"
-                      class="c17"
+                      class="c16"
                       role="slider"
                       style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 1;"
                       tabindex="0"
                     >
                       <div
-                        class="c18 EdgeControl__StyledBox-sc-1xo2yt9-0"
+                        class="c17 EdgeControl__StyledBox-sc-1xo2yt9-0"
                       />
                     </div>
                   </div>
                   <div
-                    class="c19"
+                    class="c18"
                     style="flex: 6 0 0px; cursor: ew-resize;"
                   />
                   <div
-                    class="c16"
+                    class="c15"
                     style="flex: 0 0 1px;"
                   >
                     <div
@@ -1850,23 +1883,23 @@ exports[`DataFilter range Data 1`] = `
                       aria-valuemax="5"
                       aria-valuemin="0"
                       aria-valuenow="5"
-                      class="c17"
+                      class="c16"
                       role="slider"
                       style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 1;"
                       tabindex="0"
                     >
                       <div
-                        class="c18 EdgeControl__StyledBox-sc-1xo2yt9-0"
+                        class="c17 EdgeControl__StyledBox-sc-1xo2yt9-0"
                       />
                     </div>
                   </div>
                   <div
-                    class="c15"
+                    class="c14"
                     style="flex: 0 0 0px;"
                   />
                 </div>
                 <span
-                  class="c20"
+                  class="c19"
                   style="width: 0px;"
                 >
                   5
@@ -1876,7 +1909,7 @@ exports[`DataFilter range Data 1`] = `
           </div>
         </div>
         <footer
-          class="c5"
+          class="c20"
         >
           <button
             class="c21"
@@ -1979,7 +2012,7 @@ exports[`DataFilter range prop 1`] = `
   justify-content: space-between;
 }
 
-.c8 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1997,7 +2030,7 @@ exports[`DataFilter range prop 1`] = `
   flex: 0 0 auto;
 }
 
-.c10 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2013,7 +2046,7 @@ exports[`DataFilter range prop 1`] = `
   padding: 12px;
 }
 
-.c11 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2033,7 +2066,7 @@ exports[`DataFilter range prop 1`] = `
   height: 100%;
 }
 
-.c13 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2054,7 +2087,7 @@ exports[`DataFilter range prop 1`] = `
   cursor: pointer;
 }
 
-.c15 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2073,7 +2106,7 @@ exports[`DataFilter range prop 1`] = `
   border-radius: 12px;
 }
 
-.c16 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2099,7 +2132,7 @@ exports[`DataFilter range prop 1`] = `
   overflow: visible;
 }
 
-.c17 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2124,7 +2157,7 @@ exports[`DataFilter range prop 1`] = `
   justify-content: center;
 }
 
-.c18 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2143,7 +2176,7 @@ exports[`DataFilter range prop 1`] = `
   border-radius: 100%;
 }
 
-.c19 {
+.c18 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2164,14 +2197,30 @@ exports[`DataFilter range prop 1`] = `
   border-radius: 12px;
 }
 
-.c7 {
+.c20 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-top: 12px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  -webkit-align-self: stretch;
-  -ms-flex-item-align: stretch;
-  align-self: stretch;
-  height: 6px;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
 }
 
 .c22 {
@@ -2181,10 +2230,10 @@ exports[`DataFilter range prop 1`] = `
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
   align-self: stretch;
-  width: 24px;
+  width: 12px;
 }
 
-.c9 {
+.c8 {
   margin-left: 12px;
   margin-right: 12px;
   margin-top: 6px;
@@ -2193,7 +2242,7 @@ exports[`DataFilter range prop 1`] = `
   line-height: 24px;
 }
 
-.c12 {
+.c11 {
   margin-left: 12px;
   margin-right: 12px;
   font-size: 14px;
@@ -2201,7 +2250,7 @@ exports[`DataFilter range prop 1`] = `
   text-align: right;
 }
 
-.c20 {
+.c19 {
   margin-left: 12px;
   margin-right: 12px;
   font-size: 14px;
@@ -2347,7 +2396,7 @@ exports[`DataFilter range prop 1`] = `
   border: 0;
 }
 
-.c14 {
+.c13 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -2382,44 +2431,44 @@ exports[`DataFilter range prop 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c7 {
     margin-bottom: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c10 {
+  .c9 {
     border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c10 {
+  .c9 {
     padding: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c15 {
+  .c14 {
     border-radius: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c19 {
+  .c18 {
     border-radius: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c7 {
-    height: 3px;
+  .c20 {
+    margin-top: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c22 {
-    width: 12px;
+    width: 6px;
   }
 }
 
@@ -2463,40 +2512,37 @@ exports[`DataFilter range prop 1`] = `
             </h2>
           </header>
           <div
-            class="c7"
-          />
-          <div
-            class="c8 "
+            class="c7 "
           >
             <label
-              class="c9"
+              class="c8"
               for="data-rating"
             >
               rating
             </label>
             <div
-              class="c10 FormField__FormFieldContentBox-sc-m9hood-1"
+              class="c9 FormField__FormFieldContentBox-sc-m9hood-1"
             >
               <div
-                class="c11"
+                class="c10"
                 id="data-rating"
               >
                 <span
-                  class="c12"
+                  class="c11"
                   style="width: 0px;"
                 >
                   0
                 </span>
                 <div
-                  class="c13 c14"
+                  class="c12 c13"
                   tabindex="-1"
                 >
                   <div
-                    class="c15"
+                    class="c14"
                     style="flex: 0 0 0px;"
                   />
                   <div
-                    class="c16"
+                    class="c15"
                     style="flex: 0 0 1px;"
                   >
                     <div
@@ -2504,22 +2550,22 @@ exports[`DataFilter range prop 1`] = `
                       aria-valuemax="5"
                       aria-valuemin="0"
                       aria-valuenow="0"
-                      class="c17"
+                      class="c16"
                       role="slider"
                       style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 1;"
                       tabindex="0"
                     >
                       <div
-                        class="c18 EdgeControl__StyledBox-sc-1xo2yt9-0"
+                        class="c17 EdgeControl__StyledBox-sc-1xo2yt9-0"
                       />
                     </div>
                   </div>
                   <div
-                    class="c19"
+                    class="c18"
                     style="flex: 6 0 0px; cursor: ew-resize;"
                   />
                   <div
-                    class="c16"
+                    class="c15"
                     style="flex: 0 0 1px;"
                   >
                     <div
@@ -2527,23 +2573,23 @@ exports[`DataFilter range prop 1`] = `
                       aria-valuemax="5"
                       aria-valuemin="0"
                       aria-valuenow="5"
-                      class="c17"
+                      class="c16"
                       role="slider"
                       style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 1;"
                       tabindex="0"
                     >
                       <div
-                        class="c18 EdgeControl__StyledBox-sc-1xo2yt9-0"
+                        class="c17 EdgeControl__StyledBox-sc-1xo2yt9-0"
                       />
                     </div>
                   </div>
                   <div
-                    class="c15"
+                    class="c14"
                     style="flex: 0 0 0px;"
                   />
                 </div>
                 <span
-                  class="c20"
+                  class="c19"
                   style="width: 0px;"
                 >
                   5
@@ -2553,7 +2599,7 @@ exports[`DataFilter range prop 1`] = `
           </div>
         </div>
         <footer
-          class="c5"
+          class="c20"
         >
           <button
             class="c21"
@@ -2656,7 +2702,7 @@ exports[`DataFilter renders 1`] = `
   justify-content: space-between;
 }
 
-.c8 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2674,7 +2720,7 @@ exports[`DataFilter renders 1`] = `
   flex: 0 0 auto;
 }
 
-.c10 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2690,7 +2736,7 @@ exports[`DataFilter renders 1`] = `
   padding: 12px;
 }
 
-.c11 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2704,7 +2750,7 @@ exports[`DataFilter renders 1`] = `
   flex-direction: column;
 }
 
-.c13 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2727,7 +2773,7 @@ exports[`DataFilter renders 1`] = `
   justify-content: center;
 }
 
-.c16 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2753,7 +2799,7 @@ exports[`DataFilter renders 1`] = `
   border-radius: 4px;
 }
 
-.c18 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2773,7 +2819,7 @@ exports[`DataFilter renders 1`] = `
   height: 100%;
 }
 
-.c20 {
+.c19 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2794,7 +2840,7 @@ exports[`DataFilter renders 1`] = `
   cursor: pointer;
 }
 
-.c22 {
+.c21 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2813,7 +2859,7 @@ exports[`DataFilter renders 1`] = `
   border-radius: 12px;
 }
 
-.c23 {
+.c22 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2839,7 +2885,7 @@ exports[`DataFilter renders 1`] = `
   overflow: visible;
 }
 
-.c24 {
+.c23 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2864,7 +2910,7 @@ exports[`DataFilter renders 1`] = `
   justify-content: center;
 }
 
-.c25 {
+.c24 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2883,7 +2929,7 @@ exports[`DataFilter renders 1`] = `
   border-radius: 100%;
 }
 
-.c26 {
+.c25 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2904,17 +2950,33 @@ exports[`DataFilter renders 1`] = `
   border-radius: 12px;
 }
 
-.c7 {
+.c27 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-top: 12px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  -webkit-align-self: stretch;
-  -ms-flex-item-align: stretch;
-  align-self: stretch;
-  height: 6px;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
 }
 
-.c17 {
+.c16 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -2931,10 +2993,10 @@ exports[`DataFilter renders 1`] = `
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
   align-self: stretch;
-  width: 24px;
+  width: 12px;
 }
 
-.c9 {
+.c8 {
   margin-left: 12px;
   margin-right: 12px;
   margin-top: 6px;
@@ -2943,7 +3005,7 @@ exports[`DataFilter renders 1`] = `
   line-height: 24px;
 }
 
-.c19 {
+.c18 {
   margin-left: 12px;
   margin-right: 12px;
   font-size: 14px;
@@ -2951,7 +3013,7 @@ exports[`DataFilter renders 1`] = `
   text-align: right;
 }
 
-.c27 {
+.c26 {
   margin-left: 12px;
   margin-right: 12px;
   font-size: 14px;
@@ -3097,7 +3159,7 @@ exports[`DataFilter renders 1`] = `
   border: 0;
 }
 
-.c12 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3119,12 +3181,12 @@ exports[`DataFilter renders 1`] = `
   cursor: pointer;
 }
 
-.c12:hover input:not([disabled]) + div,
-.c12:hover input:not([disabled]) + span {
+.c11:hover input:not([disabled]) + div,
+.c11:hover input:not([disabled]) + span {
   border-color: #000000;
 }
 
-.c15 {
+.c14 {
   opacity: 0;
   -moz-appearance: none;
   width: 0;
@@ -3133,18 +3195,18 @@ exports[`DataFilter renders 1`] = `
   cursor: pointer;
 }
 
-.c15:checked + span > span {
+.c14:checked + span > span {
   left: calc( 48px - 24px );
   background: #7D4CDB;
 }
 
-.c14 {
+.c13 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c21 {
+.c20 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -3179,62 +3241,62 @@ exports[`DataFilter renders 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c7 {
     margin-bottom: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c10 {
+  .c9 {
     border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c10 {
+  .c9 {
     padding: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c13 {
+  .c12 {
     margin-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c16 {
+  .c15 {
     border: solid 2px rgba(0,0,0,0.15);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c22 {
+  .c21 {
     border-radius: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c26 {
+  .c25 {
     border-radius: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c7 {
-    height: 3px;
+  .c27 {
+    margin-top: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c17 {
+  .c16 {
     height: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c29 {
-    width: 12px;
+    width: 6px;
   }
 }
 
@@ -3278,38 +3340,35 @@ exports[`DataFilter renders 1`] = `
             </h2>
           </header>
           <div
-            class="c7"
-          />
-          <div
-            class="c8 "
+            class="c7 "
           >
             <label
-              class="c9"
+              class="c8"
               for="data-name"
             >
               name
             </label>
             <div
-              class="c10 FormField__FormFieldContentBox-sc-m9hood-1"
+              class="c9 FormField__FormFieldContentBox-sc-m9hood-1"
             >
               <div
-                class="c11 StyledCheckBoxGroup-sc-2nhc5d-0"
+                class="c10 StyledCheckBoxGroup-sc-2nhc5d-0"
                 id="data-name"
                 role="group"
               >
                 <label
-                  class="c12"
+                  class="c11"
                   label="aa"
                 >
                   <div
-                    class="c13 c14"
+                    class="c12 c13"
                   >
                     <input
-                      class="c15"
+                      class="c14"
                       type="checkbox"
                     />
                     <div
-                      class="c16 "
+                      class="c15 "
                     />
                   </div>
                   <span>
@@ -3317,21 +3376,21 @@ exports[`DataFilter renders 1`] = `
                   </span>
                 </label>
                 <div
-                  class="c17"
+                  class="c16"
                 />
                 <label
-                  class="c12"
+                  class="c11"
                   label="bb"
                 >
                   <div
-                    class="c13 c14"
+                    class="c12 c13"
                   >
                     <input
-                      class="c15"
+                      class="c14"
                       type="checkbox"
                     />
                     <div
-                      class="c16 "
+                      class="c15 "
                     />
                   </div>
                   <span>
@@ -3339,21 +3398,21 @@ exports[`DataFilter renders 1`] = `
                   </span>
                 </label>
                 <div
-                  class="c17"
+                  class="c16"
                 />
                 <label
-                  class="c12"
+                  class="c11"
                   label="cc"
                 >
                   <div
-                    class="c13 c14"
+                    class="c12 c13"
                   >
                     <input
-                      class="c15"
+                      class="c14"
                       type="checkbox"
                     />
                     <div
-                      class="c16 "
+                      class="c15 "
                     />
                   </div>
                   <span>
@@ -3364,38 +3423,35 @@ exports[`DataFilter renders 1`] = `
             </div>
           </div>
           <div
-            class="c7"
-          />
-          <div
-            class="c8 "
+            class="c7 "
           >
             <label
-              class="c9"
+              class="c8"
               for="data-enabled"
             >
               enabled
             </label>
             <div
-              class="c10 FormField__FormFieldContentBox-sc-m9hood-1"
+              class="c9 FormField__FormFieldContentBox-sc-m9hood-1"
             >
               <div
-                class="c11 StyledCheckBoxGroup-sc-2nhc5d-0"
+                class="c10 StyledCheckBoxGroup-sc-2nhc5d-0"
                 id="data-enabled"
                 role="group"
               >
                 <label
-                  class="c12"
+                  class="c11"
                   label="true"
                 >
                   <div
-                    class="c13 c14"
+                    class="c12 c13"
                   >
                     <input
-                      class="c15"
+                      class="c14"
                       type="checkbox"
                     />
                     <div
-                      class="c16 "
+                      class="c15 "
                     />
                   </div>
                   <span>
@@ -3403,21 +3459,21 @@ exports[`DataFilter renders 1`] = `
                   </span>
                 </label>
                 <div
-                  class="c17"
+                  class="c16"
                 />
                 <label
-                  class="c12"
+                  class="c11"
                   label="false"
                 >
                   <div
-                    class="c13 c14"
+                    class="c12 c13"
                   >
                     <input
-                      class="c15"
+                      class="c14"
                       type="checkbox"
                     />
                     <div
-                      class="c16 "
+                      class="c15 "
                     />
                   </div>
                   <span>
@@ -3428,40 +3484,37 @@ exports[`DataFilter renders 1`] = `
             </div>
           </div>
           <div
-            class="c7"
-          />
-          <div
-            class="c8 "
+            class="c7 "
           >
             <label
-              class="c9"
+              class="c8"
               for="data-rating"
             >
               rating
             </label>
             <div
-              class="c10 FormField__FormFieldContentBox-sc-m9hood-1"
+              class="c9 FormField__FormFieldContentBox-sc-m9hood-1"
             >
               <div
-                class="c18"
+                class="c17"
                 id="data-rating"
               >
                 <span
-                  class="c19"
+                  class="c18"
                   style="width: 0px;"
                 >
                   2.0999999999999996
                 </span>
                 <div
-                  class="c20 c21"
+                  class="c19 c20"
                   tabindex="-1"
                 >
                   <div
-                    class="c22"
+                    class="c21"
                     style="flex: 0 0 0px;"
                   />
                   <div
-                    class="c23"
+                    class="c22"
                     style="flex: 0 0 1px;"
                   >
                     <div
@@ -3469,22 +3522,22 @@ exports[`DataFilter renders 1`] = `
                       aria-valuemax="4.8999999999999995"
                       aria-valuemin="2.0999999999999996"
                       aria-valuenow="2.0999999999999996"
-                      class="c24"
+                      class="c23"
                       role="slider"
                       style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 1;"
                       tabindex="0"
                     >
                       <div
-                        class="c25 EdgeControl__StyledBox-sc-1xo2yt9-0"
+                        class="c24 EdgeControl__StyledBox-sc-1xo2yt9-0"
                       />
                     </div>
                   </div>
                   <div
-                    class="c26"
+                    class="c25"
                     style="flex: 3.8 0 0px; cursor: ew-resize;"
                   />
                   <div
-                    class="c23"
+                    class="c22"
                     style="flex: 0 0 1px;"
                   >
                     <div
@@ -3492,23 +3545,23 @@ exports[`DataFilter renders 1`] = `
                       aria-valuemax="4.8999999999999995"
                       aria-valuemin="2.0999999999999996"
                       aria-valuenow="4.8999999999999995"
-                      class="c24"
+                      class="c23"
                       role="slider"
                       style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 1;"
                       tabindex="0"
                     >
                       <div
-                        class="c25 EdgeControl__StyledBox-sc-1xo2yt9-0"
+                        class="c24 EdgeControl__StyledBox-sc-1xo2yt9-0"
                       />
                     </div>
                   </div>
                   <div
-                    class="c22"
+                    class="c21"
                     style="flex: 0 0 0px;"
                   />
                 </div>
                 <span
-                  class="c27"
+                  class="c26"
                   style="width: 0px;"
                 >
                   4.8999999999999995
@@ -3518,7 +3571,7 @@ exports[`DataFilter renders 1`] = `
           </div>
         </div>
         <footer
-          class="c5"
+          class="c27"
         >
           <button
             class="c28"

--- a/src/js/components/DataFilter/__tests__/__snapshots__/DataFilter-test.tsx.snap
+++ b/src/js/components/DataFilter/__tests__/__snapshots__/DataFilter-test.tsx.snap
@@ -25,6 +25,39 @@ exports[`DataFilter children 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 100%;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  overflow: auto;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -43,7 +76,7 @@ exports[`DataFilter children 1`] = `
   justify-content: space-between;
 }
 
-.c6 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -56,9 +89,12 @@ exports[`DataFilter children 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
-.c8 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -73,17 +109,17 @@ exports[`DataFilter children 1`] = `
   flex-direction: column;
 }
 
-.c5 {
+.c7 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
   align-self: stretch;
-  height: 12px;
+  height: 6px;
 }
 
-.c12 {
+.c14 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -93,7 +129,7 @@ exports[`DataFilter children 1`] = `
   width: 24px;
 }
 
-.c7 {
+.c9 {
   margin-left: 12px;
   margin-right: 12px;
   margin-top: 6px;
@@ -102,7 +138,7 @@ exports[`DataFilter children 1`] = `
   line-height: 24px;
 }
 
-.c11 {
+.c13 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -130,75 +166,8 @@ exports[`DataFilter children 1`] = `
   transition-timing-function: ease-in-out;
 }
 
-.c11:hover {
+.c13:hover {
   box-shadow: 0px 0px 0px 2px #7D4CDB;
-}
-
-.c11:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c11:focus > circle,
-.c11:focus > ellipse,
-.c11:focus > line,
-.c11:focus > path,
-.c11:focus > polygon,
-.c11:focus > polyline,
-.c11:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c11:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c11:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c11:focus:not(:focus-visible) > circle,
-.c11:focus:not(:focus-visible) > ellipse,
-.c11:focus:not(:focus-visible) > line,
-.c11:focus:not(:focus-visible) > path,
-.c11:focus:not(:focus-visible) > polygon,
-.c11:focus:not(:focus-visible) > polyline,
-.c11:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c11:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c13 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: 2px solid #7D4CDB;
-  border-radius: 18px;
-  color: #444444;
-  padding: 4px 22px;
-  font-size: 18px;
-  line-height: 24px;
-  opacity: 0.3;
-  cursor: default;
-  -webkit-transition-property: color,background-color,border-color,box-shadow;
-  transition-property: color,background-color,border-color,box-shadow;
-  -webkit-transition-duration: 0.1s;
-  transition-duration: 0.1s;
-  -webkit-transition-timing-function: ease-in-out;
-  transition-timing-function: ease-in-out;
 }
 
 .c13:focus {
@@ -241,365 +210,6 @@ exports[`DataFilter children 1`] = `
   border: 0;
 }
 
-.c10 {
-  box-sizing: border-box;
-  font-size: inherit;
-  font-family: inherit;
-  border: none;
-  -webkit-appearance: none;
-  background: transparent;
-  color: inherit;
-  width: 100%;
-  padding: 11px;
-  font-weight: 600;
-  margin: 0;
-  border: 1px solid rgba(0,0,0,0.33);
-  border-radius: 4px;
-  outline: none;
-  border: none;
-}
-
-.c10::-webkit-input-placeholder {
-  color: #AAAAAA;
-}
-
-.c10::-moz-placeholder {
-  color: #AAAAAA;
-}
-
-.c10:-ms-input-placeholder {
-  color: #AAAAAA;
-}
-
-.c10::-webkit-search-decoration {
-  -webkit-appearance: none;
-}
-
-.c10::-moz-focus-inner {
-  border: none;
-  outline: none;
-}
-
-.c10:-moz-placeholder,
-.c10::-moz-placeholder {
-  opacity: 1;
-}
-
-.c9 {
-  position: relative;
-  width: 100%;
-}
-
-.c14 {
-  opacity: 0;
-}
-
-.c2 {
-  max-width: 100%;
-}
-
-.c4 {
-  margin: 0px;
-  font-size: 26px;
-  line-height: 32px;
-  max-width: 624px;
-  font-weight: 600;
-  overflow-wrap: break-word;
-}
-
-.c0 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
-@media only screen and (max-width:768px) {
-  .c6 {
-    margin-bottom: 6px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c8 {
-    border-bottom: solid 1px rgba(0,0,0,0.33);
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c5 {
-    height: 6px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c12 {
-    width: 12px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c4 {
-    margin: 0px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c4 {
-    font-size: 22px;
-    line-height: 28px;
-    max-width: 528px;
-  }
-}
-
-<div
-  class="c0"
->
-  <div
-    class="c1"
-    id="data"
-  >
-    <form
-      class="c2"
-    >
-      <div
-        class="c1"
-      >
-        <header
-          class="c3"
-        >
-          <h2
-            class="c4"
-          >
-            Filters
-          </h2>
-        </header>
-        <div
-          class="c5"
-        />
-        <div
-          class="c6 "
-        >
-          <label
-            class="c7"
-            for="data-name"
-          >
-            name
-          </label>
-          <div
-            class="c8 FormField__FormFieldContentBox-sc-m9hood-1"
-          >
-            <div
-              class="c9"
-            >
-              <input
-                autocomplete="off"
-                class="c10"
-                value=""
-              />
-            </div>
-          </div>
-        </div>
-        <div
-          class="c5"
-        />
-        <footer
-          class="c3"
-        >
-          <button
-            class="c11"
-            type="submit"
-          >
-            Apply filters
-          </button>
-          <div
-            class="c12"
-          />
-          <button
-            aria-hidden="true"
-            class="c13 c14"
-            disabled=""
-            tabindex="-1"
-            type="reset"
-          >
-            Undo changes
-          </button>
-        </footer>
-      </div>
-    </form>
-  </div>
-</div>
-`;
-
-exports[`DataFilter options 1`] = `
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-}
-
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-}
-
-.c6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  margin-bottom: 12px;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c8 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding: 12px;
-}
-
-.c9 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c11 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  margin-right: 12px;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-}
-
-.c14 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border: solid 2px rgba(0,0,0,0.15);
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  height: 24px;
-  width: 24px;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  border-radius: 4px;
-}
-
-.c5 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  -webkit-align-self: stretch;
-  -ms-flex-item-align: stretch;
-  align-self: stretch;
-  height: 12px;
-}
-
-.c16 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  -webkit-align-self: stretch;
-  -ms-flex-item-align: stretch;
-  align-self: stretch;
-  width: 24px;
-}
-
-.c7 {
-  margin-left: 12px;
-  margin-right: 12px;
-  margin-top: 6px;
-  margin-bottom: 6px;
-  font-size: 18px;
-  line-height: 24px;
-}
-
 .c15 {
   display: inline-block;
   box-sizing: border-box;
@@ -617,19 +227,14 @@ exports[`DataFilter options 1`] = `
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  background-color: #7D4CDB;
-  color: #f8f8f8;
-  border-radius: 18px;
+  opacity: 0.3;
+  cursor: default;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
   transition-property: color,background-color,border-color,box-shadow;
   -webkit-transition-duration: 0.1s;
   transition-duration: 0.1s;
   -webkit-transition-timing-function: ease-in-out;
   transition-timing-function: ease-in-out;
-}
-
-.c15:hover {
-  box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
 .c15:focus {
@@ -672,7 +277,485 @@ exports[`DataFilter options 1`] = `
   border: 0;
 }
 
+.c12 {
+  box-sizing: border-box;
+  font-size: inherit;
+  font-family: inherit;
+  border: none;
+  -webkit-appearance: none;
+  background: transparent;
+  color: inherit;
+  width: 100%;
+  padding: 11px;
+  font-weight: 600;
+  margin: 0;
+  border: 1px solid rgba(0,0,0,0.33);
+  border-radius: 4px;
+  outline: none;
+  border: none;
+}
+
+.c12::-webkit-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c12::-moz-placeholder {
+  color: #AAAAAA;
+}
+
+.c12:-ms-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c12::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+.c12::-moz-focus-inner {
+  border: none;
+  outline: none;
+}
+
+.c12:-moz-placeholder,
+.c12::-moz-placeholder {
+  opacity: 1;
+}
+
+.c11 {
+  position: relative;
+  width: 100%;
+}
+
+.c16 {
+  opacity: 0;
+}
+
+.c2 {
+  max-width: 100%;
+}
+
+.c6 {
+  margin: 0px;
+  font-size: 26px;
+  line-height: 32px;
+  max-width: 624px;
+  font-weight: 600;
+  overflow-wrap: break-word;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+@media only screen and (max-width:768px) {
+  .c8 {
+    margin-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c10 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    height: 3px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c14 {
+    width: 12px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    font-size: 22px;
+    line-height: 28px;
+    max-width: 528px;
+  }
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+    id="data"
+  >
+    <form
+      class="c2"
+    >
+      <div
+        class="c3"
+      >
+        <div
+          class="c4"
+        >
+          <header
+            class="c5"
+          >
+            <h2
+              class="c6"
+            >
+              Filters
+            </h2>
+          </header>
+          <div
+            class="c7"
+          />
+          <div
+            class="c8 "
+          >
+            <label
+              class="c9"
+              for="data-name"
+            >
+              name
+            </label>
+            <div
+              class="c10 FormField__FormFieldContentBox-sc-m9hood-1"
+            >
+              <div
+                class="c11"
+              >
+                <input
+                  autocomplete="off"
+                  class="c12"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+        <footer
+          class="c5"
+        >
+          <button
+            class="c13"
+            type="submit"
+          >
+            Apply filters
+          </button>
+          <div
+            class="c14"
+          />
+          <button
+            aria-hidden="true"
+            class="c15 c16"
+            disabled=""
+            tabindex="-1"
+            type="reset"
+          >
+            Undo changes
+          </button>
+        </footer>
+      </div>
+    </form>
+  </div>
+</div>
+`;
+
+exports[`DataFilter options 1`] = `
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 100%;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  overflow: auto;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-bottom: 12px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 12px;
+}
+
+.c11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c13 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-right: 12px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c16 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: solid 2px rgba(0,0,0,0.15);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 24px;
+  width: 24px;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  border-radius: 4px;
+}
+
+.c7 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  height: 6px;
+}
+
 .c17 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  height: 12px;
+}
+
+.c19 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  width: 24px;
+}
+
+.c9 {
+  margin-left: 12px;
+  margin-right: 12px;
+  margin-top: 6px;
+  margin-bottom: 6px;
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c18 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: 2px solid #7D4CDB;
+  border-radius: 18px;
+  color: #444444;
+  padding: 4px 22px;
+  font-size: 18px;
+  line-height: 24px;
+  background-color: #7D4CDB;
+  color: #f8f8f8;
+  border-radius: 18px;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+}
+
+.c18:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c18:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c18:focus > circle,
+.c18:focus > ellipse,
+.c18:focus > line,
+.c18:focus > path,
+.c18:focus > polygon,
+.c18:focus > polyline,
+.c18:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c18:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c18:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c18:focus:not(:focus-visible) > circle,
+.c18:focus:not(:focus-visible) > ellipse,
+.c18:focus:not(:focus-visible) > line,
+.c18:focus:not(:focus-visible) > path,
+.c18:focus:not(:focus-visible) > polygon,
+.c18:focus:not(:focus-visible) > polyline,
+.c18:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c18:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c20 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -699,47 +782,47 @@ exports[`DataFilter options 1`] = `
   transition-timing-function: ease-in-out;
 }
 
-.c17:focus {
+.c20:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus > circle,
-.c17:focus > ellipse,
-.c17:focus > line,
-.c17:focus > path,
-.c17:focus > polygon,
-.c17:focus > polyline,
-.c17:focus > rect {
+.c20:focus > circle,
+.c20:focus > ellipse,
+.c20:focus > line,
+.c20:focus > path,
+.c20:focus > polygon,
+.c20:focus > polyline,
+.c20:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus::-moz-focus-inner {
+.c20:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c17:focus:not(:focus-visible) {
+.c20:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible) > circle,
-.c17:focus:not(:focus-visible) > ellipse,
-.c17:focus:not(:focus-visible) > line,
-.c17:focus:not(:focus-visible) > path,
-.c17:focus:not(:focus-visible) > polygon,
-.c17:focus:not(:focus-visible) > polyline,
-.c17:focus:not(:focus-visible) > rect {
+.c20:focus:not(:focus-visible) > circle,
+.c20:focus:not(:focus-visible) > ellipse,
+.c20:focus:not(:focus-visible) > line,
+.c20:focus:not(:focus-visible) > path,
+.c20:focus:not(:focus-visible) > polygon,
+.c20:focus:not(:focus-visible) > polyline,
+.c20:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible)::-moz-focus-inner {
+.c20:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c10 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -761,12 +844,12 @@ exports[`DataFilter options 1`] = `
   cursor: pointer;
 }
 
-.c10:hover input:not([disabled]) + div,
-.c10:hover input:not([disabled]) + span {
+.c12:hover input:not([disabled]) + div,
+.c12:hover input:not([disabled]) + span {
   border-color: #000000;
 }
 
-.c13 {
+.c15 {
   opacity: 0;
   -moz-appearance: none;
   width: 0;
@@ -775,18 +858,18 @@ exports[`DataFilter options 1`] = `
   cursor: pointer;
 }
 
-.c13:checked + span > span {
+.c15:checked + span > span {
   left: calc( 48px - 24px );
   background: #7D4CDB;
 }
 
-.c12 {
+.c14 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c18 {
+.c21 {
   opacity: 0;
 }
 
@@ -794,7 +877,7 @@ exports[`DataFilter options 1`] = `
   max-width: 100%;
 }
 
-.c4 {
+.c6 {
   margin: 0px;
   font-size: 26px;
   line-height: 32px;
@@ -814,55 +897,61 @@ exports[`DataFilter options 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c6 {
+  .c8 {
     margin-bottom: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c10 {
     border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c10 {
     padding: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c11 {
+  .c13 {
     margin-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c14 {
+  .c16 {
     border: solid 2px rgba(0,0,0,0.15);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c7 {
+    height: 3px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c17 {
     height: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c16 {
+  .c19 {
     width: 12px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c6 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c6 {
     font-size: 22px;
     line-height: 28px;
     max-width: 528px;
@@ -880,249 +969,250 @@ exports[`DataFilter options 1`] = `
       class="c2"
     >
       <div
-        class="c1"
+        class="c3"
       >
-        <header
-          class="c3"
-        >
-          <h2
-            class="c4"
-          >
-            Filters
-          </h2>
-        </header>
         <div
-          class="c5"
-        />
-        <div
-          class="c6 "
+          class="c4"
         >
-          <label
-            class="c7"
-            for="data-name"
+          <header
+            class="c5"
           >
-            name
-          </label>
-          <div
-            class="c8 FormField__FormFieldContentBox-sc-m9hood-1"
-          >
-            <div
-              class="c9 StyledCheckBoxGroup-sc-2nhc5d-0"
-              id="data-name"
-              role="group"
+            <h2
+              class="c6"
             >
-              <label
-                class="c10"
-                label="aa"
-              >
-                <div
-                  class="c11 c12"
-                >
-                  <input
-                    class="c13"
-                    type="checkbox"
-                  />
-                  <div
-                    class="c14 "
-                  />
-                </div>
-                <span>
-                  aa
-                </span>
-              </label>
+              Filters
+            </h2>
+          </header>
+          <div
+            class="c7"
+          />
+          <div
+            class="c8 "
+          >
+            <label
+              class="c9"
+              for="data-name"
+            >
+              name
+            </label>
+            <div
+              class="c10 FormField__FormFieldContentBox-sc-m9hood-1"
+            >
               <div
-                class="c5"
-              />
-              <label
-                class="c10"
-                label="bb"
+                class="c11 StyledCheckBoxGroup-sc-2nhc5d-0"
+                id="data-name"
+                role="group"
               >
-                <div
-                  class="c11 c12"
+                <label
+                  class="c12"
+                  label="aa"
                 >
-                  <input
-                    class="c13"
-                    type="checkbox"
-                  />
                   <div
-                    class="c14 "
-                  />
-                </div>
-                <span>
-                  bb
-                </span>
-              </label>
+                    class="c13 c14"
+                  >
+                    <input
+                      class="c15"
+                      type="checkbox"
+                    />
+                    <div
+                      class="c16 "
+                    />
+                  </div>
+                  <span>
+                    aa
+                  </span>
+                </label>
+                <div
+                  class="c17"
+                />
+                <label
+                  class="c12"
+                  label="bb"
+                >
+                  <div
+                    class="c13 c14"
+                  >
+                    <input
+                      class="c15"
+                      type="checkbox"
+                    />
+                    <div
+                      class="c16 "
+                    />
+                  </div>
+                  <span>
+                    bb
+                  </span>
+                </label>
+                <div
+                  class="c17"
+                />
+                <label
+                  class="c12"
+                  label="cc"
+                >
+                  <div
+                    class="c13 c14"
+                  >
+                    <input
+                      class="c15"
+                      type="checkbox"
+                    />
+                    <div
+                      class="c16 "
+                    />
+                  </div>
+                  <span>
+                    cc
+                  </span>
+                </label>
+              </div>
+            </div>
+          </div>
+          <div
+            class="c7"
+          />
+          <div
+            class="c8 "
+          >
+            <label
+              class="c9"
+              for="data-enabled"
+            >
+              Enabled
+            </label>
+            <div
+              class="c10 FormField__FormFieldContentBox-sc-m9hood-1"
+            >
               <div
-                class="c5"
-              />
-              <label
-                class="c10"
-                label="cc"
+                class="c11 StyledCheckBoxGroup-sc-2nhc5d-0"
+                id="data-enabled"
+                role="group"
               >
-                <div
-                  class="c11 c12"
+                <label
+                  class="c12"
+                  label="Enabled"
                 >
-                  <input
-                    class="c13"
-                    type="checkbox"
-                  />
                   <div
-                    class="c14 "
-                  />
-                </div>
-                <span>
-                  cc
-                </span>
-              </label>
+                    class="c13 c14"
+                  >
+                    <input
+                      class="c15"
+                      type="checkbox"
+                    />
+                    <div
+                      class="c16 "
+                    />
+                  </div>
+                  <span>
+                    Enabled
+                  </span>
+                </label>
+                <div
+                  class="c17"
+                />
+                <label
+                  class="c12"
+                  label="Disabled"
+                >
+                  <div
+                    class="c13 c14"
+                  >
+                    <input
+                      class="c15"
+                      type="checkbox"
+                    />
+                    <div
+                      class="c16 "
+                    />
+                  </div>
+                  <span>
+                    Disabled
+                  </span>
+                </label>
+              </div>
+            </div>
+          </div>
+          <div
+            class="c7"
+          />
+          <div
+            class="c8 "
+          >
+            <label
+              class="c9"
+              for="data-type.name"
+            >
+              Type
+            </label>
+            <div
+              class="c10 FormField__FormFieldContentBox-sc-m9hood-1"
+            >
+              <div
+                class="c11 StyledCheckBoxGroup-sc-2nhc5d-0"
+                id="data-type.name"
+                role="group"
+              >
+                <label
+                  class="c12"
+                  label="ZZ"
+                >
+                  <div
+                    class="c13 c14"
+                  >
+                    <input
+                      class="c15"
+                      type="checkbox"
+                    />
+                    <div
+                      class="c16 "
+                    />
+                  </div>
+                  <span>
+                    ZZ
+                  </span>
+                </label>
+                <div
+                  class="c17"
+                />
+                <label
+                  class="c12"
+                  label="YY"
+                >
+                  <div
+                    class="c13 c14"
+                  >
+                    <input
+                      class="c15"
+                      type="checkbox"
+                    />
+                    <div
+                      class="c16 "
+                    />
+                  </div>
+                  <span>
+                    YY
+                  </span>
+                </label>
+              </div>
             </div>
           </div>
         </div>
-        <div
-          class="c5"
-        />
-        <div
-          class="c6 "
-        >
-          <label
-            class="c7"
-            for="data-enabled"
-          >
-            Enabled
-          </label>
-          <div
-            class="c8 FormField__FormFieldContentBox-sc-m9hood-1"
-          >
-            <div
-              class="c9 StyledCheckBoxGroup-sc-2nhc5d-0"
-              id="data-enabled"
-              role="group"
-            >
-              <label
-                class="c10"
-                label="Enabled"
-              >
-                <div
-                  class="c11 c12"
-                >
-                  <input
-                    class="c13"
-                    type="checkbox"
-                  />
-                  <div
-                    class="c14 "
-                  />
-                </div>
-                <span>
-                  Enabled
-                </span>
-              </label>
-              <div
-                class="c5"
-              />
-              <label
-                class="c10"
-                label="Disabled"
-              >
-                <div
-                  class="c11 c12"
-                >
-                  <input
-                    class="c13"
-                    type="checkbox"
-                  />
-                  <div
-                    class="c14 "
-                  />
-                </div>
-                <span>
-                  Disabled
-                </span>
-              </label>
-            </div>
-          </div>
-        </div>
-        <div
-          class="c5"
-        />
-        <div
-          class="c6 "
-        >
-          <label
-            class="c7"
-            for="data-type.name"
-          >
-            Type
-          </label>
-          <div
-            class="c8 FormField__FormFieldContentBox-sc-m9hood-1"
-          >
-            <div
-              class="c9 StyledCheckBoxGroup-sc-2nhc5d-0"
-              id="data-type.name"
-              role="group"
-            >
-              <label
-                class="c10"
-                label="ZZ"
-              >
-                <div
-                  class="c11 c12"
-                >
-                  <input
-                    class="c13"
-                    type="checkbox"
-                  />
-                  <div
-                    class="c14 "
-                  />
-                </div>
-                <span>
-                  ZZ
-                </span>
-              </label>
-              <div
-                class="c5"
-              />
-              <label
-                class="c10"
-                label="YY"
-              >
-                <div
-                  class="c11 c12"
-                >
-                  <input
-                    class="c13"
-                    type="checkbox"
-                  />
-                  <div
-                    class="c14 "
-                  />
-                </div>
-                <span>
-                  YY
-                </span>
-              </label>
-            </div>
-          </div>
-        </div>
-        <div
-          class="c5"
-        />
         <footer
-          class="c3"
+          class="c5"
         >
           <button
-            class="c15"
+            class="c18"
             type="submit"
           >
             Apply filters
           </button>
           <div
-            class="c16"
+            class="c19"
           />
           <button
             aria-hidden="true"
-            class="c17 c18"
+            class="c20 c21"
             disabled=""
             tabindex="-1"
             type="reset"
@@ -1161,6 +1251,39 @@ exports[`DataFilter range Data 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 100%;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  overflow: auto;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1179,7 +1302,7 @@ exports[`DataFilter range Data 1`] = `
   justify-content: space-between;
 }
 
-.c6 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1192,9 +1315,12 @@ exports[`DataFilter range Data 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
-.c8 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1208,26 +1334,6 @@ exports[`DataFilter range Data 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   padding: 12px;
-}
-
-.c9 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  width: 100%;
-  height: 100%;
 }
 
 .c11 {
@@ -1248,10 +1354,30 @@ exports[`DataFilter range Data 1`] = `
   flex-direction: row;
   width: 100%;
   height: 100%;
-  cursor: pointer;
 }
 
 .c13 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  width: 100%;
+  height: 100%;
+  cursor: pointer;
+}
+
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1270,7 +1396,7 @@ exports[`DataFilter range Data 1`] = `
   border-radius: 12px;
 }
 
-.c14 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1296,7 +1422,7 @@ exports[`DataFilter range Data 1`] = `
   overflow: visible;
 }
 
-.c15 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1321,7 +1447,7 @@ exports[`DataFilter range Data 1`] = `
   justify-content: center;
 }
 
-.c16 {
+.c18 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1340,7 +1466,7 @@ exports[`DataFilter range Data 1`] = `
   border-radius: 100%;
 }
 
-.c17 {
+.c19 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1361,17 +1487,17 @@ exports[`DataFilter range Data 1`] = `
   border-radius: 12px;
 }
 
-.c5 {
+.c7 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
   align-self: stretch;
-  height: 12px;
+  height: 6px;
 }
 
-.c20 {
+.c22 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -1381,7 +1507,7 @@ exports[`DataFilter range Data 1`] = `
   width: 24px;
 }
 
-.c7 {
+.c9 {
   margin-left: 12px;
   margin-right: 12px;
   margin-top: 6px;
@@ -1390,7 +1516,7 @@ exports[`DataFilter range Data 1`] = `
   line-height: 24px;
 }
 
-.c10 {
+.c12 {
   margin-left: 12px;
   margin-right: 12px;
   font-size: 14px;
@@ -1398,14 +1524,14 @@ exports[`DataFilter range Data 1`] = `
   text-align: right;
 }
 
-.c18 {
+.c20 {
   margin-left: 12px;
   margin-right: 12px;
   font-size: 14px;
   line-height: 20px;
 }
 
-.c19 {
+.c21 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -1433,75 +1559,8 @@ exports[`DataFilter range Data 1`] = `
   transition-timing-function: ease-in-out;
 }
 
-.c19:hover {
+.c21:hover {
   box-shadow: 0px 0px 0px 2px #7D4CDB;
-}
-
-.c19:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c19:focus > circle,
-.c19:focus > ellipse,
-.c19:focus > line,
-.c19:focus > path,
-.c19:focus > polygon,
-.c19:focus > polyline,
-.c19:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c19:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c19:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c19:focus:not(:focus-visible) > circle,
-.c19:focus:not(:focus-visible) > ellipse,
-.c19:focus:not(:focus-visible) > line,
-.c19:focus:not(:focus-visible) > path,
-.c19:focus:not(:focus-visible) > polygon,
-.c19:focus:not(:focus-visible) > polyline,
-.c19:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c19:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c21 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: 2px solid #7D4CDB;
-  border-radius: 18px;
-  color: #444444;
-  padding: 4px 22px;
-  font-size: 18px;
-  line-height: 24px;
-  opacity: 0.3;
-  cursor: default;
-  -webkit-transition-property: color,background-color,border-color,box-shadow;
-  transition-property: color,background-color,border-color,box-shadow;
-  -webkit-transition-duration: 0.1s;
-  transition-duration: 0.1s;
-  -webkit-transition-timing-function: ease-in-out;
-  transition-timing-function: ease-in-out;
 }
 
 .c21:focus {
@@ -1544,14 +1603,81 @@ exports[`DataFilter range Data 1`] = `
   border: 0;
 }
 
-.c12 {
+.c23 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: 2px solid #7D4CDB;
+  border-radius: 18px;
+  color: #444444;
+  padding: 4px 22px;
+  font-size: 18px;
+  line-height: 24px;
+  opacity: 0.3;
+  cursor: default;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+}
+
+.c23:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c23:focus > circle,
+.c23:focus > ellipse,
+.c23:focus > line,
+.c23:focus > path,
+.c23:focus > polygon,
+.c23:focus > polyline,
+.c23:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c23:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c23:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c23:focus:not(:focus-visible) > circle,
+.c23:focus:not(:focus-visible) > ellipse,
+.c23:focus:not(:focus-visible) > line,
+.c23:focus:not(:focus-visible) > path,
+.c23:focus:not(:focus-visible) > polygon,
+.c23:focus:not(:focus-visible) > polyline,
+.c23:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c23:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c14 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
 }
 
-.c22 {
+.c24 {
   opacity: 0;
 }
 
@@ -1559,7 +1685,7 @@ exports[`DataFilter range Data 1`] = `
   max-width: 100%;
 }
 
-.c4 {
+.c6 {
   margin: 0px;
   font-size: 26px;
   line-height: 32px;
@@ -1579,55 +1705,55 @@ exports[`DataFilter range Data 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c6 {
+  .c8 {
     margin-bottom: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c10 {
     border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c10 {
     padding: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c13 {
+  .c15 {
     border-radius: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c17 {
+  .c19 {
     border-radius: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
-    height: 6px;
+  .c7 {
+    height: 3px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c20 {
+  .c22 {
     width: 12px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c6 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c6 {
     font-size: 22px;
     line-height: 28px;
     max-width: 528px;
@@ -1645,124 +1771,125 @@ exports[`DataFilter range Data 1`] = `
       class="c2"
     >
       <div
-        class="c1"
+        class="c3"
       >
-        <header
-          class="c3"
-        >
-          <h2
-            class="c4"
-          >
-            Filters
-          </h2>
-        </header>
         <div
-          class="c5"
-        />
-        <div
-          class="c6 "
+          class="c4"
         >
-          <label
-            class="c7"
-            for="data-rating"
+          <header
+            class="c5"
           >
-            Rating
-          </label>
-          <div
-            class="c8 FormField__FormFieldContentBox-sc-m9hood-1"
-          >
-            <div
-              class="c9"
-              id="data-rating"
+            <h2
+              class="c6"
             >
-              <span
-                class="c10"
-                style="width: 0px;"
-              >
-                0
-              </span>
+              Filters
+            </h2>
+          </header>
+          <div
+            class="c7"
+          />
+          <div
+            class="c8 "
+          >
+            <label
+              class="c9"
+              for="data-rating"
+            >
+              Rating
+            </label>
+            <div
+              class="c10 FormField__FormFieldContentBox-sc-m9hood-1"
+            >
               <div
-                class="c11 c12"
-                tabindex="-1"
+                class="c11"
+                id="data-rating"
               >
+                <span
+                  class="c12"
+                  style="width: 0px;"
+                >
+                  0
+                </span>
                 <div
-                  class="c13"
-                  style="flex: 0 0 0px;"
-                />
-                <div
-                  class="c14"
-                  style="flex: 0 0 1px;"
+                  class="c13 c14"
+                  tabindex="-1"
                 >
                   <div
-                    aria-label="Lower Bounds"
-                    aria-valuemax="5"
-                    aria-valuemin="0"
-                    aria-valuenow="0"
                     class="c15"
-                    role="slider"
-                    style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 1;"
-                    tabindex="0"
-                  >
-                    <div
-                      class="c16 EdgeControl__StyledBox-sc-1xo2yt9-0"
-                    />
-                  </div>
-                </div>
-                <div
-                  class="c17"
-                  style="flex: 6 0 0px; cursor: ew-resize;"
-                />
-                <div
-                  class="c14"
-                  style="flex: 0 0 1px;"
-                >
+                    style="flex: 0 0 0px;"
+                  />
                   <div
-                    aria-label="Upper Bounds"
-                    aria-valuemax="5"
-                    aria-valuemin="0"
-                    aria-valuenow="5"
-                    class="c15"
-                    role="slider"
-                    style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 1;"
-                    tabindex="0"
+                    class="c16"
+                    style="flex: 0 0 1px;"
                   >
                     <div
-                      class="c16 EdgeControl__StyledBox-sc-1xo2yt9-0"
-                    />
+                      aria-label="Lower Bounds"
+                      aria-valuemax="5"
+                      aria-valuemin="0"
+                      aria-valuenow="0"
+                      class="c17"
+                      role="slider"
+                      style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 1;"
+                      tabindex="0"
+                    >
+                      <div
+                        class="c18 EdgeControl__StyledBox-sc-1xo2yt9-0"
+                      />
+                    </div>
                   </div>
+                  <div
+                    class="c19"
+                    style="flex: 6 0 0px; cursor: ew-resize;"
+                  />
+                  <div
+                    class="c16"
+                    style="flex: 0 0 1px;"
+                  >
+                    <div
+                      aria-label="Upper Bounds"
+                      aria-valuemax="5"
+                      aria-valuemin="0"
+                      aria-valuenow="5"
+                      class="c17"
+                      role="slider"
+                      style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 1;"
+                      tabindex="0"
+                    >
+                      <div
+                        class="c18 EdgeControl__StyledBox-sc-1xo2yt9-0"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="c15"
+                    style="flex: 0 0 0px;"
+                  />
                 </div>
-                <div
-                  class="c13"
-                  style="flex: 0 0 0px;"
-                />
+                <span
+                  class="c20"
+                  style="width: 0px;"
+                >
+                  5
+                </span>
               </div>
-              <span
-                class="c18"
-                style="width: 0px;"
-              >
-                5
-              </span>
             </div>
           </div>
         </div>
-        <div
-          class="c5"
-        />
         <footer
-          class="c3"
+          class="c5"
         >
           <button
-            class="c19"
+            class="c21"
             type="submit"
           >
             Apply filters
           </button>
           <div
-            class="c20"
+            class="c22"
           />
           <button
             aria-hidden="true"
-            class="c21 c22"
+            class="c23 c24"
             disabled=""
             tabindex="-1"
             type="reset"
@@ -1801,6 +1928,39 @@ exports[`DataFilter range prop 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 100%;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  overflow: auto;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1819,7 +1979,7 @@ exports[`DataFilter range prop 1`] = `
   justify-content: space-between;
 }
 
-.c6 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1832,9 +1992,12 @@ exports[`DataFilter range prop 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
-.c8 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1848,26 +2011,6 @@ exports[`DataFilter range prop 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   padding: 12px;
-}
-
-.c9 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  width: 100%;
-  height: 100%;
 }
 
 .c11 {
@@ -1888,10 +2031,30 @@ exports[`DataFilter range prop 1`] = `
   flex-direction: row;
   width: 100%;
   height: 100%;
-  cursor: pointer;
 }
 
 .c13 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  width: 100%;
+  height: 100%;
+  cursor: pointer;
+}
+
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1910,7 +2073,7 @@ exports[`DataFilter range prop 1`] = `
   border-radius: 12px;
 }
 
-.c14 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1936,7 +2099,7 @@ exports[`DataFilter range prop 1`] = `
   overflow: visible;
 }
 
-.c15 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1961,7 +2124,7 @@ exports[`DataFilter range prop 1`] = `
   justify-content: center;
 }
 
-.c16 {
+.c18 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1980,7 +2143,7 @@ exports[`DataFilter range prop 1`] = `
   border-radius: 100%;
 }
 
-.c17 {
+.c19 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2001,17 +2164,17 @@ exports[`DataFilter range prop 1`] = `
   border-radius: 12px;
 }
 
-.c5 {
+.c7 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
   align-self: stretch;
-  height: 12px;
+  height: 6px;
 }
 
-.c20 {
+.c22 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -2021,7 +2184,7 @@ exports[`DataFilter range prop 1`] = `
   width: 24px;
 }
 
-.c7 {
+.c9 {
   margin-left: 12px;
   margin-right: 12px;
   margin-top: 6px;
@@ -2030,7 +2193,7 @@ exports[`DataFilter range prop 1`] = `
   line-height: 24px;
 }
 
-.c10 {
+.c12 {
   margin-left: 12px;
   margin-right: 12px;
   font-size: 14px;
@@ -2038,14 +2201,14 @@ exports[`DataFilter range prop 1`] = `
   text-align: right;
 }
 
-.c18 {
+.c20 {
   margin-left: 12px;
   margin-right: 12px;
   font-size: 14px;
   line-height: 20px;
 }
 
-.c19 {
+.c21 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -2073,75 +2236,8 @@ exports[`DataFilter range prop 1`] = `
   transition-timing-function: ease-in-out;
 }
 
-.c19:hover {
+.c21:hover {
   box-shadow: 0px 0px 0px 2px #7D4CDB;
-}
-
-.c19:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c19:focus > circle,
-.c19:focus > ellipse,
-.c19:focus > line,
-.c19:focus > path,
-.c19:focus > polygon,
-.c19:focus > polyline,
-.c19:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c19:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c19:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c19:focus:not(:focus-visible) > circle,
-.c19:focus:not(:focus-visible) > ellipse,
-.c19:focus:not(:focus-visible) > line,
-.c19:focus:not(:focus-visible) > path,
-.c19:focus:not(:focus-visible) > polygon,
-.c19:focus:not(:focus-visible) > polyline,
-.c19:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c19:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c21 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: 2px solid #7D4CDB;
-  border-radius: 18px;
-  color: #444444;
-  padding: 4px 22px;
-  font-size: 18px;
-  line-height: 24px;
-  opacity: 0.3;
-  cursor: default;
-  -webkit-transition-property: color,background-color,border-color,box-shadow;
-  transition-property: color,background-color,border-color,box-shadow;
-  -webkit-transition-duration: 0.1s;
-  transition-duration: 0.1s;
-  -webkit-transition-timing-function: ease-in-out;
-  transition-timing-function: ease-in-out;
 }
 
 .c21:focus {
@@ -2184,14 +2280,81 @@ exports[`DataFilter range prop 1`] = `
   border: 0;
 }
 
-.c12 {
+.c23 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: 2px solid #7D4CDB;
+  border-radius: 18px;
+  color: #444444;
+  padding: 4px 22px;
+  font-size: 18px;
+  line-height: 24px;
+  opacity: 0.3;
+  cursor: default;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+}
+
+.c23:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c23:focus > circle,
+.c23:focus > ellipse,
+.c23:focus > line,
+.c23:focus > path,
+.c23:focus > polygon,
+.c23:focus > polyline,
+.c23:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c23:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c23:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c23:focus:not(:focus-visible) > circle,
+.c23:focus:not(:focus-visible) > ellipse,
+.c23:focus:not(:focus-visible) > line,
+.c23:focus:not(:focus-visible) > path,
+.c23:focus:not(:focus-visible) > polygon,
+.c23:focus:not(:focus-visible) > polyline,
+.c23:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c23:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c14 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
 }
 
-.c22 {
+.c24 {
   opacity: 0;
 }
 
@@ -2199,7 +2362,7 @@ exports[`DataFilter range prop 1`] = `
   max-width: 100%;
 }
 
-.c4 {
+.c6 {
   margin: 0px;
   font-size: 26px;
   line-height: 32px;
@@ -2219,55 +2382,55 @@ exports[`DataFilter range prop 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c6 {
+  .c8 {
     margin-bottom: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c10 {
     border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c10 {
     padding: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c13 {
+  .c15 {
     border-radius: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c17 {
+  .c19 {
     border-radius: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
-    height: 6px;
+  .c7 {
+    height: 3px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c20 {
+  .c22 {
     width: 12px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c6 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c6 {
     font-size: 22px;
     line-height: 28px;
     max-width: 528px;
@@ -2285,124 +2448,125 @@ exports[`DataFilter range prop 1`] = `
       class="c2"
     >
       <div
-        class="c1"
+        class="c3"
       >
-        <header
-          class="c3"
-        >
-          <h2
-            class="c4"
-          >
-            Filters
-          </h2>
-        </header>
         <div
-          class="c5"
-        />
-        <div
-          class="c6 "
+          class="c4"
         >
-          <label
-            class="c7"
-            for="data-rating"
+          <header
+            class="c5"
           >
-            rating
-          </label>
-          <div
-            class="c8 FormField__FormFieldContentBox-sc-m9hood-1"
-          >
-            <div
-              class="c9"
-              id="data-rating"
+            <h2
+              class="c6"
             >
-              <span
-                class="c10"
-                style="width: 0px;"
-              >
-                0
-              </span>
+              Filters
+            </h2>
+          </header>
+          <div
+            class="c7"
+          />
+          <div
+            class="c8 "
+          >
+            <label
+              class="c9"
+              for="data-rating"
+            >
+              rating
+            </label>
+            <div
+              class="c10 FormField__FormFieldContentBox-sc-m9hood-1"
+            >
               <div
-                class="c11 c12"
-                tabindex="-1"
+                class="c11"
+                id="data-rating"
               >
+                <span
+                  class="c12"
+                  style="width: 0px;"
+                >
+                  0
+                </span>
                 <div
-                  class="c13"
-                  style="flex: 0 0 0px;"
-                />
-                <div
-                  class="c14"
-                  style="flex: 0 0 1px;"
+                  class="c13 c14"
+                  tabindex="-1"
                 >
                   <div
-                    aria-label="Lower Bounds"
-                    aria-valuemax="5"
-                    aria-valuemin="0"
-                    aria-valuenow="0"
                     class="c15"
-                    role="slider"
-                    style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 1;"
-                    tabindex="0"
-                  >
-                    <div
-                      class="c16 EdgeControl__StyledBox-sc-1xo2yt9-0"
-                    />
-                  </div>
-                </div>
-                <div
-                  class="c17"
-                  style="flex: 6 0 0px; cursor: ew-resize;"
-                />
-                <div
-                  class="c14"
-                  style="flex: 0 0 1px;"
-                >
+                    style="flex: 0 0 0px;"
+                  />
                   <div
-                    aria-label="Upper Bounds"
-                    aria-valuemax="5"
-                    aria-valuemin="0"
-                    aria-valuenow="5"
-                    class="c15"
-                    role="slider"
-                    style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 1;"
-                    tabindex="0"
+                    class="c16"
+                    style="flex: 0 0 1px;"
                   >
                     <div
-                      class="c16 EdgeControl__StyledBox-sc-1xo2yt9-0"
-                    />
+                      aria-label="Lower Bounds"
+                      aria-valuemax="5"
+                      aria-valuemin="0"
+                      aria-valuenow="0"
+                      class="c17"
+                      role="slider"
+                      style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 1;"
+                      tabindex="0"
+                    >
+                      <div
+                        class="c18 EdgeControl__StyledBox-sc-1xo2yt9-0"
+                      />
+                    </div>
                   </div>
+                  <div
+                    class="c19"
+                    style="flex: 6 0 0px; cursor: ew-resize;"
+                  />
+                  <div
+                    class="c16"
+                    style="flex: 0 0 1px;"
+                  >
+                    <div
+                      aria-label="Upper Bounds"
+                      aria-valuemax="5"
+                      aria-valuemin="0"
+                      aria-valuenow="5"
+                      class="c17"
+                      role="slider"
+                      style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 1;"
+                      tabindex="0"
+                    >
+                      <div
+                        class="c18 EdgeControl__StyledBox-sc-1xo2yt9-0"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="c15"
+                    style="flex: 0 0 0px;"
+                  />
                 </div>
-                <div
-                  class="c13"
-                  style="flex: 0 0 0px;"
-                />
+                <span
+                  class="c20"
+                  style="width: 0px;"
+                >
+                  5
+                </span>
               </div>
-              <span
-                class="c18"
-                style="width: 0px;"
-              >
-                5
-              </span>
             </div>
           </div>
         </div>
-        <div
-          class="c5"
-        />
         <footer
-          class="c3"
+          class="c5"
         >
           <button
-            class="c19"
+            class="c21"
             type="submit"
           >
             Apply filters
           </button>
           <div
-            class="c20"
+            class="c22"
           />
           <button
             aria-hidden="true"
-            class="c21 c22"
+            class="c23 c24"
             disabled=""
             tabindex="-1"
             type="reset"
@@ -2441,6 +2605,39 @@ exports[`DataFilter renders 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 100%;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  overflow: auto;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2459,7 +2656,7 @@ exports[`DataFilter renders 1`] = `
   justify-content: space-between;
 }
 
-.c6 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2472,9 +2669,12 @@ exports[`DataFilter renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
-.c8 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2490,7 +2690,7 @@ exports[`DataFilter renders 1`] = `
   padding: 12px;
 }
 
-.c9 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2504,7 +2704,7 @@ exports[`DataFilter renders 1`] = `
   flex-direction: column;
 }
 
-.c11 {
+.c13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2527,7 +2727,7 @@ exports[`DataFilter renders 1`] = `
   justify-content: center;
 }
 
-.c14 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2553,7 +2753,7 @@ exports[`DataFilter renders 1`] = `
   border-radius: 4px;
 }
 
-.c15 {
+.c18 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2573,7 +2773,7 @@ exports[`DataFilter renders 1`] = `
   height: 100%;
 }
 
-.c17 {
+.c20 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2594,7 +2794,7 @@ exports[`DataFilter renders 1`] = `
   cursor: pointer;
 }
 
-.c19 {
+.c22 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2613,7 +2813,7 @@ exports[`DataFilter renders 1`] = `
   border-radius: 12px;
 }
 
-.c20 {
+.c23 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2639,7 +2839,7 @@ exports[`DataFilter renders 1`] = `
   overflow: visible;
 }
 
-.c21 {
+.c24 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2664,7 +2864,7 @@ exports[`DataFilter renders 1`] = `
   justify-content: center;
 }
 
-.c22 {
+.c25 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2683,7 +2883,7 @@ exports[`DataFilter renders 1`] = `
   border-radius: 100%;
 }
 
-.c23 {
+.c26 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2704,7 +2904,17 @@ exports[`DataFilter renders 1`] = `
   border-radius: 12px;
 }
 
-.c5 {
+.c7 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  height: 6px;
+}
+
+.c17 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -2714,7 +2924,7 @@ exports[`DataFilter renders 1`] = `
   height: 12px;
 }
 
-.c26 {
+.c29 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -2724,7 +2934,7 @@ exports[`DataFilter renders 1`] = `
   width: 24px;
 }
 
-.c7 {
+.c9 {
   margin-left: 12px;
   margin-right: 12px;
   margin-top: 6px;
@@ -2733,7 +2943,7 @@ exports[`DataFilter renders 1`] = `
   line-height: 24px;
 }
 
-.c16 {
+.c19 {
   margin-left: 12px;
   margin-right: 12px;
   font-size: 14px;
@@ -2741,14 +2951,14 @@ exports[`DataFilter renders 1`] = `
   text-align: right;
 }
 
-.c24 {
+.c27 {
   margin-left: 12px;
   margin-right: 12px;
   font-size: 14px;
   line-height: 20px;
 }
 
-.c25 {
+.c28 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -2776,51 +2986,51 @@ exports[`DataFilter renders 1`] = `
   transition-timing-function: ease-in-out;
 }
 
-.c25:hover {
+.c28:hover {
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c25:focus {
+.c28:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c25:focus > circle,
-.c25:focus > ellipse,
-.c25:focus > line,
-.c25:focus > path,
-.c25:focus > polygon,
-.c25:focus > polyline,
-.c25:focus > rect {
+.c28:focus > circle,
+.c28:focus > ellipse,
+.c28:focus > line,
+.c28:focus > path,
+.c28:focus > polygon,
+.c28:focus > polyline,
+.c28:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c25:focus::-moz-focus-inner {
+.c28:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c25:focus:not(:focus-visible) {
+.c28:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c25:focus:not(:focus-visible) > circle,
-.c25:focus:not(:focus-visible) > ellipse,
-.c25:focus:not(:focus-visible) > line,
-.c25:focus:not(:focus-visible) > path,
-.c25:focus:not(:focus-visible) > polygon,
-.c25:focus:not(:focus-visible) > polyline,
-.c25:focus:not(:focus-visible) > rect {
+.c28:focus:not(:focus-visible) > circle,
+.c28:focus:not(:focus-visible) > ellipse,
+.c28:focus:not(:focus-visible) > line,
+.c28:focus:not(:focus-visible) > path,
+.c28:focus:not(:focus-visible) > polygon,
+.c28:focus:not(:focus-visible) > polyline,
+.c28:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c25:focus:not(:focus-visible)::-moz-focus-inner {
+.c28:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c27 {
+.c30 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -2847,47 +3057,47 @@ exports[`DataFilter renders 1`] = `
   transition-timing-function: ease-in-out;
 }
 
-.c27:focus {
+.c30:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c27:focus > circle,
-.c27:focus > ellipse,
-.c27:focus > line,
-.c27:focus > path,
-.c27:focus > polygon,
-.c27:focus > polyline,
-.c27:focus > rect {
+.c30:focus > circle,
+.c30:focus > ellipse,
+.c30:focus > line,
+.c30:focus > path,
+.c30:focus > polygon,
+.c30:focus > polyline,
+.c30:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c27:focus::-moz-focus-inner {
+.c30:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c27:focus:not(:focus-visible) {
+.c30:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c27:focus:not(:focus-visible) > circle,
-.c27:focus:not(:focus-visible) > ellipse,
-.c27:focus:not(:focus-visible) > line,
-.c27:focus:not(:focus-visible) > path,
-.c27:focus:not(:focus-visible) > polygon,
-.c27:focus:not(:focus-visible) > polyline,
-.c27:focus:not(:focus-visible) > rect {
+.c30:focus:not(:focus-visible) > circle,
+.c30:focus:not(:focus-visible) > ellipse,
+.c30:focus:not(:focus-visible) > line,
+.c30:focus:not(:focus-visible) > path,
+.c30:focus:not(:focus-visible) > polygon,
+.c30:focus:not(:focus-visible) > polyline,
+.c30:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c27:focus:not(:focus-visible)::-moz-focus-inner {
+.c30:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c10 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2909,12 +3119,12 @@ exports[`DataFilter renders 1`] = `
   cursor: pointer;
 }
 
-.c10:hover input:not([disabled]) + div,
-.c10:hover input:not([disabled]) + span {
+.c12:hover input:not([disabled]) + div,
+.c12:hover input:not([disabled]) + span {
   border-color: #000000;
 }
 
-.c13 {
+.c15 {
   opacity: 0;
   -moz-appearance: none;
   width: 0;
@@ -2923,25 +3133,25 @@ exports[`DataFilter renders 1`] = `
   cursor: pointer;
 }
 
-.c13:checked + span > span {
+.c15:checked + span > span {
   left: calc( 48px - 24px );
   background: #7D4CDB;
 }
 
-.c12 {
+.c14 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c18 {
+.c21 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
 }
 
-.c28 {
+.c31 {
   opacity: 0;
 }
 
@@ -2949,7 +3159,7 @@ exports[`DataFilter renders 1`] = `
   max-width: 100%;
 }
 
-.c4 {
+.c6 {
   margin: 0px;
   font-size: 26px;
   line-height: 32px;
@@ -2969,67 +3179,73 @@ exports[`DataFilter renders 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c6 {
+  .c8 {
     margin-bottom: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c10 {
     border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c10 {
     padding: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c11 {
+  .c13 {
     margin-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c14 {
+  .c16 {
     border: solid 2px rgba(0,0,0,0.15);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c19 {
+  .c22 {
     border-radius: 6px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c23 {
-    border-radius: 6px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c5 {
-    height: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c26 {
+    border-radius: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    height: 3px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c17 {
+    height: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c29 {
     width: 12px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c6 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c6 {
     font-size: 22px;
     line-height: 28px;
     max-width: 528px;
@@ -3047,274 +3263,275 @@ exports[`DataFilter renders 1`] = `
       class="c2"
     >
       <div
-        class="c1"
+        class="c3"
       >
-        <header
-          class="c3"
-        >
-          <h2
-            class="c4"
-          >
-            Filters
-          </h2>
-        </header>
         <div
-          class="c5"
-        />
-        <div
-          class="c6 "
+          class="c4"
         >
-          <label
-            class="c7"
-            for="data-name"
+          <header
+            class="c5"
           >
-            name
-          </label>
-          <div
-            class="c8 FormField__FormFieldContentBox-sc-m9hood-1"
-          >
-            <div
-              class="c9 StyledCheckBoxGroup-sc-2nhc5d-0"
-              id="data-name"
-              role="group"
+            <h2
+              class="c6"
             >
-              <label
-                class="c10"
-                label="aa"
-              >
-                <div
-                  class="c11 c12"
-                >
-                  <input
-                    class="c13"
-                    type="checkbox"
-                  />
-                  <div
-                    class="c14 "
-                  />
-                </div>
-                <span>
-                  aa
-                </span>
-              </label>
-              <div
-                class="c5"
-              />
-              <label
-                class="c10"
-                label="bb"
-              >
-                <div
-                  class="c11 c12"
-                >
-                  <input
-                    class="c13"
-                    type="checkbox"
-                  />
-                  <div
-                    class="c14 "
-                  />
-                </div>
-                <span>
-                  bb
-                </span>
-              </label>
-              <div
-                class="c5"
-              />
-              <label
-                class="c10"
-                label="cc"
-              >
-                <div
-                  class="c11 c12"
-                >
-                  <input
-                    class="c13"
-                    type="checkbox"
-                  />
-                  <div
-                    class="c14 "
-                  />
-                </div>
-                <span>
-                  cc
-                </span>
-              </label>
-            </div>
-          </div>
-        </div>
-        <div
-          class="c5"
-        />
-        <div
-          class="c6 "
-        >
-          <label
-            class="c7"
-            for="data-enabled"
-          >
-            enabled
-          </label>
+              Filters
+            </h2>
+          </header>
           <div
-            class="c8 FormField__FormFieldContentBox-sc-m9hood-1"
-          >
-            <div
-              class="c9 StyledCheckBoxGroup-sc-2nhc5d-0"
-              id="data-enabled"
-              role="group"
-            >
-              <label
-                class="c10"
-                label="true"
-              >
-                <div
-                  class="c11 c12"
-                >
-                  <input
-                    class="c13"
-                    type="checkbox"
-                  />
-                  <div
-                    class="c14 "
-                  />
-                </div>
-                <span>
-                  true
-                </span>
-              </label>
-              <div
-                class="c5"
-              />
-              <label
-                class="c10"
-                label="false"
-              >
-                <div
-                  class="c11 c12"
-                >
-                  <input
-                    class="c13"
-                    type="checkbox"
-                  />
-                  <div
-                    class="c14 "
-                  />
-                </div>
-                <span>
-                  false
-                </span>
-              </label>
-            </div>
-          </div>
-        </div>
-        <div
-          class="c5"
-        />
-        <div
-          class="c6 "
-        >
-          <label
             class="c7"
-            for="data-rating"
-          >
-            rating
-          </label>
+          />
           <div
-            class="c8 FormField__FormFieldContentBox-sc-m9hood-1"
+            class="c8 "
           >
-            <div
-              class="c15"
-              id="data-rating"
+            <label
+              class="c9"
+              for="data-name"
             >
-              <span
-                class="c16"
-                style="width: 0px;"
-              >
-                2.0999999999999996
-              </span>
+              name
+            </label>
+            <div
+              class="c10 FormField__FormFieldContentBox-sc-m9hood-1"
+            >
               <div
-                class="c17 c18"
-                tabindex="-1"
+                class="c11 StyledCheckBoxGroup-sc-2nhc5d-0"
+                id="data-name"
+                role="group"
               >
-                <div
-                  class="c19"
-                  style="flex: 0 0 0px;"
-                />
-                <div
-                  class="c20"
-                  style="flex: 0 0 1px;"
+                <label
+                  class="c12"
+                  label="aa"
                 >
                   <div
-                    aria-label="Lower Bounds"
-                    aria-valuemax="4.8999999999999995"
-                    aria-valuemin="2.0999999999999996"
-                    aria-valuenow="2.0999999999999996"
-                    class="c21"
-                    role="slider"
-                    style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 1;"
-                    tabindex="0"
+                    class="c13 c14"
                   >
+                    <input
+                      class="c15"
+                      type="checkbox"
+                    />
                     <div
-                      class="c22 EdgeControl__StyledBox-sc-1xo2yt9-0"
+                      class="c16 "
                     />
                   </div>
-                </div>
+                  <span>
+                    aa
+                  </span>
+                </label>
                 <div
-                  class="c23"
-                  style="flex: 3.8 0 0px; cursor: ew-resize;"
+                  class="c17"
                 />
-                <div
-                  class="c20"
-                  style="flex: 0 0 1px;"
+                <label
+                  class="c12"
+                  label="bb"
                 >
                   <div
-                    aria-label="Upper Bounds"
-                    aria-valuemax="4.8999999999999995"
-                    aria-valuemin="2.0999999999999996"
-                    aria-valuenow="4.8999999999999995"
-                    class="c21"
-                    role="slider"
-                    style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 1;"
-                    tabindex="0"
+                    class="c13 c14"
                   >
+                    <input
+                      class="c15"
+                      type="checkbox"
+                    />
                     <div
-                      class="c22 EdgeControl__StyledBox-sc-1xo2yt9-0"
+                      class="c16 "
                     />
                   </div>
-                </div>
+                  <span>
+                    bb
+                  </span>
+                </label>
                 <div
-                  class="c19"
-                  style="flex: 0 0 0px;"
+                  class="c17"
                 />
+                <label
+                  class="c12"
+                  label="cc"
+                >
+                  <div
+                    class="c13 c14"
+                  >
+                    <input
+                      class="c15"
+                      type="checkbox"
+                    />
+                    <div
+                      class="c16 "
+                    />
+                  </div>
+                  <span>
+                    cc
+                  </span>
+                </label>
               </div>
-              <span
-                class="c24"
-                style="width: 0px;"
+            </div>
+          </div>
+          <div
+            class="c7"
+          />
+          <div
+            class="c8 "
+          >
+            <label
+              class="c9"
+              for="data-enabled"
+            >
+              enabled
+            </label>
+            <div
+              class="c10 FormField__FormFieldContentBox-sc-m9hood-1"
+            >
+              <div
+                class="c11 StyledCheckBoxGroup-sc-2nhc5d-0"
+                id="data-enabled"
+                role="group"
               >
-                4.8999999999999995
-              </span>
+                <label
+                  class="c12"
+                  label="true"
+                >
+                  <div
+                    class="c13 c14"
+                  >
+                    <input
+                      class="c15"
+                      type="checkbox"
+                    />
+                    <div
+                      class="c16 "
+                    />
+                  </div>
+                  <span>
+                    true
+                  </span>
+                </label>
+                <div
+                  class="c17"
+                />
+                <label
+                  class="c12"
+                  label="false"
+                >
+                  <div
+                    class="c13 c14"
+                  >
+                    <input
+                      class="c15"
+                      type="checkbox"
+                    />
+                    <div
+                      class="c16 "
+                    />
+                  </div>
+                  <span>
+                    false
+                  </span>
+                </label>
+              </div>
+            </div>
+          </div>
+          <div
+            class="c7"
+          />
+          <div
+            class="c8 "
+          >
+            <label
+              class="c9"
+              for="data-rating"
+            >
+              rating
+            </label>
+            <div
+              class="c10 FormField__FormFieldContentBox-sc-m9hood-1"
+            >
+              <div
+                class="c18"
+                id="data-rating"
+              >
+                <span
+                  class="c19"
+                  style="width: 0px;"
+                >
+                  2.0999999999999996
+                </span>
+                <div
+                  class="c20 c21"
+                  tabindex="-1"
+                >
+                  <div
+                    class="c22"
+                    style="flex: 0 0 0px;"
+                  />
+                  <div
+                    class="c23"
+                    style="flex: 0 0 1px;"
+                  >
+                    <div
+                      aria-label="Lower Bounds"
+                      aria-valuemax="4.8999999999999995"
+                      aria-valuemin="2.0999999999999996"
+                      aria-valuenow="2.0999999999999996"
+                      class="c24"
+                      role="slider"
+                      style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 1;"
+                      tabindex="0"
+                    >
+                      <div
+                        class="c25 EdgeControl__StyledBox-sc-1xo2yt9-0"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="c26"
+                    style="flex: 3.8 0 0px; cursor: ew-resize;"
+                  />
+                  <div
+                    class="c23"
+                    style="flex: 0 0 1px;"
+                  >
+                    <div
+                      aria-label="Upper Bounds"
+                      aria-valuemax="4.8999999999999995"
+                      aria-valuemin="2.0999999999999996"
+                      aria-valuenow="4.8999999999999995"
+                      class="c24"
+                      role="slider"
+                      style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 1;"
+                      tabindex="0"
+                    >
+                      <div
+                        class="c25 EdgeControl__StyledBox-sc-1xo2yt9-0"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="c22"
+                    style="flex: 0 0 0px;"
+                  />
+                </div>
+                <span
+                  class="c27"
+                  style="width: 0px;"
+                >
+                  4.8999999999999995
+                </span>
+              </div>
             </div>
           </div>
         </div>
-        <div
-          class="c5"
-        />
         <footer
-          class="c3"
+          class="c5"
         >
           <button
-            class="c25"
+            class="c28"
             type="submit"
           >
             Apply filters
           </button>
           <div
-            class="c26"
+            class="c29"
           />
           <button
             aria-hidden="true"
-            class="c27 c28"
+            class="c30 c31"
             disabled=""
             tabindex="-1"
             type="reset"

--- a/src/js/components/DataFilters/DataFilters.js
+++ b/src/js/components/DataFilters/DataFilters.js
@@ -63,7 +63,7 @@ export const DataFilters = ({ drop, children, heading, layer, ...rest }) => {
     </Box>
   );
 
-  let filters;
+  let content = children;
   if (Children.count(children) === 0) {
     let filtersFor;
     if (!properties && data && data.length)
@@ -75,18 +75,17 @@ export const DataFilters = ({ drop, children, heading, layer, ...rest }) => {
     else if (typeof properties === 'object')
       filtersFor = Object.keys(properties);
     else filtersFor = [];
-    filters = filtersFor.map((property) => (
+    content = filtersFor.map((property) => (
       <DataFilter key={property} property={property} />
     ));
     if (view?.sort) {
-      filters.push(<DataSort key="_sort" />);
+      content.push(<DataSort key="_sort" />);
     }
   }
 
-  const content = (
+  content = (
     <DataForm
       pad={controlled ? 'medium' : undefined}
-      gap="xsmall"
       onDone={() => setShowContent(false)}
       onTouched={
         controlled
@@ -121,14 +120,12 @@ export const DataFilters = ({ drop, children, heading, layer, ...rest }) => {
           )}
         </Header>
       )}
-      {filters}
-      {children}
+      {content}
     </DataForm>
   );
 
   if (!controlled) return content;
 
-  // drop
   let control;
   if (drop) {
     control = (

--- a/src/js/components/DataFilters/DataFilters.js
+++ b/src/js/components/DataFilters/DataFilters.js
@@ -49,7 +49,7 @@ export const DataFilters = ({ drop, children, heading, layer, ...rest }) => {
   );
 
   const clearControl = badge && (
-    <Box flex={false}>
+    <Box flex={false} margin={{ start: 'small' }}>
       <Button
         label={format({
           id: 'dataFilters.clear',
@@ -86,7 +86,7 @@ export const DataFilters = ({ drop, children, heading, layer, ...rest }) => {
   const content = (
     <DataForm
       pad={controlled ? 'medium' : undefined}
-      gap="small"
+      gap="xsmall"
       onDone={() => setShowContent(false)}
       onTouched={
         controlled
@@ -100,7 +100,7 @@ export const DataFilters = ({ drop, children, heading, layer, ...rest }) => {
               }))
           : undefined
       }
-      {...(!controlled ? rest : {})}
+      {...(!controlled ? rest : { fill: 'vertical' })}
     >
       {!drop && (
         <Header>
@@ -167,7 +167,7 @@ export const DataFilters = ({ drop, children, heading, layer, ...rest }) => {
   }
 
   return (
-    <Box flex={false} direction="row" gap="small" {...rest}>
+    <Box flex={false} direction="row" {...rest}>
       {control}
       {clearControl}
       {layer && showContent && (

--- a/src/js/components/DataFilters/__tests__/__snapshots__/DataFilters-test.tsx.snap
+++ b/src/js/components/DataFilters/__tests__/__snapshots__/DataFilters-test.tsx.snap
@@ -25,6 +25,39 @@ exports[`DataFilters clear 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 100%;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  overflow: auto;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -43,7 +76,7 @@ exports[`DataFilters clear 1`] = `
   justify-content: space-between;
 }
 
-.c6 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -56,9 +89,12 @@ exports[`DataFilters clear 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
-.c8 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -74,7 +110,7 @@ exports[`DataFilters clear 1`] = `
   padding: 12px;
 }
 
-.c9 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -88,7 +124,7 @@ exports[`DataFilters clear 1`] = `
   flex-direction: column;
 }
 
-.c11 {
+.c13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -111,7 +147,7 @@ exports[`DataFilters clear 1`] = `
   justify-content: center;
 }
 
-.c14 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -137,7 +173,7 @@ exports[`DataFilters clear 1`] = `
   border-radius: 4px;
 }
 
-.c16 {
+.c19 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -163,14 +199,14 @@ exports[`DataFilters clear 1`] = `
   border-radius: 4px;
 }
 
-.c5 {
+.c7 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
   align-self: stretch;
-  height: 12px;
+  height: 6px;
 }
 
 .c18 {
@@ -180,10 +216,20 @@ exports[`DataFilters clear 1`] = `
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
   align-self: stretch;
+  height: 12px;
+}
+
+.c21 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
   width: 24px;
 }
 
-.c7 {
+.c9 {
   margin-left: 12px;
   margin-right: 12px;
   margin-top: 6px;
@@ -192,7 +238,7 @@ exports[`DataFilters clear 1`] = `
   line-height: 24px;
 }
 
-.c17 {
+.c20 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -220,51 +266,51 @@ exports[`DataFilters clear 1`] = `
   transition-timing-function: ease-in-out;
 }
 
-.c17:hover {
+.c20:hover {
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c17:focus {
+.c20:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus > circle,
-.c17:focus > ellipse,
-.c17:focus > line,
-.c17:focus > path,
-.c17:focus > polygon,
-.c17:focus > polyline,
-.c17:focus > rect {
+.c20:focus > circle,
+.c20:focus > ellipse,
+.c20:focus > line,
+.c20:focus > path,
+.c20:focus > polygon,
+.c20:focus > polyline,
+.c20:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus::-moz-focus-inner {
+.c20:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c17:focus:not(:focus-visible) {
+.c20:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible) > circle,
-.c17:focus:not(:focus-visible) > ellipse,
-.c17:focus:not(:focus-visible) > line,
-.c17:focus:not(:focus-visible) > path,
-.c17:focus:not(:focus-visible) > polygon,
-.c17:focus:not(:focus-visible) > polyline,
-.c17:focus:not(:focus-visible) > rect {
+.c20:focus:not(:focus-visible) > circle,
+.c20:focus:not(:focus-visible) > ellipse,
+.c20:focus:not(:focus-visible) > line,
+.c20:focus:not(:focus-visible) > path,
+.c20:focus:not(:focus-visible) > polygon,
+.c20:focus:not(:focus-visible) > polyline,
+.c20:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible)::-moz-focus-inner {
+.c20:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c19 {
+.c22 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -291,47 +337,47 @@ exports[`DataFilters clear 1`] = `
   transition-timing-function: ease-in-out;
 }
 
-.c19:focus {
+.c22:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c19:focus > circle,
-.c19:focus > ellipse,
-.c19:focus > line,
-.c19:focus > path,
-.c19:focus > polygon,
-.c19:focus > polyline,
-.c19:focus > rect {
+.c22:focus > circle,
+.c22:focus > ellipse,
+.c22:focus > line,
+.c22:focus > path,
+.c22:focus > polygon,
+.c22:focus > polyline,
+.c22:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c19:focus::-moz-focus-inner {
+.c22:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c19:focus:not(:focus-visible) {
+.c22:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c19:focus:not(:focus-visible) > circle,
-.c19:focus:not(:focus-visible) > ellipse,
-.c19:focus:not(:focus-visible) > line,
-.c19:focus:not(:focus-visible) > path,
-.c19:focus:not(:focus-visible) > polygon,
-.c19:focus:not(:focus-visible) > polyline,
-.c19:focus:not(:focus-visible) > rect {
+.c22:focus:not(:focus-visible) > circle,
+.c22:focus:not(:focus-visible) > ellipse,
+.c22:focus:not(:focus-visible) > line,
+.c22:focus:not(:focus-visible) > path,
+.c22:focus:not(:focus-visible) > polygon,
+.c22:focus:not(:focus-visible) > polyline,
+.c22:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c19:focus:not(:focus-visible)::-moz-focus-inner {
+.c22:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c15 {
+.c17 {
   box-sizing: border-box;
   stroke-width: 4px;
   stroke: #7D4CDB;
@@ -339,7 +385,7 @@ exports[`DataFilters clear 1`] = `
   height: 24px;
 }
 
-.c10 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -361,12 +407,12 @@ exports[`DataFilters clear 1`] = `
   cursor: pointer;
 }
 
-.c10:hover input:not([disabled]) + div,
-.c10:hover input:not([disabled]) + span {
+.c12:hover input:not([disabled]) + div,
+.c12:hover input:not([disabled]) + span {
   border-color: #000000;
 }
 
-.c13 {
+.c15 {
   opacity: 0;
   -moz-appearance: none;
   width: 0;
@@ -375,18 +421,18 @@ exports[`DataFilters clear 1`] = `
   cursor: pointer;
 }
 
-.c13:checked + span > span {
+.c15:checked + span > span {
   left: calc( 48px - 24px );
   background: #7D4CDB;
 }
 
-.c12 {
+.c14 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c20 {
+.c23 {
   opacity: 0;
 }
 
@@ -394,7 +440,7 @@ exports[`DataFilters clear 1`] = `
   max-width: 100%;
 }
 
-.c4 {
+.c6 {
   margin: 0px;
   font-size: 26px;
   line-height: 32px;
@@ -414,61 +460,67 @@ exports[`DataFilters clear 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c6 {
+  .c8 {
     margin-bottom: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c10 {
     border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c10 {
     padding: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c11 {
+  .c13 {
     margin-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c14 {
+  .c16 {
     border: solid 2px #7D4CDB;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c16 {
+  .c19 {
     border: solid 2px rgba(0,0,0,0.15);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
-    height: 6px;
+  .c7 {
+    height: 3px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c18 {
+    height: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c21 {
     width: 12px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c6 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c6 {
     font-size: 22px;
     line-height: 28px;
     max-width: 528px;
@@ -486,111 +538,112 @@ exports[`DataFilters clear 1`] = `
       class="c2"
     >
       <div
-        class="c1"
+        class="c3"
       >
-        <header
-          class="c3"
-        >
-          <h2
-            class="c4"
-          >
-            Filters
-          </h2>
-        </header>
         <div
-          class="c5"
-        />
-        <div
-          class="c6 "
+          class="c4"
         >
-          <label
-            class="c7"
-            for="data-name"
+          <header
+            class="c5"
           >
-            name
-          </label>
-          <div
-            class="c8 FormField__FormFieldContentBox-sc-m9hood-1"
-          >
-            <div
-              class="c9 StyledCheckBoxGroup-sc-2nhc5d-0"
-              id="data-name"
-              role="group"
+            <h2
+              class="c6"
             >
-              <label
-                class="c10"
-                label="a"
-              >
-                <div
-                  class="c11 c12"
-                >
-                  <input
-                    checked=""
-                    class="c13"
-                    type="checkbox"
-                  />
-                  <div
-                    class="c14 "
-                  >
-                    <svg
-                      class="c15"
-                      preserveAspectRatio="xMidYMid meet"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M6,11.3 L10.3,16 L18,6.2"
-                        fill="none"
-                      />
-                    </svg>
-                  </div>
-                </div>
-                <span>
-                  a
-                </span>
-              </label>
+              Filters
+            </h2>
+          </header>
+          <div
+            class="c7"
+          />
+          <div
+            class="c8 "
+          >
+            <label
+              class="c9"
+              for="data-name"
+            >
+              name
+            </label>
+            <div
+              class="c10 FormField__FormFieldContentBox-sc-m9hood-1"
+            >
               <div
-                class="c5"
-              />
-              <label
-                class="c10"
-                label="b"
+                class="c11 StyledCheckBoxGroup-sc-2nhc5d-0"
+                id="data-name"
+                role="group"
               >
-                <div
-                  class="c11 c12"
+                <label
+                  class="c12"
+                  label="a"
                 >
-                  <input
-                    class="c13"
-                    type="checkbox"
-                  />
                   <div
-                    class="c16 "
-                  />
-                </div>
-                <span>
-                  b
-                </span>
-              </label>
+                    class="c13 c14"
+                  >
+                    <input
+                      checked=""
+                      class="c15"
+                      type="checkbox"
+                    />
+                    <div
+                      class="c16 "
+                    >
+                      <svg
+                        class="c17"
+                        preserveAspectRatio="xMidYMid meet"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M6,11.3 L10.3,16 L18,6.2"
+                          fill="none"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                  <span>
+                    a
+                  </span>
+                </label>
+                <div
+                  class="c18"
+                />
+                <label
+                  class="c12"
+                  label="b"
+                >
+                  <div
+                    class="c13 c14"
+                  >
+                    <input
+                      class="c15"
+                      type="checkbox"
+                    />
+                    <div
+                      class="c19 "
+                    />
+                  </div>
+                  <span>
+                    b
+                  </span>
+                </label>
+              </div>
             </div>
           </div>
         </div>
-        <div
-          class="c5"
-        />
         <footer
-          class="c3"
+          class="c5"
         >
           <button
-            class="c17"
+            class="c20"
             type="submit"
           >
             Apply filters
           </button>
           <div
-            class="c18"
+            class="c21"
           />
           <button
             aria-hidden="true"
-            class="c19 c20"
+            class="c22 c23"
             disabled=""
             tabindex="-1"
             type="reset"
@@ -808,7 +861,7 @@ exports[`DataFilters drop 2`] = `
 
 exports[`DataFilters drop 3`] = `
 "@media only screen and (max-width: 768px) {
-  .hftPdQ {
+  .hfctvB {
     margin-bottom: 6px;
   }
 }
@@ -830,6 +883,11 @@ exports[`DataFilters drop 3`] = `
 @media only screen and (max-width: 768px) {
   .dXyapD {
     border: solid 2px rgba(0, 0, 0, 0.15);
+  }
+}
+@media only screen and (max-width: 768px) {
+  .grsgKE {
+    height: 3px;
   }
 }
 @media only screen and (max-width: 768px) {
@@ -1213,7 +1271,7 @@ exports[`DataFilters layer 1`] = `
 `;
 
 exports[`DataFilters layer 2`] = `
-.c10 {
+.c11 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -1224,25 +1282,25 @@ exports[`DataFilters layer 2`] = `
   stroke: #666666;
 }
 
-.c10 g {
+.c11 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c10 *:not([stroke])[fill="none"] {
+.c11 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c10 *[stroke*="#"],
-.c10 *[STROKE*="#"] {
+.c11 *[stroke*="#"],
+.c11 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c10 *[fill-rule],
-.c10 *[FILL-RULE],
-.c10 *[fill*="#"],
-.c10 *[FILL*="#"] {
+.c11 *[fill-rule],
+.c11 *[FILL-RULE],
+.c11 *[fill*="#"],
+.c11 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -1259,13 +1317,31 @@ exports[`DataFilters layer 2`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  padding: 24px;
+  height: 100%;
 }
 
 .c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  padding-left: 24px;
+  padding-right: 24px;
+  padding-top: 24px;
+  overflow: auto;
+}
+
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1290,7 +1366,7 @@ exports[`DataFilters layer 2`] = `
   justify-content: space-between;
 }
 
-.c12 {
+.c13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1303,9 +1379,12 @@ exports[`DataFilters layer 2`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
-.c14 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1321,7 +1400,7 @@ exports[`DataFilters layer 2`] = `
   padding: 12px;
 }
 
-.c15 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1335,7 +1414,7 @@ exports[`DataFilters layer 2`] = `
   flex-direction: column;
 }
 
-.c17 {
+.c18 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1358,7 +1437,7 @@ exports[`DataFilters layer 2`] = `
   justify-content: center;
 }
 
-.c20 {
+.c21 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1384,7 +1463,33 @@ exports[`DataFilters layer 2`] = `
   border-radius: 4px;
 }
 
-.c8 {
+.c23 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding: 24px;
+}
+
+.c9 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -1394,7 +1499,17 @@ exports[`DataFilters layer 2`] = `
   width: 24px;
 }
 
-.c11 {
+.c12 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  height: 6px;
+}
+
+.c22 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -1404,7 +1519,7 @@ exports[`DataFilters layer 2`] = `
   height: 12px;
 }
 
-.c13 {
+.c14 {
   margin-left: 12px;
   margin-right: 12px;
   margin-top: 6px;
@@ -1413,7 +1528,7 @@ exports[`DataFilters layer 2`] = `
   line-height: 24px;
 }
 
-.c9 {
+.c10 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -1433,52 +1548,52 @@ exports[`DataFilters layer 2`] = `
   padding: 12px;
 }
 
-.c9:hover {
+.c10:hover {
   background-color: rgba(221,221,221,0.4);
   color: #000000;
 }
 
-.c9:focus {
+.c10:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c9:focus > circle,
-.c9:focus > ellipse,
-.c9:focus > line,
-.c9:focus > path,
-.c9:focus > polygon,
-.c9:focus > polyline,
-.c9:focus > rect {
+.c10:focus > circle,
+.c10:focus > ellipse,
+.c10:focus > line,
+.c10:focus > path,
+.c10:focus > polygon,
+.c10:focus > polyline,
+.c10:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c9:focus::-moz-focus-inner {
+.c10:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c9:focus:not(:focus-visible) {
+.c10:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c9:focus:not(:focus-visible) > circle,
-.c9:focus:not(:focus-visible) > ellipse,
-.c9:focus:not(:focus-visible) > line,
-.c9:focus:not(:focus-visible) > path,
-.c9:focus:not(:focus-visible) > polygon,
-.c9:focus:not(:focus-visible) > polyline,
-.c9:focus:not(:focus-visible) > rect {
+.c10:focus:not(:focus-visible) > circle,
+.c10:focus:not(:focus-visible) > ellipse,
+.c10:focus:not(:focus-visible) > line,
+.c10:focus:not(:focus-visible) > path,
+.c10:focus:not(:focus-visible) > polygon,
+.c10:focus:not(:focus-visible) > polyline,
+.c10:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c9:focus:not(:focus-visible)::-moz-focus-inner {
+.c10:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c21 {
+.c24 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -1506,51 +1621,51 @@ exports[`DataFilters layer 2`] = `
   transition-timing-function: ease-in-out;
 }
 
-.c21:hover {
+.c24:hover {
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c21:focus {
+.c24:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c21:focus > circle,
-.c21:focus > ellipse,
-.c21:focus > line,
-.c21:focus > path,
-.c21:focus > polygon,
-.c21:focus > polyline,
-.c21:focus > rect {
+.c24:focus > circle,
+.c24:focus > ellipse,
+.c24:focus > line,
+.c24:focus > path,
+.c24:focus > polygon,
+.c24:focus > polyline,
+.c24:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c21:focus::-moz-focus-inner {
+.c24:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c21:focus:not(:focus-visible) {
+.c24:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c21:focus:not(:focus-visible) > circle,
-.c21:focus:not(:focus-visible) > ellipse,
-.c21:focus:not(:focus-visible) > line,
-.c21:focus:not(:focus-visible) > path,
-.c21:focus:not(:focus-visible) > polygon,
-.c21:focus:not(:focus-visible) > polyline,
-.c21:focus:not(:focus-visible) > rect {
+.c24:focus:not(:focus-visible) > circle,
+.c24:focus:not(:focus-visible) > ellipse,
+.c24:focus:not(:focus-visible) > line,
+.c24:focus:not(:focus-visible) > path,
+.c24:focus:not(:focus-visible) > polygon,
+.c24:focus:not(:focus-visible) > polyline,
+.c24:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c21:focus:not(:focus-visible)::-moz-focus-inner {
+.c24:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c22 {
+.c25 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -1577,47 +1692,47 @@ exports[`DataFilters layer 2`] = `
   transition-timing-function: ease-in-out;
 }
 
-.c22:focus {
+.c25:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c22:focus > circle,
-.c22:focus > ellipse,
-.c22:focus > line,
-.c22:focus > path,
-.c22:focus > polygon,
-.c22:focus > polyline,
-.c22:focus > rect {
+.c25:focus > circle,
+.c25:focus > ellipse,
+.c25:focus > line,
+.c25:focus > path,
+.c25:focus > polygon,
+.c25:focus > polyline,
+.c25:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c22:focus::-moz-focus-inner {
+.c25:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c22:focus:not(:focus-visible) {
+.c25:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c22:focus:not(:focus-visible) > circle,
-.c22:focus:not(:focus-visible) > ellipse,
-.c22:focus:not(:focus-visible) > line,
-.c22:focus:not(:focus-visible) > path,
-.c22:focus:not(:focus-visible) > polygon,
-.c22:focus:not(:focus-visible) > polyline,
-.c22:focus:not(:focus-visible) > rect {
+.c25:focus:not(:focus-visible) > circle,
+.c25:focus:not(:focus-visible) > ellipse,
+.c25:focus:not(:focus-visible) > line,
+.c25:focus:not(:focus-visible) > path,
+.c25:focus:not(:focus-visible) > polygon,
+.c25:focus:not(:focus-visible) > polyline,
+.c25:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c22:focus:not(:focus-visible)::-moz-focus-inner {
+.c25:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c16 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1639,12 +1754,12 @@ exports[`DataFilters layer 2`] = `
   cursor: pointer;
 }
 
-.c16:hover input:not([disabled]) + div,
-.c16:hover input:not([disabled]) + span {
+.c17:hover input:not([disabled]) + div,
+.c17:hover input:not([disabled]) + span {
   border-color: #000000;
 }
 
-.c19 {
+.c20 {
   opacity: 0;
   -moz-appearance: none;
   width: 0;
@@ -1653,26 +1768,27 @@ exports[`DataFilters layer 2`] = `
   cursor: pointer;
 }
 
-.c19:checked + span > span {
+.c20:checked + span > span {
   left: calc( 48px - 24px );
   background: #7D4CDB;
 }
 
-.c18 {
+.c19 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c23 {
+.c26 {
   opacity: 0;
 }
 
 .c4 {
   max-width: 100%;
+  max-height: 100%;
 }
 
-.c7 {
+.c8 {
   margin: 0px;
   font-size: 26px;
   line-height: 32px;
@@ -1749,65 +1865,80 @@ exports[`DataFilters layer 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
-    padding: 12px;
+  .c6 {
+    padding-left: 12px;
+    padding-right: 12px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c12 {
+  .c6 {
+    padding-top: 12px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c13 {
     margin-bottom: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c14 {
+  .c15 {
     border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c14 {
+  .c15 {
     padding: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c17 {
+  .c18 {
     margin-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c20 {
+  .c21 {
     border: solid 2px rgba(0,0,0,0.15);
   }
 }
 
 @media only screen and (max-width:768px) {
-
+  .c23 {
+    padding: 12px;
+  }
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c9 {
     width: 12px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c11 {
+  .c12 {
+    height: 3px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c22 {
     height: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c7 {
+  .c8 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c7 {
+  .c8 {
     font-size: 22px;
     line-height: 28px;
     max-width: 528px;
@@ -1860,121 +1991,123 @@ exports[`DataFilters layer 2`] = `
     />
     <form
       class="c4"
+      fill="vertical"
     >
       <div
         class="c5"
       >
-        <header
+        <div
           class="c6"
         >
-          <h2
+          <header
             class="c7"
           >
-            Filters
-          </h2>
-          <div
-            class="c8"
-          />
-          <button
-            class="c9"
-            type="button"
-          >
-            <svg
-              aria-label="FormClose"
-              class="c10"
-              viewBox="0 0 24 24"
+            <h2
+              class="c8"
             >
-              <path
-                d="m7 7 10 10M7 17 17 7"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </button>
-        </header>
-        <div
-          class="c11"
-        />
-        <div
-          class="c12 "
-        >
-          <label
-            class="c13"
-            for="test-data-name"
-          >
-            name
-          </label>
-          <div
-            class="c14 FormField__FormFieldContentBox-sc-m9hood-1"
-          >
+              Filters
+            </h2>
             <div
-              class="c15 StyledCheckBoxGroup-sc-2nhc5d-0"
-              id="test-data-name"
-              role="group"
+              class="c9"
+            />
+            <button
+              class="c10"
+              type="button"
             >
-              <label
-                class="c16"
-                label="a"
-              >
-                <div
-                  class="c17 c18"
-                >
-                  <input
-                    class="c19"
-                    type="checkbox"
-                  />
-                  <div
-                    class="c20 "
-                  />
-                </div>
-                <span>
-                  a
-                </span>
-              </label>
-              <div
+              <svg
+                aria-label="FormClose"
                 class="c11"
-              />
-              <label
-                class="c16"
-                label="b"
+                viewBox="0 0 24 24"
               >
-                <div
-                  class="c17 c18"
+                <path
+                  d="m7 7 10 10M7 17 17 7"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </button>
+          </header>
+          <div
+            class="c12"
+          />
+          <div
+            class="c13 "
+          >
+            <label
+              class="c14"
+              for="test-data-name"
+            >
+              name
+            </label>
+            <div
+              class="c15 FormField__FormFieldContentBox-sc-m9hood-1"
+            >
+              <div
+                class="c16 StyledCheckBoxGroup-sc-2nhc5d-0"
+                id="test-data-name"
+                role="group"
+              >
+                <label
+                  class="c17"
+                  label="a"
                 >
-                  <input
-                    class="c19"
-                    type="checkbox"
-                  />
                   <div
-                    class="c20 "
-                  />
-                </div>
-                <span>
-                  b
-                </span>
-              </label>
+                    class="c18 c19"
+                  >
+                    <input
+                      class="c20"
+                      type="checkbox"
+                    />
+                    <div
+                      class="c21 "
+                    />
+                  </div>
+                  <span>
+                    a
+                  </span>
+                </label>
+                <div
+                  class="c22"
+                />
+                <label
+                  class="c17"
+                  label="b"
+                >
+                  <div
+                    class="c18 c19"
+                  >
+                    <input
+                      class="c20"
+                      type="checkbox"
+                    />
+                    <div
+                      class="c21 "
+                    />
+                  </div>
+                  <span>
+                    b
+                  </span>
+                </label>
+              </div>
             </div>
           </div>
         </div>
-        <div
-          class="c11"
-        />
         <footer
-          class="c6"
+          class="c23"
         >
           <button
-            class="c21"
+            class="c24"
             type="submit"
           >
             Apply filters
           </button>
           <div
-            class="c8"
+            class="c9"
           />
           <button
             aria-hidden="true"
-            class="c22 c23"
+            class="c25 c26"
             disabled=""
             tabindex="-1"
             type="reset"
@@ -1990,7 +2123,7 @@ exports[`DataFilters layer 2`] = `
 
 exports[`DataFilters layer 3`] = `
 "@media only screen and (max-width: 768px) {
-  .hftPdQ {
+  .hfctvB {
     margin-bottom: 6px;
   }
 }
@@ -2012,6 +2145,11 @@ exports[`DataFilters layer 3`] = `
 @media only screen and (max-width: 768px) {
   .dXyapD {
     border: solid 2px rgba(0, 0, 0, 0.15);
+  }
+}
+@media only screen and (max-width: 768px) {
+  .grsgKE {
+    height: 3px;
   }
 }
 @media only screen and (max-width: 768px) {
@@ -2063,6 +2201,39 @@ exports[`DataFilters properties array 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 100%;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  overflow: auto;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2081,7 +2252,7 @@ exports[`DataFilters properties array 1`] = `
   justify-content: space-between;
 }
 
-.c6 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2094,9 +2265,12 @@ exports[`DataFilters properties array 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
-.c8 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2112,7 +2286,7 @@ exports[`DataFilters properties array 1`] = `
   padding: 12px;
 }
 
-.c9 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2126,7 +2300,7 @@ exports[`DataFilters properties array 1`] = `
   flex-direction: column;
 }
 
-.c11 {
+.c13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2149,7 +2323,7 @@ exports[`DataFilters properties array 1`] = `
   justify-content: center;
 }
 
-.c14 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2175,7 +2349,17 @@ exports[`DataFilters properties array 1`] = `
   border-radius: 4px;
 }
 
-.c5 {
+.c7 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  height: 6px;
+}
+
+.c17 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -2185,7 +2369,7 @@ exports[`DataFilters properties array 1`] = `
   height: 12px;
 }
 
-.c16 {
+.c19 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -2195,7 +2379,7 @@ exports[`DataFilters properties array 1`] = `
   width: 24px;
 }
 
-.c7 {
+.c9 {
   margin-left: 12px;
   margin-right: 12px;
   margin-top: 6px;
@@ -2204,7 +2388,7 @@ exports[`DataFilters properties array 1`] = `
   line-height: 24px;
 }
 
-.c15 {
+.c18 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -2232,51 +2416,51 @@ exports[`DataFilters properties array 1`] = `
   transition-timing-function: ease-in-out;
 }
 
-.c15:hover {
+.c18:hover {
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c15:focus {
+.c18:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c15:focus > circle,
-.c15:focus > ellipse,
-.c15:focus > line,
-.c15:focus > path,
-.c15:focus > polygon,
-.c15:focus > polyline,
-.c15:focus > rect {
+.c18:focus > circle,
+.c18:focus > ellipse,
+.c18:focus > line,
+.c18:focus > path,
+.c18:focus > polygon,
+.c18:focus > polyline,
+.c18:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c15:focus::-moz-focus-inner {
+.c18:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c15:focus:not(:focus-visible) {
+.c18:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c15:focus:not(:focus-visible) > circle,
-.c15:focus:not(:focus-visible) > ellipse,
-.c15:focus:not(:focus-visible) > line,
-.c15:focus:not(:focus-visible) > path,
-.c15:focus:not(:focus-visible) > polygon,
-.c15:focus:not(:focus-visible) > polyline,
-.c15:focus:not(:focus-visible) > rect {
+.c18:focus:not(:focus-visible) > circle,
+.c18:focus:not(:focus-visible) > ellipse,
+.c18:focus:not(:focus-visible) > line,
+.c18:focus:not(:focus-visible) > path,
+.c18:focus:not(:focus-visible) > polygon,
+.c18:focus:not(:focus-visible) > polyline,
+.c18:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c15:focus:not(:focus-visible)::-moz-focus-inner {
+.c18:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c17 {
+.c20 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -2303,47 +2487,47 @@ exports[`DataFilters properties array 1`] = `
   transition-timing-function: ease-in-out;
 }
 
-.c17:focus {
+.c20:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus > circle,
-.c17:focus > ellipse,
-.c17:focus > line,
-.c17:focus > path,
-.c17:focus > polygon,
-.c17:focus > polyline,
-.c17:focus > rect {
+.c20:focus > circle,
+.c20:focus > ellipse,
+.c20:focus > line,
+.c20:focus > path,
+.c20:focus > polygon,
+.c20:focus > polyline,
+.c20:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus::-moz-focus-inner {
+.c20:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c17:focus:not(:focus-visible) {
+.c20:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible) > circle,
-.c17:focus:not(:focus-visible) > ellipse,
-.c17:focus:not(:focus-visible) > line,
-.c17:focus:not(:focus-visible) > path,
-.c17:focus:not(:focus-visible) > polygon,
-.c17:focus:not(:focus-visible) > polyline,
-.c17:focus:not(:focus-visible) > rect {
+.c20:focus:not(:focus-visible) > circle,
+.c20:focus:not(:focus-visible) > ellipse,
+.c20:focus:not(:focus-visible) > line,
+.c20:focus:not(:focus-visible) > path,
+.c20:focus:not(:focus-visible) > polygon,
+.c20:focus:not(:focus-visible) > polyline,
+.c20:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible)::-moz-focus-inner {
+.c20:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c10 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2365,12 +2549,12 @@ exports[`DataFilters properties array 1`] = `
   cursor: pointer;
 }
 
-.c10:hover input:not([disabled]) + div,
-.c10:hover input:not([disabled]) + span {
+.c12:hover input:not([disabled]) + div,
+.c12:hover input:not([disabled]) + span {
   border-color: #000000;
 }
 
-.c13 {
+.c15 {
   opacity: 0;
   -moz-appearance: none;
   width: 0;
@@ -2379,18 +2563,18 @@ exports[`DataFilters properties array 1`] = `
   cursor: pointer;
 }
 
-.c13:checked + span > span {
+.c15:checked + span > span {
   left: calc( 48px - 24px );
   background: #7D4CDB;
 }
 
-.c12 {
+.c14 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c18 {
+.c21 {
   opacity: 0;
 }
 
@@ -2398,7 +2582,7 @@ exports[`DataFilters properties array 1`] = `
   max-width: 100%;
 }
 
-.c4 {
+.c6 {
   margin: 0px;
   font-size: 26px;
   line-height: 32px;
@@ -2418,55 +2602,61 @@ exports[`DataFilters properties array 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c6 {
+  .c8 {
     margin-bottom: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c10 {
     border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c10 {
     padding: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c11 {
+  .c13 {
     margin-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c14 {
+  .c16 {
     border: solid 2px rgba(0,0,0,0.15);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c7 {
+    height: 3px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c17 {
     height: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c16 {
+  .c19 {
     width: 12px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c6 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c6 {
     font-size: 22px;
     line-height: 28px;
     max-width: 528px;
@@ -2484,99 +2674,100 @@ exports[`DataFilters properties array 1`] = `
       class="c2"
     >
       <div
-        class="c1"
+        class="c3"
       >
-        <header
-          class="c3"
-        >
-          <h2
-            class="c4"
-          >
-            Filters
-          </h2>
-        </header>
         <div
-          class="c5"
-        />
-        <div
-          class="c6 "
+          class="c4"
         >
-          <label
-            class="c7"
-            for="data-name"
+          <header
+            class="c5"
           >
-            name
-          </label>
-          <div
-            class="c8 FormField__FormFieldContentBox-sc-m9hood-1"
-          >
-            <div
-              class="c9 StyledCheckBoxGroup-sc-2nhc5d-0"
-              id="data-name"
-              role="group"
+            <h2
+              class="c6"
             >
-              <label
-                class="c10"
-                label="a"
-              >
-                <div
-                  class="c11 c12"
-                >
-                  <input
-                    class="c13"
-                    type="checkbox"
-                  />
-                  <div
-                    class="c14 "
-                  />
-                </div>
-                <span>
-                  a
-                </span>
-              </label>
+              Filters
+            </h2>
+          </header>
+          <div
+            class="c7"
+          />
+          <div
+            class="c8 "
+          >
+            <label
+              class="c9"
+              for="data-name"
+            >
+              name
+            </label>
+            <div
+              class="c10 FormField__FormFieldContentBox-sc-m9hood-1"
+            >
               <div
-                class="c5"
-              />
-              <label
-                class="c10"
-                label="b"
+                class="c11 StyledCheckBoxGroup-sc-2nhc5d-0"
+                id="data-name"
+                role="group"
               >
-                <div
-                  class="c11 c12"
+                <label
+                  class="c12"
+                  label="a"
                 >
-                  <input
-                    class="c13"
-                    type="checkbox"
-                  />
                   <div
-                    class="c14 "
-                  />
-                </div>
-                <span>
-                  b
-                </span>
-              </label>
+                    class="c13 c14"
+                  >
+                    <input
+                      class="c15"
+                      type="checkbox"
+                    />
+                    <div
+                      class="c16 "
+                    />
+                  </div>
+                  <span>
+                    a
+                  </span>
+                </label>
+                <div
+                  class="c17"
+                />
+                <label
+                  class="c12"
+                  label="b"
+                >
+                  <div
+                    class="c13 c14"
+                  >
+                    <input
+                      class="c15"
+                      type="checkbox"
+                    />
+                    <div
+                      class="c16 "
+                    />
+                  </div>
+                  <span>
+                    b
+                  </span>
+                </label>
+              </div>
             </div>
           </div>
         </div>
-        <div
-          class="c5"
-        />
         <footer
-          class="c3"
+          class="c5"
         >
           <button
-            class="c15"
+            class="c18"
             type="submit"
           >
             Apply filters
           </button>
           <div
-            class="c16"
+            class="c19"
           />
           <button
             aria-hidden="true"
-            class="c17 c18"
+            class="c20 c21"
             disabled=""
             tabindex="-1"
             type="reset"
@@ -2615,6 +2806,39 @@ exports[`DataFilters properties object 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 100%;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  overflow: auto;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2633,7 +2857,7 @@ exports[`DataFilters properties object 1`] = `
   justify-content: space-between;
 }
 
-.c6 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2646,9 +2870,12 @@ exports[`DataFilters properties object 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
-.c8 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2664,7 +2891,7 @@ exports[`DataFilters properties object 1`] = `
   padding: 12px;
 }
 
-.c9 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2678,7 +2905,7 @@ exports[`DataFilters properties object 1`] = `
   flex-direction: column;
 }
 
-.c11 {
+.c13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2701,7 +2928,7 @@ exports[`DataFilters properties object 1`] = `
   justify-content: center;
 }
 
-.c14 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2727,7 +2954,17 @@ exports[`DataFilters properties object 1`] = `
   border-radius: 4px;
 }
 
-.c5 {
+.c7 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  height: 6px;
+}
+
+.c17 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -2737,7 +2974,7 @@ exports[`DataFilters properties object 1`] = `
   height: 12px;
 }
 
-.c16 {
+.c19 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -2747,7 +2984,7 @@ exports[`DataFilters properties object 1`] = `
   width: 24px;
 }
 
-.c7 {
+.c9 {
   margin-left: 12px;
   margin-right: 12px;
   margin-top: 6px;
@@ -2756,7 +2993,7 @@ exports[`DataFilters properties object 1`] = `
   line-height: 24px;
 }
 
-.c15 {
+.c18 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -2784,51 +3021,51 @@ exports[`DataFilters properties object 1`] = `
   transition-timing-function: ease-in-out;
 }
 
-.c15:hover {
+.c18:hover {
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c15:focus {
+.c18:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c15:focus > circle,
-.c15:focus > ellipse,
-.c15:focus > line,
-.c15:focus > path,
-.c15:focus > polygon,
-.c15:focus > polyline,
-.c15:focus > rect {
+.c18:focus > circle,
+.c18:focus > ellipse,
+.c18:focus > line,
+.c18:focus > path,
+.c18:focus > polygon,
+.c18:focus > polyline,
+.c18:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c15:focus::-moz-focus-inner {
+.c18:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c15:focus:not(:focus-visible) {
+.c18:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c15:focus:not(:focus-visible) > circle,
-.c15:focus:not(:focus-visible) > ellipse,
-.c15:focus:not(:focus-visible) > line,
-.c15:focus:not(:focus-visible) > path,
-.c15:focus:not(:focus-visible) > polygon,
-.c15:focus:not(:focus-visible) > polyline,
-.c15:focus:not(:focus-visible) > rect {
+.c18:focus:not(:focus-visible) > circle,
+.c18:focus:not(:focus-visible) > ellipse,
+.c18:focus:not(:focus-visible) > line,
+.c18:focus:not(:focus-visible) > path,
+.c18:focus:not(:focus-visible) > polygon,
+.c18:focus:not(:focus-visible) > polyline,
+.c18:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c15:focus:not(:focus-visible)::-moz-focus-inner {
+.c18:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c17 {
+.c20 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -2855,47 +3092,47 @@ exports[`DataFilters properties object 1`] = `
   transition-timing-function: ease-in-out;
 }
 
-.c17:focus {
+.c20:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus > circle,
-.c17:focus > ellipse,
-.c17:focus > line,
-.c17:focus > path,
-.c17:focus > polygon,
-.c17:focus > polyline,
-.c17:focus > rect {
+.c20:focus > circle,
+.c20:focus > ellipse,
+.c20:focus > line,
+.c20:focus > path,
+.c20:focus > polygon,
+.c20:focus > polyline,
+.c20:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus::-moz-focus-inner {
+.c20:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c17:focus:not(:focus-visible) {
+.c20:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible) > circle,
-.c17:focus:not(:focus-visible) > ellipse,
-.c17:focus:not(:focus-visible) > line,
-.c17:focus:not(:focus-visible) > path,
-.c17:focus:not(:focus-visible) > polygon,
-.c17:focus:not(:focus-visible) > polyline,
-.c17:focus:not(:focus-visible) > rect {
+.c20:focus:not(:focus-visible) > circle,
+.c20:focus:not(:focus-visible) > ellipse,
+.c20:focus:not(:focus-visible) > line,
+.c20:focus:not(:focus-visible) > path,
+.c20:focus:not(:focus-visible) > polygon,
+.c20:focus:not(:focus-visible) > polyline,
+.c20:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible)::-moz-focus-inner {
+.c20:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c10 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2917,12 +3154,12 @@ exports[`DataFilters properties object 1`] = `
   cursor: pointer;
 }
 
-.c10:hover input:not([disabled]) + div,
-.c10:hover input:not([disabled]) + span {
+.c12:hover input:not([disabled]) + div,
+.c12:hover input:not([disabled]) + span {
   border-color: #000000;
 }
 
-.c13 {
+.c15 {
   opacity: 0;
   -moz-appearance: none;
   width: 0;
@@ -2931,18 +3168,18 @@ exports[`DataFilters properties object 1`] = `
   cursor: pointer;
 }
 
-.c13:checked + span > span {
+.c15:checked + span > span {
   left: calc( 48px - 24px );
   background: #7D4CDB;
 }
 
-.c12 {
+.c14 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c18 {
+.c21 {
   opacity: 0;
 }
 
@@ -2950,7 +3187,7 @@ exports[`DataFilters properties object 1`] = `
   max-width: 100%;
 }
 
-.c4 {
+.c6 {
   margin: 0px;
   font-size: 26px;
   line-height: 32px;
@@ -2970,55 +3207,61 @@ exports[`DataFilters properties object 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c6 {
+  .c8 {
     margin-bottom: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c10 {
     border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c10 {
     padding: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c11 {
+  .c13 {
     margin-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c14 {
+  .c16 {
     border: solid 2px rgba(0,0,0,0.15);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c7 {
+    height: 3px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c17 {
     height: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c16 {
+  .c19 {
     width: 12px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c6 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c6 {
     font-size: 22px;
     line-height: 28px;
     max-width: 528px;
@@ -3036,99 +3279,100 @@ exports[`DataFilters properties object 1`] = `
       class="c2"
     >
       <div
-        class="c1"
+        class="c3"
       >
-        <header
-          class="c3"
-        >
-          <h2
-            class="c4"
-          >
-            Filters
-          </h2>
-        </header>
         <div
-          class="c5"
-        />
-        <div
-          class="c6 "
+          class="c4"
         >
-          <label
-            class="c7"
-            for="data-name"
+          <header
+            class="c5"
           >
-            name
-          </label>
-          <div
-            class="c8 FormField__FormFieldContentBox-sc-m9hood-1"
-          >
-            <div
-              class="c9 StyledCheckBoxGroup-sc-2nhc5d-0"
-              id="data-name"
-              role="group"
+            <h2
+              class="c6"
             >
-              <label
-                class="c10"
-                label="a"
-              >
-                <div
-                  class="c11 c12"
-                >
-                  <input
-                    class="c13"
-                    type="checkbox"
-                  />
-                  <div
-                    class="c14 "
-                  />
-                </div>
-                <span>
-                  a
-                </span>
-              </label>
+              Filters
+            </h2>
+          </header>
+          <div
+            class="c7"
+          />
+          <div
+            class="c8 "
+          >
+            <label
+              class="c9"
+              for="data-name"
+            >
+              name
+            </label>
+            <div
+              class="c10 FormField__FormFieldContentBox-sc-m9hood-1"
+            >
               <div
-                class="c5"
-              />
-              <label
-                class="c10"
-                label="b"
+                class="c11 StyledCheckBoxGroup-sc-2nhc5d-0"
+                id="data-name"
+                role="group"
               >
-                <div
-                  class="c11 c12"
+                <label
+                  class="c12"
+                  label="a"
                 >
-                  <input
-                    class="c13"
-                    type="checkbox"
-                  />
                   <div
-                    class="c14 "
-                  />
-                </div>
-                <span>
-                  b
-                </span>
-              </label>
+                    class="c13 c14"
+                  >
+                    <input
+                      class="c15"
+                      type="checkbox"
+                    />
+                    <div
+                      class="c16 "
+                    />
+                  </div>
+                  <span>
+                    a
+                  </span>
+                </label>
+                <div
+                  class="c17"
+                />
+                <label
+                  class="c12"
+                  label="b"
+                >
+                  <div
+                    class="c13 c14"
+                  >
+                    <input
+                      class="c15"
+                      type="checkbox"
+                    />
+                    <div
+                      class="c16 "
+                    />
+                  </div>
+                  <span>
+                    b
+                  </span>
+                </label>
+              </div>
             </div>
           </div>
         </div>
-        <div
-          class="c5"
-        />
         <footer
-          class="c3"
+          class="c5"
         >
           <button
-            class="c15"
+            class="c18"
             type="submit"
           >
             Apply filters
           </button>
           <div
-            class="c16"
+            class="c19"
           />
           <button
             aria-hidden="true"
-            class="c17 c18"
+            class="c20 c21"
             disabled=""
             tabindex="-1"
             type="reset"
@@ -3167,6 +3411,39 @@ exports[`DataFilters renders 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 100%;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  overflow: auto;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -3185,7 +3462,7 @@ exports[`DataFilters renders 1`] = `
   justify-content: space-between;
 }
 
-.c6 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3198,9 +3475,12 @@ exports[`DataFilters renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
-.c8 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3216,7 +3496,7 @@ exports[`DataFilters renders 1`] = `
   padding: 12px;
 }
 
-.c9 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3230,7 +3510,7 @@ exports[`DataFilters renders 1`] = `
   flex-direction: column;
 }
 
-.c11 {
+.c13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3253,7 +3533,7 @@ exports[`DataFilters renders 1`] = `
   justify-content: center;
 }
 
-.c14 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3279,7 +3559,17 @@ exports[`DataFilters renders 1`] = `
   border-radius: 4px;
 }
 
-.c5 {
+.c7 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  height: 6px;
+}
+
+.c17 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -3289,7 +3579,7 @@ exports[`DataFilters renders 1`] = `
   height: 12px;
 }
 
-.c16 {
+.c19 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -3299,7 +3589,7 @@ exports[`DataFilters renders 1`] = `
   width: 24px;
 }
 
-.c7 {
+.c9 {
   margin-left: 12px;
   margin-right: 12px;
   margin-top: 6px;
@@ -3308,7 +3598,7 @@ exports[`DataFilters renders 1`] = `
   line-height: 24px;
 }
 
-.c15 {
+.c18 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -3336,51 +3626,51 @@ exports[`DataFilters renders 1`] = `
   transition-timing-function: ease-in-out;
 }
 
-.c15:hover {
+.c18:hover {
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c15:focus {
+.c18:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c15:focus > circle,
-.c15:focus > ellipse,
-.c15:focus > line,
-.c15:focus > path,
-.c15:focus > polygon,
-.c15:focus > polyline,
-.c15:focus > rect {
+.c18:focus > circle,
+.c18:focus > ellipse,
+.c18:focus > line,
+.c18:focus > path,
+.c18:focus > polygon,
+.c18:focus > polyline,
+.c18:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c15:focus::-moz-focus-inner {
+.c18:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c15:focus:not(:focus-visible) {
+.c18:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c15:focus:not(:focus-visible) > circle,
-.c15:focus:not(:focus-visible) > ellipse,
-.c15:focus:not(:focus-visible) > line,
-.c15:focus:not(:focus-visible) > path,
-.c15:focus:not(:focus-visible) > polygon,
-.c15:focus:not(:focus-visible) > polyline,
-.c15:focus:not(:focus-visible) > rect {
+.c18:focus:not(:focus-visible) > circle,
+.c18:focus:not(:focus-visible) > ellipse,
+.c18:focus:not(:focus-visible) > line,
+.c18:focus:not(:focus-visible) > path,
+.c18:focus:not(:focus-visible) > polygon,
+.c18:focus:not(:focus-visible) > polyline,
+.c18:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c15:focus:not(:focus-visible)::-moz-focus-inner {
+.c18:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c17 {
+.c20 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -3407,47 +3697,47 @@ exports[`DataFilters renders 1`] = `
   transition-timing-function: ease-in-out;
 }
 
-.c17:focus {
+.c20:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus > circle,
-.c17:focus > ellipse,
-.c17:focus > line,
-.c17:focus > path,
-.c17:focus > polygon,
-.c17:focus > polyline,
-.c17:focus > rect {
+.c20:focus > circle,
+.c20:focus > ellipse,
+.c20:focus > line,
+.c20:focus > path,
+.c20:focus > polygon,
+.c20:focus > polyline,
+.c20:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c17:focus::-moz-focus-inner {
+.c20:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c17:focus:not(:focus-visible) {
+.c20:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible) > circle,
-.c17:focus:not(:focus-visible) > ellipse,
-.c17:focus:not(:focus-visible) > line,
-.c17:focus:not(:focus-visible) > path,
-.c17:focus:not(:focus-visible) > polygon,
-.c17:focus:not(:focus-visible) > polyline,
-.c17:focus:not(:focus-visible) > rect {
+.c20:focus:not(:focus-visible) > circle,
+.c20:focus:not(:focus-visible) > ellipse,
+.c20:focus:not(:focus-visible) > line,
+.c20:focus:not(:focus-visible) > path,
+.c20:focus:not(:focus-visible) > polygon,
+.c20:focus:not(:focus-visible) > polyline,
+.c20:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c17:focus:not(:focus-visible)::-moz-focus-inner {
+.c20:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c10 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3469,12 +3759,12 @@ exports[`DataFilters renders 1`] = `
   cursor: pointer;
 }
 
-.c10:hover input:not([disabled]) + div,
-.c10:hover input:not([disabled]) + span {
+.c12:hover input:not([disabled]) + div,
+.c12:hover input:not([disabled]) + span {
   border-color: #000000;
 }
 
-.c13 {
+.c15 {
   opacity: 0;
   -moz-appearance: none;
   width: 0;
@@ -3483,18 +3773,18 @@ exports[`DataFilters renders 1`] = `
   cursor: pointer;
 }
 
-.c13:checked + span > span {
+.c15:checked + span > span {
   left: calc( 48px - 24px );
   background: #7D4CDB;
 }
 
-.c12 {
+.c14 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c18 {
+.c21 {
   opacity: 0;
 }
 
@@ -3502,7 +3792,7 @@ exports[`DataFilters renders 1`] = `
   max-width: 100%;
 }
 
-.c4 {
+.c6 {
   margin: 0px;
   font-size: 26px;
   line-height: 32px;
@@ -3522,55 +3812,61 @@ exports[`DataFilters renders 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c6 {
+  .c8 {
     margin-bottom: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c10 {
     border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c10 {
     padding: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c11 {
+  .c13 {
     margin-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c14 {
+  .c16 {
     border: solid 2px rgba(0,0,0,0.15);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c7 {
+    height: 3px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c17 {
     height: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c16 {
+  .c19 {
     width: 12px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c6 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c6 {
     font-size: 22px;
     line-height: 28px;
     max-width: 528px;
@@ -3588,99 +3884,100 @@ exports[`DataFilters renders 1`] = `
       class="c2"
     >
       <div
-        class="c1"
+        class="c3"
       >
-        <header
-          class="c3"
-        >
-          <h2
-            class="c4"
-          >
-            Filters
-          </h2>
-        </header>
         <div
-          class="c5"
-        />
-        <div
-          class="c6 "
+          class="c4"
         >
-          <label
-            class="c7"
-            for="data-name"
+          <header
+            class="c5"
           >
-            name
-          </label>
-          <div
-            class="c8 FormField__FormFieldContentBox-sc-m9hood-1"
-          >
-            <div
-              class="c9 StyledCheckBoxGroup-sc-2nhc5d-0"
-              id="data-name"
-              role="group"
+            <h2
+              class="c6"
             >
-              <label
-                class="c10"
-                label="a"
-              >
-                <div
-                  class="c11 c12"
-                >
-                  <input
-                    class="c13"
-                    type="checkbox"
-                  />
-                  <div
-                    class="c14 "
-                  />
-                </div>
-                <span>
-                  a
-                </span>
-              </label>
+              Filters
+            </h2>
+          </header>
+          <div
+            class="c7"
+          />
+          <div
+            class="c8 "
+          >
+            <label
+              class="c9"
+              for="data-name"
+            >
+              name
+            </label>
+            <div
+              class="c10 FormField__FormFieldContentBox-sc-m9hood-1"
+            >
               <div
-                class="c5"
-              />
-              <label
-                class="c10"
-                label="b"
+                class="c11 StyledCheckBoxGroup-sc-2nhc5d-0"
+                id="data-name"
+                role="group"
               >
-                <div
-                  class="c11 c12"
+                <label
+                  class="c12"
+                  label="a"
                 >
-                  <input
-                    class="c13"
-                    type="checkbox"
-                  />
                   <div
-                    class="c14 "
-                  />
-                </div>
-                <span>
-                  b
-                </span>
-              </label>
+                    class="c13 c14"
+                  >
+                    <input
+                      class="c15"
+                      type="checkbox"
+                    />
+                    <div
+                      class="c16 "
+                    />
+                  </div>
+                  <span>
+                    a
+                  </span>
+                </label>
+                <div
+                  class="c17"
+                />
+                <label
+                  class="c12"
+                  label="b"
+                >
+                  <div
+                    class="c13 c14"
+                  >
+                    <input
+                      class="c15"
+                      type="checkbox"
+                    />
+                    <div
+                      class="c16 "
+                    />
+                  </div>
+                  <span>
+                    b
+                  </span>
+                </label>
+              </div>
             </div>
           </div>
         </div>
-        <div
-          class="c5"
-        />
         <footer
-          class="c3"
+          class="c5"
         >
           <button
-            class="c15"
+            class="c18"
             type="submit"
           >
             Apply filters
           </button>
           <div
-            class="c16"
+            class="c19"
           />
           <button
             aria-hidden="true"
-            class="c17 c18"
+            class="c20 c21"
             disabled=""
             tabindex="-1"
             type="reset"

--- a/src/js/components/DataFilters/__tests__/__snapshots__/DataFilters-test.tsx.snap
+++ b/src/js/components/DataFilters/__tests__/__snapshots__/DataFilters-test.tsx.snap
@@ -76,7 +76,7 @@ exports[`DataFilters clear 1`] = `
   justify-content: space-between;
 }
 
-.c8 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -94,7 +94,7 @@ exports[`DataFilters clear 1`] = `
   flex: 0 0 auto;
 }
 
-.c10 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -110,7 +110,7 @@ exports[`DataFilters clear 1`] = `
   padding: 12px;
 }
 
-.c11 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -124,7 +124,7 @@ exports[`DataFilters clear 1`] = `
   flex-direction: column;
 }
 
-.c13 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -147,7 +147,7 @@ exports[`DataFilters clear 1`] = `
   justify-content: center;
 }
 
-.c16 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -173,7 +173,7 @@ exports[`DataFilters clear 1`] = `
   border-radius: 4px;
 }
 
-.c19 {
+.c18 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -199,17 +199,33 @@ exports[`DataFilters clear 1`] = `
   border-radius: 4px;
 }
 
-.c7 {
+.c19 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-top: 12px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  -webkit-align-self: stretch;
-  -ms-flex-item-align: stretch;
-  align-self: stretch;
-  height: 6px;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
 }
 
-.c18 {
+.c17 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -226,10 +242,10 @@ exports[`DataFilters clear 1`] = `
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
   align-self: stretch;
-  width: 24px;
+  width: 12px;
 }
 
-.c9 {
+.c8 {
   margin-left: 12px;
   margin-right: 12px;
   margin-top: 6px;
@@ -377,7 +393,7 @@ exports[`DataFilters clear 1`] = `
   border: 0;
 }
 
-.c17 {
+.c16 {
   box-sizing: border-box;
   stroke-width: 4px;
   stroke: #7D4CDB;
@@ -385,7 +401,7 @@ exports[`DataFilters clear 1`] = `
   height: 24px;
 }
 
-.c12 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -407,12 +423,12 @@ exports[`DataFilters clear 1`] = `
   cursor: pointer;
 }
 
-.c12:hover input:not([disabled]) + div,
-.c12:hover input:not([disabled]) + span {
+.c11:hover input:not([disabled]) + div,
+.c11:hover input:not([disabled]) + span {
   border-color: #000000;
 }
 
-.c15 {
+.c14 {
   opacity: 0;
   -moz-appearance: none;
   width: 0;
@@ -421,12 +437,12 @@ exports[`DataFilters clear 1`] = `
   cursor: pointer;
 }
 
-.c15:checked + span > span {
+.c14:checked + span > span {
   left: calc( 48px - 24px );
   background: #7D4CDB;
 }
 
-.c14 {
+.c13 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -460,56 +476,56 @@ exports[`DataFilters clear 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c7 {
     margin-bottom: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c10 {
+  .c9 {
     border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c10 {
+  .c9 {
     padding: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c13 {
+  .c12 {
     margin-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c16 {
+  .c15 {
     border: solid 2px #7D4CDB;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c19 {
+  .c18 {
     border: solid 2px rgba(0,0,0,0.15);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c7 {
-    height: 3px;
+  .c19 {
+    margin-top: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c18 {
+  .c17 {
     height: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c21 {
-    width: 12px;
+    width: 6px;
   }
 }
 
@@ -553,42 +569,39 @@ exports[`DataFilters clear 1`] = `
             </h2>
           </header>
           <div
-            class="c7"
-          />
-          <div
-            class="c8 "
+            class="c7 "
           >
             <label
-              class="c9"
+              class="c8"
               for="data-name"
             >
               name
             </label>
             <div
-              class="c10 FormField__FormFieldContentBox-sc-m9hood-1"
+              class="c9 FormField__FormFieldContentBox-sc-m9hood-1"
             >
               <div
-                class="c11 StyledCheckBoxGroup-sc-2nhc5d-0"
+                class="c10 StyledCheckBoxGroup-sc-2nhc5d-0"
                 id="data-name"
                 role="group"
               >
                 <label
-                  class="c12"
+                  class="c11"
                   label="a"
                 >
                   <div
-                    class="c13 c14"
+                    class="c12 c13"
                   >
                     <input
                       checked=""
-                      class="c15"
+                      class="c14"
                       type="checkbox"
                     />
                     <div
-                      class="c16 "
+                      class="c15 "
                     >
                       <svg
-                        class="c17"
+                        class="c16"
                         preserveAspectRatio="xMidYMid meet"
                         viewBox="0 0 24 24"
                       >
@@ -604,21 +617,21 @@ exports[`DataFilters clear 1`] = `
                   </span>
                 </label>
                 <div
-                  class="c18"
+                  class="c17"
                 />
                 <label
-                  class="c12"
+                  class="c11"
                   label="b"
                 >
                   <div
-                    class="c13 c14"
+                    class="c12 c13"
                   >
                     <input
-                      class="c15"
+                      class="c14"
                       type="checkbox"
                     />
                     <div
-                      class="c19 "
+                      class="c18 "
                     />
                   </div>
                   <span>
@@ -630,7 +643,7 @@ exports[`DataFilters clear 1`] = `
           </div>
         </div>
         <footer
-          class="c5"
+          class="c19"
         >
           <button
             class="c20"
@@ -886,8 +899,8 @@ exports[`DataFilters drop 3`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .grsgKE {
-    height: 3px;
+  .gcEjSx {
+    margin-top: 6px;
   }
 }
 @media only screen and (max-width: 768px) {
@@ -896,8 +909,8 @@ exports[`DataFilters drop 3`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .iISQcM {
-    width: 12px;
+  .ilMzAg {
+    width: 6px;
   }
 }
 @media only screen and (max-width: 768px) {
@@ -1366,7 +1379,7 @@ exports[`DataFilters layer 2`] = `
   justify-content: space-between;
 }
 
-.c13 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1384,7 +1397,7 @@ exports[`DataFilters layer 2`] = `
   flex: 0 0 auto;
 }
 
-.c15 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1400,7 +1413,7 @@ exports[`DataFilters layer 2`] = `
   padding: 12px;
 }
 
-.c16 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1414,7 +1427,7 @@ exports[`DataFilters layer 2`] = `
   flex-direction: column;
 }
 
-.c18 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1437,7 +1450,7 @@ exports[`DataFilters layer 2`] = `
   justify-content: center;
 }
 
-.c21 {
+.c20 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1463,13 +1476,14 @@ exports[`DataFilters layer 2`] = `
   border-radius: 4px;
 }
 
-.c23 {
+.c22 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  margin-top: 12px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1486,7 +1500,9 @@ exports[`DataFilters layer 2`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  padding: 24px;
+  padding-left: 24px;
+  padding-right: 24px;
+  padding-bottom: 24px;
 }
 
 .c9 {
@@ -1499,17 +1515,7 @@ exports[`DataFilters layer 2`] = `
   width: 24px;
 }
 
-.c12 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  -webkit-align-self: stretch;
-  -ms-flex-item-align: stretch;
-  align-self: stretch;
-  height: 6px;
-}
-
-.c22 {
+.c21 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -1519,7 +1525,17 @@ exports[`DataFilters layer 2`] = `
   height: 12px;
 }
 
-.c14 {
+.c24 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  width: 12px;
+}
+
+.c13 {
   margin-left: 12px;
   margin-right: 12px;
   margin-top: 6px;
@@ -1593,7 +1609,7 @@ exports[`DataFilters layer 2`] = `
   border: 0;
 }
 
-.c24 {
+.c23 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -1621,47 +1637,47 @@ exports[`DataFilters layer 2`] = `
   transition-timing-function: ease-in-out;
 }
 
-.c24:hover {
+.c23:hover {
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c24:focus {
+.c23:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c24:focus > circle,
-.c24:focus > ellipse,
-.c24:focus > line,
-.c24:focus > path,
-.c24:focus > polygon,
-.c24:focus > polyline,
-.c24:focus > rect {
+.c23:focus > circle,
+.c23:focus > ellipse,
+.c23:focus > line,
+.c23:focus > path,
+.c23:focus > polygon,
+.c23:focus > polyline,
+.c23:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c24:focus::-moz-focus-inner {
+.c23:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c24:focus:not(:focus-visible) {
+.c23:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c24:focus:not(:focus-visible) > circle,
-.c24:focus:not(:focus-visible) > ellipse,
-.c24:focus:not(:focus-visible) > line,
-.c24:focus:not(:focus-visible) > path,
-.c24:focus:not(:focus-visible) > polygon,
-.c24:focus:not(:focus-visible) > polyline,
-.c24:focus:not(:focus-visible) > rect {
+.c23:focus:not(:focus-visible) > circle,
+.c23:focus:not(:focus-visible) > ellipse,
+.c23:focus:not(:focus-visible) > line,
+.c23:focus:not(:focus-visible) > path,
+.c23:focus:not(:focus-visible) > polygon,
+.c23:focus:not(:focus-visible) > polyline,
+.c23:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c24:focus:not(:focus-visible)::-moz-focus-inner {
+.c23:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
@@ -1732,7 +1748,7 @@ exports[`DataFilters layer 2`] = `
   border: 0;
 }
 
-.c17 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1754,12 +1770,12 @@ exports[`DataFilters layer 2`] = `
   cursor: pointer;
 }
 
-.c17:hover input:not([disabled]) + div,
-.c17:hover input:not([disabled]) + span {
+.c16:hover input:not([disabled]) + div,
+.c16:hover input:not([disabled]) + span {
   border-color: #000000;
 }
 
-.c20 {
+.c19 {
   opacity: 0;
   -moz-appearance: none;
   width: 0;
@@ -1768,12 +1784,12 @@ exports[`DataFilters layer 2`] = `
   cursor: pointer;
 }
 
-.c20:checked + span > span {
+.c19:checked + span > span {
   left: calc( 48px - 24px );
   background: #7D4CDB;
 }
 
-.c19 {
+.c18 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -1878,38 +1894,51 @@ exports[`DataFilters layer 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c13 {
+  .c12 {
     margin-bottom: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c15 {
+  .c14 {
     border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c15 {
+  .c14 {
     padding: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c18 {
+  .c17 {
     margin-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c21 {
+  .c20 {
     border: solid 2px rgba(0,0,0,0.15);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c23 {
-    padding: 12px;
+  .c22 {
+    margin-top: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c22 {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c22 {
+    padding-bottom: 12px;
   }
 }
 
@@ -1920,14 +1949,14 @@ exports[`DataFilters layer 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c12 {
-    height: 3px;
+  .c21 {
+    height: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c22 {
-    height: 6px;
+  .c24 {
+    width: 6px;
   }
 }
 
@@ -2029,38 +2058,35 @@ exports[`DataFilters layer 2`] = `
             </button>
           </header>
           <div
-            class="c12"
-          />
-          <div
-            class="c13 "
+            class="c12 "
           >
             <label
-              class="c14"
+              class="c13"
               for="test-data-name"
             >
               name
             </label>
             <div
-              class="c15 FormField__FormFieldContentBox-sc-m9hood-1"
+              class="c14 FormField__FormFieldContentBox-sc-m9hood-1"
             >
               <div
-                class="c16 StyledCheckBoxGroup-sc-2nhc5d-0"
+                class="c15 StyledCheckBoxGroup-sc-2nhc5d-0"
                 id="test-data-name"
                 role="group"
               >
                 <label
-                  class="c17"
+                  class="c16"
                   label="a"
                 >
                   <div
-                    class="c18 c19"
+                    class="c17 c18"
                   >
                     <input
-                      class="c20"
+                      class="c19"
                       type="checkbox"
                     />
                     <div
-                      class="c21 "
+                      class="c20 "
                     />
                   </div>
                   <span>
@@ -2068,21 +2094,21 @@ exports[`DataFilters layer 2`] = `
                   </span>
                 </label>
                 <div
-                  class="c22"
+                  class="c21"
                 />
                 <label
-                  class="c17"
+                  class="c16"
                   label="b"
                 >
                   <div
-                    class="c18 c19"
+                    class="c17 c18"
                   >
                     <input
-                      class="c20"
+                      class="c19"
                       type="checkbox"
                     />
                     <div
-                      class="c21 "
+                      class="c20 "
                     />
                   </div>
                   <span>
@@ -2094,16 +2120,16 @@ exports[`DataFilters layer 2`] = `
           </div>
         </div>
         <footer
-          class="c23"
+          class="c22"
         >
           <button
-            class="c24"
+            class="c23"
             type="submit"
           >
             Apply filters
           </button>
           <div
-            class="c9"
+            class="c24"
           />
           <button
             aria-hidden="true"
@@ -2148,8 +2174,8 @@ exports[`DataFilters layer 3`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .grsgKE {
-    height: 3px;
+  .gcEjSx {
+    margin-top: 6px;
   }
 }
 @media only screen and (max-width: 768px) {
@@ -2158,8 +2184,8 @@ exports[`DataFilters layer 3`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .iISQcM {
-    width: 12px;
+  .ilMzAg {
+    width: 6px;
   }
 }
 @media only screen and (max-width: 768px) {
@@ -2252,7 +2278,7 @@ exports[`DataFilters properties array 1`] = `
   justify-content: space-between;
 }
 
-.c8 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2270,7 +2296,7 @@ exports[`DataFilters properties array 1`] = `
   flex: 0 0 auto;
 }
 
-.c10 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2286,7 +2312,7 @@ exports[`DataFilters properties array 1`] = `
   padding: 12px;
 }
 
-.c11 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2300,7 +2326,7 @@ exports[`DataFilters properties array 1`] = `
   flex-direction: column;
 }
 
-.c13 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2323,7 +2349,7 @@ exports[`DataFilters properties array 1`] = `
   justify-content: center;
 }
 
-.c16 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2349,17 +2375,33 @@ exports[`DataFilters properties array 1`] = `
   border-radius: 4px;
 }
 
-.c7 {
+.c17 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-top: 12px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  -webkit-align-self: stretch;
-  -ms-flex-item-align: stretch;
-  align-self: stretch;
-  height: 6px;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
 }
 
-.c17 {
+.c16 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -2376,10 +2418,10 @@ exports[`DataFilters properties array 1`] = `
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
   align-self: stretch;
-  width: 24px;
+  width: 12px;
 }
 
-.c9 {
+.c8 {
   margin-left: 12px;
   margin-right: 12px;
   margin-top: 6px;
@@ -2527,7 +2569,7 @@ exports[`DataFilters properties array 1`] = `
   border: 0;
 }
 
-.c12 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2549,12 +2591,12 @@ exports[`DataFilters properties array 1`] = `
   cursor: pointer;
 }
 
-.c12:hover input:not([disabled]) + div,
-.c12:hover input:not([disabled]) + span {
+.c11:hover input:not([disabled]) + div,
+.c11:hover input:not([disabled]) + span {
   border-color: #000000;
 }
 
-.c15 {
+.c14 {
   opacity: 0;
   -moz-appearance: none;
   width: 0;
@@ -2563,12 +2605,12 @@ exports[`DataFilters properties array 1`] = `
   cursor: pointer;
 }
 
-.c15:checked + span > span {
+.c14:checked + span > span {
   left: calc( 48px - 24px );
   background: #7D4CDB;
 }
 
-.c14 {
+.c13 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -2602,50 +2644,50 @@ exports[`DataFilters properties array 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c7 {
     margin-bottom: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c10 {
+  .c9 {
     border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c10 {
+  .c9 {
     padding: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c13 {
+  .c12 {
     margin-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c16 {
+  .c15 {
     border: solid 2px rgba(0,0,0,0.15);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c7 {
-    height: 3px;
+  .c17 {
+    margin-top: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c17 {
+  .c16 {
     height: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c19 {
-    width: 12px;
+    width: 6px;
   }
 }
 
@@ -2689,38 +2731,35 @@ exports[`DataFilters properties array 1`] = `
             </h2>
           </header>
           <div
-            class="c7"
-          />
-          <div
-            class="c8 "
+            class="c7 "
           >
             <label
-              class="c9"
+              class="c8"
               for="data-name"
             >
               name
             </label>
             <div
-              class="c10 FormField__FormFieldContentBox-sc-m9hood-1"
+              class="c9 FormField__FormFieldContentBox-sc-m9hood-1"
             >
               <div
-                class="c11 StyledCheckBoxGroup-sc-2nhc5d-0"
+                class="c10 StyledCheckBoxGroup-sc-2nhc5d-0"
                 id="data-name"
                 role="group"
               >
                 <label
-                  class="c12"
+                  class="c11"
                   label="a"
                 >
                   <div
-                    class="c13 c14"
+                    class="c12 c13"
                   >
                     <input
-                      class="c15"
+                      class="c14"
                       type="checkbox"
                     />
                     <div
-                      class="c16 "
+                      class="c15 "
                     />
                   </div>
                   <span>
@@ -2728,21 +2767,21 @@ exports[`DataFilters properties array 1`] = `
                   </span>
                 </label>
                 <div
-                  class="c17"
+                  class="c16"
                 />
                 <label
-                  class="c12"
+                  class="c11"
                   label="b"
                 >
                   <div
-                    class="c13 c14"
+                    class="c12 c13"
                   >
                     <input
-                      class="c15"
+                      class="c14"
                       type="checkbox"
                     />
                     <div
-                      class="c16 "
+                      class="c15 "
                     />
                   </div>
                   <span>
@@ -2754,7 +2793,7 @@ exports[`DataFilters properties array 1`] = `
           </div>
         </div>
         <footer
-          class="c5"
+          class="c17"
         >
           <button
             class="c18"
@@ -2857,7 +2896,7 @@ exports[`DataFilters properties object 1`] = `
   justify-content: space-between;
 }
 
-.c8 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2875,7 +2914,7 @@ exports[`DataFilters properties object 1`] = `
   flex: 0 0 auto;
 }
 
-.c10 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2891,7 +2930,7 @@ exports[`DataFilters properties object 1`] = `
   padding: 12px;
 }
 
-.c11 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2905,7 +2944,7 @@ exports[`DataFilters properties object 1`] = `
   flex-direction: column;
 }
 
-.c13 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2928,7 +2967,7 @@ exports[`DataFilters properties object 1`] = `
   justify-content: center;
 }
 
-.c16 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2954,17 +2993,33 @@ exports[`DataFilters properties object 1`] = `
   border-radius: 4px;
 }
 
-.c7 {
+.c17 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-top: 12px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  -webkit-align-self: stretch;
-  -ms-flex-item-align: stretch;
-  align-self: stretch;
-  height: 6px;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
 }
 
-.c17 {
+.c16 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -2981,10 +3036,10 @@ exports[`DataFilters properties object 1`] = `
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
   align-self: stretch;
-  width: 24px;
+  width: 12px;
 }
 
-.c9 {
+.c8 {
   margin-left: 12px;
   margin-right: 12px;
   margin-top: 6px;
@@ -3132,7 +3187,7 @@ exports[`DataFilters properties object 1`] = `
   border: 0;
 }
 
-.c12 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3154,12 +3209,12 @@ exports[`DataFilters properties object 1`] = `
   cursor: pointer;
 }
 
-.c12:hover input:not([disabled]) + div,
-.c12:hover input:not([disabled]) + span {
+.c11:hover input:not([disabled]) + div,
+.c11:hover input:not([disabled]) + span {
   border-color: #000000;
 }
 
-.c15 {
+.c14 {
   opacity: 0;
   -moz-appearance: none;
   width: 0;
@@ -3168,12 +3223,12 @@ exports[`DataFilters properties object 1`] = `
   cursor: pointer;
 }
 
-.c15:checked + span > span {
+.c14:checked + span > span {
   left: calc( 48px - 24px );
   background: #7D4CDB;
 }
 
-.c14 {
+.c13 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -3207,50 +3262,50 @@ exports[`DataFilters properties object 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c7 {
     margin-bottom: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c10 {
+  .c9 {
     border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c10 {
+  .c9 {
     padding: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c13 {
+  .c12 {
     margin-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c16 {
+  .c15 {
     border: solid 2px rgba(0,0,0,0.15);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c7 {
-    height: 3px;
+  .c17 {
+    margin-top: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c17 {
+  .c16 {
     height: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c19 {
-    width: 12px;
+    width: 6px;
   }
 }
 
@@ -3294,38 +3349,35 @@ exports[`DataFilters properties object 1`] = `
             </h2>
           </header>
           <div
-            class="c7"
-          />
-          <div
-            class="c8 "
+            class="c7 "
           >
             <label
-              class="c9"
+              class="c8"
               for="data-name"
             >
               name
             </label>
             <div
-              class="c10 FormField__FormFieldContentBox-sc-m9hood-1"
+              class="c9 FormField__FormFieldContentBox-sc-m9hood-1"
             >
               <div
-                class="c11 StyledCheckBoxGroup-sc-2nhc5d-0"
+                class="c10 StyledCheckBoxGroup-sc-2nhc5d-0"
                 id="data-name"
                 role="group"
               >
                 <label
-                  class="c12"
+                  class="c11"
                   label="a"
                 >
                   <div
-                    class="c13 c14"
+                    class="c12 c13"
                   >
                     <input
-                      class="c15"
+                      class="c14"
                       type="checkbox"
                     />
                     <div
-                      class="c16 "
+                      class="c15 "
                     />
                   </div>
                   <span>
@@ -3333,21 +3385,21 @@ exports[`DataFilters properties object 1`] = `
                   </span>
                 </label>
                 <div
-                  class="c17"
+                  class="c16"
                 />
                 <label
-                  class="c12"
+                  class="c11"
                   label="b"
                 >
                   <div
-                    class="c13 c14"
+                    class="c12 c13"
                   >
                     <input
-                      class="c15"
+                      class="c14"
                       type="checkbox"
                     />
                     <div
-                      class="c16 "
+                      class="c15 "
                     />
                   </div>
                   <span>
@@ -3359,7 +3411,7 @@ exports[`DataFilters properties object 1`] = `
           </div>
         </div>
         <footer
-          class="c5"
+          class="c17"
         >
           <button
             class="c18"
@@ -3462,7 +3514,7 @@ exports[`DataFilters renders 1`] = `
   justify-content: space-between;
 }
 
-.c8 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3480,7 +3532,7 @@ exports[`DataFilters renders 1`] = `
   flex: 0 0 auto;
 }
 
-.c10 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3496,7 +3548,7 @@ exports[`DataFilters renders 1`] = `
   padding: 12px;
 }
 
-.c11 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3510,7 +3562,7 @@ exports[`DataFilters renders 1`] = `
   flex-direction: column;
 }
 
-.c13 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3533,7 +3585,7 @@ exports[`DataFilters renders 1`] = `
   justify-content: center;
 }
 
-.c16 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3559,17 +3611,33 @@ exports[`DataFilters renders 1`] = `
   border-radius: 4px;
 }
 
-.c7 {
+.c17 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-top: 12px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  -webkit-align-self: stretch;
-  -ms-flex-item-align: stretch;
-  align-self: stretch;
-  height: 6px;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
 }
 
-.c17 {
+.c16 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -3586,10 +3654,10 @@ exports[`DataFilters renders 1`] = `
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
   align-self: stretch;
-  width: 24px;
+  width: 12px;
 }
 
-.c9 {
+.c8 {
   margin-left: 12px;
   margin-right: 12px;
   margin-top: 6px;
@@ -3737,7 +3805,7 @@ exports[`DataFilters renders 1`] = `
   border: 0;
 }
 
-.c12 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3759,12 +3827,12 @@ exports[`DataFilters renders 1`] = `
   cursor: pointer;
 }
 
-.c12:hover input:not([disabled]) + div,
-.c12:hover input:not([disabled]) + span {
+.c11:hover input:not([disabled]) + div,
+.c11:hover input:not([disabled]) + span {
   border-color: #000000;
 }
 
-.c15 {
+.c14 {
   opacity: 0;
   -moz-appearance: none;
   width: 0;
@@ -3773,12 +3841,12 @@ exports[`DataFilters renders 1`] = `
   cursor: pointer;
 }
 
-.c15:checked + span > span {
+.c14:checked + span > span {
   left: calc( 48px - 24px );
   background: #7D4CDB;
 }
 
-.c14 {
+.c13 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -3812,50 +3880,50 @@ exports[`DataFilters renders 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c7 {
     margin-bottom: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c10 {
+  .c9 {
     border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c10 {
+  .c9 {
     padding: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c13 {
+  .c12 {
     margin-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c16 {
+  .c15 {
     border: solid 2px rgba(0,0,0,0.15);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c7 {
-    height: 3px;
+  .c17 {
+    margin-top: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c17 {
+  .c16 {
     height: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c19 {
-    width: 12px;
+    width: 6px;
   }
 }
 
@@ -3899,38 +3967,35 @@ exports[`DataFilters renders 1`] = `
             </h2>
           </header>
           <div
-            class="c7"
-          />
-          <div
-            class="c8 "
+            class="c7 "
           >
             <label
-              class="c9"
+              class="c8"
               for="data-name"
             >
               name
             </label>
             <div
-              class="c10 FormField__FormFieldContentBox-sc-m9hood-1"
+              class="c9 FormField__FormFieldContentBox-sc-m9hood-1"
             >
               <div
-                class="c11 StyledCheckBoxGroup-sc-2nhc5d-0"
+                class="c10 StyledCheckBoxGroup-sc-2nhc5d-0"
                 id="data-name"
                 role="group"
               >
                 <label
-                  class="c12"
+                  class="c11"
                   label="a"
                 >
                   <div
-                    class="c13 c14"
+                    class="c12 c13"
                   >
                     <input
-                      class="c15"
+                      class="c14"
                       type="checkbox"
                     />
                     <div
-                      class="c16 "
+                      class="c15 "
                     />
                   </div>
                   <span>
@@ -3938,21 +4003,21 @@ exports[`DataFilters renders 1`] = `
                   </span>
                 </label>
                 <div
-                  class="c17"
+                  class="c16"
                 />
                 <label
-                  class="c12"
+                  class="c11"
                   label="b"
                 >
                   <div
-                    class="c13 c14"
+                    class="c12 c13"
                   >
                     <input
-                      class="c15"
+                      class="c14"
                       type="checkbox"
                     />
                     <div
-                      class="c16 "
+                      class="c15 "
                     />
                   </div>
                   <span>
@@ -3964,7 +4029,7 @@ exports[`DataFilters renders 1`] = `
           </div>
         </div>
         <footer
-          class="c5"
+          class="c17"
         >
           <button
             class="c18"

--- a/src/js/components/DataFilters/stories/Inline.js
+++ b/src/js/components/DataFilters/stories/Inline.js
@@ -6,6 +6,7 @@ import {
   DataFilter,
   DataSearch,
   DataSort,
+  DataView,
   Notification,
 } from 'grommet';
 
@@ -20,8 +21,15 @@ export const Inline = () => (
       status="info"
       message="Data is in 'beta'. The API surface is subject to change."
     />
-    <Data data={DATA}>
+    <Data
+      data={DATA}
+      views={[
+        { name: 'latest', sort: { property: 'date', direction: 'desc' } },
+        { name: 'behind', properties: { percent: { min: 0, max: 30 } } },
+      ]}
+    >
       <DataFilters>
+        <DataView />
         <DataSearch />
         <DataFilter property="location" />
         <DataFilter property="percent" />

--- a/src/js/components/DataFilters/stories/Layer.js
+++ b/src/js/components/DataFilters/stories/Layer.js
@@ -15,7 +15,10 @@ export const Layer = () => (
     />
     <Data data={DATA}>
       <DataFilters layer>
+        <DataFilter property="name" />
         <DataFilter property="location" />
+        <DataFilter property="percent" />
+        <DataFilter property="paid" />
       </DataFilters>
     </Data>
   </Box>

--- a/src/js/components/DataSearch/DataSearch.js
+++ b/src/js/components/DataSearch/DataSearch.js
@@ -16,11 +16,14 @@ const dropProps = {
   align: { top: 'bottom', left: 'left' },
 };
 
-const Content = ({ id, ...rest }) => {
+export const DataSearch = ({ drop, id: idProp, responsive, ...rest }) => {
   const { id: dataId, messages, addToolbarKey } = useContext(DataContext);
   const { noForm } = useContext(FormContext);
-  const skeleton = useSkeleton();
   const { format } = useContext(MessageContext);
+  const size = useContext(ResponsiveContext);
+  const skeleton = useSkeleton();
+  const [showContent, setShowContent] = useState();
+  const id = idProp || `${dataId}--search`;
 
   useEffect(() => {
     if (noForm) addToolbarKey('_search');
@@ -30,9 +33,9 @@ const Content = ({ id, ...rest }) => {
     <TextInput
       aria-label={format({
         id: 'dataSearch.label',
-        messages: messages?.DataSearch,
+        messages: messages?.dataSearch,
       })}
-      id={id || `${dataId}--search`}
+      id={id}
       name="_search"
       icon={<Search />}
       type="search"
@@ -41,33 +44,31 @@ const Content = ({ id, ...rest }) => {
   );
 
   if (noForm)
+    // likely in Toolbar
     content = (
       <DataForm footer={false} updateOn="change">
         {content}
       </DataForm>
     );
-  else content = <FormField>{content}</FormField>;
-
-  return content;
-};
-
-export const DataSearch = ({ drop, id, responsive, ...rest }) => {
-  const { id: dataId, messages } = useContext(DataContext);
-  const { noForm } = useContext(FormContext);
-  const { format } = useContext(MessageContext);
-  const size = useContext(ResponsiveContext);
-  const [showContent, setShowContent] = useState();
-
-  let content = <Content id={drop ? undefined : id} />;
-
-  if (noForm) content = <DataForm footer={false}>{content}</DataForm>;
+  else
+    content = (
+      <FormField
+        htmlFor={id}
+        label={format({
+          id: 'dataSearch.label',
+          messages: messages?.dataSearch,
+        })}
+      >
+        {content}
+      </FormField>
+    );
 
   if (!drop && (!responsive || (size !== 'small' && size !== 'xsmall')))
     return content;
 
   const control = (
     <DropButton
-      id={id || `${dataId}--search-control`}
+      id={`${dataId}--search-control`}
       aria-label={format({
         id: 'dataSearch.open',
         messages: messages?.dataSort,

--- a/src/js/components/DataSearch/DataSearch.js
+++ b/src/js/components/DataSearch/DataSearch.js
@@ -5,6 +5,7 @@ import { DataContext } from '../../contexts/DataContext';
 import { DataForm } from '../Data/DataForm';
 import { DropButton } from '../DropButton';
 import { FormContext } from '../Form/FormContext';
+import { FormField } from '../FormField';
 import { useSkeleton } from '../Skeleton';
 import { TextInput } from '../TextInput';
 import { MessageContext } from '../../contexts/MessageContext';
@@ -45,6 +46,7 @@ const Content = ({ id, ...rest }) => {
         {content}
       </DataForm>
     );
+  else content = <FormField>{content}</FormField>;
 
   return content;
 };

--- a/src/js/components/DataSearch/__tests__/__snapshots__/DataSearch-test.tsx.snap
+++ b/src/js/components/DataSearch/__tests__/__snapshots__/DataSearch-test.tsx.snap
@@ -212,7 +212,7 @@ exports[`DataSearch drop 3`] = `
 `;
 
 exports[`DataSearch renders 1`] = `
-.c11 {
+.c12 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -223,25 +223,25 @@ exports[`DataSearch renders 1`] = `
   stroke: #666666;
 }
 
-.c11 g {
+.c12 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c11 *:not([stroke])[fill="none"] {
+.c12 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c11 *[stroke*="#"],
-.c11 *[STROKE*="#"] {
+.c12 *[stroke*="#"],
+.c12 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c11 *[fill-rule],
-.c11 *[FILL-RULE],
-.c11 *[fill*="#"],
-.c11 *[FILL*="#"] {
+.c12 *[fill-rule],
+.c12 *[FILL-RULE],
+.c12 *[fill*="#"],
+.c12 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -339,7 +339,7 @@ exports[`DataSearch renders 1`] = `
   flex: 0 0 auto;
 }
 
-.c8 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -354,7 +354,7 @@ exports[`DataSearch renders 1`] = `
   flex-direction: column;
 }
 
-.c13 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -380,7 +380,7 @@ exports[`DataSearch renders 1`] = `
   justify-content: space-between;
 }
 
-.c15 {
+.c16 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -390,7 +390,16 @@ exports[`DataSearch renders 1`] = `
   width: 12px;
 }
 
-.c14 {
+.c8 {
+  margin-left: 12px;
+  margin-right: 12px;
+  margin-top: 6px;
+  margin-bottom: 6px;
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c15 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -418,51 +427,51 @@ exports[`DataSearch renders 1`] = `
   transition-timing-function: ease-in-out;
 }
 
-.c14:hover {
+.c15:hover {
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c14:focus {
+.c15:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c14:focus > circle,
-.c14:focus > ellipse,
-.c14:focus > line,
-.c14:focus > path,
-.c14:focus > polygon,
-.c14:focus > polyline,
-.c14:focus > rect {
+.c15:focus > circle,
+.c15:focus > ellipse,
+.c15:focus > line,
+.c15:focus > path,
+.c15:focus > polygon,
+.c15:focus > polyline,
+.c15:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c14:focus::-moz-focus-inner {
+.c15:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c14:focus:not(:focus-visible) {
+.c15:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c14:focus:not(:focus-visible) > circle,
-.c14:focus:not(:focus-visible) > ellipse,
-.c14:focus:not(:focus-visible) > line,
-.c14:focus:not(:focus-visible) > path,
-.c14:focus:not(:focus-visible) > polygon,
-.c14:focus:not(:focus-visible) > polyline,
-.c14:focus:not(:focus-visible) > rect {
+.c15:focus:not(:focus-visible) > circle,
+.c15:focus:not(:focus-visible) > ellipse,
+.c15:focus:not(:focus-visible) > line,
+.c15:focus:not(:focus-visible) > path,
+.c15:focus:not(:focus-visible) > polygon,
+.c15:focus:not(:focus-visible) > polyline,
+.c15:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c14:focus:not(:focus-visible)::-moz-focus-inner {
+.c15:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c16 {
+.c17 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -489,47 +498,47 @@ exports[`DataSearch renders 1`] = `
   transition-timing-function: ease-in-out;
 }
 
-.c16:focus {
+.c17:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c16:focus > circle,
-.c16:focus > ellipse,
-.c16:focus > line,
-.c16:focus > path,
-.c16:focus > polygon,
-.c16:focus > polyline,
-.c16:focus > rect {
+.c17:focus > circle,
+.c17:focus > ellipse,
+.c17:focus > line,
+.c17:focus > path,
+.c17:focus > polygon,
+.c17:focus > polyline,
+.c17:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c16:focus::-moz-focus-inner {
+.c17:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c16:focus:not(:focus-visible) {
+.c17:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c16:focus:not(:focus-visible) > circle,
-.c16:focus:not(:focus-visible) > ellipse,
-.c16:focus:not(:focus-visible) > line,
-.c16:focus:not(:focus-visible) > path,
-.c16:focus:not(:focus-visible) > polygon,
-.c16:focus:not(:focus-visible) > polyline,
-.c16:focus:not(:focus-visible) > rect {
+.c17:focus:not(:focus-visible) > circle,
+.c17:focus:not(:focus-visible) > ellipse,
+.c17:focus:not(:focus-visible) > line,
+.c17:focus:not(:focus-visible) > path,
+.c17:focus:not(:focus-visible) > polygon,
+.c17:focus:not(:focus-visible) > polyline,
+.c17:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c16:focus:not(:focus-visible)::-moz-focus-inner {
+.c17:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c12 {
+.c13 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -548,38 +557,38 @@ exports[`DataSearch renders 1`] = `
   padding-left: 48px;
 }
 
-.c12::-webkit-input-placeholder {
+.c13::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c12::-moz-placeholder {
+.c13::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c12:-ms-input-placeholder {
+.c13:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c12::-webkit-search-decoration {
+.c13::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c12::-moz-focus-inner {
+.c13::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c12:-moz-placeholder,
-.c12::-moz-placeholder {
+.c13:-moz-placeholder,
+.c13::-moz-placeholder {
   opacity: 1;
 }
 
-.c9 {
+.c10 {
   position: relative;
   width: 100%;
 }
 
-.c10 {
+.c11 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -597,7 +606,7 @@ exports[`DataSearch renders 1`] = `
   left: 12px;
 }
 
-.c17 {
+.c18 {
   opacity: 0;
 }
 
@@ -631,19 +640,19 @@ exports[`DataSearch renders 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c9 {
     border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c13 {
+  .c14 {
     margin-top: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c15 {
+  .c16 {
     width: 6px;
   }
 }
@@ -690,18 +699,24 @@ exports[`DataSearch renders 1`] = `
           <div
             class="c7 "
           >
+            <label
+              class="c8"
+              for="data--search"
+            >
+              Search
+            </label>
             <div
-              class="c8 FormField__FormFieldContentBox-sc-m9hood-1"
+              class="c9 FormField__FormFieldContentBox-sc-m9hood-1"
             >
               <div
-                class="c9"
+                class="c10"
               >
                 <div
-                  class="c10"
+                  class="c11"
                 >
                   <svg
                     aria-label="Search"
-                    class="c11"
+                    class="c12"
                     viewBox="0 0 24 24"
                   >
                     <path
@@ -713,9 +728,9 @@ exports[`DataSearch renders 1`] = `
                   </svg>
                 </div>
                 <input
-                  aria-label="Search data"
+                  aria-label="Search"
                   autocomplete="off"
-                  class="c12"
+                  class="c13"
                   id="data--search"
                   name="_search"
                   type="search"
@@ -726,20 +741,20 @@ exports[`DataSearch renders 1`] = `
           </div>
         </div>
         <footer
-          class="c13"
+          class="c14"
         >
           <button
-            class="c14"
+            class="c15"
             type="submit"
           >
             Apply filters
           </button>
           <div
-            class="c15"
+            class="c16"
           />
           <button
             aria-hidden="true"
-            class="c16 c17"
+            class="c17 c18"
             disabled=""
             tabindex="-1"
             type="reset"

--- a/src/js/components/DataSearch/__tests__/__snapshots__/DataSearch-test.tsx.snap
+++ b/src/js/components/DataSearch/__tests__/__snapshots__/DataSearch-test.tsx.snap
@@ -178,13 +178,23 @@ exports[`DataSearch drop 2`] = `
 
 exports[`DataSearch drop 3`] = `
 "@media only screen and (max-width: 768px) {
-  .drdMXk {
-    height: 6px;
+  .hfctvB {
+    margin-bottom: 6px;
   }
 }
 @media only screen and (max-width: 768px) {
-  .iISQcM {
-    width: 12px;
+  .cqRjpC {
+    border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  }
+}
+@media only screen and (max-width: 768px) {
+  .gcEjSx {
+    margin-top: 6px;
+  }
+}
+@media only screen and (max-width: 768px) {
+  .ilMzAg {
+    width: 6px;
   }
 }
 @media only screen and (max-width: 768px) {
@@ -202,7 +212,7 @@ exports[`DataSearch drop 3`] = `
 `;
 
 exports[`DataSearch renders 1`] = `
-.c10 {
+.c11 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -213,25 +223,25 @@ exports[`DataSearch renders 1`] = `
   stroke: #666666;
 }
 
-.c10 g {
+.c11 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c10 *:not([stroke])[fill="none"] {
+.c11 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c10 *[stroke*="#"],
-.c10 *[STROKE*="#"] {
+.c11 *[stroke*="#"],
+.c11 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c10 *[fill-rule],
-.c10 *[FILL-RULE],
-.c10 *[fill*="#"],
-.c10 *[FILL*="#"] {
+.c11 *[fill-rule],
+.c11 *[FILL-RULE],
+.c11 *[fill*="#"],
+.c11 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -312,26 +322,75 @@ exports[`DataSearch renders 1`] = `
 }
 
 .c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-bottom: 12px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  -webkit-align-self: stretch;
-  -ms-flex-item-align: stretch;
-  align-self: stretch;
-  height: 6px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
 }
 
 .c13 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-top: 12px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c15 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
   align-self: stretch;
-  width: 24px;
+  width: 12px;
 }
 
-.c12 {
+.c14 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -359,75 +418,8 @@ exports[`DataSearch renders 1`] = `
   transition-timing-function: ease-in-out;
 }
 
-.c12:hover {
+.c14:hover {
   box-shadow: 0px 0px 0px 2px #7D4CDB;
-}
-
-.c12:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c12:focus > circle,
-.c12:focus > ellipse,
-.c12:focus > line,
-.c12:focus > path,
-.c12:focus > polygon,
-.c12:focus > polyline,
-.c12:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c12:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c12:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c12:focus:not(:focus-visible) > circle,
-.c12:focus:not(:focus-visible) > ellipse,
-.c12:focus:not(:focus-visible) > line,
-.c12:focus:not(:focus-visible) > path,
-.c12:focus:not(:focus-visible) > polygon,
-.c12:focus:not(:focus-visible) > polyline,
-.c12:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c12:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c14 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: 2px solid #7D4CDB;
-  border-radius: 18px;
-  color: #444444;
-  padding: 4px 22px;
-  font-size: 18px;
-  line-height: 24px;
-  opacity: 0.3;
-  cursor: default;
-  -webkit-transition-property: color,background-color,border-color,box-shadow;
-  transition-property: color,background-color,border-color,box-shadow;
-  -webkit-transition-duration: 0.1s;
-  transition-duration: 0.1s;
-  -webkit-transition-timing-function: ease-in-out;
-  transition-timing-function: ease-in-out;
 }
 
 .c14:focus {
@@ -470,7 +462,74 @@ exports[`DataSearch renders 1`] = `
   border: 0;
 }
 
-.c11 {
+.c16 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: 2px solid #7D4CDB;
+  border-radius: 18px;
+  color: #444444;
+  padding: 4px 22px;
+  font-size: 18px;
+  line-height: 24px;
+  opacity: 0.3;
+  cursor: default;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+}
+
+.c16:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c16:focus > circle,
+.c16:focus > ellipse,
+.c16:focus > line,
+.c16:focus > path,
+.c16:focus > polygon,
+.c16:focus > polyline,
+.c16:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c16:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c16:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c16:focus:not(:focus-visible) > circle,
+.c16:focus:not(:focus-visible) > ellipse,
+.c16:focus:not(:focus-visible) > line,
+.c16:focus:not(:focus-visible) > path,
+.c16:focus:not(:focus-visible) > polygon,
+.c16:focus:not(:focus-visible) > polyline,
+.c16:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c16:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c12 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -484,61 +543,43 @@ exports[`DataSearch renders 1`] = `
   margin: 0;
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
+  outline: none;
+  border: none;
   padding-left: 48px;
 }
 
-.c11:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c11:focus > circle,
-.c11:focus > ellipse,
-.c11:focus > line,
-.c11:focus > path,
-.c11:focus > polygon,
-.c11:focus > polyline,
-.c11:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c11:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c11::-webkit-input-placeholder {
+.c12::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c11::-moz-placeholder {
+.c12::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c11:-ms-input-placeholder {
+.c12:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c11::-webkit-search-decoration {
+.c12::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c11::-moz-focus-inner {
+.c12::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c11:-moz-placeholder,
-.c11::-moz-placeholder {
+.c12:-moz-placeholder,
+.c12::-moz-placeholder {
   opacity: 1;
 }
 
-.c8 {
+.c9 {
   position: relative;
   width: 100%;
 }
 
-.c9 {
+.c10 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -556,7 +597,7 @@ exports[`DataSearch renders 1`] = `
   left: 12px;
 }
 
-.c15 {
+.c17 {
   opacity: 0;
 }
 
@@ -585,13 +626,25 @@ exports[`DataSearch renders 1`] = `
 
 @media only screen and (max-width:768px) {
   .c7 {
-    height: 3px;
+    margin-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c8 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:768px) {
   .c13 {
-    width: 12px;
+    margin-top: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c15 {
+    width: 6px;
   }
 }
 
@@ -635,53 +688,58 @@ exports[`DataSearch renders 1`] = `
             </h2>
           </header>
           <div
-            class="c7"
-          />
-          <div
-            class="c8"
+            class="c7 "
           >
             <div
-              class="c9"
+              class="c8 FormField__FormFieldContentBox-sc-m9hood-1"
             >
-              <svg
-                aria-label="Search"
-                class="c10"
-                viewBox="0 0 24 24"
+              <div
+                class="c9"
               >
-                <path
-                  d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                  fill="none"
-                  stroke="#000"
-                  stroke-width="2"
+                <div
+                  class="c10"
+                >
+                  <svg
+                    aria-label="Search"
+                    class="c11"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                      fill="none"
+                      stroke="#000"
+                      stroke-width="2"
+                    />
+                  </svg>
+                </div>
+                <input
+                  aria-label="Search data"
+                  autocomplete="off"
+                  class="c12"
+                  id="data--search"
+                  name="_search"
+                  type="search"
+                  value=""
                 />
-              </svg>
+              </div>
             </div>
-            <input
-              aria-label="Search data"
-              autocomplete="off"
-              class="c11"
-              id="data--search"
-              name="_search"
-              type="search"
-              value=""
-            />
           </div>
         </div>
         <footer
-          class="c5"
+          class="c13"
         >
           <button
-            class="c12"
+            class="c14"
             type="submit"
           >
             Apply filters
           </button>
           <div
-            class="c13"
+            class="c15"
           />
           <button
             aria-hidden="true"
-            class="c14 c15"
+            class="c16 c17"
             disabled=""
             tabindex="-1"
             type="reset"

--- a/src/js/components/DataSearch/__tests__/__snapshots__/DataSearch-test.tsx.snap
+++ b/src/js/components/DataSearch/__tests__/__snapshots__/DataSearch-test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DataSearch renders 1`] = `
-.c8 {
+.c10 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -12,25 +12,25 @@ exports[`DataSearch renders 1`] = `
   stroke: #666666;
 }
 
-.c8 g {
+.c10 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c8 *:not([stroke])[fill="none"] {
+.c10 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c8 *[stroke*="#"],
-.c8 *[STROKE*="#"] {
+.c10 *[stroke*="#"],
+.c10 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c8 *[fill-rule],
-.c8 *[FILL-RULE],
-.c8 *[fill*="#"],
-.c8 *[FILL*="#"] {
+.c10 *[fill-rule],
+.c10 *[FILL-RULE],
+.c10 *[fill*="#"],
+.c10 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -59,6 +59,39 @@ exports[`DataSearch renders 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 100%;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  overflow: auto;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -77,17 +110,17 @@ exports[`DataSearch renders 1`] = `
   justify-content: space-between;
 }
 
-.c5 {
+.c7 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
   align-self: stretch;
-  height: 12px;
+  height: 6px;
 }
 
-.c11 {
+.c13 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -97,7 +130,7 @@ exports[`DataSearch renders 1`] = `
   width: 24px;
 }
 
-.c10 {
+.c12 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -125,75 +158,8 @@ exports[`DataSearch renders 1`] = `
   transition-timing-function: ease-in-out;
 }
 
-.c10:hover {
+.c12:hover {
   box-shadow: 0px 0px 0px 2px #7D4CDB;
-}
-
-.c10:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c10:focus > circle,
-.c10:focus > ellipse,
-.c10:focus > line,
-.c10:focus > path,
-.c10:focus > polygon,
-.c10:focus > polyline,
-.c10:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c10:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c10:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c10:focus:not(:focus-visible) > circle,
-.c10:focus:not(:focus-visible) > ellipse,
-.c10:focus:not(:focus-visible) > line,
-.c10:focus:not(:focus-visible) > path,
-.c10:focus:not(:focus-visible) > polygon,
-.c10:focus:not(:focus-visible) > polyline,
-.c10:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c10:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c12 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: 2px solid #7D4CDB;
-  border-radius: 18px;
-  color: #444444;
-  padding: 4px 22px;
-  font-size: 18px;
-  line-height: 24px;
-  opacity: 0.3;
-  cursor: default;
-  -webkit-transition-property: color,background-color,border-color,box-shadow;
-  transition-property: color,background-color,border-color,box-shadow;
-  -webkit-transition-duration: 0.1s;
-  transition-duration: 0.1s;
-  -webkit-transition-timing-function: ease-in-out;
-  transition-timing-function: ease-in-out;
 }
 
 .c12:focus {
@@ -236,7 +202,74 @@ exports[`DataSearch renders 1`] = `
   border: 0;
 }
 
-.c9 {
+.c14 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: 2px solid #7D4CDB;
+  border-radius: 18px;
+  color: #444444;
+  padding: 4px 22px;
+  font-size: 18px;
+  line-height: 24px;
+  opacity: 0.3;
+  cursor: default;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+}
+
+.c14:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c14:focus > circle,
+.c14:focus > ellipse,
+.c14:focus > line,
+.c14:focus > path,
+.c14:focus > polygon,
+.c14:focus > polyline,
+.c14:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c14:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c14:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c14:focus:not(:focus-visible) > circle,
+.c14:focus:not(:focus-visible) > ellipse,
+.c14:focus:not(:focus-visible) > line,
+.c14:focus:not(:focus-visible) > path,
+.c14:focus:not(:focus-visible) > polygon,
+.c14:focus:not(:focus-visible) > polyline,
+.c14:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c14:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c11 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -253,58 +286,58 @@ exports[`DataSearch renders 1`] = `
   padding-left: 48px;
 }
 
-.c9:focus {
+.c11:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c9:focus > circle,
-.c9:focus > ellipse,
-.c9:focus > line,
-.c9:focus > path,
-.c9:focus > polygon,
-.c9:focus > polyline,
-.c9:focus > rect {
+.c11:focus > circle,
+.c11:focus > ellipse,
+.c11:focus > line,
+.c11:focus > path,
+.c11:focus > polygon,
+.c11:focus > polyline,
+.c11:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c9:focus::-moz-focus-inner {
+.c11:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c9::-webkit-input-placeholder {
+.c11::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c9::-moz-placeholder {
+.c11::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c9:-ms-input-placeholder {
+.c11:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c9::-webkit-search-decoration {
+.c11::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c9::-moz-focus-inner {
+.c11::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c9:-moz-placeholder,
-.c9::-moz-placeholder {
+.c11:-moz-placeholder,
+.c11::-moz-placeholder {
   opacity: 1;
 }
 
-.c6 {
+.c8 {
   position: relative;
   width: 100%;
 }
 
-.c7 {
+.c9 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -322,7 +355,7 @@ exports[`DataSearch renders 1`] = `
   left: 12px;
 }
 
-.c13 {
+.c15 {
   opacity: 0;
 }
 
@@ -330,7 +363,7 @@ exports[`DataSearch renders 1`] = `
   max-width: 100%;
 }
 
-.c4 {
+.c6 {
   margin: 0px;
   font-size: 26px;
   line-height: 32px;
@@ -350,25 +383,25 @@ exports[`DataSearch renders 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
-    height: 6px;
+  .c7 {
+    height: 3px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c11 {
+  .c13 {
     width: 12px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c6 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c6 {
     font-size: 22px;
     line-height: 28px;
     max-width: 528px;
@@ -386,67 +419,68 @@ exports[`DataSearch renders 1`] = `
       class="c2"
     >
       <div
-        class="c1"
+        class="c3"
       >
-        <header
-          class="c3"
+        <div
+          class="c4"
         >
-          <h2
-            class="c4"
+          <header
+            class="c5"
           >
-            Filters
-          </h2>
-        </header>
-        <div
-          class="c5"
-        />
-        <div
-          class="c6"
-        >
+            <h2
+              class="c6"
+            >
+              Filters
+            </h2>
+          </header>
           <div
             class="c7"
-          >
-            <svg
-              aria-label="Search"
-              class="c8"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </div>
-          <input
-            aria-label="Search data"
-            autocomplete="off"
-            class="c9"
-            id="data--search"
-            name="_search"
-            type="search"
-            value=""
           />
+          <div
+            class="c8"
+          >
+            <div
+              class="c9"
+            >
+              <svg
+                aria-label="Search"
+                class="c10"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
+            <input
+              aria-label="Search data"
+              autocomplete="off"
+              class="c11"
+              id="data--search"
+              name="_search"
+              type="search"
+              value=""
+            />
+          </div>
         </div>
-        <div
-          class="c5"
-        />
         <footer
-          class="c3"
+          class="c5"
         >
           <button
-            class="c10"
+            class="c12"
             type="submit"
           >
             Apply filters
           </button>
           <div
-            class="c11"
+            class="c13"
           />
           <button
             aria-hidden="true"
-            class="c12 c13"
+            class="c14 c15"
             disabled=""
             tabindex="-1"
             type="reset"

--- a/src/js/components/DataSort/DataSort.js
+++ b/src/js/components/DataSort/DataSort.js
@@ -31,14 +31,14 @@ const Content = ({ options: optionsArg }) => {
     {
       label: format({
         id: 'dataSort.ascending',
-        messages: messages?.DataSort,
+        messages: messages?.dataSort,
       }),
       value: 'asc',
     },
     {
       label: format({
         id: 'dataSort.descending',
-        messages: messages?.DataSort,
+        messages: messages?.dataSort,
       }),
       value: 'desc',
     },
@@ -53,7 +53,7 @@ const Content = ({ options: optionsArg }) => {
       htmlFor={sortPropertyId}
       label={format({
         id: 'dataSort.by',
-        messages: messages?.DataSort,
+        messages: messages?.dataSort,
       })}
     >
       <Select id={sortPropertyId} name="_sort.property" options={options} />
@@ -63,7 +63,7 @@ const Content = ({ options: optionsArg }) => {
       htmlFor={sortDirectionId}
       label={format({
         id: 'dataSort.direction',
-        messages: messages?.DataSort,
+        messages: messages?.dataSort,
       })}
     >
       <RadioButtonGroup

--- a/src/js/components/DataSort/__tests__/__snapshots__/DataSort-test.tsx.snap
+++ b/src/js/components/DataSort/__tests__/__snapshots__/DataSort-test.tsx.snap
@@ -214,8 +214,8 @@ exports[`DataSort drop 3`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .grsgKE {
-    height: 3px;
+  .gcEjSx {
+    margin-top: 6px;
   }
 }
 @media only screen and (max-width: 768px) {
@@ -224,8 +224,8 @@ exports[`DataSort drop 3`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .iISQcM {
-    width: 12px;
+  .ilMzAg {
+    width: 6px;
   }
 }
 @media only screen and (max-width: 768px) {
@@ -243,7 +243,7 @@ exports[`DataSort drop 3`] = `
 `;
 
 exports[`DataSort renders 1`] = `
-.c18 {
+.c17 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -254,25 +254,25 @@ exports[`DataSort renders 1`] = `
   stroke: #7D4CDB;
 }
 
-.c18 g {
+.c17 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c18 *:not([stroke])[fill="none"] {
+.c17 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c18 *[stroke*="#"],
-.c18 *[STROKE*="#"] {
+.c17 *[stroke*="#"],
+.c17 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c18 *[fill-rule],
-.c18 *[FILL-RULE],
-.c18 *[fill*="#"],
-.c18 *[FILL*="#"] {
+.c17 *[fill-rule],
+.c17 *[FILL-RULE],
+.c17 *[fill*="#"],
+.c17 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -352,7 +352,7 @@ exports[`DataSort renders 1`] = `
   justify-content: space-between;
 }
 
-.c8 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -370,7 +370,7 @@ exports[`DataSort renders 1`] = `
   flex: 0 0 auto;
 }
 
-.c10 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -385,7 +385,7 @@ exports[`DataSort renders 1`] = `
   flex-direction: column;
 }
 
-.c12 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -407,7 +407,7 @@ exports[`DataSort renders 1`] = `
   justify-content: space-between;
 }
 
-.c13 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -426,7 +426,7 @@ exports[`DataSort renders 1`] = `
   flex-basis: auto;
 }
 
-.c17 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -445,7 +445,7 @@ exports[`DataSort renders 1`] = `
   flex: 0 0 auto;
 }
 
-.c19 {
+.c18 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -461,7 +461,7 @@ exports[`DataSort renders 1`] = `
   padding: 12px;
 }
 
-.c20 {
+.c19 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -475,7 +475,7 @@ exports[`DataSort renders 1`] = `
   flex-direction: column;
 }
 
-.c22 {
+.c21 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -493,7 +493,7 @@ exports[`DataSort renders 1`] = `
   flex: 0 0 auto;
 }
 
-.c24 {
+.c23 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -519,17 +519,33 @@ exports[`DataSort renders 1`] = `
   border-radius: 100%;
 }
 
-.c7 {
+.c25 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-top: 12px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  -webkit-align-self: stretch;
-  -ms-flex-item-align: stretch;
-  align-self: stretch;
-  height: 6px;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
 }
 
-.c25 {
+.c24 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -546,10 +562,10 @@ exports[`DataSort renders 1`] = `
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
   align-self: stretch;
-  width: 24px;
+  width: 12px;
 }
 
-.c9 {
+.c8 {
   margin-left: 12px;
   margin-right: 12px;
   margin-top: 6px;
@@ -558,7 +574,7 @@ exports[`DataSort renders 1`] = `
   line-height: 24px;
 }
 
-.c11 {
+.c10 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -576,23 +592,23 @@ exports[`DataSort renders 1`] = `
   text-align: inherit;
 }
 
-.c11:focus:not(:focus-visible) {
+.c10:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c11:focus:not(:focus-visible) > circle,
-.c11:focus:not(:focus-visible) > ellipse,
-.c11:focus:not(:focus-visible) > line,
-.c11:focus:not(:focus-visible) > path,
-.c11:focus:not(:focus-visible) > polygon,
-.c11:focus:not(:focus-visible) > polyline,
-.c11:focus:not(:focus-visible) > rect {
+.c10:focus:not(:focus-visible) > circle,
+.c10:focus:not(:focus-visible) > ellipse,
+.c10:focus:not(:focus-visible) > line,
+.c10:focus:not(:focus-visible) > path,
+.c10:focus:not(:focus-visible) > polygon,
+.c10:focus:not(:focus-visible) > polyline,
+.c10:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c11:focus:not(:focus-visible)::-moz-focus-inner {
+.c10:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
@@ -735,7 +751,7 @@ exports[`DataSort renders 1`] = `
   border: 0;
 }
 
-.c21 {
+.c20 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -757,12 +773,12 @@ exports[`DataSort renders 1`] = `
   cursor: pointer;
 }
 
-.c21:hover input:not([disabled]) + div,
-.c21:hover input:not([disabled]) + span {
+.c20:hover input:not([disabled]) + div,
+.c20:hover input:not([disabled]) + span {
   border-color: #000000;
 }
 
-.c23 {
+.c22 {
   opacity: 0;
   -moz-appearance: none;
   width: 0;
@@ -771,7 +787,7 @@ exports[`DataSort renders 1`] = `
   cursor: pointer;
 }
 
-.c15 {
+.c14 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -789,38 +805,38 @@ exports[`DataSort renders 1`] = `
   border: none;
 }
 
-.c15::-webkit-input-placeholder {
+.c14::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c15::-moz-placeholder {
+.c14::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c15:-ms-input-placeholder {
+.c14:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c15::-webkit-search-decoration {
+.c14::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c15::-moz-focus-inner {
+.c14::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c15:-moz-placeholder,
-.c15::-moz-placeholder {
+.c14:-moz-placeholder,
+.c14::-moz-placeholder {
   opacity: 1;
 }
 
-.c14 {
+.c13 {
   position: relative;
   width: 100%;
 }
 
-.c16 {
+.c15 {
   cursor: pointer;
 }
 
@@ -852,63 +868,63 @@ exports[`DataSort renders 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c7 {
     margin-bottom: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c10 {
+  .c9 {
     border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c17 {
+  .c16 {
     margin-left: 6px;
     margin-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c19 {
+  .c18 {
     border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c19 {
+  .c18 {
     padding: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c22 {
+  .c21 {
     margin-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c24 {
+  .c23 {
     border: solid 2px rgba(0,0,0,0.15);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c7 {
-    height: 3px;
+  .c25 {
+    margin-top: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c25 {
+  .c24 {
     height: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c27 {
-    width: 12px;
+    width: 6px;
   }
 }
 
@@ -952,40 +968,37 @@ exports[`DataSort renders 1`] = `
             </h2>
           </header>
           <div
-            class="c7"
-          />
-          <div
-            class="c8 "
+            class="c7 "
           >
             <label
-              class="c9"
+              class="c8"
               for="data--sort-property"
             >
               Sort by
             </label>
             <div
-              class="c10 FormField__FormFieldContentBox-sc-m9hood-1"
+              class="c9 FormField__FormFieldContentBox-sc-m9hood-1"
             >
               <button
                 aria-expanded="false"
                 aria-haspopup="listbox"
                 aria-label="Open Drop"
-                class="c11 "
+                class="c10 "
                 id="data--sort-property"
                 type="button"
               >
                 <div
-                  class="c12"
+                  class="c11"
                 >
                   <div
-                    class="c13"
+                    class="c12"
                   >
                     <div
-                      class="c14"
+                      class="c13"
                     >
                       <input
                         autocomplete="off"
-                        class="c15 c16"
+                        class="c14 c15"
                         id="data--sort-property__input"
                         name="_sort.property"
                         readonly=""
@@ -996,12 +1009,12 @@ exports[`DataSort renders 1`] = `
                     </div>
                   </div>
                   <div
-                    class="c17"
+                    class="c16"
                     style="min-width: auto;"
                   >
                     <svg
                       aria-label="FormDown"
-                      class="c18"
+                      class="c17"
                       viewBox="0 0 24 24"
                     >
                       <path
@@ -1017,37 +1030,37 @@ exports[`DataSort renders 1`] = `
             </div>
           </div>
           <div
-            class="c8 "
+            class="c7 "
           >
             <label
-              class="c9"
+              class="c8"
               for="data--sort-direction"
             >
               Sort direction
             </label>
             <div
-              class="c19 FormField__FormFieldContentBox-sc-m9hood-1"
+              class="c18 FormField__FormFieldContentBox-sc-m9hood-1"
             >
               <div
-                class="c20"
+                class="c19"
                 id="data--sort-direction"
                 role="radiogroup"
               >
                 <label
-                  class="c21"
+                  class="c20"
                 >
                   <div
-                    class="c22 "
+                    class="c21 "
                   >
                     <input
-                      class="c23"
+                      class="c22"
                       name="_sort.direction"
                       tabindex="0"
                       type="radio"
                       value="asc"
                     />
                     <div
-                      class="c24 "
+                      class="c23 "
                     />
                   </div>
                   <span
@@ -1057,23 +1070,23 @@ exports[`DataSort renders 1`] = `
                   </span>
                 </label>
                 <div
-                  class="c25"
+                  class="c24"
                 />
                 <label
-                  class="c21"
+                  class="c20"
                 >
                   <div
-                    class="c22 "
+                    class="c21 "
                   >
                     <input
-                      class="c23"
+                      class="c22"
                       name="_sort.direction"
                       tabindex="-1"
                       type="radio"
                       value="desc"
                     />
                     <div
-                      class="c24 "
+                      class="c23 "
                     />
                   </div>
                   <span
@@ -1087,7 +1100,7 @@ exports[`DataSort renders 1`] = `
           </div>
         </div>
         <footer
-          class="c5"
+          class="c25"
         >
           <button
             class="c26"

--- a/src/js/components/DataSort/__tests__/__snapshots__/DataSort-test.tsx.snap
+++ b/src/js/components/DataSort/__tests__/__snapshots__/DataSort-test.tsx.snap
@@ -178,7 +178,7 @@ exports[`DataSort drop 2`] = `
 
 exports[`DataSort drop 3`] = `
 "@media only screen and (max-width: 768px) {
-  .hftPdQ {
+  .hfctvB {
     margin-bottom: 6px;
   }
 }
@@ -214,6 +214,11 @@ exports[`DataSort drop 3`] = `
   }
 }
 @media only screen and (max-width: 768px) {
+  .grsgKE {
+    height: 3px;
+  }
+}
+@media only screen and (max-width: 768px) {
   .drdMXk {
     height: 6px;
   }
@@ -238,7 +243,7 @@ exports[`DataSort drop 3`] = `
 `;
 
 exports[`DataSort renders 1`] = `
-.c16 {
+.c18 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -249,25 +254,25 @@ exports[`DataSort renders 1`] = `
   stroke: #7D4CDB;
 }
 
-.c16 g {
+.c18 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c16 *:not([stroke])[fill="none"] {
+.c18 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c16 *[stroke*="#"],
-.c16 *[STROKE*="#"] {
+.c18 *[stroke*="#"],
+.c18 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c16 *[fill-rule],
-.c16 *[FILL-RULE],
-.c16 *[fill*="#"],
-.c16 *[FILL*="#"] {
+.c18 *[fill-rule],
+.c18 *[FILL-RULE],
+.c18 *[fill*="#"],
+.c18 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -296,6 +301,39 @@ exports[`DataSort renders 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 100%;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  overflow: auto;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -314,7 +352,7 @@ exports[`DataSort renders 1`] = `
   justify-content: space-between;
 }
 
-.c6 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -327,9 +365,12 @@ exports[`DataSort renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
-.c8 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -344,7 +385,7 @@ exports[`DataSort renders 1`] = `
   flex-direction: column;
 }
 
-.c10 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -366,7 +407,7 @@ exports[`DataSort renders 1`] = `
   justify-content: space-between;
 }
 
-.c11 {
+.c13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -385,7 +426,7 @@ exports[`DataSort renders 1`] = `
   flex-basis: auto;
 }
 
-.c15 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -404,7 +445,7 @@ exports[`DataSort renders 1`] = `
   flex: 0 0 auto;
 }
 
-.c17 {
+.c19 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -420,7 +461,7 @@ exports[`DataSort renders 1`] = `
   padding: 12px;
 }
 
-.c18 {
+.c20 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -434,7 +475,7 @@ exports[`DataSort renders 1`] = `
   flex-direction: column;
 }
 
-.c20 {
+.c22 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -452,7 +493,7 @@ exports[`DataSort renders 1`] = `
   flex: 0 0 auto;
 }
 
-.c22 {
+.c24 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -478,7 +519,17 @@ exports[`DataSort renders 1`] = `
   border-radius: 100%;
 }
 
-.c5 {
+.c7 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  height: 6px;
+}
+
+.c25 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -488,7 +539,7 @@ exports[`DataSort renders 1`] = `
   height: 12px;
 }
 
-.c24 {
+.c27 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -498,7 +549,7 @@ exports[`DataSort renders 1`] = `
   width: 24px;
 }
 
-.c7 {
+.c9 {
   margin-left: 12px;
   margin-right: 12px;
   margin-top: 6px;
@@ -507,7 +558,7 @@ exports[`DataSort renders 1`] = `
   line-height: 24px;
 }
 
-.c9 {
+.c11 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -525,27 +576,27 @@ exports[`DataSort renders 1`] = `
   text-align: inherit;
 }
 
-.c9:focus:not(:focus-visible) {
+.c11:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c9:focus:not(:focus-visible) > circle,
-.c9:focus:not(:focus-visible) > ellipse,
-.c9:focus:not(:focus-visible) > line,
-.c9:focus:not(:focus-visible) > path,
-.c9:focus:not(:focus-visible) > polygon,
-.c9:focus:not(:focus-visible) > polyline,
-.c9:focus:not(:focus-visible) > rect {
+.c11:focus:not(:focus-visible) > circle,
+.c11:focus:not(:focus-visible) > ellipse,
+.c11:focus:not(:focus-visible) > line,
+.c11:focus:not(:focus-visible) > path,
+.c11:focus:not(:focus-visible) > polygon,
+.c11:focus:not(:focus-visible) > polyline,
+.c11:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c9:focus:not(:focus-visible)::-moz-focus-inner {
+.c11:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c23 {
+.c26 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -573,51 +624,51 @@ exports[`DataSort renders 1`] = `
   transition-timing-function: ease-in-out;
 }
 
-.c23:hover {
+.c26:hover {
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c23:focus {
+.c26:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c23:focus > circle,
-.c23:focus > ellipse,
-.c23:focus > line,
-.c23:focus > path,
-.c23:focus > polygon,
-.c23:focus > polyline,
-.c23:focus > rect {
+.c26:focus > circle,
+.c26:focus > ellipse,
+.c26:focus > line,
+.c26:focus > path,
+.c26:focus > polygon,
+.c26:focus > polyline,
+.c26:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c23:focus::-moz-focus-inner {
+.c26:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c23:focus:not(:focus-visible) {
+.c26:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c23:focus:not(:focus-visible) > circle,
-.c23:focus:not(:focus-visible) > ellipse,
-.c23:focus:not(:focus-visible) > line,
-.c23:focus:not(:focus-visible) > path,
-.c23:focus:not(:focus-visible) > polygon,
-.c23:focus:not(:focus-visible) > polyline,
-.c23:focus:not(:focus-visible) > rect {
+.c26:focus:not(:focus-visible) > circle,
+.c26:focus:not(:focus-visible) > ellipse,
+.c26:focus:not(:focus-visible) > line,
+.c26:focus:not(:focus-visible) > path,
+.c26:focus:not(:focus-visible) > polygon,
+.c26:focus:not(:focus-visible) > polyline,
+.c26:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c23:focus:not(:focus-visible)::-moz-focus-inner {
+.c26:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c25 {
+.c28 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -644,47 +695,47 @@ exports[`DataSort renders 1`] = `
   transition-timing-function: ease-in-out;
 }
 
-.c25:focus {
+.c28:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c25:focus > circle,
-.c25:focus > ellipse,
-.c25:focus > line,
-.c25:focus > path,
-.c25:focus > polygon,
-.c25:focus > polyline,
-.c25:focus > rect {
+.c28:focus > circle,
+.c28:focus > ellipse,
+.c28:focus > line,
+.c28:focus > path,
+.c28:focus > polygon,
+.c28:focus > polyline,
+.c28:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c25:focus::-moz-focus-inner {
+.c28:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c25:focus:not(:focus-visible) {
+.c28:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c25:focus:not(:focus-visible) > circle,
-.c25:focus:not(:focus-visible) > ellipse,
-.c25:focus:not(:focus-visible) > line,
-.c25:focus:not(:focus-visible) > path,
-.c25:focus:not(:focus-visible) > polygon,
-.c25:focus:not(:focus-visible) > polyline,
-.c25:focus:not(:focus-visible) > rect {
+.c28:focus:not(:focus-visible) > circle,
+.c28:focus:not(:focus-visible) > ellipse,
+.c28:focus:not(:focus-visible) > line,
+.c28:focus:not(:focus-visible) > path,
+.c28:focus:not(:focus-visible) > polygon,
+.c28:focus:not(:focus-visible) > polyline,
+.c28:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c25:focus:not(:focus-visible)::-moz-focus-inner {
+.c28:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c19 {
+.c21 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -706,12 +757,12 @@ exports[`DataSort renders 1`] = `
   cursor: pointer;
 }
 
-.c19:hover input:not([disabled]) + div,
-.c19:hover input:not([disabled]) + span {
+.c21:hover input:not([disabled]) + div,
+.c21:hover input:not([disabled]) + span {
   border-color: #000000;
 }
 
-.c21 {
+.c23 {
   opacity: 0;
   -moz-appearance: none;
   width: 0;
@@ -720,7 +771,7 @@ exports[`DataSort renders 1`] = `
   cursor: pointer;
 }
 
-.c13 {
+.c15 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -738,42 +789,42 @@ exports[`DataSort renders 1`] = `
   border: none;
 }
 
-.c13::-webkit-input-placeholder {
+.c15::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c13::-moz-placeholder {
+.c15::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c13:-ms-input-placeholder {
+.c15:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c13::-webkit-search-decoration {
+.c15::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c13::-moz-focus-inner {
+.c15::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c13:-moz-placeholder,
-.c13::-moz-placeholder {
+.c15:-moz-placeholder,
+.c15::-moz-placeholder {
   opacity: 1;
 }
 
-.c12 {
+.c14 {
   position: relative;
   width: 100%;
 }
 
-.c14 {
+.c16 {
   cursor: pointer;
 }
 
-.c26 {
+.c29 {
   opacity: 0;
 }
 
@@ -781,7 +832,7 @@ exports[`DataSort renders 1`] = `
   max-width: 100%;
 }
 
-.c4 {
+.c6 {
   margin: 0px;
   font-size: 26px;
   line-height: 32px;
@@ -801,68 +852,74 @@ exports[`DataSort renders 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c6 {
+  .c8 {
     margin-bottom: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c10 {
     border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c15 {
+  .c17 {
     margin-left: 6px;
     margin-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c17 {
+  .c19 {
     border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c17 {
+  .c19 {
     padding: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c20 {
+  .c22 {
     margin-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c22 {
+  .c24 {
     border: solid 2px rgba(0,0,0,0.15);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
+  .c7 {
+    height: 3px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c25 {
     height: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c24 {
+  .c27 {
     width: 12px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c6 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c6 {
     font-size: 22px;
     line-height: 28px;
     max-width: 528px;
@@ -880,169 +937,170 @@ exports[`DataSort renders 1`] = `
       class="c2"
     >
       <div
-        class="c1"
+        class="c3"
       >
-        <header
-          class="c3"
-        >
-          <h2
-            class="c4"
-          >
-            Filters
-          </h2>
-        </header>
         <div
-          class="c5"
-        />
-        <div
-          class="c6 "
+          class="c4"
         >
-          <label
-            class="c7"
-            for="data--sort-property"
+          <header
+            class="c5"
           >
-            Sort by
-          </label>
-          <div
-            class="c8 FormField__FormFieldContentBox-sc-m9hood-1"
-          >
-            <button
-              aria-expanded="false"
-              aria-haspopup="listbox"
-              aria-label="Open Drop"
-              class="c9 "
-              id="data--sort-property"
-              type="button"
+            <h2
+              class="c6"
             >
-              <div
-                class="c10"
+              Filters
+            </h2>
+          </header>
+          <div
+            class="c7"
+          />
+          <div
+            class="c8 "
+          >
+            <label
+              class="c9"
+              for="data--sort-property"
+            >
+              Sort by
+            </label>
+            <div
+              class="c10 FormField__FormFieldContentBox-sc-m9hood-1"
+            >
+              <button
+                aria-expanded="false"
+                aria-haspopup="listbox"
+                aria-label="Open Drop"
+                class="c11 "
+                id="data--sort-property"
+                type="button"
               >
                 <div
-                  class="c11"
+                  class="c12"
                 >
                   <div
-                    class="c12"
+                    class="c13"
                   >
-                    <input
-                      autocomplete="off"
-                      class="c13 c14"
-                      id="data--sort-property__input"
-                      name="_sort.property"
-                      readonly=""
-                      tabindex="-1"
-                      type="text"
-                      value=""
-                    />
+                    <div
+                      class="c14"
+                    >
+                      <input
+                        autocomplete="off"
+                        class="c15 c16"
+                        id="data--sort-property__input"
+                        name="_sort.property"
+                        readonly=""
+                        tabindex="-1"
+                        type="text"
+                        value=""
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="c17"
+                    style="min-width: auto;"
+                  >
+                    <svg
+                      aria-label="FormDown"
+                      class="c18"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="m18 9-6 6-6-6"
+                        fill="none"
+                        stroke="#000"
+                        stroke-width="2"
+                      />
+                    </svg>
                   </div>
                 </div>
-                <div
-                  class="c15"
-                  style="min-width: auto;"
-                >
-                  <svg
-                    aria-label="FormDown"
-                    class="c16"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="m18 9-6 6-6-6"
-                      fill="none"
-                      stroke="#000"
-                      stroke-width="2"
-                    />
-                  </svg>
-                </div>
-              </div>
-            </button>
+              </button>
+            </div>
           </div>
-        </div>
-        <div
-          class="c6 "
-        >
-          <label
-            class="c7"
-            for="data--sort-direction"
-          >
-            Sort direction
-          </label>
           <div
-            class="c17 FormField__FormFieldContentBox-sc-m9hood-1"
+            class="c8 "
           >
-            <div
-              class="c18"
-              id="data--sort-direction"
-              role="radiogroup"
+            <label
+              class="c9"
+              for="data--sort-direction"
             >
-              <label
-                class="c19"
-              >
-                <div
-                  class="c20 "
-                >
-                  <input
-                    class="c21"
-                    name="_sort.direction"
-                    tabindex="0"
-                    type="radio"
-                    value="asc"
-                  />
-                  <div
-                    class="c22 "
-                  />
-                </div>
-                <span
-                  class="StyledRadioButton__StyledRadioButtonLabel-sc-g1f6ld-2"
-                >
-                  Ascending
-                </span>
-              </label>
+              Sort direction
+            </label>
+            <div
+              class="c19 FormField__FormFieldContentBox-sc-m9hood-1"
+            >
               <div
-                class="c5"
-              />
-              <label
-                class="c19"
+                class="c20"
+                id="data--sort-direction"
+                role="radiogroup"
               >
-                <div
-                  class="c20 "
+                <label
+                  class="c21"
                 >
-                  <input
-                    class="c21"
-                    name="_sort.direction"
-                    tabindex="-1"
-                    type="radio"
-                    value="desc"
-                  />
                   <div
                     class="c22 "
-                  />
-                </div>
-                <span
-                  class="StyledRadioButton__StyledRadioButtonLabel-sc-g1f6ld-2"
+                  >
+                    <input
+                      class="c23"
+                      name="_sort.direction"
+                      tabindex="0"
+                      type="radio"
+                      value="asc"
+                    />
+                    <div
+                      class="c24 "
+                    />
+                  </div>
+                  <span
+                    class="StyledRadioButton__StyledRadioButtonLabel-sc-g1f6ld-2"
+                  >
+                    Ascending
+                  </span>
+                </label>
+                <div
+                  class="c25"
+                />
+                <label
+                  class="c21"
                 >
-                  Descending
-                </span>
-              </label>
+                  <div
+                    class="c22 "
+                  >
+                    <input
+                      class="c23"
+                      name="_sort.direction"
+                      tabindex="-1"
+                      type="radio"
+                      value="desc"
+                    />
+                    <div
+                      class="c24 "
+                    />
+                  </div>
+                  <span
+                    class="StyledRadioButton__StyledRadioButtonLabel-sc-g1f6ld-2"
+                  >
+                    Descending
+                  </span>
+                </label>
+              </div>
             </div>
           </div>
         </div>
-        <div
-          class="c5"
-        />
         <footer
-          class="c3"
+          class="c5"
         >
           <button
-            class="c23"
+            class="c26"
             type="submit"
           >
             Apply filters
           </button>
           <div
-            class="c24"
+            class="c27"
           />
           <button
             aria-hidden="true"
-            class="c25 c26"
+            class="c28 c29"
             disabled=""
             tabindex="-1"
             type="reset"

--- a/src/js/components/DataSummary/__tests__/__snapshots__/DataSummary-test.tsx.snap
+++ b/src/js/components/DataSummary/__tests__/__snapshots__/DataSummary-test.tsx.snap
@@ -76,14 +76,30 @@ exports[`DataSummary renders 1`] = `
   justify-content: space-between;
 }
 
-.c7 {
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-top: 12px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
-  -webkit-align-self: stretch;
-  -ms-flex-item-align: stretch;
-  align-self: stretch;
-  height: 6px;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
 }
 
 .c10 {
@@ -93,10 +109,10 @@ exports[`DataSummary renders 1`] = `
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
   align-self: stretch;
-  width: 24px;
+  width: 12px;
 }
 
-.c8 {
+.c7 {
   margin-top: 6px;
   margin-bottom: 6px;
   font-size: 18px;
@@ -270,14 +286,14 @@ exports[`DataSummary renders 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c7 {
-    height: 3px;
+  .c8 {
+    margin-top: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c10 {
-    width: 12px;
+    width: 6px;
   }
 }
 
@@ -320,17 +336,14 @@ exports[`DataSummary renders 1`] = `
               Filters
             </h2>
           </header>
-          <div
-            class="c7"
-          />
           <span
-            class="c8"
+            class="c7"
           >
             2 items
           </span>
         </div>
         <footer
-          class="c5"
+          class="c8"
         >
           <button
             class="c9"

--- a/src/js/components/DataSummary/__tests__/__snapshots__/DataSummary-test.tsx.snap
+++ b/src/js/components/DataSummary/__tests__/__snapshots__/DataSummary-test.tsx.snap
@@ -25,6 +25,39 @@ exports[`DataSummary renders 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 100%;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  overflow: auto;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -43,17 +76,17 @@ exports[`DataSummary renders 1`] = `
   justify-content: space-between;
 }
 
-.c5 {
+.c7 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
   align-self: stretch;
-  height: 12px;
+  height: 6px;
 }
 
-.c8 {
+.c10 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -63,14 +96,14 @@ exports[`DataSummary renders 1`] = `
   width: 24px;
 }
 
-.c6 {
+.c8 {
   margin-top: 6px;
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
 }
 
-.c7 {
+.c9 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -98,75 +131,8 @@ exports[`DataSummary renders 1`] = `
   transition-timing-function: ease-in-out;
 }
 
-.c7:hover {
+.c9:hover {
   box-shadow: 0px 0px 0px 2px #7D4CDB;
-}
-
-.c7:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c7:focus > circle,
-.c7:focus > ellipse,
-.c7:focus > line,
-.c7:focus > path,
-.c7:focus > polygon,
-.c7:focus > polyline,
-.c7:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c7:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c7:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c7:focus:not(:focus-visible) > circle,
-.c7:focus:not(:focus-visible) > ellipse,
-.c7:focus:not(:focus-visible) > line,
-.c7:focus:not(:focus-visible) > path,
-.c7:focus:not(:focus-visible) > polygon,
-.c7:focus:not(:focus-visible) > polyline,
-.c7:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c7:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c9 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: 2px solid #7D4CDB;
-  border-radius: 18px;
-  color: #444444;
-  padding: 4px 22px;
-  font-size: 18px;
-  line-height: 24px;
-  opacity: 0.3;
-  cursor: default;
-  -webkit-transition-property: color,background-color,border-color,box-shadow;
-  transition-property: color,background-color,border-color,box-shadow;
-  -webkit-transition-duration: 0.1s;
-  transition-duration: 0.1s;
-  -webkit-transition-timing-function: ease-in-out;
-  transition-timing-function: ease-in-out;
 }
 
 .c9:focus {
@@ -209,7 +175,74 @@ exports[`DataSummary renders 1`] = `
   border: 0;
 }
 
-.c10 {
+.c11 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: 2px solid #7D4CDB;
+  border-radius: 18px;
+  color: #444444;
+  padding: 4px 22px;
+  font-size: 18px;
+  line-height: 24px;
+  opacity: 0.3;
+  cursor: default;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+}
+
+.c11:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus > circle,
+.c11:focus > ellipse,
+.c11:focus > line,
+.c11:focus > path,
+.c11:focus > polygon,
+.c11:focus > polyline,
+.c11:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c11:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c11:focus:not(:focus-visible) > circle,
+.c11:focus:not(:focus-visible) > ellipse,
+.c11:focus:not(:focus-visible) > line,
+.c11:focus:not(:focus-visible) > path,
+.c11:focus:not(:focus-visible) > polygon,
+.c11:focus:not(:focus-visible) > polyline,
+.c11:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c11:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c12 {
   opacity: 0;
 }
 
@@ -217,7 +250,7 @@ exports[`DataSummary renders 1`] = `
   max-width: 100%;
 }
 
-.c4 {
+.c6 {
   margin: 0px;
   font-size: 26px;
   line-height: 32px;
@@ -237,25 +270,25 @@ exports[`DataSummary renders 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
-    height: 6px;
+  .c7 {
+    height: 3px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c8 {
+  .c10 {
     width: 12px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c6 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c6 {
     font-size: 22px;
     line-height: 28px;
     max-width: 528px;
@@ -273,43 +306,44 @@ exports[`DataSummary renders 1`] = `
       class="c2"
     >
       <div
-        class="c1"
+        class="c3"
       >
-        <header
-          class="c3"
+        <div
+          class="c4"
         >
-          <h2
-            class="c4"
+          <header
+            class="c5"
           >
-            Filters
-          </h2>
-        </header>
-        <div
-          class="c5"
-        />
-        <span
-          class="c6"
-        >
-          2 items
-        </span>
-        <div
-          class="c5"
-        />
+            <h2
+              class="c6"
+            >
+              Filters
+            </h2>
+          </header>
+          <div
+            class="c7"
+          />
+          <span
+            class="c8"
+          >
+            2 items
+          </span>
+        </div>
         <footer
-          class="c3"
+          class="c5"
         >
           <button
-            class="c7"
+            class="c9"
             type="submit"
           >
             Apply filters
           </button>
           <div
-            class="c8"
+            class="c10"
           />
           <button
             aria-hidden="true"
-            class="c9 c10"
+            class="c11 c12"
             disabled=""
             tabindex="-1"
             type="reset"

--- a/src/js/components/DataTableColumns/__tests__/__snapshots__/DataTableColumns-test.tsx.snap
+++ b/src/js/components/DataTableColumns/__tests__/__snapshots__/DataTableColumns-test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DataTableColumns remove column 1`] = `
-.c9 {
+.c8 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -12,25 +12,25 @@ exports[`DataTableColumns remove column 1`] = `
   stroke: #666666;
 }
 
-.c9 g {
+.c8 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c9 *:not([stroke])[fill="none"] {
+.c8 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c9 *[stroke*="#"],
-.c9 *[STROKE*="#"] {
+.c8 *[stroke*="#"],
+.c8 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c9 *[fill-rule],
-.c9 *[FILL-RULE],
-.c9 *[fill*="#"],
-.c9 *[FILL*="#"] {
+.c8 *[fill-rule],
+.c8 *[FILL-RULE],
+.c8 *[fill*="#"],
+.c8 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -110,7 +110,7 @@ exports[`DataTableColumns remove column 1`] = `
   justify-content: space-between;
 }
 
-.c13 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -131,7 +131,7 @@ exports[`DataTableColumns remove column 1`] = `
   justify-content: center;
 }
 
-.c17 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -145,28 +145,18 @@ exports[`DataTableColumns remove column 1`] = `
   flex-direction: column;
 }
 
-.c7 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  -webkit-align-self: stretch;
-  -ms-flex-item-align: stretch;
-  align-self: stretch;
-  height: 6px;
-}
-
-.c14 {
+.c13 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c18 {
+.c17 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
 }
 
-.c8 {
+.c7 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -186,43 +176,43 @@ exports[`DataTableColumns remove column 1`] = `
   padding: 12px;
 }
 
-.c8:focus {
+.c7:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c8:focus > circle,
-.c8:focus > ellipse,
-.c8:focus > line,
-.c8:focus > path,
-.c8:focus > polygon,
-.c8:focus > polyline,
-.c8:focus > rect {
+.c7:focus > circle,
+.c7:focus > ellipse,
+.c7:focus > line,
+.c7:focus > path,
+.c7:focus > polygon,
+.c7:focus > polyline,
+.c7:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c8:focus::-moz-focus-inner {
+.c7:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c8:focus:not(:focus-visible) {
+.c7:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c8:focus:not(:focus-visible) > circle,
-.c8:focus:not(:focus-visible) > ellipse,
-.c8:focus:not(:focus-visible) > line,
-.c8:focus:not(:focus-visible) > path,
-.c8:focus:not(:focus-visible) > polygon,
-.c8:focus:not(:focus-visible) > polyline,
-.c8:focus:not(:focus-visible) > rect {
+.c7:focus:not(:focus-visible) > circle,
+.c7:focus:not(:focus-visible) > ellipse,
+.c7:focus:not(:focus-visible) > line,
+.c7:focus:not(:focus-visible) > path,
+.c7:focus:not(:focus-visible) > polygon,
+.c7:focus:not(:focus-visible) > polyline,
+.c7:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c8:focus:not(:focus-visible)::-moz-focus-inner {
+.c7:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
@@ -239,7 +229,7 @@ exports[`DataTableColumns remove column 1`] = `
   overflow-wrap: break-word;
 }
 
-.c12 {
+.c11 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -252,7 +242,7 @@ exports[`DataTableColumns remove column 1`] = `
   padding-bottom: 6px;
 }
 
-.c16 {
+.c15 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -264,23 +254,23 @@ exports[`DataTableColumns remove column 1`] = `
   padding-bottom: 6px;
 }
 
-.c10 {
+.c9 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
 }
 
-.c11 {
+.c10 {
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
 }
 
-.c15:focus {
+.c14:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c15:focus:not(:focus-visible) {
+.c14:focus:not(:focus-visible) {
   outline: none;
 }
 
@@ -292,12 +282,6 @@ exports[`DataTableColumns remove column 1`] = `
   -ms-text-size-adjust: 100%;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
-}
-
-@media only screen and (max-width:768px) {
-  .c7 {
-    height: 3px;
-  }
 }
 
 @media only screen and (max-width:768px) {
@@ -339,18 +323,15 @@ exports[`DataTableColumns remove column 1`] = `
               Filters
             </h2>
           </header>
-          <div
-            class="c7"
-          />
           <button
             aria-label="Open column selector"
-            class="c8"
+            class="c7"
             id="test-data--columns-control"
             type="button"
           >
             <svg
               aria-label="Splits"
-              class="c9"
+              class="c8"
               viewBox="0 0 24 24"
             >
               <path
@@ -365,7 +346,7 @@ exports[`DataTableColumns remove column 1`] = `
       </div>
     </form>
     <table
-      class="c10 c11"
+      class="c9 c10"
     >
       <thead
         class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -374,42 +355,42 @@ exports[`DataTableColumns remove column 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c12 "
+            class="c11 "
             scope="col"
           >
             <div
-              class="c13"
+              class="c12"
             >
               <span
-                class="c14"
+                class="c13"
               >
                 Name
               </span>
             </div>
           </th>
           <th
-            class="c12 "
+            class="c11 "
             scope="col"
           >
             <div
-              class="c13"
+              class="c12"
             >
               <span
-                class="c14"
+                class="c13"
               >
                 Age
               </span>
             </div>
           </th>
           <th
-            class="c12 "
+            class="c11 "
             scope="col"
           >
             <div
-              class="c13"
+              class="c12"
             >
               <span
-                class="c14"
+                class="c13"
               >
                 Size
               </span>
@@ -418,40 +399,40 @@ exports[`DataTableColumns remove column 1`] = `
         </tr>
       </thead>
       <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c15"
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c14"
       >
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c16 "
+            class="c15 "
             scope="row"
           >
             <div
-              class="c17"
+              class="c16"
             >
               <span
-                class="c18"
+                class="c17"
               >
                 a
               </span>
             </div>
           </th>
           <td
-            class="c16 "
+            class="c15 "
           >
             <div
-              class="c17"
+              class="c16"
             />
           </td>
           <td
-            class="c16 "
+            class="c15 "
           >
             <div
-              class="c17"
+              class="c16"
             >
               <span
-                class="c14"
+                class="c13"
               >
                 s
               </span>
@@ -462,34 +443,34 @@ exports[`DataTableColumns remove column 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c16 "
+            class="c15 "
             scope="row"
           >
             <div
-              class="c17"
+              class="c16"
             >
               <span
-                class="c18"
+                class="c17"
               >
                 b
               </span>
             </div>
           </th>
           <td
-            class="c16 "
+            class="c15 "
           >
             <div
-              class="c17"
+              class="c16"
             />
           </td>
           <td
-            class="c16 "
+            class="c15 "
           >
             <div
-              class="c17"
+              class="c16"
             >
               <span
-                class="c14"
+                class="c13"
               >
                 m
               </span>
@@ -528,13 +509,13 @@ exports[`DataTableColumns remove column 2`] = `
 
 exports[`DataTableColumns remove column 3`] = `
 "@media only screen and (max-width: 768px) {
-  .grsgKE {
-    height: 3px;
+  .gcEjSx {
+    margin-top: 6px;
   }
 }
 @media only screen and (max-width: 768px) {
-  .iISQcM {
-    width: 12px;
+  .ilMzAg {
+    width: 6px;
   }
 }
 .emhJYD {
@@ -605,7 +586,7 @@ exports[`DataTableColumns remove column 3`] = `
 `;
 
 exports[`DataTableColumns renders 1`] = `
-.c9 {
+.c8 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -616,25 +597,25 @@ exports[`DataTableColumns renders 1`] = `
   stroke: #666666;
 }
 
-.c9 g {
+.c8 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c9 *:not([stroke])[fill="none"] {
+.c8 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c9 *[stroke*="#"],
-.c9 *[STROKE*="#"] {
+.c8 *[stroke*="#"],
+.c8 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c9 *[fill-rule],
-.c9 *[FILL-RULE],
-.c9 *[fill*="#"],
-.c9 *[FILL*="#"] {
+.c8 *[fill-rule],
+.c8 *[FILL-RULE],
+.c8 *[fill*="#"],
+.c8 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -714,6 +695,32 @@ exports[`DataTableColumns renders 1`] = `
   justify-content: space-between;
 }
 
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-top: 12px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
 .c17 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -749,16 +756,6 @@ exports[`DataTableColumns renders 1`] = `
   flex-direction: column;
 }
 
-.c7 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  -webkit-align-self: stretch;
-  -ms-flex-item-align: stretch;
-  align-self: stretch;
-  height: 6px;
-}
-
 .c11 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -766,7 +763,7 @@ exports[`DataTableColumns renders 1`] = `
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
   align-self: stretch;
-  width: 24px;
+  width: 12px;
 }
 
 .c18 {
@@ -780,7 +777,7 @@ exports[`DataTableColumns renders 1`] = `
   font-weight: bold;
 }
 
-.c8 {
+.c7 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -800,43 +797,43 @@ exports[`DataTableColumns renders 1`] = `
   padding: 12px;
 }
 
-.c8:focus {
+.c7:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c8:focus > circle,
-.c8:focus > ellipse,
-.c8:focus > line,
-.c8:focus > path,
-.c8:focus > polygon,
-.c8:focus > polyline,
-.c8:focus > rect {
+.c7:focus > circle,
+.c7:focus > ellipse,
+.c7:focus > line,
+.c7:focus > path,
+.c7:focus > polygon,
+.c7:focus > polyline,
+.c7:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c8:focus::-moz-focus-inner {
+.c7:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c8:focus:not(:focus-visible) {
+.c7:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c8:focus:not(:focus-visible) > circle,
-.c8:focus:not(:focus-visible) > ellipse,
-.c8:focus:not(:focus-visible) > line,
-.c8:focus:not(:focus-visible) > path,
-.c8:focus:not(:focus-visible) > polygon,
-.c8:focus:not(:focus-visible) > polyline,
-.c8:focus:not(:focus-visible) > rect {
+.c7:focus:not(:focus-visible) > circle,
+.c7:focus:not(:focus-visible) > ellipse,
+.c7:focus:not(:focus-visible) > line,
+.c7:focus:not(:focus-visible) > path,
+.c7:focus:not(:focus-visible) > polygon,
+.c7:focus:not(:focus-visible) > polyline,
+.c7:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c8:focus:not(:focus-visible)::-moz-focus-inner {
+.c7:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
@@ -1052,14 +1049,14 @@ exports[`DataTableColumns renders 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c7 {
-    height: 3px;
+  .c9 {
+    margin-top: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
   .c11 {
-    width: 12px;
+    width: 6px;
   }
 }
 
@@ -1102,18 +1099,15 @@ exports[`DataTableColumns renders 1`] = `
               Filters
             </h2>
           </header>
-          <div
-            class="c7"
-          />
           <button
             aria-label="Open column selector"
-            class="c8"
+            class="c7"
             id="test-data--columns-control"
             type="button"
           >
             <svg
               aria-label="Splits"
-              class="c9"
+              class="c8"
               viewBox="0 0 24 24"
             >
               <path
@@ -1126,7 +1120,7 @@ exports[`DataTableColumns renders 1`] = `
           </button>
         </div>
         <footer
-          class="c5"
+          class="c9"
         >
           <button
             class="c10"
@@ -1260,7 +1254,7 @@ exports[`DataTableColumns renders 1`] = `
 `;
 
 exports[`DataTableColumns search 1`] = `
-.c9 {
+.c8 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -1271,25 +1265,25 @@ exports[`DataTableColumns search 1`] = `
   stroke: #666666;
 }
 
-.c9 g {
+.c8 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c9 *:not([stroke])[fill="none"] {
+.c8 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c9 *[stroke*="#"],
-.c9 *[STROKE*="#"] {
+.c8 *[stroke*="#"],
+.c8 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c9 *[fill-rule],
-.c9 *[FILL-RULE],
-.c9 *[fill*="#"],
-.c9 *[FILL*="#"] {
+.c8 *[fill-rule],
+.c8 *[FILL-RULE],
+.c8 *[fill*="#"],
+.c8 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -1369,7 +1363,7 @@ exports[`DataTableColumns search 1`] = `
   justify-content: space-between;
 }
 
-.c13 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1390,7 +1384,7 @@ exports[`DataTableColumns search 1`] = `
   justify-content: center;
 }
 
-.c17 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1404,28 +1398,18 @@ exports[`DataTableColumns search 1`] = `
   flex-direction: column;
 }
 
-.c7 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  -webkit-align-self: stretch;
-  -ms-flex-item-align: stretch;
-  align-self: stretch;
-  height: 6px;
-}
-
-.c14 {
+.c13 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c18 {
+.c17 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
 }
 
-.c8 {
+.c7 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -1445,43 +1429,43 @@ exports[`DataTableColumns search 1`] = `
   padding: 12px;
 }
 
-.c8:focus {
+.c7:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c8:focus > circle,
-.c8:focus > ellipse,
-.c8:focus > line,
-.c8:focus > path,
-.c8:focus > polygon,
-.c8:focus > polyline,
-.c8:focus > rect {
+.c7:focus > circle,
+.c7:focus > ellipse,
+.c7:focus > line,
+.c7:focus > path,
+.c7:focus > polygon,
+.c7:focus > polyline,
+.c7:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c8:focus::-moz-focus-inner {
+.c7:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c8:focus:not(:focus-visible) {
+.c7:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c8:focus:not(:focus-visible) > circle,
-.c8:focus:not(:focus-visible) > ellipse,
-.c8:focus:not(:focus-visible) > line,
-.c8:focus:not(:focus-visible) > path,
-.c8:focus:not(:focus-visible) > polygon,
-.c8:focus:not(:focus-visible) > polyline,
-.c8:focus:not(:focus-visible) > rect {
+.c7:focus:not(:focus-visible) > circle,
+.c7:focus:not(:focus-visible) > ellipse,
+.c7:focus:not(:focus-visible) > line,
+.c7:focus:not(:focus-visible) > path,
+.c7:focus:not(:focus-visible) > polygon,
+.c7:focus:not(:focus-visible) > polyline,
+.c7:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c8:focus:not(:focus-visible)::-moz-focus-inner {
+.c7:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
@@ -1498,7 +1482,7 @@ exports[`DataTableColumns search 1`] = `
   overflow-wrap: break-word;
 }
 
-.c12 {
+.c11 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -1511,7 +1495,7 @@ exports[`DataTableColumns search 1`] = `
   padding-bottom: 6px;
 }
 
-.c16 {
+.c15 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -1523,23 +1507,23 @@ exports[`DataTableColumns search 1`] = `
   padding-bottom: 6px;
 }
 
-.c10 {
+.c9 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
 }
 
-.c11 {
+.c10 {
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
 }
 
-.c15:focus {
+.c14:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c15:focus:not(:focus-visible) {
+.c14:focus:not(:focus-visible) {
   outline: none;
 }
 
@@ -1551,12 +1535,6 @@ exports[`DataTableColumns search 1`] = `
   -ms-text-size-adjust: 100%;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
-}
-
-@media only screen and (max-width:768px) {
-  .c7 {
-    height: 3px;
-  }
 }
 
 @media only screen and (max-width:768px) {
@@ -1598,18 +1576,15 @@ exports[`DataTableColumns search 1`] = `
               Filters
             </h2>
           </header>
-          <div
-            class="c7"
-          />
           <button
             aria-label="Open column selector"
-            class="c8"
+            class="c7"
             id="test-data--columns-control"
             type="button"
           >
             <svg
               aria-label="Splits"
-              class="c9"
+              class="c8"
               viewBox="0 0 24 24"
             >
               <path
@@ -1624,7 +1599,7 @@ exports[`DataTableColumns search 1`] = `
       </div>
     </form>
     <table
-      class="c10 c11"
+      class="c9 c10"
     >
       <thead
         class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -1633,28 +1608,28 @@ exports[`DataTableColumns search 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c12 "
+            class="c11 "
             scope="col"
           >
             <div
-              class="c13"
+              class="c12"
             >
               <span
-                class="c14"
+                class="c13"
               >
                 Name
               </span>
             </div>
           </th>
           <th
-            class="c12 "
+            class="c11 "
             scope="col"
           >
             <div
-              class="c13"
+              class="c12"
             >
               <span
-                class="c14"
+                class="c13"
               >
                 Size
               </span>
@@ -1663,33 +1638,33 @@ exports[`DataTableColumns search 1`] = `
         </tr>
       </thead>
       <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c15"
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c14"
       >
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c16 "
+            class="c15 "
             scope="row"
           >
             <div
-              class="c17"
+              class="c16"
             >
               <span
-                class="c18"
+                class="c17"
               >
                 a
               </span>
             </div>
           </th>
           <td
-            class="c16 "
+            class="c15 "
           >
             <div
-              class="c17"
+              class="c16"
             >
               <span
-                class="c14"
+                class="c13"
               >
                 s
               </span>
@@ -1700,27 +1675,27 @@ exports[`DataTableColumns search 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c16 "
+            class="c15 "
             scope="row"
           >
             <div
-              class="c17"
+              class="c16"
             >
               <span
-                class="c18"
+                class="c17"
               >
                 b
               </span>
             </div>
           </th>
           <td
-            class="c16 "
+            class="c15 "
           >
             <div
-              class="c17"
+              class="c16"
             >
               <span
-                class="c14"
+                class="c13"
               >
                 m
               </span>
@@ -1759,13 +1734,13 @@ exports[`DataTableColumns search 2`] = `
 
 exports[`DataTableColumns search 3`] = `
 "@media only screen and (max-width: 768px) {
-  .grsgKE {
-    height: 3px;
+  .gcEjSx {
+    margin-top: 6px;
   }
 }
 @media only screen and (max-width: 768px) {
-  .iISQcM {
-    width: 12px;
+  .ilMzAg {
+    width: 6px;
   }
 }
 .emhJYD {
@@ -1861,13 +1836,13 @@ exports[`DataTableColumns search 4`] = `
 
 exports[`DataTableColumns search 5`] = `
 "@media only screen and (max-width: 768px) {
-  .grsgKE {
-    height: 3px;
+  .gcEjSx {
+    margin-top: 6px;
   }
 }
 @media only screen and (max-width: 768px) {
-  .iISQcM {
-    width: 12px;
+  .ilMzAg {
+    width: 6px;
   }
 }
 .emhJYD {

--- a/src/js/components/DataTableColumns/__tests__/__snapshots__/DataTableColumns-test.tsx.snap
+++ b/src/js/components/DataTableColumns/__tests__/__snapshots__/DataTableColumns-test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DataTableColumns remove column 1`] = `
-.c7 {
+.c9 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -12,25 +12,25 @@ exports[`DataTableColumns remove column 1`] = `
   stroke: #666666;
 }
 
-.c7 g {
+.c9 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c7 *:not([stroke])[fill="none"] {
+.c9 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c7 *[stroke*="#"],
-.c7 *[STROKE*="#"] {
+.c9 *[stroke*="#"],
+.c9 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c7 *[fill-rule],
-.c7 *[FILL-RULE],
-.c7 *[fill*="#"],
-.c7 *[FILL*="#"] {
+.c9 *[fill-rule],
+.c9 *[FILL-RULE],
+.c9 *[fill*="#"],
+.c9 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -59,6 +59,39 @@ exports[`DataTableColumns remove column 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 100%;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  overflow: auto;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -77,7 +110,7 @@ exports[`DataTableColumns remove column 1`] = `
   justify-content: space-between;
 }
 
-.c11 {
+.c13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -98,7 +131,7 @@ exports[`DataTableColumns remove column 1`] = `
   justify-content: center;
 }
 
-.c15 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -112,28 +145,28 @@ exports[`DataTableColumns remove column 1`] = `
   flex-direction: column;
 }
 
-.c5 {
+.c7 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
   align-self: stretch;
-  height: 12px;
+  height: 6px;
 }
 
-.c12 {
+.c14 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c16 {
+.c18 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
 }
 
-.c6 {
+.c8 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -153,43 +186,43 @@ exports[`DataTableColumns remove column 1`] = `
   padding: 12px;
 }
 
-.c6:focus {
+.c8:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c6:focus > circle,
-.c6:focus > ellipse,
-.c6:focus > line,
-.c6:focus > path,
-.c6:focus > polygon,
-.c6:focus > polyline,
-.c6:focus > rect {
+.c8:focus > circle,
+.c8:focus > ellipse,
+.c8:focus > line,
+.c8:focus > path,
+.c8:focus > polygon,
+.c8:focus > polyline,
+.c8:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c6:focus::-moz-focus-inner {
+.c8:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c6:focus:not(:focus-visible) {
+.c8:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c6:focus:not(:focus-visible) > circle,
-.c6:focus:not(:focus-visible) > ellipse,
-.c6:focus:not(:focus-visible) > line,
-.c6:focus:not(:focus-visible) > path,
-.c6:focus:not(:focus-visible) > polygon,
-.c6:focus:not(:focus-visible) > polyline,
-.c6:focus:not(:focus-visible) > rect {
+.c8:focus:not(:focus-visible) > circle,
+.c8:focus:not(:focus-visible) > ellipse,
+.c8:focus:not(:focus-visible) > line,
+.c8:focus:not(:focus-visible) > path,
+.c8:focus:not(:focus-visible) > polygon,
+.c8:focus:not(:focus-visible) > polyline,
+.c8:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c6:focus:not(:focus-visible)::-moz-focus-inner {
+.c8:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
@@ -197,7 +230,7 @@ exports[`DataTableColumns remove column 1`] = `
   max-width: 100%;
 }
 
-.c4 {
+.c6 {
   margin: 0px;
   font-size: 26px;
   line-height: 32px;
@@ -206,7 +239,7 @@ exports[`DataTableColumns remove column 1`] = `
   overflow-wrap: break-word;
 }
 
-.c10 {
+.c12 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -219,7 +252,7 @@ exports[`DataTableColumns remove column 1`] = `
   padding-bottom: 6px;
 }
 
-.c14 {
+.c16 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -231,23 +264,23 @@ exports[`DataTableColumns remove column 1`] = `
   padding-bottom: 6px;
 }
 
-.c8 {
+.c10 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
 }
 
-.c9 {
+.c11 {
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
 }
 
-.c13:focus {
+.c15:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c13:focus:not(:focus-visible) {
+.c15:focus:not(:focus-visible) {
   outline: none;
 }
 
@@ -262,19 +295,19 @@ exports[`DataTableColumns remove column 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
-    height: 6px;
+  .c7 {
+    height: 3px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c6 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c6 {
     font-size: 22px;
     line-height: 28px;
     max-width: 528px;
@@ -292,43 +325,47 @@ exports[`DataTableColumns remove column 1`] = `
       class="c2"
     >
       <div
-        class="c1"
+        class="c3"
       >
-        <header
-          class="c3"
-        >
-          <h2
-            class="c4"
-          >
-            Filters
-          </h2>
-        </header>
         <div
-          class="c5"
-        />
-        <button
-          aria-label="Open column selector"
-          class="c6"
-          id="test-data--columns-control"
-          type="button"
+          class="c4"
         >
-          <svg
-            aria-label="Splits"
-            class="c7"
-            viewBox="0 0 24 24"
+          <header
+            class="c5"
           >
-            <path
-              d="M1 22h22V2H1v20zM8 2v20V2zm8 0v20V2z"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
+            <h2
+              class="c6"
+            >
+              Filters
+            </h2>
+          </header>
+          <div
+            class="c7"
+          />
+          <button
+            aria-label="Open column selector"
+            class="c8"
+            id="test-data--columns-control"
+            type="button"
+          >
+            <svg
+              aria-label="Splits"
+              class="c9"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M1 22h22V2H1v20zM8 2v20V2zm8 0v20V2z"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </div>
       </div>
     </form>
     <table
-      class="c8 c9"
+      class="c10 c11"
     >
       <thead
         class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -337,42 +374,42 @@ exports[`DataTableColumns remove column 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c10 "
+            class="c12 "
             scope="col"
           >
             <div
-              class="c11"
+              class="c13"
             >
               <span
-                class="c12"
+                class="c14"
               >
                 Name
               </span>
             </div>
           </th>
           <th
-            class="c10 "
+            class="c12 "
             scope="col"
           >
             <div
-              class="c11"
+              class="c13"
             >
               <span
-                class="c12"
+                class="c14"
               >
                 Age
               </span>
             </div>
           </th>
           <th
-            class="c10 "
+            class="c12 "
             scope="col"
           >
             <div
-              class="c11"
+              class="c13"
             >
               <span
-                class="c12"
+                class="c14"
               >
                 Size
               </span>
@@ -381,40 +418,40 @@ exports[`DataTableColumns remove column 1`] = `
         </tr>
       </thead>
       <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c13"
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c15"
       >
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c14 "
+            class="c16 "
             scope="row"
           >
             <div
-              class="c15"
+              class="c17"
             >
               <span
-                class="c16"
+                class="c18"
               >
                 a
               </span>
             </div>
           </th>
           <td
-            class="c14 "
+            class="c16 "
           >
             <div
-              class="c15"
+              class="c17"
             />
           </td>
           <td
-            class="c14 "
+            class="c16 "
           >
             <div
-              class="c15"
+              class="c17"
             >
               <span
-                class="c12"
+                class="c14"
               >
                 s
               </span>
@@ -425,34 +462,34 @@ exports[`DataTableColumns remove column 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c14 "
+            class="c16 "
             scope="row"
           >
             <div
-              class="c15"
+              class="c17"
             >
               <span
-                class="c16"
+                class="c18"
               >
                 b
               </span>
             </div>
           </th>
           <td
-            class="c14 "
+            class="c16 "
           >
             <div
-              class="c15"
+              class="c17"
             />
           </td>
           <td
-            class="c14 "
+            class="c16 "
           >
             <div
-              class="c15"
+              class="c17"
             >
               <span
-                class="c12"
+                class="c14"
               >
                 m
               </span>
@@ -491,8 +528,8 @@ exports[`DataTableColumns remove column 2`] = `
 
 exports[`DataTableColumns remove column 3`] = `
 "@media only screen and (max-width: 768px) {
-  .drdMXk {
-    height: 6px;
+  .grsgKE {
+    height: 3px;
   }
 }
 @media only screen and (max-width: 768px) {
@@ -568,7 +605,7 @@ exports[`DataTableColumns remove column 3`] = `
 `;
 
 exports[`DataTableColumns renders 1`] = `
-.c7 {
+.c9 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -579,25 +616,25 @@ exports[`DataTableColumns renders 1`] = `
   stroke: #666666;
 }
 
-.c7 g {
+.c9 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c7 *:not([stroke])[fill="none"] {
+.c9 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c7 *[stroke*="#"],
-.c7 *[STROKE*="#"] {
+.c9 *[stroke*="#"],
+.c9 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c7 *[fill-rule],
-.c7 *[FILL-RULE],
-.c7 *[fill*="#"],
-.c7 *[FILL*="#"] {
+.c9 *[fill-rule],
+.c9 *[FILL-RULE],
+.c9 *[fill*="#"],
+.c9 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -626,6 +663,39 @@ exports[`DataTableColumns renders 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 100%;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  overflow: auto;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -644,7 +714,7 @@ exports[`DataTableColumns renders 1`] = `
   justify-content: space-between;
 }
 
-.c15 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -665,7 +735,7 @@ exports[`DataTableColumns renders 1`] = `
   justify-content: center;
 }
 
-.c19 {
+.c21 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -679,17 +749,17 @@ exports[`DataTableColumns renders 1`] = `
   flex-direction: column;
 }
 
-.c5 {
+.c7 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
   align-self: stretch;
-  height: 12px;
+  height: 6px;
 }
 
-.c9 {
+.c11 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -699,18 +769,18 @@ exports[`DataTableColumns renders 1`] = `
   width: 24px;
 }
 
-.c16 {
+.c18 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c20 {
+.c22 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
 }
 
-.c6 {
+.c8 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -728,78 +798,6 @@ exports[`DataTableColumns renders 1`] = `
   text-align: inherit;
   line-height: 0;
   padding: 12px;
-}
-
-.c6:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c6:focus > circle,
-.c6:focus > ellipse,
-.c6:focus > line,
-.c6:focus > path,
-.c6:focus > polygon,
-.c6:focus > polyline,
-.c6:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c6:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c6:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c6:focus:not(:focus-visible) > circle,
-.c6:focus:not(:focus-visible) > ellipse,
-.c6:focus:not(:focus-visible) > line,
-.c6:focus:not(:focus-visible) > path,
-.c6:focus:not(:focus-visible) > polygon,
-.c6:focus:not(:focus-visible) > polyline,
-.c6:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c6:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}
-
-.c8 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: 2px solid #7D4CDB;
-  border-radius: 18px;
-  color: #444444;
-  padding: 4px 22px;
-  font-size: 18px;
-  line-height: 24px;
-  background-color: #7D4CDB;
-  color: #f8f8f8;
-  border-radius: 18px;
-  -webkit-transition-property: color,background-color,border-color,box-shadow;
-  transition-property: color,background-color,border-color,box-shadow;
-  -webkit-transition-duration: 0.1s;
-  transition-duration: 0.1s;
-  -webkit-transition-timing-function: ease-in-out;
-  transition-timing-function: ease-in-out;
-}
-
-.c8:hover {
-  box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
 .c8:focus {
@@ -859,14 +857,19 @@ exports[`DataTableColumns renders 1`] = `
   padding: 4px 22px;
   font-size: 18px;
   line-height: 24px;
-  opacity: 0.3;
-  cursor: default;
+  background-color: #7D4CDB;
+  color: #f8f8f8;
+  border-radius: 18px;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
   transition-property: color,background-color,border-color,box-shadow;
   -webkit-transition-duration: 0.1s;
   transition-duration: 0.1s;
   -webkit-transition-timing-function: ease-in-out;
   transition-timing-function: ease-in-out;
+}
+
+.c10:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
 .c10:focus {
@@ -909,7 +912,74 @@ exports[`DataTableColumns renders 1`] = `
   border: 0;
 }
 
-.c11 {
+.c12 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: 2px solid #7D4CDB;
+  border-radius: 18px;
+  color: #444444;
+  padding: 4px 22px;
+  font-size: 18px;
+  line-height: 24px;
+  opacity: 0.3;
+  cursor: default;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+}
+
+.c12:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c12:focus > circle,
+.c12:focus > ellipse,
+.c12:focus > line,
+.c12:focus > path,
+.c12:focus > polygon,
+.c12:focus > polyline,
+.c12:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c12:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c12:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c12:focus:not(:focus-visible) > circle,
+.c12:focus:not(:focus-visible) > ellipse,
+.c12:focus:not(:focus-visible) > line,
+.c12:focus:not(:focus-visible) > path,
+.c12:focus:not(:focus-visible) > polygon,
+.c12:focus:not(:focus-visible) > polyline,
+.c12:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c12:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c13 {
   opacity: 0;
 }
 
@@ -917,7 +987,7 @@ exports[`DataTableColumns renders 1`] = `
   max-width: 100%;
 }
 
-.c4 {
+.c6 {
   margin: 0px;
   font-size: 26px;
   line-height: 32px;
@@ -926,7 +996,7 @@ exports[`DataTableColumns renders 1`] = `
   overflow-wrap: break-word;
 }
 
-.c14 {
+.c16 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -939,7 +1009,7 @@ exports[`DataTableColumns renders 1`] = `
   padding-bottom: 6px;
 }
 
-.c18 {
+.c20 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -951,23 +1021,23 @@ exports[`DataTableColumns renders 1`] = `
   padding-bottom: 6px;
 }
 
-.c12 {
+.c14 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
 }
 
-.c13 {
+.c15 {
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
 }
 
-.c17:focus {
+.c19:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c17:focus:not(:focus-visible) {
+.c19:focus:not(:focus-visible) {
   outline: none;
 }
 
@@ -982,25 +1052,25 @@ exports[`DataTableColumns renders 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
-    height: 6px;
+  .c7 {
+    height: 3px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c9 {
+  .c11 {
     width: 12px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c6 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c6 {
     font-size: 22px;
     line-height: 28px;
     max-width: 528px;
@@ -1018,57 +1088,58 @@ exports[`DataTableColumns renders 1`] = `
       class="c2"
     >
       <div
-        class="c1"
+        class="c3"
       >
-        <header
-          class="c3"
-        >
-          <h2
-            class="c4"
-          >
-            Filters
-          </h2>
-        </header>
         <div
-          class="c5"
-        />
-        <button
-          aria-label="Open column selector"
-          class="c6"
-          id="test-data--columns-control"
-          type="button"
+          class="c4"
         >
-          <svg
-            aria-label="Splits"
+          <header
+            class="c5"
+          >
+            <h2
+              class="c6"
+            >
+              Filters
+            </h2>
+          </header>
+          <div
             class="c7"
-            viewBox="0 0 24 24"
+          />
+          <button
+            aria-label="Open column selector"
+            class="c8"
+            id="test-data--columns-control"
+            type="button"
           >
-            <path
-              d="M1 22h22V2H1v20zM8 2v20V2zm8 0v20V2z"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-        <div
-          class="c5"
-        />
+            <svg
+              aria-label="Splits"
+              class="c9"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M1 22h22V2H1v20zM8 2v20V2zm8 0v20V2z"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </div>
         <footer
-          class="c3"
+          class="c5"
         >
           <button
-            class="c8"
+            class="c10"
             type="submit"
           >
             Apply filters
           </button>
           <div
-            class="c9"
+            class="c11"
           />
           <button
             aria-hidden="true"
-            class="c10 c11"
+            class="c12 c13"
             disabled=""
             tabindex="-1"
             type="reset"
@@ -1079,7 +1150,7 @@ exports[`DataTableColumns renders 1`] = `
       </div>
     </form>
     <table
-      class="c12 c13"
+      class="c14 c15"
     >
       <thead
         class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -1088,28 +1159,28 @@ exports[`DataTableColumns renders 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c14 "
+            class="c16 "
             scope="col"
           >
             <div
-              class="c15"
+              class="c17"
             >
               <span
-                class="c16"
+                class="c18"
               >
                 Name
               </span>
             </div>
           </th>
           <th
-            class="c14 "
+            class="c16 "
             scope="col"
           >
             <div
-              class="c15"
+              class="c17"
             >
               <span
-                class="c16"
+                class="c18"
               >
                 Size
               </span>
@@ -1118,33 +1189,33 @@ exports[`DataTableColumns renders 1`] = `
         </tr>
       </thead>
       <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c17"
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c19"
       >
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c18 "
+            class="c20 "
             scope="row"
           >
             <div
-              class="c19"
+              class="c21"
             >
               <span
-                class="c20"
+                class="c22"
               >
                 a
               </span>
             </div>
           </th>
           <td
-            class="c18 "
+            class="c20 "
           >
             <div
-              class="c19"
+              class="c21"
             >
               <span
-                class="c16"
+                class="c18"
               >
                 s
               </span>
@@ -1155,27 +1226,27 @@ exports[`DataTableColumns renders 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c18 "
+            class="c20 "
             scope="row"
           >
             <div
-              class="c19"
+              class="c21"
             >
               <span
-                class="c20"
+                class="c22"
               >
                 b
               </span>
             </div>
           </th>
           <td
-            class="c18 "
+            class="c20 "
           >
             <div
-              class="c19"
+              class="c21"
             >
               <span
-                class="c16"
+                class="c18"
               >
                 m
               </span>
@@ -1189,7 +1260,7 @@ exports[`DataTableColumns renders 1`] = `
 `;
 
 exports[`DataTableColumns search 1`] = `
-.c7 {
+.c9 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -1200,25 +1271,25 @@ exports[`DataTableColumns search 1`] = `
   stroke: #666666;
 }
 
-.c7 g {
+.c9 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c7 *:not([stroke])[fill="none"] {
+.c9 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c7 *[stroke*="#"],
-.c7 *[STROKE*="#"] {
+.c9 *[stroke*="#"],
+.c9 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c7 *[fill-rule],
-.c7 *[FILL-RULE],
-.c7 *[fill*="#"],
-.c7 *[FILL*="#"] {
+.c9 *[fill-rule],
+.c9 *[FILL-RULE],
+.c9 *[fill*="#"],
+.c9 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -1247,6 +1318,39 @@ exports[`DataTableColumns search 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 100%;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  overflow: auto;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1265,7 +1369,7 @@ exports[`DataTableColumns search 1`] = `
   justify-content: space-between;
 }
 
-.c11 {
+.c13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1286,7 +1390,7 @@ exports[`DataTableColumns search 1`] = `
   justify-content: center;
 }
 
-.c15 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1300,28 +1404,28 @@ exports[`DataTableColumns search 1`] = `
   flex-direction: column;
 }
 
-.c5 {
+.c7 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
   align-self: stretch;
-  height: 12px;
+  height: 6px;
 }
 
-.c12 {
+.c14 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c16 {
+.c18 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
 }
 
-.c6 {
+.c8 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -1341,43 +1445,43 @@ exports[`DataTableColumns search 1`] = `
   padding: 12px;
 }
 
-.c6:focus {
+.c8:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c6:focus > circle,
-.c6:focus > ellipse,
-.c6:focus > line,
-.c6:focus > path,
-.c6:focus > polygon,
-.c6:focus > polyline,
-.c6:focus > rect {
+.c8:focus > circle,
+.c8:focus > ellipse,
+.c8:focus > line,
+.c8:focus > path,
+.c8:focus > polygon,
+.c8:focus > polyline,
+.c8:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c6:focus::-moz-focus-inner {
+.c8:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c6:focus:not(:focus-visible) {
+.c8:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c6:focus:not(:focus-visible) > circle,
-.c6:focus:not(:focus-visible) > ellipse,
-.c6:focus:not(:focus-visible) > line,
-.c6:focus:not(:focus-visible) > path,
-.c6:focus:not(:focus-visible) > polygon,
-.c6:focus:not(:focus-visible) > polyline,
-.c6:focus:not(:focus-visible) > rect {
+.c8:focus:not(:focus-visible) > circle,
+.c8:focus:not(:focus-visible) > ellipse,
+.c8:focus:not(:focus-visible) > line,
+.c8:focus:not(:focus-visible) > path,
+.c8:focus:not(:focus-visible) > polygon,
+.c8:focus:not(:focus-visible) > polyline,
+.c8:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c6:focus:not(:focus-visible)::-moz-focus-inner {
+.c8:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
@@ -1385,7 +1489,7 @@ exports[`DataTableColumns search 1`] = `
   max-width: 100%;
 }
 
-.c4 {
+.c6 {
   margin: 0px;
   font-size: 26px;
   line-height: 32px;
@@ -1394,7 +1498,7 @@ exports[`DataTableColumns search 1`] = `
   overflow-wrap: break-word;
 }
 
-.c10 {
+.c12 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -1407,7 +1511,7 @@ exports[`DataTableColumns search 1`] = `
   padding-bottom: 6px;
 }
 
-.c14 {
+.c16 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -1419,23 +1523,23 @@ exports[`DataTableColumns search 1`] = `
   padding-bottom: 6px;
 }
 
-.c8 {
+.c10 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
 }
 
-.c9 {
+.c11 {
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
 }
 
-.c13:focus {
+.c15:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c13:focus:not(:focus-visible) {
+.c15:focus:not(:focus-visible) {
   outline: none;
 }
 
@@ -1450,19 +1554,19 @@ exports[`DataTableColumns search 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c5 {
-    height: 6px;
+  .c7 {
+    height: 3px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c6 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c6 {
     font-size: 22px;
     line-height: 28px;
     max-width: 528px;
@@ -1480,43 +1584,47 @@ exports[`DataTableColumns search 1`] = `
       class="c2"
     >
       <div
-        class="c1"
+        class="c3"
       >
-        <header
-          class="c3"
-        >
-          <h2
-            class="c4"
-          >
-            Filters
-          </h2>
-        </header>
         <div
-          class="c5"
-        />
-        <button
-          aria-label="Open column selector"
-          class="c6"
-          id="test-data--columns-control"
-          type="button"
+          class="c4"
         >
-          <svg
-            aria-label="Splits"
-            class="c7"
-            viewBox="0 0 24 24"
+          <header
+            class="c5"
           >
-            <path
-              d="M1 22h22V2H1v20zM8 2v20V2zm8 0v20V2z"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
+            <h2
+              class="c6"
+            >
+              Filters
+            </h2>
+          </header>
+          <div
+            class="c7"
+          />
+          <button
+            aria-label="Open column selector"
+            class="c8"
+            id="test-data--columns-control"
+            type="button"
+          >
+            <svg
+              aria-label="Splits"
+              class="c9"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M1 22h22V2H1v20zM8 2v20V2zm8 0v20V2z"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </div>
       </div>
     </form>
     <table
-      class="c8 c9"
+      class="c10 c11"
     >
       <thead
         class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -1525,28 +1633,28 @@ exports[`DataTableColumns search 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c10 "
+            class="c12 "
             scope="col"
           >
             <div
-              class="c11"
+              class="c13"
             >
               <span
-                class="c12"
+                class="c14"
               >
                 Name
               </span>
             </div>
           </th>
           <th
-            class="c10 "
+            class="c12 "
             scope="col"
           >
             <div
-              class="c11"
+              class="c13"
             >
               <span
-                class="c12"
+                class="c14"
               >
                 Size
               </span>
@@ -1555,33 +1663,33 @@ exports[`DataTableColumns search 1`] = `
         </tr>
       </thead>
       <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c13"
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c15"
       >
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c14 "
+            class="c16 "
             scope="row"
           >
             <div
-              class="c15"
+              class="c17"
             >
               <span
-                class="c16"
+                class="c18"
               >
                 a
               </span>
             </div>
           </th>
           <td
-            class="c14 "
+            class="c16 "
           >
             <div
-              class="c15"
+              class="c17"
             >
               <span
-                class="c12"
+                class="c14"
               >
                 s
               </span>
@@ -1592,27 +1700,27 @@ exports[`DataTableColumns search 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c14 "
+            class="c16 "
             scope="row"
           >
             <div
-              class="c15"
+              class="c17"
             >
               <span
-                class="c16"
+                class="c18"
               >
                 b
               </span>
             </div>
           </th>
           <td
-            class="c14 "
+            class="c16 "
           >
             <div
-              class="c15"
+              class="c17"
             >
               <span
-                class="c12"
+                class="c14"
               >
                 m
               </span>
@@ -1651,8 +1759,8 @@ exports[`DataTableColumns search 2`] = `
 
 exports[`DataTableColumns search 3`] = `
 "@media only screen and (max-width: 768px) {
-  .drdMXk {
-    height: 6px;
+  .grsgKE {
+    height: 3px;
   }
 }
 @media only screen and (max-width: 768px) {
@@ -1753,8 +1861,8 @@ exports[`DataTableColumns search 4`] = `
 
 exports[`DataTableColumns search 5`] = `
 "@media only screen and (max-width: 768px) {
-  .drdMXk {
-    height: 6px;
+  .grsgKE {
+    height: 3px;
   }
 }
 @media only screen and (max-width: 768px) {

--- a/src/js/components/DataView/DataView.js
+++ b/src/js/components/DataView/DataView.js
@@ -5,11 +5,20 @@ import { FormContext } from '../Form/FormContext';
 import { FormField } from '../FormField';
 import { RadioButtonGroup } from '../RadioButtonGroup';
 import { Select } from '../Select';
+import { MessageContext } from '../../contexts/MessageContext';
 import { DataViewPropTypes } from './propTypes';
 
-export const DataView = ({ ...rest }) => {
-  const { id: dataId, view, views, addToolbarKey } = useContext(DataContext);
+export const DataView = ({ id: idProp, ...rest }) => {
+  const {
+    id: dataId,
+    messages,
+    view,
+    views,
+    addToolbarKey,
+  } = useContext(DataContext);
   const { noForm } = useContext(FormContext);
+  const { format } = useContext(MessageContext);
+  const id = idProp || `${dataId}--view`;
 
   useEffect(() => {
     if (noForm) addToolbarKey('_view');
@@ -19,7 +28,6 @@ export const DataView = ({ ...rest }) => {
 
   const names = views.map((v) => v.name);
 
-  const id = `${dataId}-view`;
   let content;
 
   if (!noForm && names.length < 7) {
@@ -47,12 +55,24 @@ export const DataView = ({ ...rest }) => {
   }
 
   if (noForm)
+    // likely in Toolbar
     content = (
       <DataForm footer={false} updateOn="change">
         {content}
       </DataForm>
     );
-  else content = <FormField>{content}</FormField>;
+  else
+    content = (
+      <FormField
+        htmlFor={id}
+        label={format({
+          id: 'dataView.label',
+          messages: messages?.dataView,
+        })}
+      >
+        {content}
+      </FormField>
+    );
 
   return content;
 };

--- a/src/js/components/DataView/DataView.js
+++ b/src/js/components/DataView/DataView.js
@@ -2,6 +2,7 @@ import React, { useContext, useEffect } from 'react';
 import { DataForm } from '../Data/DataForm';
 import { DataContext } from '../../contexts/DataContext';
 import { FormContext } from '../Form/FormContext';
+import { FormField } from '../FormField';
 import { RadioButtonGroup } from '../RadioButtonGroup';
 import { Select } from '../Select';
 import { DataViewPropTypes } from './propTypes';
@@ -51,6 +52,7 @@ export const DataView = ({ ...rest }) => {
         {content}
       </DataForm>
     );
+  else content = <FormField>{content}</FormField>;
 
   return content;
 };

--- a/src/js/components/DataView/__tests__/__snapshots__/DataView-test.tsx.snap
+++ b/src/js/components/DataView/__tests__/__snapshots__/DataView-test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DataView preset view 1`] = `
-.c11 {
+.c13 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -12,25 +12,25 @@ exports[`DataView preset view 1`] = `
   stroke: #7D4CDB;
 }
 
-.c11 g {
+.c13 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c11 *:not([stroke])[fill="none"] {
+.c13 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c11 *[stroke*="#"],
-.c11 *[STROKE*="#"] {
+.c13 *[stroke*="#"],
+.c13 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c11 *[fill-rule],
-.c11 *[FILL-RULE],
-.c11 *[fill*="#"],
-.c11 *[FILL*="#"] {
+.c13 *[fill-rule],
+.c13 *[FILL-RULE],
+.c13 *[fill*="#"],
+.c13 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -52,7 +52,40 @@ exports[`DataView preset view 1`] = `
   flex: 0 0 auto;
 }
 
-.c5 {
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 100%;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  overflow: auto;
+}
+
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -74,7 +107,7 @@ exports[`DataView preset view 1`] = `
   justify-content: space-between;
 }
 
-.c6 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -93,7 +126,7 @@ exports[`DataView preset view 1`] = `
   flex-basis: auto;
 }
 
-.c10 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -112,7 +145,7 @@ exports[`DataView preset view 1`] = `
   flex: 0 0 auto;
 }
 
-.c3 {
+.c5 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -130,47 +163,47 @@ exports[`DataView preset view 1`] = `
   text-align: inherit;
 }
 
-.c3:focus {
+.c5:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
+.c5:focus > circle,
+.c5:focus > ellipse,
+.c5:focus > line,
+.c5:focus > path,
+.c5:focus > polygon,
+.c5:focus > polyline,
+.c5:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus::-moz-focus-inner {
+.c5:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c3:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible) > circle,
+.c5:focus:not(:focus-visible) > ellipse,
+.c5:focus:not(:focus-visible) > line,
+.c5:focus:not(:focus-visible) > path,
+.c5:focus:not(:focus-visible) > polygon,
+.c5:focus:not(:focus-visible) > polyline,
+.c5:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c8 {
+.c10 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -188,42 +221,42 @@ exports[`DataView preset view 1`] = `
   border: none;
 }
 
-.c8::-webkit-input-placeholder {
+.c10::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c8::-moz-placeholder {
+.c10::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c8:-ms-input-placeholder {
+.c10:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c8::-webkit-search-decoration {
+.c10::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c8::-moz-focus-inner {
+.c10::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c8:-moz-placeholder,
-.c8::-moz-placeholder {
+.c10:-moz-placeholder,
+.c10::-moz-placeholder {
   opacity: 1;
 }
 
-.c7 {
+.c9 {
   position: relative;
   width: 100%;
 }
 
-.c9 {
+.c11 {
   cursor: pointer;
 }
 
-.c4 {
+.c6 {
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
 }
@@ -243,7 +276,7 @@ exports[`DataView preset view 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c10 {
+  .c12 {
     margin-left: 6px;
     margin-right: 6px;
   }
@@ -260,57 +293,61 @@ exports[`DataView preset view 1`] = `
       class="c2"
     >
       <div
-        class="c1"
+        class="c3"
       >
-        <button
-          aria-expanded="false"
-          aria-haspopup="listbox"
-          aria-label="Select view ...; Selected: top"
-          class="c3 c4"
-          id="data-view"
-          type="button"
+        <div
+          class="c4"
         >
-          <div
-            class="c5"
+          <button
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            aria-label="Select view ...; Selected: top"
+            class="c5 c6"
+            id="data-view"
+            type="button"
           >
             <div
-              class="c6"
+              class="c7"
             >
               <div
-                class="c7"
+                class="c8"
               >
-                <input
-                  autocomplete="off"
-                  class="c8 c9"
-                  id="data-view__input"
-                  name="_view"
-                  placeholder="Select view ..."
-                  readonly=""
-                  tabindex="-1"
-                  type="text"
-                  value="top"
-                />
+                <div
+                  class="c9"
+                >
+                  <input
+                    autocomplete="off"
+                    class="c10 c11"
+                    id="data-view__input"
+                    name="_view"
+                    placeholder="Select view ..."
+                    readonly=""
+                    tabindex="-1"
+                    type="text"
+                    value="top"
+                  />
+                </div>
+              </div>
+              <div
+                class="c12"
+                style="min-width: auto;"
+              >
+                <svg
+                  aria-label="FormDown"
+                  class="c13"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="m18 9-6 6-6-6"
+                    fill="none"
+                    stroke="#000"
+                    stroke-width="2"
+                  />
+                </svg>
               </div>
             </div>
-            <div
-              class="c10"
-              style="min-width: auto;"
-            >
-              <svg
-                aria-label="FormDown"
-                class="c11"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="m18 9-6 6-6-6"
-                  fill="none"
-                  stroke="#000"
-                  stroke-width="2"
-                />
-              </svg>
-            </div>
-          </div>
-        </button>
+          </button>
+        </div>
       </div>
     </form>
   </div>
@@ -318,7 +355,7 @@ exports[`DataView preset view 1`] = `
 `;
 
 exports[`DataView renders 1`] = `
-.c11 {
+.c13 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -329,25 +366,25 @@ exports[`DataView renders 1`] = `
   stroke: #7D4CDB;
 }
 
-.c11 g {
+.c13 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c11 *:not([stroke])[fill="none"] {
+.c13 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c11 *[stroke*="#"],
-.c11 *[STROKE*="#"] {
+.c13 *[stroke*="#"],
+.c13 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c11 *[fill-rule],
-.c11 *[FILL-RULE],
-.c11 *[fill*="#"],
-.c11 *[FILL*="#"] {
+.c13 *[fill-rule],
+.c13 *[FILL-RULE],
+.c13 *[fill*="#"],
+.c13 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -369,7 +406,40 @@ exports[`DataView renders 1`] = `
   flex: 0 0 auto;
 }
 
-.c5 {
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 100%;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  overflow: auto;
+}
+
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -391,7 +461,7 @@ exports[`DataView renders 1`] = `
   justify-content: space-between;
 }
 
-.c6 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -410,7 +480,7 @@ exports[`DataView renders 1`] = `
   flex-basis: auto;
 }
 
-.c10 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -429,7 +499,7 @@ exports[`DataView renders 1`] = `
   flex: 0 0 auto;
 }
 
-.c3 {
+.c5 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -447,47 +517,47 @@ exports[`DataView renders 1`] = `
   text-align: inherit;
 }
 
-.c3:focus {
+.c5:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
+.c5:focus > circle,
+.c5:focus > ellipse,
+.c5:focus > line,
+.c5:focus > path,
+.c5:focus > polygon,
+.c5:focus > polyline,
+.c5:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus::-moz-focus-inner {
+.c5:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c3:focus:not(:focus-visible) {
+.c5:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
+.c5:focus:not(:focus-visible) > circle,
+.c5:focus:not(:focus-visible) > ellipse,
+.c5:focus:not(:focus-visible) > line,
+.c5:focus:not(:focus-visible) > path,
+.c5:focus:not(:focus-visible) > polygon,
+.c5:focus:not(:focus-visible) > polyline,
+.c5:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
+.c5:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c8 {
+.c10 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -505,42 +575,42 @@ exports[`DataView renders 1`] = `
   border: none;
 }
 
-.c8::-webkit-input-placeholder {
+.c10::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c8::-moz-placeholder {
+.c10::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c8:-ms-input-placeholder {
+.c10:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c8::-webkit-search-decoration {
+.c10::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c8::-moz-focus-inner {
+.c10::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c8:-moz-placeholder,
-.c8::-moz-placeholder {
+.c10:-moz-placeholder,
+.c10::-moz-placeholder {
   opacity: 1;
 }
 
-.c7 {
+.c9 {
   position: relative;
   width: 100%;
 }
 
-.c9 {
+.c11 {
   cursor: pointer;
 }
 
-.c4 {
+.c6 {
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
 }
@@ -560,7 +630,7 @@ exports[`DataView renders 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c10 {
+  .c12 {
     margin-left: 6px;
     margin-right: 6px;
   }
@@ -577,57 +647,61 @@ exports[`DataView renders 1`] = `
       class="c2"
     >
       <div
-        class="c1"
+        class="c3"
       >
-        <button
-          aria-expanded="false"
-          aria-haspopup="listbox"
-          aria-label="Select view ..."
-          class="c3 c4"
-          id="data-view"
-          type="button"
+        <div
+          class="c4"
         >
-          <div
-            class="c5"
+          <button
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            aria-label="Select view ..."
+            class="c5 c6"
+            id="data-view"
+            type="button"
           >
             <div
-              class="c6"
+              class="c7"
             >
               <div
-                class="c7"
+                class="c8"
               >
-                <input
-                  autocomplete="off"
-                  class="c8 c9"
-                  id="data-view__input"
-                  name="_view"
-                  placeholder="Select view ..."
-                  readonly=""
-                  tabindex="-1"
-                  type="text"
-                  value=""
-                />
+                <div
+                  class="c9"
+                >
+                  <input
+                    autocomplete="off"
+                    class="c10 c11"
+                    id="data-view__input"
+                    name="_view"
+                    placeholder="Select view ..."
+                    readonly=""
+                    tabindex="-1"
+                    type="text"
+                    value=""
+                  />
+                </div>
+              </div>
+              <div
+                class="c12"
+                style="min-width: auto;"
+              >
+                <svg
+                  aria-label="FormDown"
+                  class="c13"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="m18 9-6 6-6-6"
+                    fill="none"
+                    stroke="#000"
+                    stroke-width="2"
+                  />
+                </svg>
               </div>
             </div>
-            <div
-              class="c10"
-              style="min-width: auto;"
-            >
-              <svg
-                aria-label="FormDown"
-                class="c11"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="m18 9-6 6-6-6"
-                  fill="none"
-                  stroke="#000"
-                  stroke-width="2"
-                />
-              </svg>
-            </div>
-          </div>
-        </button>
+          </button>
+        </div>
       </div>
     </form>
   </div>

--- a/src/js/components/DataView/__tests__/__snapshots__/DataView-test.tsx.snap
+++ b/src/js/components/DataView/__tests__/__snapshots__/DataView-test.tsx.snap
@@ -303,7 +303,7 @@ exports[`DataView preset view 1`] = `
             aria-haspopup="listbox"
             aria-label="Select view ...; Selected: top"
             class="c5 c6"
-            id="data-view"
+            id="data--view"
             type="button"
           >
             <div
@@ -318,7 +318,7 @@ exports[`DataView preset view 1`] = `
                   <input
                     autocomplete="off"
                     class="c10 c11"
-                    id="data-view__input"
+                    id="data--view__input"
                     name="_view"
                     placeholder="Select view ..."
                     readonly=""
@@ -657,7 +657,7 @@ exports[`DataView renders 1`] = `
             aria-haspopup="listbox"
             aria-label="Select view ..."
             class="c5 c6"
-            id="data-view"
+            id="data--view"
             type="button"
           >
             <div
@@ -672,7 +672,7 @@ exports[`DataView renders 1`] = `
                   <input
                     autocomplete="off"
                     class="c10 c11"
-                    id="data-view__input"
+                    id="data--view__input"
                     name="_view"
                     placeholder="Select view ..."
                     readonly=""

--- a/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.tsx.snap
+++ b/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.tsx.snap
@@ -8259,6 +8259,9 @@ exports[`DateInput handle focus in FormField 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c2 {
@@ -8547,6 +8550,9 @@ exports[`DateInput handle focus in FormField 2`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c2 {

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-controlled.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-controlled.js.snap
@@ -24,6 +24,9 @@ exports[`Form controlled controlled 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c2 {
@@ -213,7 +216,7 @@ exports[`Form controlled controlled 2`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 hftPdQ FormField__FormFieldBox-sc-m9hood-0 chvcoo"
+      class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 cqRjpC FormField__FormFieldContentBox-sc-m9hood-1"
@@ -247,7 +250,7 @@ exports[`Form controlled controlled 3`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 hftPdQ FormField__FormFieldBox-sc-m9hood-0 chvcoo"
+      class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 cqRjpC FormField__FormFieldContentBox-sc-m9hood-1"
@@ -321,6 +324,9 @@ exports[`Form controlled controlled Array of Form Fields 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c3 {
@@ -620,7 +626,7 @@ exports[`Form controlled controlled Array of Form Fields 2`] = `
       class="StyledBox-sc-13pk1d4-0 kOZkFt"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 hftPdQ FormField__FormFieldBox-sc-m9hood-0 chvcoo"
+        class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
       >
         <div
           class="StyledBox-sc-13pk1d4-0 cqRjpC FormField__FormFieldContentBox-sc-m9hood-1"
@@ -639,7 +645,7 @@ exports[`Form controlled controlled Array of Form Fields 2`] = `
         </div>
       </div>
       <div
-        class="StyledBox-sc-13pk1d4-0 hftPdQ FormField__FormFieldBox-sc-m9hood-0 chvcoo"
+        class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
       >
         <div
           class="StyledBox-sc-13pk1d4-0 cqRjpC FormField__FormFieldContentBox-sc-m9hood-1"
@@ -662,7 +668,7 @@ exports[`Form controlled controlled Array of Form Fields 2`] = `
       class="StyledBox-sc-13pk1d4-0 kOZkFt"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 hftPdQ FormField__FormFieldBox-sc-m9hood-0 chvcoo"
+        class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
       >
         <div
           class="StyledBox-sc-13pk1d4-0 cqRjpC FormField__FormFieldContentBox-sc-m9hood-1"
@@ -681,7 +687,7 @@ exports[`Form controlled controlled Array of Form Fields 2`] = `
         </div>
       </div>
       <div
-        class="StyledBox-sc-13pk1d4-0 hftPdQ FormField__FormFieldBox-sc-m9hood-0 chvcoo"
+        class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
       >
         <div
           class="StyledBox-sc-13pk1d4-0 cqRjpC FormField__FormFieldContentBox-sc-m9hood-1"
@@ -704,7 +710,7 @@ exports[`Form controlled controlled Array of Form Fields 2`] = `
       class="StyledBox-sc-13pk1d4-0 kOZkFt"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 hftPdQ FormField__FormFieldBox-sc-m9hood-0 chvcoo"
+        class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
       >
         <div
           class="StyledBox-sc-13pk1d4-0 cqRjpC FormField__FormFieldContentBox-sc-m9hood-1"
@@ -723,7 +729,7 @@ exports[`Form controlled controlled Array of Form Fields 2`] = `
         </div>
       </div>
       <div
-        class="StyledBox-sc-13pk1d4-0 hftPdQ FormField__FormFieldBox-sc-m9hood-0 chvcoo"
+        class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
       >
         <div
           class="StyledBox-sc-13pk1d4-0 cqRjpC FormField__FormFieldContentBox-sc-m9hood-1"
@@ -761,7 +767,7 @@ exports[`Form controlled controlled Array of Form Fields 3`] = `
       class="StyledBox-sc-13pk1d4-0 kOZkFt"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 hftPdQ FormField__FormFieldBox-sc-m9hood-0 chvcoo"
+        class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
       >
         <div
           class="StyledBox-sc-13pk1d4-0 cqRjpC FormField__FormFieldContentBox-sc-m9hood-1"
@@ -780,7 +786,7 @@ exports[`Form controlled controlled Array of Form Fields 3`] = `
         </div>
       </div>
       <div
-        class="StyledBox-sc-13pk1d4-0 hftPdQ FormField__FormFieldBox-sc-m9hood-0 chvcoo"
+        class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
       >
         <div
           class="StyledBox-sc-13pk1d4-0 cqRjpC FormField__FormFieldContentBox-sc-m9hood-1"
@@ -803,7 +809,7 @@ exports[`Form controlled controlled Array of Form Fields 3`] = `
       class="StyledBox-sc-13pk1d4-0 kOZkFt"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 hftPdQ FormField__FormFieldBox-sc-m9hood-0 chvcoo"
+        class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
       >
         <div
           class="StyledBox-sc-13pk1d4-0 cqRjpC FormField__FormFieldContentBox-sc-m9hood-1"
@@ -822,7 +828,7 @@ exports[`Form controlled controlled Array of Form Fields 3`] = `
         </div>
       </div>
       <div
-        class="StyledBox-sc-13pk1d4-0 hftPdQ FormField__FormFieldBox-sc-m9hood-0 chvcoo"
+        class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
       >
         <div
           class="StyledBox-sc-13pk1d4-0 cqRjpC FormField__FormFieldContentBox-sc-m9hood-1"
@@ -845,7 +851,7 @@ exports[`Form controlled controlled Array of Form Fields 3`] = `
       class="StyledBox-sc-13pk1d4-0 kOZkFt"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 hftPdQ FormField__FormFieldBox-sc-m9hood-0 chvcoo"
+        class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
       >
         <div
           class="StyledBox-sc-13pk1d4-0 cqRjpC FormField__FormFieldContentBox-sc-m9hood-1"
@@ -864,7 +870,7 @@ exports[`Form controlled controlled Array of Form Fields 3`] = `
         </div>
       </div>
       <div
-        class="StyledBox-sc-13pk1d4-0 hftPdQ FormField__FormFieldBox-sc-m9hood-0 chvcoo"
+        class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
       >
         <div
           class="StyledBox-sc-13pk1d4-0 cqRjpC FormField__FormFieldContentBox-sc-m9hood-1"
@@ -939,6 +945,9 @@ exports[`Form controlled controlled Array of Form Fields onValidate 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c3 {
@@ -1196,7 +1205,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate 2`] = `
       class="StyledBox-sc-13pk1d4-0 kOZkFt"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 hftPdQ FormField__FormFieldBox-sc-m9hood-0 chvcoo"
+        class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
       >
         <div
           class="StyledBox-sc-13pk1d4-0 cXkhIG FormField__FormFieldContentBox-sc-m9hood-1"
@@ -1242,7 +1251,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate 2`] = `
         </span>
       </div>
       <div
-        class="StyledBox-sc-13pk1d4-0 hftPdQ FormField__FormFieldBox-sc-m9hood-0 chvcoo"
+        class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
       >
         <div
           class="StyledBox-sc-13pk1d4-0 cqRjpC FormField__FormFieldContentBox-sc-m9hood-1"
@@ -1265,7 +1274,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate 2`] = `
       class="StyledBox-sc-13pk1d4-0 kOZkFt"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 hftPdQ FormField__FormFieldBox-sc-m9hood-0 chvcoo"
+        class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
       >
         <div
           class="StyledBox-sc-13pk1d4-0 cXkhIG FormField__FormFieldContentBox-sc-m9hood-1"
@@ -1311,7 +1320,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate 2`] = `
         </span>
       </div>
       <div
-        class="StyledBox-sc-13pk1d4-0 hftPdQ FormField__FormFieldBox-sc-m9hood-0 chvcoo"
+        class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
       >
         <div
           class="StyledBox-sc-13pk1d4-0 cqRjpC FormField__FormFieldContentBox-sc-m9hood-1"
@@ -1386,6 +1395,9 @@ exports[`Form controlled controlled Array of Form Fields onValidate custom error
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c3 {
@@ -1643,7 +1655,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate custom error
       class="StyledBox-sc-13pk1d4-0 kOZkFt"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 hftPdQ FormField__FormFieldBox-sc-m9hood-0 chvcoo"
+        class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
       >
         <div
           class="StyledBox-sc-13pk1d4-0 cqRjpC FormField__FormFieldContentBox-sc-m9hood-1"
@@ -1662,7 +1674,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate custom error
         </div>
       </div>
       <div
-        class="StyledBox-sc-13pk1d4-0 hftPdQ FormField__FormFieldBox-sc-m9hood-0 chvcoo"
+        class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
       >
         <div
           class="StyledBox-sc-13pk1d4-0 cqRjpC FormField__FormFieldContentBox-sc-m9hood-1"
@@ -1685,7 +1697,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate custom error
       class="StyledBox-sc-13pk1d4-0 kOZkFt"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 hftPdQ FormField__FormFieldBox-sc-m9hood-0 chvcoo"
+        class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
       >
         <div
           class="StyledBox-sc-13pk1d4-0 cXkhIG FormField__FormFieldContentBox-sc-m9hood-1"
@@ -1731,7 +1743,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate custom error
         </span>
       </div>
       <div
-        class="StyledBox-sc-13pk1d4-0 hftPdQ FormField__FormFieldBox-sc-m9hood-0 chvcoo"
+        class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
       >
         <div
           class="StyledBox-sc-13pk1d4-0 cqRjpC FormField__FormFieldContentBox-sc-m9hood-1"
@@ -1784,6 +1796,9 @@ exports[`Form controlled controlled FormField deprecated 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c3 {
@@ -1988,7 +2003,7 @@ exports[`Form controlled controlled FormField deprecated 2`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 hftPdQ FormField__FormFieldBox-sc-m9hood-0 chvcoo"
+      class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
     >
       <label
         class="StyledText-sc-1sadyjn-0 kKrMsX"
@@ -2028,7 +2043,7 @@ exports[`Form controlled controlled FormField deprecated 3`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 hftPdQ FormField__FormFieldBox-sc-m9hood-0 chvcoo"
+      class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
     >
       <label
         class="StyledText-sc-1sadyjn-0 kKrMsX"
@@ -2086,6 +2101,9 @@ exports[`Form controlled controlled input 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c2 {
@@ -2275,7 +2293,7 @@ exports[`Form controlled controlled input 2`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 hftPdQ FormField__FormFieldBox-sc-m9hood-0 chvcoo"
+      class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 cqRjpC FormField__FormFieldContentBox-sc-m9hood-1"
@@ -2309,7 +2327,7 @@ exports[`Form controlled controlled input 3`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 hftPdQ FormField__FormFieldBox-sc-m9hood-0 chvcoo"
+      class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 cqRjpC FormField__FormFieldContentBox-sc-m9hood-1"
@@ -2361,6 +2379,9 @@ exports[`Form controlled controlled input lazy 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c2 {
@@ -2550,7 +2571,7 @@ exports[`Form controlled controlled input lazy 2`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 hftPdQ FormField__FormFieldBox-sc-m9hood-0 chvcoo"
+      class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 cqRjpC FormField__FormFieldContentBox-sc-m9hood-1"
@@ -2584,7 +2605,7 @@ exports[`Form controlled controlled input lazy 3`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 hftPdQ FormField__FormFieldBox-sc-m9hood-0 chvcoo"
+      class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 cqRjpC FormField__FormFieldContentBox-sc-m9hood-1"
@@ -2636,6 +2657,9 @@ exports[`Form controlled controlled lazy 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c2 {
@@ -2825,7 +2849,7 @@ exports[`Form controlled controlled lazy 2`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 hftPdQ FormField__FormFieldBox-sc-m9hood-0 chvcoo"
+      class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 cqRjpC FormField__FormFieldContentBox-sc-m9hood-1"
@@ -2859,7 +2883,7 @@ exports[`Form controlled controlled lazy 3`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 hftPdQ FormField__FormFieldBox-sc-m9hood-0 chvcoo"
+      class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 cqRjpC FormField__FormFieldContentBox-sc-m9hood-1"
@@ -2911,6 +2935,9 @@ exports[`Form controlled controlled onChange touched 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c2 {
@@ -3118,6 +3145,9 @@ exports[`Form controlled controlled onValidate 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c2 {
@@ -3307,7 +3337,7 @@ exports[`Form controlled controlled onValidate 2`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 hftPdQ FormField__FormFieldBox-sc-m9hood-0 chvcoo"
+      class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 cXkhIG FormField__FormFieldContentBox-sc-m9hood-1"
@@ -3386,6 +3416,9 @@ exports[`Form controlled controlled onValidate custom error 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c2 {
@@ -3575,7 +3608,7 @@ exports[`Form controlled controlled onValidate custom error 2`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 hftPdQ FormField__FormFieldBox-sc-m9hood-0 chvcoo"
+      class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 cXkhIG FormField__FormFieldContentBox-sc-m9hood-1"
@@ -3654,6 +3687,9 @@ exports[`Form controlled controlled onValidate custom info 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c2 {
@@ -3843,7 +3879,7 @@ exports[`Form controlled controlled onValidate custom info 2`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 hftPdQ FormField__FormFieldBox-sc-m9hood-0 chvcoo"
+      class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 cqRjpC FormField__FormFieldContentBox-sc-m9hood-1"
@@ -3952,6 +3988,9 @@ exports[`Form controlled custom theme 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c3 {
@@ -4184,6 +4223,9 @@ exports[`Form controlled dynamicly removed fields using blur validation
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c2 {
@@ -4538,7 +4580,7 @@ exports[`Form controlled dynamicly removed fields using blur validation
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 hftPdQ FormField__FormFieldBox-sc-m9hood-0 chvcoo"
+      class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 cqRjpC FormField__FormFieldContentBox-sc-m9hood-1"
@@ -4557,7 +4599,7 @@ exports[`Form controlled dynamicly removed fields using blur validation
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 hftPdQ FormField__FormFieldBox-sc-m9hood-0 chvcoo"
+      class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 zPnFT FormField__FormFieldContentBox-sc-m9hood-1"
@@ -4644,6 +4686,9 @@ exports[`Form controlled dynamicly removed fields using blur validation
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c1 {
@@ -4778,7 +4823,7 @@ exports[`Form controlled dynamicly removed fields using blur validation
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 hftPdQ FormField__FormFieldBox-sc-m9hood-0 chvcoo"
+      class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 cqRjpC FormField__FormFieldContentBox-sc-m9hood-1"
@@ -4797,7 +4842,7 @@ exports[`Form controlled dynamicly removed fields using blur validation
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 hftPdQ FormField__FormFieldBox-sc-m9hood-0 chvcoo"
+      class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 zPnFT FormField__FormFieldContentBox-sc-m9hood-1 dSTFCs"

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
@@ -25,6 +25,9 @@ exports[`Form accessibility Box with TextInput in Form should
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c2 {
@@ -189,6 +192,9 @@ exports[`Form accessibility CheckBox in Form should have no accessibility violat
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c2 {
@@ -393,6 +399,9 @@ exports[`Form accessibility FormField with an explicit TextInput child
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c2 {
@@ -555,6 +564,9 @@ exports[`Form accessibility Select in Form should have no accessibility violatio
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c2 {
@@ -829,6 +841,9 @@ exports[`Form accessibility TextInput in Form should have
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c2 {
@@ -957,6 +972,9 @@ exports[`Form uncontrolled dynamicly removed fields should be removed from form 
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c2 {
@@ -1310,7 +1328,7 @@ exports[`Form uncontrolled dynamicly removed fields should be removed from form 
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 hftPdQ FormField__FormFieldBox-sc-m9hood-0 chvcoo"
+      class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 cqRjpC FormField__FormFieldContentBox-sc-m9hood-1"
@@ -1329,7 +1347,7 @@ exports[`Form uncontrolled dynamicly removed fields should be removed from form 
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 hftPdQ FormField__FormFieldBox-sc-m9hood-0 chvcoo"
+      class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 zPnFT FormField__FormFieldContentBox-sc-m9hood-1"
@@ -1391,6 +1409,9 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c2 {
@@ -1745,7 +1766,7 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 hftPdQ FormField__FormFieldBox-sc-m9hood-0 chvcoo"
+      class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 cqRjpC FormField__FormFieldContentBox-sc-m9hood-1"
@@ -1764,7 +1785,7 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 hftPdQ FormField__FormFieldBox-sc-m9hood-0 chvcoo"
+      class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 zPnFT FormField__FormFieldContentBox-sc-m9hood-1"
@@ -1851,6 +1872,9 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c1 {
@@ -1985,7 +2009,7 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 hftPdQ FormField__FormFieldBox-sc-m9hood-0 chvcoo"
+      class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 cqRjpC FormField__FormFieldContentBox-sc-m9hood-1"
@@ -2004,7 +2028,7 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 hftPdQ FormField__FormFieldBox-sc-m9hood-0 chvcoo"
+      class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 zPnFT FormField__FormFieldContentBox-sc-m9hood-1 dSTFCs"
@@ -2083,6 +2107,9 @@ exports[`Form uncontrolled errors 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c2 {
@@ -2227,6 +2254,9 @@ exports[`Form uncontrolled infos 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c2 {
@@ -2515,6 +2545,9 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 1`] =
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c3 {
@@ -3347,7 +3380,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 hftPdQ FormField__FormFieldBox-sc-m9hood-0 chvcoo"
+      class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
     >
       <label
         class="StyledText-sc-1sadyjn-0 kKrMsX"
@@ -3410,7 +3443,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 hftPdQ FormField__FormFieldBox-sc-m9hood-0 chvcoo"
+      class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
     >
       <label
         class="StyledText-sc-1sadyjn-0 kKrMsX"
@@ -3446,7 +3479,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 hftPdQ FormField__FormFieldBox-sc-m9hood-0 chvcoo"
+      class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
     >
       <label
         class="StyledText-sc-1sadyjn-0 kKrMsX"
@@ -3580,6 +3613,9 @@ exports[`Form uncontrolled uncontrolled 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c2 {
@@ -3769,7 +3805,7 @@ exports[`Form uncontrolled uncontrolled 2`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 hftPdQ FormField__FormFieldBox-sc-m9hood-0 chvcoo"
+      class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 cqRjpC FormField__FormFieldContentBox-sc-m9hood-1"
@@ -3803,7 +3839,7 @@ exports[`Form uncontrolled uncontrolled 3`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 hftPdQ FormField__FormFieldBox-sc-m9hood-0 chvcoo"
+      class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 cqRjpC FormField__FormFieldContentBox-sc-m9hood-1"
@@ -3855,6 +3891,9 @@ exports[`Form uncontrolled uncontrolled onValidate 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c2 {
@@ -4044,7 +4083,7 @@ exports[`Form uncontrolled uncontrolled onValidate 2`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 hftPdQ FormField__FormFieldBox-sc-m9hood-0 chvcoo"
+      class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 cXkhIG FormField__FormFieldContentBox-sc-m9hood-1"
@@ -4123,6 +4162,9 @@ exports[`Form uncontrolled uncontrolled onValidate custom error 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c2 {
@@ -4312,7 +4354,7 @@ exports[`Form uncontrolled uncontrolled onValidate custom error 2`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 hftPdQ FormField__FormFieldBox-sc-m9hood-0 chvcoo"
+      class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 cXkhIG FormField__FormFieldContentBox-sc-m9hood-1"
@@ -4391,6 +4433,9 @@ exports[`Form uncontrolled uncontrolled onValidate custom info 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c2 {
@@ -4580,7 +4625,7 @@ exports[`Form uncontrolled uncontrolled onValidate custom info 2`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 hftPdQ FormField__FormFieldBox-sc-m9hood-0 chvcoo"
+      class="StyledBox-sc-13pk1d4-0 hfctvB FormField__FormFieldBox-sc-m9hood-0 chvcoo"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 cqRjpC FormField__FormFieldContentBox-sc-m9hood-1"
@@ -4655,6 +4700,9 @@ exports[`Form uncontrolled update 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c2 {
@@ -5020,6 +5068,9 @@ exports[`Form uncontrolled with field 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c2 {

--- a/src/js/components/FormField/FormField.js
+++ b/src/js/components/FormField/FormField.js
@@ -496,6 +496,7 @@ const FormField = forwardRef(
       <FormFieldBox
         ref={formFieldRef}
         className={className}
+        flex={false}
         background={outerBackground}
         margin={abut ? abutMargin : margin || { ...formFieldTheme.margin }}
         {...outerProps}

--- a/src/js/components/FormField/__tests__/__snapshots__/FormField-test.js.snap
+++ b/src/js/components/FormField/__tests__/__snapshots__/FormField-test.js.snap
@@ -25,6 +25,9 @@ exports[`FormField abut 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c2 {
@@ -91,6 +94,9 @@ exports[`FormField abut with margin 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c2 {
@@ -156,6 +162,9 @@ exports[`FormField checkbox pad is defined in formfield 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c3 {
@@ -423,6 +432,9 @@ exports[`FormField contentProps 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c3 {
@@ -591,6 +603,9 @@ exports[`FormField custom error and info icon and container 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c3 {
@@ -852,6 +867,9 @@ exports[`FormField custom formfield 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c3 {
@@ -922,6 +940,9 @@ exports[`FormField custom input margin 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c3 {
@@ -1072,6 +1093,9 @@ exports[`FormField custom label 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c3 {
@@ -1212,6 +1236,9 @@ exports[`FormField default 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c2 {
@@ -1344,6 +1371,9 @@ exports[`FormField disabled 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c2 {
@@ -1484,6 +1514,9 @@ exports[`FormField disabled with custom label 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c3 {
@@ -1629,6 +1662,9 @@ exports[`FormField empty margin 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c2 {
@@ -1695,6 +1731,9 @@ exports[`FormField error 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c2 {
@@ -1776,6 +1815,9 @@ exports[`FormField help 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c3 {
@@ -1854,6 +1896,9 @@ exports[`FormField htmlFor 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c2 {
@@ -1920,6 +1965,9 @@ exports[`FormField info 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c2 {
@@ -2001,6 +2049,9 @@ exports[`FormField label 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c3 {
@@ -2081,6 +2132,9 @@ exports[`FormField margin 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c2 {
@@ -2147,6 +2201,9 @@ exports[`FormField pad 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c2 {
@@ -2220,6 +2277,9 @@ exports[`FormField pad with border undefined 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c3 {
@@ -2361,6 +2421,9 @@ exports[`FormField required 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c2 {
@@ -2496,6 +2559,9 @@ exports[`FormField should have no accessibility violations 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c2 {
@@ -2562,6 +2628,9 @@ exports[`FormField should not render asterisk when required.indicator === false 
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c3 {
@@ -2703,6 +2772,9 @@ exports[`FormField should render asterisk when requiredIndicator === true 1`] = 
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c6 {
@@ -2913,6 +2985,9 @@ exports[`FormField should render custom indicator when requiredIndicator is
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c4 {

--- a/src/js/components/StarRating/__tests__/__snapshots__/StarRating-tests.tsx.snap
+++ b/src/js/components/StarRating/__tests__/__snapshots__/StarRating-tests.tsx.snap
@@ -655,6 +655,9 @@ exports[`StarRating value for rating 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c3 {

--- a/src/js/components/ThumbsRating/__tests__/__snapshots__/ThumbsRating.tsx.snap
+++ b/src/js/components/ThumbsRating/__tests__/__snapshots__/ThumbsRating.tsx.snap
@@ -453,6 +453,9 @@ exports[`ThumbsRating value for thumbs 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .c3 {

--- a/src/js/components/Toolbar/__tests__/__snapshots__/Toolbar-test.js.snap
+++ b/src/js/components/Toolbar/__tests__/__snapshots__/Toolbar-test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DataFilters renders 1`] = `
-.c8 {
+.c10 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -12,25 +12,25 @@ exports[`DataFilters renders 1`] = `
   stroke: #666666;
 }
 
-.c8 g {
+.c10 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c8 *:not([stroke])[fill="none"] {
+.c10 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c8 *[stroke*="#"],
-.c8 *[STROKE*="#"] {
+.c10 *[stroke*="#"],
+.c10 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c8 *[fill-rule],
-.c8 *[FILL-RULE],
-.c8 *[fill*="#"],
-.c8 *[FILL*="#"] {
+.c10 *[fill-rule],
+.c10 *[FILL-RULE],
+.c10 *[fill*="#"],
+.c10 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -85,7 +85,40 @@ exports[`DataFilters renders 1`] = `
   overflow: auto;
 }
 
-.c10 {
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-bottom: 12px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -108,24 +141,6 @@ exports[`DataFilters renders 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-}
-
-.c13 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  margin-bottom: 12px;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c15 {
@@ -207,6 +222,32 @@ exports[`DataFilters renders 1`] = `
   border-radius: 4px;
 }
 
+.c23 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-top: 12px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
 .c2 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -234,16 +275,6 @@ exports[`DataFilters renders 1`] = `
   row-gap: 12px;
 }
 
-.c12 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  -webkit-align-self: stretch;
-  -ms-flex-item-align: stretch;
-  align-self: stretch;
-  height: 6px;
-}
-
 .c22 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -254,7 +285,7 @@ exports[`DataFilters renders 1`] = `
   height: 12px;
 }
 
-.c24 {
+.c25 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -273,7 +304,7 @@ exports[`DataFilters renders 1`] = `
   line-height: 24px;
 }
 
-.c23 {
+.c24 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -301,51 +332,51 @@ exports[`DataFilters renders 1`] = `
   transition-timing-function: ease-in-out;
 }
 
-.c23:hover {
+.c24:hover {
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c23:focus {
+.c24:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c23:focus > circle,
-.c23:focus > ellipse,
-.c23:focus > line,
-.c23:focus > path,
-.c23:focus > polygon,
-.c23:focus > polyline,
-.c23:focus > rect {
+.c24:focus > circle,
+.c24:focus > ellipse,
+.c24:focus > line,
+.c24:focus > path,
+.c24:focus > polygon,
+.c24:focus > polyline,
+.c24:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c23:focus::-moz-focus-inner {
+.c24:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c23:focus:not(:focus-visible) {
+.c24:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c23:focus:not(:focus-visible) > circle,
-.c23:focus:not(:focus-visible) > ellipse,
-.c23:focus:not(:focus-visible) > line,
-.c23:focus:not(:focus-visible) > path,
-.c23:focus:not(:focus-visible) > polygon,
-.c23:focus:not(:focus-visible) > polyline,
-.c23:focus:not(:focus-visible) > rect {
+.c24:focus:not(:focus-visible) > circle,
+.c24:focus:not(:focus-visible) > ellipse,
+.c24:focus:not(:focus-visible) > line,
+.c24:focus:not(:focus-visible) > path,
+.c24:focus:not(:focus-visible) > polygon,
+.c24:focus:not(:focus-visible) > polyline,
+.c24:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c23:focus:not(:focus-visible)::-moz-focus-inner {
+.c24:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c25 {
+.c26 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -372,43 +403,43 @@ exports[`DataFilters renders 1`] = `
   transition-timing-function: ease-in-out;
 }
 
-.c25:focus {
+.c26:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c25:focus > circle,
-.c25:focus > ellipse,
-.c25:focus > line,
-.c25:focus > path,
-.c25:focus > polygon,
-.c25:focus > polyline,
-.c25:focus > rect {
+.c26:focus > circle,
+.c26:focus > ellipse,
+.c26:focus > line,
+.c26:focus > path,
+.c26:focus > polygon,
+.c26:focus > polyline,
+.c26:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c25:focus::-moz-focus-inner {
+.c26:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c25:focus:not(:focus-visible) {
+.c26:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c25:focus:not(:focus-visible) > circle,
-.c25:focus:not(:focus-visible) > ellipse,
-.c25:focus:not(:focus-visible) > line,
-.c25:focus:not(:focus-visible) > path,
-.c25:focus:not(:focus-visible) > polygon,
-.c25:focus:not(:focus-visible) > polyline,
-.c25:focus:not(:focus-visible) > rect {
+.c26:focus:not(:focus-visible) > circle,
+.c26:focus:not(:focus-visible) > ellipse,
+.c26:focus:not(:focus-visible) > line,
+.c26:focus:not(:focus-visible) > path,
+.c26:focus:not(:focus-visible) > polygon,
+.c26:focus:not(:focus-visible) > polyline,
+.c26:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c25:focus:not(:focus-visible)::-moz-focus-inner {
+.c26:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
@@ -459,7 +490,7 @@ exports[`DataFilters renders 1`] = `
   flex-shrink: 0;
 }
 
-.c9 {
+.c11 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -473,61 +504,43 @@ exports[`DataFilters renders 1`] = `
   margin: 0;
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
+  outline: none;
+  border: none;
   padding-left: 48px;
 }
 
-.c9:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c9:focus > circle,
-.c9:focus > ellipse,
-.c9:focus > line,
-.c9:focus > path,
-.c9:focus > polygon,
-.c9:focus > polyline,
-.c9:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c9:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c9::-webkit-input-placeholder {
+.c11::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c9::-moz-placeholder {
+.c11::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c9:-ms-input-placeholder {
+.c11:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c9::-webkit-search-decoration {
+.c11::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c9::-moz-focus-inner {
+.c11::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c9:-moz-placeholder,
-.c9::-moz-placeholder {
+.c11:-moz-placeholder,
+.c11::-moz-placeholder {
   opacity: 1;
 }
 
-.c6 {
+.c8 {
   position: relative;
   width: 100%;
 }
 
-.c7 {
+.c9 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -545,7 +558,7 @@ exports[`DataFilters renders 1`] = `
   left: 12px;
 }
 
-.c26 {
+.c27 {
   opacity: 0;
 }
 
@@ -553,7 +566,7 @@ exports[`DataFilters renders 1`] = `
   max-width: 100%;
 }
 
-.c11 {
+.c13 {
   margin: 0px;
   font-size: 26px;
   line-height: 32px;
@@ -577,8 +590,14 @@ exports[`DataFilters renders 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c13 {
+  .c6 {
     margin-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
@@ -607,15 +626,15 @@ exports[`DataFilters renders 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c2 {
-    -webkit-column-gap: 6px;
-    column-gap: 6px;
+  .c23 {
+    margin-top: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c12 {
-    height: 3px;
+  .c2 {
+    -webkit-column-gap: 6px;
+    column-gap: 6px;
   }
 }
 
@@ -626,19 +645,19 @@ exports[`DataFilters renders 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c24 {
+  .c25 {
     width: 12px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c11 {
+  .c13 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c11 {
+  .c13 {
     font-size: 22px;
     line-height: 28px;
     max-width: 528px;
@@ -665,33 +684,41 @@ exports[`DataFilters renders 1`] = `
             class="c5"
           >
             <div
-              class="c6"
+              class="c6 "
             >
               <div
-                class="c7"
+                class="c7 FormField__FormFieldContentBox-sc-m9hood-1"
               >
-                <svg
-                  aria-label="Search"
+                <div
                   class="c8"
-                  viewBox="0 0 24 24"
                 >
-                  <path
-                    d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                    fill="none"
-                    stroke="#000"
-                    stroke-width="2"
+                  <div
+                    class="c9"
+                  >
+                    <svg
+                      aria-label="Search"
+                      class="c10"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                        fill="none"
+                        stroke="#000"
+                        stroke-width="2"
+                      />
+                    </svg>
+                  </div>
+                  <input
+                    aria-label="Search data"
+                    autocomplete="off"
+                    class="c11"
+                    id="data--search"
+                    name="_search"
+                    type="search"
+                    value=""
                   />
-                </svg>
+                </div>
               </div>
-              <input
-                aria-label="Search data"
-                autocomplete="off"
-                class="c9"
-                id="data--search"
-                name="_search"
-                type="search"
-                value=""
-              />
             </div>
           </div>
         </div>
@@ -706,19 +733,16 @@ exports[`DataFilters renders 1`] = `
             class="c5"
           >
             <header
-              class="c10"
+              class="c12"
             >
               <h2
-                class="c11"
+                class="c13"
               >
                 Filters
               </h2>
             </header>
             <div
-              class="c12"
-            />
-            <div
-              class="c13 "
+              class="c6 "
             >
               <label
                 class="c14"
@@ -780,20 +804,20 @@ exports[`DataFilters renders 1`] = `
             </div>
           </div>
           <footer
-            class="c10"
+            class="c23"
           >
             <button
-              class="c23"
+              class="c24"
               type="submit"
             >
               Apply filters
             </button>
             <div
-              class="c24"
+              class="c25"
             />
             <button
               aria-hidden="true"
-              class="c25 c26"
+              class="c26 c27"
               disabled=""
               tabindex="-1"
               type="reset"

--- a/src/js/components/Toolbar/__tests__/__snapshots__/Toolbar-test.js.snap
+++ b/src/js/components/Toolbar/__tests__/__snapshots__/Toolbar-test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DataFilters renders 1`] = `
-.c6 {
+.c8 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -12,25 +12,25 @@ exports[`DataFilters renders 1`] = `
   stroke: #666666;
 }
 
-.c6 g {
+.c8 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c6 *:not([stroke])[fill="none"] {
+.c8 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c6 *[stroke*="#"],
-.c6 *[STROKE*="#"] {
+.c8 *[stroke*="#"],
+.c8 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c6 *[fill-rule],
-.c6 *[FILL-RULE],
-.c6 *[fill*="#"],
-.c6 *[FILL*="#"] {
+.c8 *[fill-rule],
+.c8 *[FILL-RULE],
+.c8 *[fill*="#"],
+.c8 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -52,7 +52,40 @@ exports[`DataFilters renders 1`] = `
   flex: 0 0 auto;
 }
 
-.c8 {
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 100%;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  overflow: auto;
+}
+
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -77,7 +110,7 @@ exports[`DataFilters renders 1`] = `
   justify-content: space-between;
 }
 
-.c11 {
+.c13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -90,9 +123,12 @@ exports[`DataFilters renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
-.c13 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -108,7 +144,7 @@ exports[`DataFilters renders 1`] = `
   padding: 12px;
 }
 
-.c14 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -122,7 +158,7 @@ exports[`DataFilters renders 1`] = `
   flex-direction: column;
 }
 
-.c16 {
+.c18 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -145,7 +181,7 @@ exports[`DataFilters renders 1`] = `
   justify-content: center;
 }
 
-.c19 {
+.c21 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -198,7 +234,17 @@ exports[`DataFilters renders 1`] = `
   row-gap: 12px;
 }
 
-.c10 {
+.c12 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  height: 6px;
+}
+
+.c22 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -208,7 +254,7 @@ exports[`DataFilters renders 1`] = `
   height: 12px;
 }
 
-.c21 {
+.c24 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -218,7 +264,7 @@ exports[`DataFilters renders 1`] = `
   width: 24px;
 }
 
-.c12 {
+.c14 {
   margin-left: 12px;
   margin-right: 12px;
   margin-top: 6px;
@@ -227,7 +273,7 @@ exports[`DataFilters renders 1`] = `
   line-height: 24px;
 }
 
-.c20 {
+.c23 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -255,51 +301,51 @@ exports[`DataFilters renders 1`] = `
   transition-timing-function: ease-in-out;
 }
 
-.c20:hover {
+.c23:hover {
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c20:focus {
+.c23:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c20:focus > circle,
-.c20:focus > ellipse,
-.c20:focus > line,
-.c20:focus > path,
-.c20:focus > polygon,
-.c20:focus > polyline,
-.c20:focus > rect {
+.c23:focus > circle,
+.c23:focus > ellipse,
+.c23:focus > line,
+.c23:focus > path,
+.c23:focus > polygon,
+.c23:focus > polyline,
+.c23:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c20:focus::-moz-focus-inner {
+.c23:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c20:focus:not(:focus-visible) {
+.c23:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c20:focus:not(:focus-visible) > circle,
-.c20:focus:not(:focus-visible) > ellipse,
-.c20:focus:not(:focus-visible) > line,
-.c20:focus:not(:focus-visible) > path,
-.c20:focus:not(:focus-visible) > polygon,
-.c20:focus:not(:focus-visible) > polyline,
-.c20:focus:not(:focus-visible) > rect {
+.c23:focus:not(:focus-visible) > circle,
+.c23:focus:not(:focus-visible) > ellipse,
+.c23:focus:not(:focus-visible) > line,
+.c23:focus:not(:focus-visible) > path,
+.c23:focus:not(:focus-visible) > polygon,
+.c23:focus:not(:focus-visible) > polyline,
+.c23:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c20:focus:not(:focus-visible)::-moz-focus-inner {
+.c23:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c22 {
+.c25 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -326,47 +372,47 @@ exports[`DataFilters renders 1`] = `
   transition-timing-function: ease-in-out;
 }
 
-.c22:focus {
+.c25:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c22:focus > circle,
-.c22:focus > ellipse,
-.c22:focus > line,
-.c22:focus > path,
-.c22:focus > polygon,
-.c22:focus > polyline,
-.c22:focus > rect {
+.c25:focus > circle,
+.c25:focus > ellipse,
+.c25:focus > line,
+.c25:focus > path,
+.c25:focus > polygon,
+.c25:focus > polyline,
+.c25:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c22:focus::-moz-focus-inner {
+.c25:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c22:focus:not(:focus-visible) {
+.c25:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c22:focus:not(:focus-visible) > circle,
-.c22:focus:not(:focus-visible) > ellipse,
-.c22:focus:not(:focus-visible) > line,
-.c22:focus:not(:focus-visible) > path,
-.c22:focus:not(:focus-visible) > polygon,
-.c22:focus:not(:focus-visible) > polyline,
-.c22:focus:not(:focus-visible) > rect {
+.c25:focus:not(:focus-visible) > circle,
+.c25:focus:not(:focus-visible) > ellipse,
+.c25:focus:not(:focus-visible) > line,
+.c25:focus:not(:focus-visible) > path,
+.c25:focus:not(:focus-visible) > polygon,
+.c25:focus:not(:focus-visible) > polyline,
+.c25:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c22:focus:not(:focus-visible)::-moz-focus-inner {
+.c25:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c15 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -388,12 +434,12 @@ exports[`DataFilters renders 1`] = `
   cursor: pointer;
 }
 
-.c15:hover input:not([disabled]) + div,
-.c15:hover input:not([disabled]) + span {
+.c17:hover input:not([disabled]) + div,
+.c17:hover input:not([disabled]) + span {
   border-color: #000000;
 }
 
-.c18 {
+.c20 {
   opacity: 0;
   -moz-appearance: none;
   width: 0;
@@ -402,18 +448,18 @@ exports[`DataFilters renders 1`] = `
   cursor: pointer;
 }
 
-.c18:checked + span > span {
+.c20:checked + span > span {
   left: calc( 48px - 24px );
   background: #7D4CDB;
 }
 
-.c17 {
+.c19 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c7 {
+.c9 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -430,58 +476,58 @@ exports[`DataFilters renders 1`] = `
   padding-left: 48px;
 }
 
-.c7:focus {
+.c9:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus > circle,
-.c7:focus > ellipse,
-.c7:focus > line,
-.c7:focus > path,
-.c7:focus > polygon,
-.c7:focus > polyline,
-.c7:focus > rect {
+.c9:focus > circle,
+.c9:focus > ellipse,
+.c9:focus > line,
+.c9:focus > path,
+.c9:focus > polygon,
+.c9:focus > polyline,
+.c9:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus::-moz-focus-inner {
+.c9:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c7::-webkit-input-placeholder {
+.c9::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-moz-placeholder {
+.c9::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c7:-ms-input-placeholder {
+.c9:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-webkit-search-decoration {
+.c9::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c7::-moz-focus-inner {
+.c9::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c7:-moz-placeholder,
-.c7::-moz-placeholder {
+.c9:-moz-placeholder,
+.c9::-moz-placeholder {
   opacity: 1;
 }
 
-.c4 {
+.c6 {
   position: relative;
   width: 100%;
 }
 
-.c5 {
+.c7 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -499,7 +545,7 @@ exports[`DataFilters renders 1`] = `
   left: 12px;
 }
 
-.c23 {
+.c26 {
   opacity: 0;
 }
 
@@ -507,7 +553,7 @@ exports[`DataFilters renders 1`] = `
   max-width: 100%;
 }
 
-.c9 {
+.c11 {
   margin: 0px;
   font-size: 26px;
   line-height: 32px;
@@ -531,31 +577,31 @@ exports[`DataFilters renders 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c11 {
+  .c13 {
     margin-bottom: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c13 {
+  .c15 {
     border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c13 {
+  .c15 {
     padding: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c16 {
+  .c18 {
     margin-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c19 {
+  .c21 {
     border: solid 2px rgba(0,0,0,0.15);
   }
 }
@@ -568,25 +614,31 @@ exports[`DataFilters renders 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c10 {
+  .c12 {
+    height: 3px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c22 {
     height: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c21 {
+  .c24 {
     width: 12px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c9 {
+  .c11 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c9 {
+  .c11 {
     font-size: 22px;
     line-height: 28px;
     max-width: 528px;
@@ -607,36 +659,40 @@ exports[`DataFilters renders 1`] = `
         class="c3"
       >
         <div
-          class="c1"
+          class="c4"
         >
           <div
-            class="c4"
+            class="c5"
           >
             <div
-              class="c5"
+              class="c6"
             >
-              <svg
-                aria-label="Search"
-                class="c6"
-                viewBox="0 0 24 24"
+              <div
+                class="c7"
               >
-                <path
-                  d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                  fill="none"
-                  stroke="#000"
-                  stroke-width="2"
-                />
-              </svg>
+                <svg
+                  aria-label="Search"
+                  class="c8"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                    fill="none"
+                    stroke="#000"
+                    stroke-width="2"
+                  />
+                </svg>
+              </div>
+              <input
+                aria-label="Search data"
+                autocomplete="off"
+                class="c9"
+                id="data--search"
+                name="_search"
+                type="search"
+                value=""
+              />
             </div>
-            <input
-              aria-label="Search data"
-              autocomplete="off"
-              class="c7"
-              id="data--search"
-              name="_search"
-              type="search"
-              value=""
-            />
           </div>
         </div>
       </form>
@@ -644,99 +700,100 @@ exports[`DataFilters renders 1`] = `
         class="c3"
       >
         <div
-          class="c1"
+          class="c4"
         >
-          <header
-            class="c8"
-          >
-            <h2
-              class="c9"
-            >
-              Filters
-            </h2>
-          </header>
           <div
-            class="c10"
-          />
-          <div
-            class="c11 "
+            class="c5"
           >
-            <label
-              class="c12"
-              for="data-name"
+            <header
+              class="c10"
             >
-              name
-            </label>
-            <div
-              class="c13 FormField__FormFieldContentBox-sc-m9hood-1"
-            >
-              <div
-                class="c14 StyledCheckBoxGroup-sc-2nhc5d-0"
-                id="data-name"
-                role="group"
+              <h2
+                class="c11"
               >
-                <label
-                  class="c15"
-                  label="a"
-                >
-                  <div
-                    class="c16 c17"
-                  >
-                    <input
-                      class="c18"
-                      type="checkbox"
-                    />
-                    <div
-                      class="c19 "
-                    />
-                  </div>
-                  <span>
-                    a
-                  </span>
-                </label>
+                Filters
+              </h2>
+            </header>
+            <div
+              class="c12"
+            />
+            <div
+              class="c13 "
+            >
+              <label
+                class="c14"
+                for="data-name"
+              >
+                name
+              </label>
+              <div
+                class="c15 FormField__FormFieldContentBox-sc-m9hood-1"
+              >
                 <div
-                  class="c10"
-                />
-                <label
-                  class="c15"
-                  label="b"
+                  class="c16 StyledCheckBoxGroup-sc-2nhc5d-0"
+                  id="data-name"
+                  role="group"
                 >
-                  <div
-                    class="c16 c17"
+                  <label
+                    class="c17"
+                    label="a"
                   >
-                    <input
-                      class="c18"
-                      type="checkbox"
-                    />
                     <div
-                      class="c19 "
-                    />
-                  </div>
-                  <span>
-                    b
-                  </span>
-                </label>
+                      class="c18 c19"
+                    >
+                      <input
+                        class="c20"
+                        type="checkbox"
+                      />
+                      <div
+                        class="c21 "
+                      />
+                    </div>
+                    <span>
+                      a
+                    </span>
+                  </label>
+                  <div
+                    class="c22"
+                  />
+                  <label
+                    class="c17"
+                    label="b"
+                  >
+                    <div
+                      class="c18 c19"
+                    >
+                      <input
+                        class="c20"
+                        type="checkbox"
+                      />
+                      <div
+                        class="c21 "
+                      />
+                    </div>
+                    <span>
+                      b
+                    </span>
+                  </label>
+                </div>
               </div>
             </div>
           </div>
-          <div
-            class="c10"
-          />
           <footer
-            class="c8"
+            class="c10"
           >
             <button
-              class="c20"
+              class="c23"
               type="submit"
             >
               Apply filters
             </button>
             <div
-              class="c21"
+              class="c24"
             />
             <button
               aria-hidden="true"
-              class="c22 c23"
+              class="c25 c26"
               disabled=""
               tabindex="-1"
               type="reset"

--- a/src/js/components/Toolbar/__tests__/__snapshots__/Toolbar-test.js.snap
+++ b/src/js/components/Toolbar/__tests__/__snapshots__/Toolbar-test.js.snap
@@ -292,7 +292,7 @@ exports[`DataFilters renders 1`] = `
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
   align-self: stretch;
-  width: 24px;
+  width: 12px;
 }
 
 .c14 {
@@ -646,7 +646,7 @@ exports[`DataFilters renders 1`] = `
 
 @media only screen and (max-width:768px) {
   .c25 {
-    width: 12px;
+    width: 6px;
   }
 }
 

--- a/src/js/components/Toolbar/__tests__/__snapshots__/Toolbar-test.js.snap
+++ b/src/js/components/Toolbar/__tests__/__snapshots__/Toolbar-test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DataFilters renders 1`] = `
-.c10 {
+.c8 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -12,25 +12,25 @@ exports[`DataFilters renders 1`] = `
   stroke: #666666;
 }
 
-.c10 g {
+.c8 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c10 *:not([stroke])[fill="none"] {
+.c8 *:not([stroke])[fill="none"] {
   stroke-width: 0;
 }
 
-.c10 *[stroke*="#"],
-.c10 *[STROKE*="#"] {
+.c8 *[stroke*="#"],
+.c8 *[STROKE*="#"] {
   stroke: inherit;
   fill: none;
 }
 
-.c10 *[fill-rule],
-.c10 *[FILL-RULE],
-.c10 *[fill*="#"],
-.c10 *[FILL*="#"] {
+.c8 *[fill-rule],
+.c8 *[FILL-RULE],
+.c8 *[fill*="#"],
+.c8 *[FILL*="#"] {
   fill: inherit;
   stroke: none;
 }
@@ -85,40 +85,7 @@ exports[`DataFilters renders 1`] = `
   overflow: auto;
 }
 
-.c6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  margin-bottom: 12px;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-}
-
-.c7 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c12 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -143,7 +110,25 @@ exports[`DataFilters renders 1`] = `
   justify-content: space-between;
 }
 
-.c15 {
+.c12 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-bottom: 12px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -159,7 +144,7 @@ exports[`DataFilters renders 1`] = `
   padding: 12px;
 }
 
-.c16 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -173,7 +158,7 @@ exports[`DataFilters renders 1`] = `
   flex-direction: column;
 }
 
-.c18 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -196,7 +181,7 @@ exports[`DataFilters renders 1`] = `
   justify-content: center;
 }
 
-.c21 {
+.c20 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -222,7 +207,7 @@ exports[`DataFilters renders 1`] = `
   border-radius: 4px;
 }
 
-.c23 {
+.c22 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -275,7 +260,7 @@ exports[`DataFilters renders 1`] = `
   row-gap: 12px;
 }
 
-.c22 {
+.c21 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -285,7 +270,7 @@ exports[`DataFilters renders 1`] = `
   height: 12px;
 }
 
-.c25 {
+.c24 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -295,7 +280,7 @@ exports[`DataFilters renders 1`] = `
   width: 12px;
 }
 
-.c14 {
+.c13 {
   margin-left: 12px;
   margin-right: 12px;
   margin-top: 6px;
@@ -304,7 +289,7 @@ exports[`DataFilters renders 1`] = `
   line-height: 24px;
 }
 
-.c24 {
+.c23 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -332,51 +317,51 @@ exports[`DataFilters renders 1`] = `
   transition-timing-function: ease-in-out;
 }
 
-.c24:hover {
+.c23:hover {
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c24:focus {
+.c23:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c24:focus > circle,
-.c24:focus > ellipse,
-.c24:focus > line,
-.c24:focus > path,
-.c24:focus > polygon,
-.c24:focus > polyline,
-.c24:focus > rect {
+.c23:focus > circle,
+.c23:focus > ellipse,
+.c23:focus > line,
+.c23:focus > path,
+.c23:focus > polygon,
+.c23:focus > polyline,
+.c23:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c24:focus::-moz-focus-inner {
+.c23:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c24:focus:not(:focus-visible) {
+.c23:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c24:focus:not(:focus-visible) > circle,
-.c24:focus:not(:focus-visible) > ellipse,
-.c24:focus:not(:focus-visible) > line,
-.c24:focus:not(:focus-visible) > path,
-.c24:focus:not(:focus-visible) > polygon,
-.c24:focus:not(:focus-visible) > polyline,
-.c24:focus:not(:focus-visible) > rect {
+.c23:focus:not(:focus-visible) > circle,
+.c23:focus:not(:focus-visible) > ellipse,
+.c23:focus:not(:focus-visible) > line,
+.c23:focus:not(:focus-visible) > path,
+.c23:focus:not(:focus-visible) > polygon,
+.c23:focus:not(:focus-visible) > polyline,
+.c23:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c24:focus:not(:focus-visible)::-moz-focus-inner {
+.c23:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c26 {
+.c25 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -403,47 +388,47 @@ exports[`DataFilters renders 1`] = `
   transition-timing-function: ease-in-out;
 }
 
-.c26:focus {
+.c25:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c26:focus > circle,
-.c26:focus > ellipse,
-.c26:focus > line,
-.c26:focus > path,
-.c26:focus > polygon,
-.c26:focus > polyline,
-.c26:focus > rect {
+.c25:focus > circle,
+.c25:focus > ellipse,
+.c25:focus > line,
+.c25:focus > path,
+.c25:focus > polygon,
+.c25:focus > polyline,
+.c25:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c26:focus::-moz-focus-inner {
+.c25:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c26:focus:not(:focus-visible) {
+.c25:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c26:focus:not(:focus-visible) > circle,
-.c26:focus:not(:focus-visible) > ellipse,
-.c26:focus:not(:focus-visible) > line,
-.c26:focus:not(:focus-visible) > path,
-.c26:focus:not(:focus-visible) > polygon,
-.c26:focus:not(:focus-visible) > polyline,
-.c26:focus:not(:focus-visible) > rect {
+.c25:focus:not(:focus-visible) > circle,
+.c25:focus:not(:focus-visible) > ellipse,
+.c25:focus:not(:focus-visible) > line,
+.c25:focus:not(:focus-visible) > path,
+.c25:focus:not(:focus-visible) > polygon,
+.c25:focus:not(:focus-visible) > polyline,
+.c25:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c26:focus:not(:focus-visible)::-moz-focus-inner {
+.c25:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c17 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -465,12 +450,12 @@ exports[`DataFilters renders 1`] = `
   cursor: pointer;
 }
 
-.c17:hover input:not([disabled]) + div,
-.c17:hover input:not([disabled]) + span {
+.c16:hover input:not([disabled]) + div,
+.c16:hover input:not([disabled]) + span {
   border-color: #000000;
 }
 
-.c20 {
+.c19 {
   opacity: 0;
   -moz-appearance: none;
   width: 0;
@@ -479,18 +464,18 @@ exports[`DataFilters renders 1`] = `
   cursor: pointer;
 }
 
-.c20:checked + span > span {
+.c19:checked + span > span {
   left: calc( 48px - 24px );
   background: #7D4CDB;
 }
 
-.c19 {
+.c18 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c11 {
+.c9 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -504,43 +489,61 @@ exports[`DataFilters renders 1`] = `
   margin: 0;
   border: 1px solid rgba(0,0,0,0.33);
   border-radius: 4px;
-  outline: none;
-  border: none;
   padding-left: 48px;
 }
 
-.c11::-webkit-input-placeholder {
+.c9:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9:focus > circle,
+.c9:focus > ellipse,
+.c9:focus > line,
+.c9:focus > path,
+.c9:focus > polygon,
+.c9:focus > polyline,
+.c9:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c9::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c11::-moz-placeholder {
+.c9::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c11:-ms-input-placeholder {
+.c9:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c11::-webkit-search-decoration {
+.c9::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c11::-moz-focus-inner {
+.c9::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c11:-moz-placeholder,
-.c11::-moz-placeholder {
+.c9:-moz-placeholder,
+.c9::-moz-placeholder {
   opacity: 1;
 }
 
-.c8 {
+.c6 {
   position: relative;
   width: 100%;
 }
 
-.c9 {
+.c7 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -558,7 +561,7 @@ exports[`DataFilters renders 1`] = `
   left: 12px;
 }
 
-.c27 {
+.c26 {
   opacity: 0;
 }
 
@@ -566,7 +569,7 @@ exports[`DataFilters renders 1`] = `
   max-width: 100%;
 }
 
-.c13 {
+.c11 {
   margin: 0px;
   font-size: 26px;
   line-height: 32px;
@@ -590,43 +593,37 @@ exports[`DataFilters renders 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c6 {
+  .c12 {
     margin-bottom: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c7 {
+  .c14 {
     border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c15 {
-    border-bottom: solid 1px rgba(0,0,0,0.33);
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c15 {
+  .c14 {
     padding: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c18 {
+  .c17 {
     margin-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c21 {
+  .c20 {
     border: solid 2px rgba(0,0,0,0.15);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c23 {
+  .c22 {
     margin-top: 6px;
   }
 }
@@ -639,25 +636,25 @@ exports[`DataFilters renders 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c22 {
+  .c21 {
     height: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c25 {
+  .c24 {
     width: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c13 {
+  .c11 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c13 {
+  .c11 {
     font-size: 22px;
     line-height: 28px;
     max-width: 528px;
@@ -684,41 +681,33 @@ exports[`DataFilters renders 1`] = `
             class="c5"
           >
             <div
-              class="c6 "
+              class="c6"
             >
               <div
-                class="c7 FormField__FormFieldContentBox-sc-m9hood-1"
+                class="c7"
               >
-                <div
+                <svg
+                  aria-label="Search"
                   class="c8"
+                  viewBox="0 0 24 24"
                 >
-                  <div
-                    class="c9"
-                  >
-                    <svg
-                      aria-label="Search"
-                      class="c10"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                        fill="none"
-                        stroke="#000"
-                        stroke-width="2"
-                      />
-                    </svg>
-                  </div>
-                  <input
-                    aria-label="Search data"
-                    autocomplete="off"
-                    class="c11"
-                    id="data--search"
-                    name="_search"
-                    type="search"
-                    value=""
+                  <path
+                    d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                    fill="none"
+                    stroke="#000"
+                    stroke-width="2"
                   />
-                </div>
+                </svg>
               </div>
+              <input
+                aria-label="Search"
+                autocomplete="off"
+                class="c9"
+                id="data--search"
+                name="_search"
+                type="search"
+                value=""
+              />
             </div>
           </div>
         </div>
@@ -733,44 +722,44 @@ exports[`DataFilters renders 1`] = `
             class="c5"
           >
             <header
-              class="c12"
+              class="c10"
             >
               <h2
-                class="c13"
+                class="c11"
               >
                 Filters
               </h2>
             </header>
             <div
-              class="c6 "
+              class="c12 "
             >
               <label
-                class="c14"
+                class="c13"
                 for="data-name"
               >
                 name
               </label>
               <div
-                class="c15 FormField__FormFieldContentBox-sc-m9hood-1"
+                class="c14 FormField__FormFieldContentBox-sc-m9hood-1"
               >
                 <div
-                  class="c16 StyledCheckBoxGroup-sc-2nhc5d-0"
+                  class="c15 StyledCheckBoxGroup-sc-2nhc5d-0"
                   id="data-name"
                   role="group"
                 >
                   <label
-                    class="c17"
+                    class="c16"
                     label="a"
                   >
                     <div
-                      class="c18 c19"
+                      class="c17 c18"
                     >
                       <input
-                        class="c20"
+                        class="c19"
                         type="checkbox"
                       />
                       <div
-                        class="c21 "
+                        class="c20 "
                       />
                     </div>
                     <span>
@@ -778,21 +767,21 @@ exports[`DataFilters renders 1`] = `
                     </span>
                   </label>
                   <div
-                    class="c22"
+                    class="c21"
                   />
                   <label
-                    class="c17"
+                    class="c16"
                     label="b"
                   >
                     <div
-                      class="c18 c19"
+                      class="c17 c18"
                     >
                       <input
-                        class="c20"
+                        class="c19"
                         type="checkbox"
                       />
                       <div
-                        class="c21 "
+                        class="c20 "
                       />
                     </div>
                     <span>
@@ -804,20 +793,20 @@ exports[`DataFilters renders 1`] = `
             </div>
           </div>
           <footer
-            class="c23"
+            class="c22"
           >
             <button
-              class="c24"
+              class="c23"
               type="submit"
             >
               Apply filters
             </button>
             <div
-              class="c25"
+              class="c24"
             />
             <button
               aria-hidden="true"
-              class="c26 c27"
+              class="c25 c26"
               disabled=""
               tabindex="-1"
               type="reset"

--- a/src/js/languages/default.json
+++ b/src/js/languages/default.json
@@ -25,7 +25,7 @@
     "submit": "Apply filters"
   },
   "dataSearch": {
-    "label": "Search data",
+    "label": "Search",
     "open": "Open search"
   },
   "dataSort": {
@@ -44,6 +44,9 @@
     "open": "Open column selector",
     "order": "Order columns",
     "select": "Select columns"
+  },
+  "dataView": {
+    "label": "View"
   },
   "fileInput": {
     "browse": "browse",


### PR DESCRIPTION
#### What does this PR do?

Changed DataFilters to have overflow when using `drop` or `layer`.

The snapshot changes are primarily due to two reasons:
- the restructuring of DataForm
- adding `flex={false}` to FormField

#### Where should the reviewer start?

DataForm.js

#### What testing has been done on this PR?

storys

#### How should this be manually tested?

storys

#### Do Jest tests follow these best practices?

no tests were changed in the creation of this pull request

#### Any background context you want to provide?

#### What are the relevant issues?

#6626 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
