### PR TITLE
Calendar - add `calendar[size].title` prop to theme

### DIFF
--- a/src/js/components/Calendar/Calendar.js
+++ b/src/js/components/Calendar/Calendar.js
@@ -14,6 +14,7 @@ import { defaultProps } from '../../default-props';
 
 import { Box } from '../Box';
 import { Button } from '../Button';
+import { Header } from '../Header';
 import { Heading } from '../Heading';
 import { Keyboard } from '../Keyboard';
 import { Text } from '../Text';
@@ -587,19 +588,24 @@ const Calendar = forwardRef(
           ? theme.calendar.icons.small.next
           : theme.calendar.icons.next;
 
+      const monthAndYear = reference.toLocaleDateString(locale, {
+        month: 'long',
+        year: 'numeric',
+      });
+
       return (
         <Box direction="row" justify="between" align="center">
-          <Box flex pad={{ horizontal: headingPadMap[size] || 'small' }}>
-            {theme.calendar.heading && theme.calendar[size].titleSize ? (
-              <Text weight="bold" size={theme.calendar[size].titleSize}>
-                {reference.toLocaleDateString(locale, {
-                  month: 'long',
-                  year: 'numeric',
-                })}
+          <Header flex pad={{ horizontal: headingPadMap[size] || 'small' }}>
+            {theme.calendar[size]?.title ? (
+              <Text
+                weight={theme.calendar[size].title?.weight || 'normal'}
+                size={theme.calendar[size].title?.size || 'medium'}
+              >
+                {monthAndYear}
               </Text>
             ) : (
               // theme.calendar.heading.level should be removed in v3 of grommet
-              // theme.calendar[size].titleSize should be used instead
+              // theme.calendar[size].title should be used instead
               <Heading
                 level={
                   size === 'small'
@@ -614,13 +620,10 @@ const Calendar = forwardRef(
                 margin="none"
                 overflowWrap="normal"
               >
-                {reference.toLocaleDateString(locale, {
-                  month: 'long',
-                  year: 'numeric',
-                })}
+                {monthAndYear}
               </Heading>
             )}
-          </Box>
+          </Header>
           <Box flex={false} direction="row" align="center">
             <Button
               a11yTitle={format({

--- a/src/js/components/Calendar/Calendar.js
+++ b/src/js/components/Calendar/Calendar.js
@@ -16,6 +16,7 @@ import { Box } from '../Box';
 import { Button } from '../Button';
 import { Heading } from '../Heading';
 import { Keyboard } from '../Keyboard';
+import { Text } from '../Text';
 
 import { CalendarPropTypes } from './propTypes';
 import {
@@ -589,23 +590,36 @@ const Calendar = forwardRef(
       return (
         <Box direction="row" justify="between" align="center">
           <Box flex pad={{ horizontal: headingPadMap[size] || 'small' }}>
-            <Heading
-              level={
-                size === 'small'
-                  ? (theme.calendar.heading && theme.calendar.heading.level) ||
-                    4
-                  : ((theme.calendar.heading && theme.calendar.heading.level) ||
-                      4) - 1
-              }
-              size={size}
-              margin="none"
-              overflowWrap="normal"
-            >
-              {reference.toLocaleDateString(locale, {
-                month: 'long',
-                year: 'numeric',
-              })}
-            </Heading>
+            {theme.calendar.heading && theme.calendar[size].headingSize ? (
+              <Text weight="bold" size={theme.calendar[size].headingSize}>
+                {reference.toLocaleDateString(locale, {
+                  month: 'long',
+                  year: 'numeric',
+                })}
+              </Text>
+            ) : (
+              // theme.calendar.heading.level should be removed in v3 of grommet
+              // theme.calendar[size].headingSize should be used instead
+              <Heading
+                level={
+                  size === 'small'
+                    ? (theme.calendar.heading &&
+                        theme.calendar.heading.level) ||
+                      4
+                    : ((theme.calendar.heading &&
+                        theme.calendar.heading.level) ||
+                        4) - 1
+                }
+                size={size}
+                margin="none"
+                overflowWrap="normal"
+              >
+                {reference.toLocaleDateString(locale, {
+                  month: 'long',
+                  year: 'numeric',
+                })}
+              </Heading>
+            )}
           </Box>
           <Box flex={false} direction="row" align="center">
             <Button

--- a/src/js/components/Calendar/Calendar.js
+++ b/src/js/components/Calendar/Calendar.js
@@ -590,8 +590,8 @@ const Calendar = forwardRef(
       return (
         <Box direction="row" justify="between" align="center">
           <Box flex pad={{ horizontal: headingPadMap[size] || 'small' }}>
-            {theme.calendar.heading && theme.calendar[size].headingSize ? (
-              <Text weight="bold" size={theme.calendar[size].headingSize}>
+            {theme.calendar.heading && theme.calendar[size].titleSize ? (
+              <Text weight="bold" size={theme.calendar[size].titleSize}>
                 {reference.toLocaleDateString(locale, {
                   month: 'long',
                   year: 'numeric',
@@ -599,7 +599,7 @@ const Calendar = forwardRef(
               </Text>
             ) : (
               // theme.calendar.heading.level should be removed in v3 of grommet
-              // theme.calendar[size].headingSize should be used instead
+              // theme.calendar[size].titleSize should be used instead
               <Heading
                 level={
                   size === 'small'

--- a/src/js/components/Calendar/Calendar.js
+++ b/src/js/components/Calendar/Calendar.js
@@ -597,12 +597,7 @@ const Calendar = forwardRef(
         <Box direction="row" justify="between" align="center">
           <Header flex pad={{ horizontal: headingPadMap[size] || 'small' }}>
             {theme.calendar[size]?.title ? (
-              <Text
-                weight={theme.calendar[size].title?.weight || 'normal'}
-                size={theme.calendar[size].title?.size || 'medium'}
-              >
-                {monthAndYear}
-              </Text>
+              <Text {...theme.calendar[size].title}>{monthAndYear}</Text>
             ) : (
               // theme.calendar.heading.level should be removed in v3 of grommet
               // theme.calendar[size].title should be used instead

--- a/src/js/components/Calendar/__tests__/Calendar-test.tsx
+++ b/src/js/components/Calendar/__tests__/Calendar-test.tsx
@@ -761,13 +761,19 @@ describe('Calendar Keyboard events', () => {
         theme={{
           calendar: {
             small: {
-              titleSize: 'medium',
+              title: {
+                size: 'medium',
+              },
             },
             medium: {
-              titleSize: 'large',
+              title: {
+                size: 'large',
+              },
             },
             large: {
-              titleSize: 'xxlarge',
+              title: {
+                size: 'xxlarge',
+              },
             },
           },
         }}

--- a/src/js/components/Calendar/__tests__/Calendar-test.tsx
+++ b/src/js/components/Calendar/__tests__/Calendar-test.tsx
@@ -761,13 +761,13 @@ describe('Calendar Keyboard events', () => {
         theme={{
           calendar: {
             small: {
-              headingSize: 'medium',
+              titleSize: 'medium',
             },
             medium: {
-              headingSize: 'large',
+              titleSize: 'large',
             },
             large: {
-              headingSize: 'xxlarge',
+              titleSize: 'xxlarge',
             },
           },
         }}

--- a/src/js/components/Calendar/__tests__/Calendar-test.tsx
+++ b/src/js/components/Calendar/__tests__/Calendar-test.tsx
@@ -754,4 +754,27 @@ describe('Calendar Keyboard events', () => {
     // Jan 16th is set to active
     expect(onSelect).toBeCalledWith(expect.stringMatching(/^2020-01-16T/));
   });
+
+  test('heading text font size', () => {
+    const { asFragment } = render(
+      <Grommet
+        theme={{
+          calendar: {
+            small: {
+              headingSize: 'medium',
+            },
+            medium: {
+              headingSize: 'large',
+            },
+            large: {
+              headingSize: 'xxlarge',
+            },
+          },
+        }}
+      >
+        <Calendar date={DATE} daysOfWeek size="large" />
+      </Grommet>,
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
 });

--- a/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.tsx.snap
+++ b/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.tsx.snap
@@ -79,14 +79,22 @@ exports[`Calendar Keyboard events heading text font size 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding-left: 24px;
   padding-right: 24px;
 }
@@ -115,7 +123,7 @@ exports[`Calendar Keyboard events heading text font size 1`] = `
 .c5 {
   font-size: 34px;
   line-height: 40px;
-  font-weight: bold;
+  font-weight: normal;
 }
 
 .c7 {
@@ -352,7 +360,7 @@ exports[`Calendar Keyboard events heading text font size 1`] = `
         <div
           class="c3"
         >
-          <div
+          <header
             class="c4"
           >
             <span
@@ -360,7 +368,7 @@ exports[`Calendar Keyboard events heading text font size 1`] = `
             >
               January 2020
             </span>
-          </div>
+          </header>
           <div
             class="c6"
           >
@@ -1316,14 +1324,22 @@ exports[`Calendar change months 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -1586,7 +1602,7 @@ exports[`Calendar change months 1`] = `
       <div
         class="c3"
       >
-        <div
+        <header
           class="c4"
         >
           <h3
@@ -1594,7 +1610,7 @@ exports[`Calendar change months 1`] = `
           >
             December 2019
           </h3>
-        </div>
+        </header>
         <div
           class="c6"
         >
@@ -2409,15 +2425,15 @@ exports[`Calendar change months 2`] = `
       <div
         class="StyledBox-sc-13pk1d4-0 kOZkFt"
       >
-        <div
-          class="StyledBox-sc-13pk1d4-0 ebVTCF"
+        <header
+          class="StyledBox-sc-13pk1d4-0 oGcPZ"
         >
           <h3
             class="StyledHeading-sc-1rdh4aw-0 eGutsY"
           >
             January 2020
           </h3>
-        </div>
+        </header>
         <div
           class="StyledBox-sc-13pk1d4-0 dFwpuo"
         >
@@ -3754,14 +3770,22 @@ exports[`Calendar children 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -3958,7 +3982,7 @@ exports[`Calendar children 1`] = `
       <div
         class="c3"
       >
-        <div
+        <header
           class="c4"
         >
           <h3
@@ -3966,7 +3990,7 @@ exports[`Calendar children 1`] = `
           >
             January 2020
           </h3>
-        </div>
+        </header>
         <div
           class="c6"
         >
@@ -4552,14 +4576,22 @@ exports[`Calendar date 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -4842,7 +4874,7 @@ exports[`Calendar date 1`] = `
       <div
         class="c3"
       >
-        <div
+        <header
           class="c4"
         >
           <h3
@@ -4850,7 +4882,7 @@ exports[`Calendar date 1`] = `
           >
             January 2020
           </h3>
-        </div>
+        </header>
         <div
           class="c6"
         >
@@ -5730,14 +5762,22 @@ exports[`Calendar dates 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -6038,7 +6078,7 @@ exports[`Calendar dates 1`] = `
       <div
         class="c3"
       >
-        <div
+        <header
           class="c4"
         >
           <h3
@@ -6046,7 +6086,7 @@ exports[`Calendar dates 1`] = `
           >
             January 2020
           </h3>
-        </div>
+        </header>
         <div
           class="c6"
         >
@@ -6926,14 +6966,22 @@ exports[`Calendar daysOfWeek 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -7234,7 +7282,7 @@ exports[`Calendar daysOfWeek 1`] = `
       <div
         class="c3"
       >
-        <div
+        <header
           class="c4"
         >
           <h3
@@ -7242,7 +7290,7 @@ exports[`Calendar daysOfWeek 1`] = `
           >
             January 2020
           </h3>
-        </div>
+        </header>
         <div
           class="c6"
         >
@@ -8198,14 +8246,22 @@ exports[`Calendar disabled 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -8548,7 +8604,7 @@ exports[`Calendar disabled 1`] = `
         <div
           class="c3"
         >
-          <div
+          <header
             class="c4"
           >
             <h3
@@ -8556,7 +8612,7 @@ exports[`Calendar disabled 1`] = `
             >
               January 2020
             </h3>
-          </div>
+          </header>
           <div
             class="c6"
           >
@@ -9440,14 +9496,22 @@ exports[`Calendar fill 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -9749,7 +9813,7 @@ exports[`Calendar fill 1`] = `
       <div
         class="c3"
       >
-        <div
+        <header
           class="c4"
         >
           <h3
@@ -9757,7 +9821,7 @@ exports[`Calendar fill 1`] = `
           >
             January 2020
           </h3>
-        </div>
+        </header>
         <div
           class="c6"
         >
@@ -10637,14 +10701,22 @@ exports[`Calendar first day sunday week monday 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -10927,7 +10999,7 @@ exports[`Calendar first day sunday week monday 1`] = `
       <div
         class="c3"
       >
-        <div
+        <header
           class="c4"
         >
           <h3
@@ -10935,7 +11007,7 @@ exports[`Calendar first day sunday week monday 1`] = `
           >
             March 2020
           </h3>
-        </div>
+        </header>
         <div
           class="c6"
         >
@@ -11815,14 +11887,22 @@ exports[`Calendar firstDayOfWeek 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -12105,7 +12185,7 @@ exports[`Calendar firstDayOfWeek 1`] = `
       <div
         class="c3"
       >
-        <div
+        <header
           class="c4"
         >
           <h3
@@ -12113,7 +12193,7 @@ exports[`Calendar firstDayOfWeek 1`] = `
           >
             January 2020
           </h3>
-        </div>
+        </header>
         <div
           class="c6"
         >
@@ -12921,7 +13001,7 @@ exports[`Calendar firstDayOfWeek 1`] = `
       <div
         class="c3"
       >
-        <div
+        <header
           class="c4"
         >
           <h3
@@ -12929,7 +13009,7 @@ exports[`Calendar firstDayOfWeek 1`] = `
           >
             January 2020
           </h3>
-        </div>
+        </header>
         <div
           class="c6"
         >
@@ -14964,14 +15044,22 @@ exports[`Calendar reference 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -15234,7 +15322,7 @@ exports[`Calendar reference 1`] = `
       <div
         class="c3"
       >
-        <div
+        <header
           class="c4"
         >
           <h3
@@ -15242,7 +15330,7 @@ exports[`Calendar reference 1`] = `
           >
             January 2020
           </h3>
-        </div>
+        </header>
         <div
           class="c6"
         >
@@ -16122,14 +16210,22 @@ exports[`Calendar select date 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -16412,7 +16508,7 @@ exports[`Calendar select date 1`] = `
       <div
         class="c3"
       >
-        <div
+        <header
           class="c4"
         >
           <h3
@@ -16420,7 +16516,7 @@ exports[`Calendar select date 1`] = `
           >
             January 2020
           </h3>
-        </div>
+        </header>
         <div
           class="c6"
         >
@@ -17235,15 +17331,15 @@ exports[`Calendar select date 2`] = `
       <div
         class="StyledBox-sc-13pk1d4-0 kOZkFt"
       >
-        <div
-          class="StyledBox-sc-13pk1d4-0 ebVTCF"
+        <header
+          class="StyledBox-sc-13pk1d4-0 oGcPZ"
         >
           <h3
             class="StyledHeading-sc-1rdh4aw-0 eGutsY"
           >
             January 2020
           </h3>
-        </div>
+        </header>
         <div
           class="StyledBox-sc-13pk1d4-0 dFwpuo"
         >
@@ -18123,14 +18219,22 @@ exports[`Calendar select dates 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -18431,7 +18535,7 @@ exports[`Calendar select dates 1`] = `
       <div
         class="c3"
       >
-        <div
+        <header
           class="c4"
         >
           <h3
@@ -18439,7 +18543,7 @@ exports[`Calendar select dates 1`] = `
           >
             January 2020
           </h3>
-        </div>
+        </header>
         <div
           class="c6"
         >
@@ -19254,15 +19358,15 @@ exports[`Calendar select dates 2`] = `
       <div
         class="StyledBox-sc-13pk1d4-0 kOZkFt"
       >
-        <div
-          class="StyledBox-sc-13pk1d4-0 ebVTCF"
+        <header
+          class="StyledBox-sc-13pk1d4-0 oGcPZ"
         >
           <h3
             class="StyledHeading-sc-1rdh4aw-0 eGutsY"
           >
             January 2020
           </h3>
-        </div>
+        </header>
         <div
           class="StyledBox-sc-13pk1d4-0 dFwpuo"
         >
@@ -20142,14 +20246,22 @@ exports[`Calendar showAdjacentDays 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -20432,7 +20544,7 @@ exports[`Calendar showAdjacentDays 1`] = `
       <div
         class="c3"
       >
-        <div
+        <header
           class="c4"
         >
           <h3
@@ -20440,7 +20552,7 @@ exports[`Calendar showAdjacentDays 1`] = `
           >
             January 2020
           </h3>
-        </div>
+        </header>
         <div
           class="c6"
         >
@@ -21248,7 +21360,7 @@ exports[`Calendar showAdjacentDays 1`] = `
       <div
         class="c3"
       >
-        <div
+        <header
           class="c4"
         >
           <h3
@@ -21256,7 +21368,7 @@ exports[`Calendar showAdjacentDays 1`] = `
           >
             January 2020
           </h3>
-        </div>
+        </header>
         <div
           class="c6"
         >
@@ -21953,7 +22065,7 @@ exports[`Calendar showAdjacentDays 1`] = `
       <div
         class="c3"
       >
-        <div
+        <header
           class="c4"
         >
           <h3
@@ -21961,7 +22073,7 @@ exports[`Calendar showAdjacentDays 1`] = `
           >
             January 2020
           </h3>
-        </div>
+        </header>
         <div
           class="c6"
         >
@@ -22804,14 +22916,22 @@ exports[`Calendar size 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding-left: 6px;
   padding-right: 6px;
 }
@@ -22844,14 +22964,22 @@ exports[`Calendar size 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -22863,14 +22991,22 @@ exports[`Calendar size 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding-left: 24px;
   padding-right: 24px;
 }
@@ -23324,7 +23460,7 @@ exports[`Calendar size 1`] = `
       <div
         class="c3"
       >
-        <div
+        <header
           class="c4"
         >
           <h4
@@ -23332,7 +23468,7 @@ exports[`Calendar size 1`] = `
           >
             January 2020
           </h4>
-        </div>
+        </header>
         <div
           class="c6"
         >
@@ -24140,7 +24276,7 @@ exports[`Calendar size 1`] = `
       <div
         class="c3"
       >
-        <div
+        <header
           class="c18"
         >
           <h3
@@ -24148,7 +24284,7 @@ exports[`Calendar size 1`] = `
           >
             January 2020
           </h3>
-        </div>
+        </header>
         <div
           class="c6"
         >
@@ -24956,7 +25092,7 @@ exports[`Calendar size 1`] = `
       <div
         class="c3"
       >
-        <div
+        <header
           class="c25"
         >
           <h3
@@ -24964,7 +25100,7 @@ exports[`Calendar size 1`] = `
           >
             January 2020
           </h3>
-        </div>
+        </header>
         <div
           class="c6"
         >

--- a/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.tsx.snap
+++ b/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.tsx.snap
@@ -1,5 +1,1243 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Calendar Keyboard events heading text font size 1`] = `
+<DocumentFragment>
+  .c8 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 48px;
+  height: 48px;
+  fill: #666666;
+  stroke: #666666;
+}
+
+.c8 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c8 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c8 *[stroke*="#"],
+.c8 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c8 *[fill-rule],
+.c8 *[FILL-RULE],
+.c8 *[fill*="#"],
+.c8 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  padding-left: 24px;
+  padding-right: 24px;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c5 {
+  font-size: 34px;
+  line-height: 40px;
+  font-weight: bold;
+}
+
+.c7 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  line-height: 0;
+  padding: 12px;
+}
+
+.c7:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c7:focus > circle,
+.c7:focus > ellipse,
+.c7:focus > line,
+.c7:focus > path,
+.c7:focus > polygon,
+.c7:focus > polyline,
+.c7:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c7:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c7:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c7:focus:not(:focus-visible) > circle,
+.c7:focus:not(:focus-visible) > ellipse,
+.c7:focus:not(:focus-visible) > line,
+.c7:focus:not(:focus-visible) > path,
+.c7:focus:not(:focus-visible) > polygon,
+.c7:focus:not(:focus-visible) > polyline,
+.c7:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c7:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c14 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c14:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c14:focus > circle,
+.c14:focus > ellipse,
+.c14:focus > line,
+.c14:focus > path,
+.c14:focus > polygon,
+.c14:focus > polyline,
+.c14:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c14:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c14:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c14:focus:not(:focus-visible) > circle,
+.c14:focus:not(:focus-visible) > ellipse,
+.c14:focus:not(:focus-visible) > line,
+.c14:focus:not(:focus-visible) > path,
+.c14:focus:not(:focus-visible) > polygon,
+.c14:focus:not(:focus-visible) > polyline,
+.c14:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c14:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c1 {
+  font-size: 30px;
+  line-height: 1.11;
+  width: 768px;
+}
+
+.c12 {
+  overflow: hidden;
+  height: 658.2857142857142px;
+}
+
+.c13 {
+  position: relative;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c10 {
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
+}
+
+.c11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  width: 109.71428571428571px;
+  height: 109.71428571428571px;
+  opacity: 0.5;
+}
+
+.c15 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  width: 109.71428571428571px;
+  height: 109.71428571428571px;
+}
+
+.c16 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  width: 109.71428571428571px;
+  height: 109.71428571428571px;
+  background-color: #7D4CDB;
+  color: #f8f8f8;
+  font-weight: bold;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+@media only screen and (max-width:768px) {
+  .c4 {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+}
+
+<div
+    class="c0"
+  >
+    <div
+      class="c1"
+    >
+      <div
+        class="c2"
+      >
+        <div
+          class="c3"
+        >
+          <div
+            class="c4"
+          >
+            <span
+              class="c5"
+            >
+              January 2020
+            </span>
+          </div>
+          <div
+            class="c6"
+          >
+            <button
+              aria-label="Go to December 2019"
+              class="c7"
+              type="button"
+            >
+              <svg
+                aria-label="Previous"
+                class="c8"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M17 2 7 12l10 10"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </button>
+            <button
+              aria-label="Go to February 2020"
+              class="c7"
+              type="button"
+            >
+              <svg
+                aria-label="Next"
+                class="c8"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m7 2 10 10L7 22"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div
+          class="c9"
+          role="row"
+        >
+          <div
+            class="c10"
+            role="gridcell"
+          >
+            <div
+              class="c11"
+            >
+              S
+            </div>
+          </div>
+          <div
+            class="c10"
+            role="gridcell"
+          >
+            <div
+              class="c11"
+            >
+              M
+            </div>
+          </div>
+          <div
+            class="c10"
+            role="gridcell"
+          >
+            <div
+              class="c11"
+            >
+              T
+            </div>
+          </div>
+          <div
+            class="c10"
+            role="gridcell"
+          >
+            <div
+              class="c11"
+            >
+              W
+            </div>
+          </div>
+          <div
+            class="c10"
+            role="gridcell"
+          >
+            <div
+              class="c11"
+            >
+              T
+            </div>
+          </div>
+          <div
+            class="c10"
+            role="gridcell"
+          >
+            <div
+              class="c11"
+            >
+              F
+            </div>
+          </div>
+          <div
+            class="c10"
+            role="gridcell"
+          >
+            <div
+              class="c11"
+            >
+              S
+            </div>
+          </div>
+        </div>
+        <div
+          aria-label="January 2020; Currently selected January 15, 2020;"
+          class="c12"
+          role="grid"
+          tabindex="0"
+        >
+          <div
+            class="c13"
+          >
+            <div
+              class="c9"
+              role="row"
+            >
+              <div
+                class="c10"
+                role="gridcell"
+              >
+                <button
+                  aria-label="Sun Dec 29 2019"
+                  class="c14"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <div
+                    class="c11"
+                  >
+                    29
+                  </div>
+                </button>
+              </div>
+              <div
+                class="c10"
+                role="gridcell"
+              >
+                <button
+                  aria-label="Mon Dec 30 2019"
+                  class="c14"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <div
+                    class="c11"
+                  >
+                    30
+                  </div>
+                </button>
+              </div>
+              <div
+                class="c10"
+                role="gridcell"
+              >
+                <button
+                  aria-label="Tue Dec 31 2019"
+                  class="c14"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <div
+                    class="c11"
+                  >
+                    31
+                  </div>
+                </button>
+              </div>
+              <div
+                class="c10"
+                role="gridcell"
+              >
+                <button
+                  aria-label="Wed Jan 01 2020"
+                  class="c14"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <div
+                    class="c15"
+                  >
+                    1
+                  </div>
+                </button>
+              </div>
+              <div
+                class="c10"
+                role="gridcell"
+              >
+                <button
+                  aria-label="Thu Jan 02 2020"
+                  class="c14"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <div
+                    class="c15"
+                  >
+                    2
+                  </div>
+                </button>
+              </div>
+              <div
+                class="c10"
+                role="gridcell"
+              >
+                <button
+                  aria-label="Fri Jan 03 2020"
+                  class="c14"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <div
+                    class="c15"
+                  >
+                    3
+                  </div>
+                </button>
+              </div>
+              <div
+                class="c10"
+                role="gridcell"
+              >
+                <button
+                  aria-label="Sat Jan 04 2020"
+                  class="c14"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <div
+                    class="c15"
+                  >
+                    4
+                  </div>
+                </button>
+              </div>
+            </div>
+            <div
+              class="c9"
+              role="row"
+            >
+              <div
+                class="c10"
+                role="gridcell"
+              >
+                <button
+                  aria-label="Sun Jan 05 2020"
+                  class="c14"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <div
+                    class="c15"
+                  >
+                    5
+                  </div>
+                </button>
+              </div>
+              <div
+                class="c10"
+                role="gridcell"
+              >
+                <button
+                  aria-label="Mon Jan 06 2020"
+                  class="c14"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <div
+                    class="c15"
+                  >
+                    6
+                  </div>
+                </button>
+              </div>
+              <div
+                class="c10"
+                role="gridcell"
+              >
+                <button
+                  aria-label="Tue Jan 07 2020"
+                  class="c14"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <div
+                    class="c15"
+                  >
+                    7
+                  </div>
+                </button>
+              </div>
+              <div
+                class="c10"
+                role="gridcell"
+              >
+                <button
+                  aria-label="Wed Jan 08 2020"
+                  class="c14"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <div
+                    class="c15"
+                  >
+                    8
+                  </div>
+                </button>
+              </div>
+              <div
+                class="c10"
+                role="gridcell"
+              >
+                <button
+                  aria-label="Thu Jan 09 2020"
+                  class="c14"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <div
+                    class="c15"
+                  >
+                    9
+                  </div>
+                </button>
+              </div>
+              <div
+                class="c10"
+                role="gridcell"
+              >
+                <button
+                  aria-label="Fri Jan 10 2020"
+                  class="c14"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <div
+                    class="c15"
+                  >
+                    10
+                  </div>
+                </button>
+              </div>
+              <div
+                class="c10"
+                role="gridcell"
+              >
+                <button
+                  aria-label="Sat Jan 11 2020"
+                  class="c14"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <div
+                    class="c15"
+                  >
+                    11
+                  </div>
+                </button>
+              </div>
+            </div>
+            <div
+              class="c9"
+              role="row"
+            >
+              <div
+                class="c10"
+                role="gridcell"
+              >
+                <button
+                  aria-label="Sun Jan 12 2020"
+                  class="c14"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <div
+                    class="c15"
+                  >
+                    12
+                  </div>
+                </button>
+              </div>
+              <div
+                class="c10"
+                role="gridcell"
+              >
+                <button
+                  aria-label="Mon Jan 13 2020"
+                  class="c14"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <div
+                    class="c15"
+                  >
+                    13
+                  </div>
+                </button>
+              </div>
+              <div
+                class="c10"
+                role="gridcell"
+              >
+                <button
+                  aria-label="Tue Jan 14 2020"
+                  class="c14"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <div
+                    class="c15"
+                  >
+                    14
+                  </div>
+                </button>
+              </div>
+              <div
+                class="c10"
+                role="gridcell"
+              >
+                <button
+                  aria-label="Wed Jan 15 2020"
+                  class="c14"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <div
+                    class="c16"
+                  >
+                    15
+                  </div>
+                </button>
+              </div>
+              <div
+                class="c10"
+                role="gridcell"
+              >
+                <button
+                  aria-label="Thu Jan 16 2020"
+                  class="c14"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <div
+                    class="c15"
+                  >
+                    16
+                  </div>
+                </button>
+              </div>
+              <div
+                class="c10"
+                role="gridcell"
+              >
+                <button
+                  aria-label="Fri Jan 17 2020"
+                  class="c14"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <div
+                    class="c15"
+                  >
+                    17
+                  </div>
+                </button>
+              </div>
+              <div
+                class="c10"
+                role="gridcell"
+              >
+                <button
+                  aria-label="Sat Jan 18 2020"
+                  class="c14"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <div
+                    class="c15"
+                  >
+                    18
+                  </div>
+                </button>
+              </div>
+            </div>
+            <div
+              class="c9"
+              role="row"
+            >
+              <div
+                class="c10"
+                role="gridcell"
+              >
+                <button
+                  aria-label="Sun Jan 19 2020"
+                  class="c14"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <div
+                    class="c15"
+                  >
+                    19
+                  </div>
+                </button>
+              </div>
+              <div
+                class="c10"
+                role="gridcell"
+              >
+                <button
+                  aria-label="Mon Jan 20 2020"
+                  class="c14"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <div
+                    class="c15"
+                  >
+                    20
+                  </div>
+                </button>
+              </div>
+              <div
+                class="c10"
+                role="gridcell"
+              >
+                <button
+                  aria-label="Tue Jan 21 2020"
+                  class="c14"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <div
+                    class="c15"
+                  >
+                    21
+                  </div>
+                </button>
+              </div>
+              <div
+                class="c10"
+                role="gridcell"
+              >
+                <button
+                  aria-label="Wed Jan 22 2020"
+                  class="c14"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <div
+                    class="c15"
+                  >
+                    22
+                  </div>
+                </button>
+              </div>
+              <div
+                class="c10"
+                role="gridcell"
+              >
+                <button
+                  aria-label="Thu Jan 23 2020"
+                  class="c14"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <div
+                    class="c15"
+                  >
+                    23
+                  </div>
+                </button>
+              </div>
+              <div
+                class="c10"
+                role="gridcell"
+              >
+                <button
+                  aria-label="Fri Jan 24 2020"
+                  class="c14"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <div
+                    class="c15"
+                  >
+                    24
+                  </div>
+                </button>
+              </div>
+              <div
+                class="c10"
+                role="gridcell"
+              >
+                <button
+                  aria-label="Sat Jan 25 2020"
+                  class="c14"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <div
+                    class="c15"
+                  >
+                    25
+                  </div>
+                </button>
+              </div>
+            </div>
+            <div
+              class="c9"
+              role="row"
+            >
+              <div
+                class="c10"
+                role="gridcell"
+              >
+                <button
+                  aria-label="Sun Jan 26 2020"
+                  class="c14"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <div
+                    class="c15"
+                  >
+                    26
+                  </div>
+                </button>
+              </div>
+              <div
+                class="c10"
+                role="gridcell"
+              >
+                <button
+                  aria-label="Mon Jan 27 2020"
+                  class="c14"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <div
+                    class="c15"
+                  >
+                    27
+                  </div>
+                </button>
+              </div>
+              <div
+                class="c10"
+                role="gridcell"
+              >
+                <button
+                  aria-label="Tue Jan 28 2020"
+                  class="c14"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <div
+                    class="c15"
+                  >
+                    28
+                  </div>
+                </button>
+              </div>
+              <div
+                class="c10"
+                role="gridcell"
+              >
+                <button
+                  aria-label="Wed Jan 29 2020"
+                  class="c14"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <div
+                    class="c15"
+                  >
+                    29
+                  </div>
+                </button>
+              </div>
+              <div
+                class="c10"
+                role="gridcell"
+              >
+                <button
+                  aria-label="Thu Jan 30 2020"
+                  class="c14"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <div
+                    class="c15"
+                  >
+                    30
+                  </div>
+                </button>
+              </div>
+              <div
+                class="c10"
+                role="gridcell"
+              >
+                <button
+                  aria-label="Fri Jan 31 2020"
+                  class="c14"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <div
+                    class="c15"
+                  >
+                    31
+                  </div>
+                </button>
+              </div>
+              <div
+                class="c10"
+                role="gridcell"
+              >
+                <button
+                  aria-label="Sat Feb 01 2020"
+                  class="c14"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <div
+                    class="c11"
+                  >
+                    1
+                  </div>
+                </button>
+              </div>
+            </div>
+            <div
+              class="c9"
+              role="row"
+            >
+              <div
+                class="c10"
+                role="gridcell"
+              >
+                <button
+                  aria-label="Sun Feb 02 2020"
+                  class="c14"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <div
+                    class="c11"
+                  >
+                    2
+                  </div>
+                </button>
+              </div>
+              <div
+                class="c10"
+                role="gridcell"
+              >
+                <button
+                  aria-label="Mon Feb 03 2020"
+                  class="c14"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <div
+                    class="c11"
+                  >
+                    3
+                  </div>
+                </button>
+              </div>
+              <div
+                class="c10"
+                role="gridcell"
+              >
+                <button
+                  aria-label="Tue Feb 04 2020"
+                  class="c14"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <div
+                    class="c11"
+                  >
+                    4
+                  </div>
+                </button>
+              </div>
+              <div
+                class="c10"
+                role="gridcell"
+              >
+                <button
+                  aria-label="Wed Feb 05 2020"
+                  class="c14"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <div
+                    class="c11"
+                  >
+                    5
+                  </div>
+                </button>
+              </div>
+              <div
+                class="c10"
+                role="gridcell"
+              >
+                <button
+                  aria-label="Thu Feb 06 2020"
+                  class="c14"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <div
+                    class="c11"
+                  >
+                    6
+                  </div>
+                </button>
+              </div>
+              <div
+                class="c10"
+                role="gridcell"
+              >
+                <button
+                  aria-label="Fri Feb 07 2020"
+                  class="c14"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <div
+                    class="c11"
+                  >
+                    7
+                  </div>
+                </button>
+              </div>
+              <div
+                class="c10"
+                role="gridcell"
+              >
+                <button
+                  aria-label="Sat Feb 08 2020"
+                  class="c14"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <div
+                    class="c11"
+                  >
+                    8
+                  </div>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`Calendar change months 1`] = `
 .c8 {
   display: inline-block;

--- a/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.tsx.snap
+++ b/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.tsx.snap
@@ -123,7 +123,6 @@ exports[`Calendar Keyboard events heading text font size 1`] = `
 .c5 {
   font-size: 34px;
   line-height: 40px;
-  font-weight: normal;
 }
 
 .c7 {

--- a/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.tsx.snap
+++ b/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.tsx.snap
@@ -369,14 +369,22 @@ exports[`DateInput controlled format inline 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -895,7 +903,7 @@ exports[`DateInput controlled format inline 1`] = `
         <div
           class="c8"
         >
-          <div
+          <header
             class="c9"
           >
             <h3
@@ -903,7 +911,7 @@ exports[`DateInput controlled format inline 1`] = `
             >
               July 2020
             </h3>
-          </div>
+          </header>
           <div
             class="c11"
           >
@@ -1761,15 +1769,15 @@ exports[`DateInput controlled format inline 2`] = `
         <div
           class="StyledBox-sc-13pk1d4-0 kOZkFt"
         >
-          <div
-            class="StyledBox-sc-13pk1d4-0 ebVTCF"
+          <header
+            class="StyledBox-sc-13pk1d4-0 oGcPZ"
           >
             <h3
               class="StyledHeading-sc-1rdh4aw-0 eGutsY"
             >
               July 2020
             </h3>
-          </div>
+          </header>
           <div
             class="StyledBox-sc-13pk1d4-0 dFwpuo"
           >
@@ -2685,14 +2693,22 @@ exports[`DateInput controlled format inline without timezone 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -3211,7 +3227,7 @@ exports[`DateInput controlled format inline without timezone 1`] = `
           <div
             class="c8"
           >
-            <div
+            <header
               class="c9"
             >
               <h3
@@ -3219,7 +3235,7 @@ exports[`DateInput controlled format inline without timezone 1`] = `
               >
                 July 2020
               </h3>
-            </div>
+            </header>
             <div
               class="c11"
             >
@@ -4136,14 +4152,22 @@ exports[`DateInput controlled format inline without timezone 2`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -4662,7 +4686,7 @@ exports[`DateInput controlled format inline without timezone 2`] = `
           <div
             class="c8"
           >
-            <div
+            <header
               class="c9"
             >
               <h3
@@ -4670,7 +4694,7 @@ exports[`DateInput controlled format inline without timezone 2`] = `
               >
                 July 2020
               </h3>
-            </div>
+            </header>
             <div
               class="c11"
             >
@@ -6932,14 +6956,22 @@ exports[`DateInput format inline 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -7389,7 +7421,7 @@ exports[`DateInput format inline 1`] = `
         <div
           class="c8"
         >
-          <div
+          <header
             class="c9"
           >
             <h3
@@ -7397,7 +7429,7 @@ exports[`DateInput format inline 1`] = `
             >
               July 2020
             </h3>
-          </div>
+          </header>
           <div
             class="c11"
           >
@@ -8959,14 +8991,22 @@ exports[`DateInput inline 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -9240,7 +9280,7 @@ exports[`DateInput inline 1`] = `
       <div
         class="c3"
       >
-        <div
+        <header
           class="c4"
         >
           <h3
@@ -9248,7 +9288,7 @@ exports[`DateInput inline 1`] = `
           >
             July 2020
           </h3>
-        </div>
+        </header>
         <div
           class="c6"
         >
@@ -11509,14 +11549,22 @@ exports[`DateInput range format inline 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -11984,7 +12032,7 @@ exports[`DateInput range format inline 1`] = `
         <div
           class="c8"
         >
-          <div
+          <header
             class="c9"
           >
             <h3
@@ -11992,7 +12040,7 @@ exports[`DateInput range format inline 1`] = `
             >
               July 2020
             </h3>
-          </div>
+          </header>
           <div
             class="c11"
           >
@@ -12883,14 +12931,22 @@ exports[`DateInput range inline 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -13182,7 +13238,7 @@ exports[`DateInput range inline 1`] = `
       <div
         class="c3"
       >
-        <div
+        <header
           class="c4"
         >
           <h3
@@ -13190,7 +13246,7 @@ exports[`DateInput range inline 1`] = `
           >
             July 2020
           </h3>
-        </div>
+        </header>
         <div
           class="c6"
         >
@@ -14977,14 +15033,22 @@ exports[`DateInput select format 3`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -15383,7 +15447,7 @@ exports[`DateInput select format 3`] = `
       <div
         class="c4"
       >
-        <div
+        <header
           class="c5"
         >
           <h3
@@ -15391,7 +15455,7 @@ exports[`DateInput select format 3`] = `
           >
             July 2020
           </h3>
-        </div>
+        </header>
         <div
           class="c7"
         >
@@ -16205,7 +16269,7 @@ exports[`DateInput select format 4`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .ebVTCF {
+  .oGcPZ {
     padding-left: 6px;
     padding-right: 6px;
   }
@@ -16330,14 +16394,22 @@ exports[`DateInput select format inline 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -16787,7 +16859,7 @@ exports[`DateInput select format inline 1`] = `
         <div
           class="c8"
         >
-          <div
+          <header
             class="c9"
           >
             <h3
@@ -16795,7 +16867,7 @@ exports[`DateInput select format inline 1`] = `
             >
               July 2020
             </h3>
-          </div>
+          </header>
           <div
             class="c11"
           >
@@ -17647,15 +17719,15 @@ exports[`DateInput select format inline 2`] = `
         <div
           class="StyledBox-sc-13pk1d4-0 kOZkFt"
         >
-          <div
-            class="StyledBox-sc-13pk1d4-0 ebVTCF"
+          <header
+            class="StyledBox-sc-13pk1d4-0 oGcPZ"
           >
             <h3
               class="StyledHeading-sc-1rdh4aw-0 eGutsY"
             >
               July 2020
             </h3>
-          </div>
+          </header>
           <div
             class="StyledBox-sc-13pk1d4-0 dFwpuo"
           >
@@ -18565,14 +18637,22 @@ exports[`DateInput select format inline 3`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -19022,7 +19102,7 @@ exports[`DateInput select format inline 3`] = `
           <div
             class="c8"
           >
-            <div
+            <header
               class="c9"
             >
               <h3
@@ -19030,7 +19110,7 @@ exports[`DateInput select format inline 3`] = `
               >
                 July 2020
               </h3>
-            </div>
+            </header>
             <div
               class="c11"
             >
@@ -19941,14 +20021,22 @@ exports[`DateInput select format inline 4`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -20475,7 +20563,7 @@ exports[`DateInput select format inline 4`] = `
           <div
             class="c8"
           >
-            <div
+            <header
               class="c9"
             >
               <h3
@@ -20483,7 +20571,7 @@ exports[`DateInput select format inline 4`] = `
               >
                 July 2020
               </h3>
-            </div>
+            </header>
             <div
               class="c11"
             >
@@ -21393,14 +21481,22 @@ exports[`DateInput select format inline range 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -21868,7 +21964,7 @@ exports[`DateInput select format inline range 1`] = `
         <div
           class="c8"
         >
-          <div
+          <header
             class="c9"
           >
             <h3
@@ -21876,7 +21972,7 @@ exports[`DateInput select format inline range 1`] = `
             >
               July 2020
             </h3>
-          </div>
+          </header>
           <div
             class="c11"
           >
@@ -22728,15 +22824,15 @@ exports[`DateInput select format inline range 2`] = `
         <div
           class="StyledBox-sc-13pk1d4-0 kOZkFt"
         >
-          <div
-            class="StyledBox-sc-13pk1d4-0 ebVTCF"
+          <header
+            class="StyledBox-sc-13pk1d4-0 oGcPZ"
           >
             <h3
               class="StyledHeading-sc-1rdh4aw-0 eGutsY"
             >
               July 2020
             </h3>
-          </div>
+          </header>
           <div
             class="StyledBox-sc-13pk1d4-0 dFwpuo"
           >
@@ -23646,14 +23742,22 @@ exports[`DateInput select format inline range without timezone 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -24121,7 +24225,7 @@ exports[`DateInput select format inline range without timezone 1`] = `
           <div
             class="c8"
           >
-            <div
+            <header
               class="c9"
             >
               <h3
@@ -24129,7 +24233,7 @@ exports[`DateInput select format inline range without timezone 1`] = `
               >
                 July 2020
               </h3>
-            </div>
+            </header>
             <div
               class="c11"
             >
@@ -25040,14 +25144,22 @@ exports[`DateInput select format inline range without timezone 2`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -25574,7 +25686,7 @@ exports[`DateInput select format inline range without timezone 2`] = `
           <div
             class="c8"
           >
-            <div
+            <header
               class="c9"
             >
               <h3
@@ -25582,7 +25694,7 @@ exports[`DateInput select format inline range without timezone 2`] = `
               >
                 July 2020
               </h3>
-            </div>
+            </header>
             <div
               class="c11"
             >
@@ -26970,14 +27082,22 @@ exports[`DateInput select format no timezone 3`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -27376,7 +27496,7 @@ exports[`DateInput select format no timezone 3`] = `
       <div
         class="c4"
       >
-        <div
+        <header
           class="c5"
         >
           <h3
@@ -27384,7 +27504,7 @@ exports[`DateInput select format no timezone 3`] = `
           >
             July 2020
           </h3>
-        </div>
+        </header>
         <div
           class="c7"
         >
@@ -28198,7 +28318,7 @@ exports[`DateInput select format no timezone 4`] = `
   }
 }
 @media only screen and (max-width: 768px) {
-  .ebVTCF {
+  .oGcPZ {
     padding-left: 6px;
     padding-right: 6px;
   }
@@ -28305,14 +28425,22 @@ exports[`DateInput select inline 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -28586,7 +28714,7 @@ exports[`DateInput select inline 1`] = `
       <div
         class="c3"
       >
-        <div
+        <header
           class="c4"
         >
           <h3
@@ -28594,7 +28722,7 @@ exports[`DateInput select inline 1`] = `
           >
             July 2020
           </h3>
-        </div>
+        </header>
         <div
           class="c6"
         >
@@ -29484,14 +29612,22 @@ exports[`DateInput select inline without timezone 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -29765,7 +29901,7 @@ exports[`DateInput select inline without timezone 1`] = `
       <div
         class="c3"
       >
-        <div
+        <header
           class="c4"
         >
           <h3
@@ -29773,7 +29909,7 @@ exports[`DateInput select inline without timezone 1`] = `
           >
             July 2020
           </h3>
-        </div>
+        </header>
         <div
           class="c6"
         >
@@ -30681,14 +30817,22 @@ exports[`DateInput type format inline 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -31138,7 +31282,7 @@ exports[`DateInput type format inline 1`] = `
         <div
           class="c8"
         >
-          <div
+          <header
             class="c9"
           >
             <h3
@@ -31146,7 +31290,7 @@ exports[`DateInput type format inline 1`] = `
             >
               July 2020
             </h3>
-          </div>
+          </header>
           <div
             class="c11"
           >
@@ -31998,15 +32142,15 @@ exports[`DateInput type format inline 2`] = `
         <div
           class="StyledBox-sc-13pk1d4-0 kOZkFt"
         >
-          <div
-            class="StyledBox-sc-13pk1d4-0 ebVTCF"
+          <header
+            class="StyledBox-sc-13pk1d4-0 oGcPZ"
           >
             <h3
               class="StyledHeading-sc-1rdh4aw-0 eGutsY"
             >
               July 2020
             </h3>
-          </div>
+          </header>
           <div
             class="StyledBox-sc-13pk1d4-0 dFwpuo"
           >
@@ -32915,14 +33059,22 @@ exports[`DateInput type format inline partial 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -33372,7 +33524,7 @@ exports[`DateInput type format inline partial 1`] = `
         <div
           class="c8"
         >
-          <div
+          <header
             class="c9"
           >
             <h3
@@ -33380,7 +33532,7 @@ exports[`DateInput type format inline partial 1`] = `
             >
               July 2020
             </h3>
-          </div>
+          </header>
           <div
             class="c11"
           >
@@ -34290,14 +34442,22 @@ exports[`DateInput type format inline partial without timezone 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -34747,7 +34907,7 @@ exports[`DateInput type format inline partial without timezone 1`] = `
           <div
             class="c8"
           >
-            <div
+            <header
               class="c9"
             >
               <h3
@@ -34755,7 +34915,7 @@ exports[`DateInput type format inline partial without timezone 1`] = `
               >
                 July 2020
               </h3>
-            </div>
+            </header>
             <div
               class="c11"
             >
@@ -35665,14 +35825,22 @@ exports[`DateInput type format inline range 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -36140,7 +36308,7 @@ exports[`DateInput type format inline range 1`] = `
         <div
           class="c8"
         >
-          <div
+          <header
             class="c9"
           >
             <h3
@@ -36148,7 +36316,7 @@ exports[`DateInput type format inline range 1`] = `
             >
               July 2020
             </h3>
-          </div>
+          </header>
           <div
             class="c11"
           >
@@ -37000,15 +37168,15 @@ exports[`DateInput type format inline range 2`] = `
         <div
           class="StyledBox-sc-13pk1d4-0 kOZkFt"
         >
-          <div
-            class="StyledBox-sc-13pk1d4-0 ebVTCF"
+          <header
+            class="StyledBox-sc-13pk1d4-0 oGcPZ"
           >
             <h3
               class="StyledHeading-sc-1rdh4aw-0 eGutsY"
             >
               July 2020
             </h3>
-          </div>
+          </header>
           <div
             class="StyledBox-sc-13pk1d4-0 dFwpuo"
           >
@@ -37917,14 +38085,22 @@ exports[`DateInput type format inline range partial 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -38392,7 +38568,7 @@ exports[`DateInput type format inline range partial 1`] = `
         <div
           class="c8"
         >
-          <div
+          <header
             class="c9"
           >
             <h3
@@ -38400,7 +38576,7 @@ exports[`DateInput type format inline range partial 1`] = `
             >
               July 2020
             </h3>
-          </div>
+          </header>
           <div
             class="c11"
           >
@@ -39252,15 +39428,15 @@ exports[`DateInput type format inline range partial 2`] = `
         <div
           class="StyledBox-sc-13pk1d4-0 kOZkFt"
         >
-          <div
-            class="StyledBox-sc-13pk1d4-0 ebVTCF"
+          <header
+            class="StyledBox-sc-13pk1d4-0 oGcPZ"
           >
             <h3
               class="StyledHeading-sc-1rdh4aw-0 eGutsY"
             >
               July 2020
             </h3>
-          </div>
+          </header>
           <div
             class="StyledBox-sc-13pk1d4-0 dFwpuo"
           >
@@ -40112,15 +40288,15 @@ exports[`DateInput type format inline range partial 3`] = `
         <div
           class="StyledBox-sc-13pk1d4-0 kOZkFt"
         >
-          <div
-            class="StyledBox-sc-13pk1d4-0 ebVTCF"
+          <header
+            class="StyledBox-sc-13pk1d4-0 oGcPZ"
           >
             <h3
               class="StyledHeading-sc-1rdh4aw-0 eGutsY"
             >
               July 2020
             </h3>
-          </div>
+          </header>
           <div
             class="StyledBox-sc-13pk1d4-0 dFwpuo"
           >
@@ -41030,14 +41206,22 @@ exports[`DateInput type format inline range partial without timezone 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -41505,7 +41689,7 @@ exports[`DateInput type format inline range partial without timezone 1`] = `
           <div
             class="c8"
           >
-            <div
+            <header
               class="c9"
             >
               <h3
@@ -41513,7 +41697,7 @@ exports[`DateInput type format inline range partial without timezone 1`] = `
               >
                 July 2020
               </h3>
-            </div>
+            </header>
             <div
               class="c11"
             >
@@ -42424,14 +42608,22 @@ exports[`DateInput type format inline range partial without timezone 2`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -42881,7 +43073,7 @@ exports[`DateInput type format inline range partial without timezone 2`] = `
           <div
             class="c8"
           >
-            <div
+            <header
               class="c9"
             >
               <h3
@@ -42889,7 +43081,7 @@ exports[`DateInput type format inline range partial without timezone 2`] = `
               >
                 July 2020
               </h3>
-            </div>
+            </header>
             <div
               class="c11"
             >
@@ -43800,14 +43992,22 @@ exports[`DateInput type format inline range partial without timezone 3`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -44257,7 +44457,7 @@ exports[`DateInput type format inline range partial without timezone 3`] = `
           <div
             class="c8"
           >
-            <div
+            <header
               class="c9"
             >
               <h3
@@ -44265,7 +44465,7 @@ exports[`DateInput type format inline range partial without timezone 3`] = `
               >
                 July 2020
               </h3>
-            </div>
+            </header>
             <div
               class="c11"
             >
@@ -45176,14 +45376,22 @@ exports[`DateInput type format inline range without timezone 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -45651,7 +45859,7 @@ exports[`DateInput type format inline range without timezone 1`] = `
           <div
             class="c8"
           >
-            <div
+            <header
               class="c9"
             >
               <h3
@@ -45659,7 +45867,7 @@ exports[`DateInput type format inline range without timezone 1`] = `
               >
                 July 2020
               </h3>
-            </div>
+            </header>
             <div
               class="c11"
             >
@@ -46570,14 +46778,22 @@ exports[`DateInput type format inline range without timezone 2`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -47045,7 +47261,7 @@ exports[`DateInput type format inline range without timezone 2`] = `
           <div
             class="c8"
           >
-            <div
+            <header
               class="c9"
             >
               <h3
@@ -47053,7 +47269,7 @@ exports[`DateInput type format inline range without timezone 2`] = `
               >
                 July 2020
               </h3>
-            </div>
+            </header>
             <div
               class="c11"
             >
@@ -47963,14 +48179,22 @@ exports[`DateInput type format inline short 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -48420,7 +48644,7 @@ exports[`DateInput type format inline short 1`] = `
         <div
           class="c8"
         >
-          <div
+          <header
             class="c9"
           >
             <h3
@@ -48428,7 +48652,7 @@ exports[`DateInput type format inline short 1`] = `
             >
               July 2020
             </h3>
-          </div>
+          </header>
           <div
             class="c11"
           >
@@ -49280,15 +49504,15 @@ exports[`DateInput type format inline short 2`] = `
         <div
           class="StyledBox-sc-13pk1d4-0 kOZkFt"
         >
-          <div
-            class="StyledBox-sc-13pk1d4-0 ebVTCF"
+          <header
+            class="StyledBox-sc-13pk1d4-0 oGcPZ"
           >
             <h3
               class="StyledHeading-sc-1rdh4aw-0 eGutsY"
             >
               July 2020
             </h3>
-          </div>
+          </header>
           <div
             class="StyledBox-sc-13pk1d4-0 dFwpuo"
           >
@@ -50198,14 +50422,22 @@ exports[`DateInput type format inline short without timezone 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -50655,7 +50887,7 @@ exports[`DateInput type format inline short without timezone 1`] = `
           <div
             class="c8"
           >
-            <div
+            <header
               class="c9"
             >
               <h3
@@ -50663,7 +50895,7 @@ exports[`DateInput type format inline short without timezone 1`] = `
               >
                 July 2020
               </h3>
-            </div>
+            </header>
             <div
               class="c11"
             >
@@ -51574,14 +51806,22 @@ exports[`DateInput type format inline short without timezone 2`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -52031,7 +52271,7 @@ exports[`DateInput type format inline short without timezone 2`] = `
           <div
             class="c8"
           >
-            <div
+            <header
               class="c9"
             >
               <h3
@@ -52039,7 +52279,7 @@ exports[`DateInput type format inline short without timezone 2`] = `
               >
                 July 2020
               </h3>
-            </div>
+            </header>
             <div
               class="c11"
             >
@@ -52950,14 +53190,22 @@ exports[`DateInput type format inline without timezone 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -53407,7 +53655,7 @@ exports[`DateInput type format inline without timezone 1`] = `
           <div
             class="c8"
           >
-            <div
+            <header
               class="c9"
             >
               <h3
@@ -53415,7 +53663,7 @@ exports[`DateInput type format inline without timezone 1`] = `
               >
                 July 2020
               </h3>
-            </div>
+            </header>
             <div
               class="c11"
             >
@@ -54326,14 +54574,22 @@ exports[`DateInput type format inline without timezone 2`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   min-width: 0;
   min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 1 1;
   -ms-flex: 1 1;
   flex: 1 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -54783,7 +55039,7 @@ exports[`DateInput type format inline without timezone 2`] = `
           <div
             class="c8"
           >
-            <div
+            <header
               class="c9"
             >
               <h3
@@ -54791,7 +55047,7 @@ exports[`DateInput type format inline without timezone 2`] = `
               >
                 July 2020
               </h3>
-            </div>
+            </header>
             <div
               class="c11"
             >

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -533,21 +533,21 @@ export interface ThemeType {
     };
     extend?: ExtendType;
     small?: {
-      headingSize?: string;
+      titleSize?: string;
       fontSize?: string;
       lineHeight?: number;
       daySize?: string;
       slideDuration?: string;
     };
     medium?: {
-      headingSize?: string;
+      titleSize?: string;
       fontSize?: string;
       lineHeight?: number;
       daySize?: string;
       slideDuration?: string;
     };
     large?: {
-      headingSize?: string;
+      titleSize?: string;
       fontSize?: string;
       lineHeight?: number;
       daySize?: string;

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -533,18 +533,21 @@ export interface ThemeType {
     };
     extend?: ExtendType;
     small?: {
+      headingSize?: string;
       fontSize?: string;
       lineHeight?: number;
       daySize?: string;
       slideDuration?: string;
     };
     medium?: {
+      headingSize?: string;
       fontSize?: string;
       lineHeight?: number;
       daySize?: string;
       slideDuration?: string;
     };
     large?: {
+      headingSize?: string;
       fontSize?: string;
       lineHeight?: number;
       daySize?: string;

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -533,21 +533,21 @@ export interface ThemeType {
     };
     extend?: ExtendType;
     small?: {
-      titleSize?: string;
+      title?: TextProps;
       fontSize?: string;
       lineHeight?: number;
       daySize?: string;
       slideDuration?: string;
     };
     medium?: {
-      titleSize?: string;
+      title?: TextProps;
       fontSize?: string;
       lineHeight?: number;
       daySize?: string;
       slideDuration?: string;
     };
     large?: {
-      titleSize?: string;
+      title?: TextProps;
       fontSize?: string;
       lineHeight?: number;
       daySize?: string;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -589,18 +589,21 @@ export const generate = (baseSpacing = 24, scale = 6) => {
     calendar: {
       // daySize must align with global.size
       small: {
+        // title: {},
         fontSize: `${baseFontSize - fontScale}px`,
         lineHeight: 1.375,
         daySize: `${(baseSpacing * 8) / 7}px`,
         slideDuration: '0.2s',
       },
       medium: {
+        // title: {},
         fontSize: `${baseFontSize}px`,
         lineHeight: 1.45,
         daySize: `${(baseSpacing * 16) / 7}px`,
         slideDuration: '0.5s',
       },
       large: {
+        // title: {},
         fontSize: `${baseFontSize + 3 * fontScale}px`,
         lineHeight: 1.11,
         daySize: `${(baseSpacing * 32) / 7}px`,


### PR DESCRIPTION
#### What does this PR do?
Adds a new prop `calendar[size].headingSize` to the theme. Specifying this prop will override the `calendar.heading.level` prop and change the calendar to use `<Text>` instead of `<Heading>` to display the date and year. This prop also gives the flexibility to specify different font sizes for each calendar size (small, medium, and large).

In addition to this PR I will file a PR on grommet-theme-hpe to opt into this behavior for the hpe theme.

#### Where should the reviewer start?

#### What testing has been done on this PR?
Added a jest test and tested by adding a custom theme to calendar stories

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [x] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Related to https://github.com/grommet/grommet/issues/6637

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Yes, we need to document the new theme prop as well as mention that using `calendar[size].headingSize` is preferred over `calendar.heading.level`

#### Should this PR be mentioned in the release notes?
Yes

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible