### PR TITLE
Changed Data to handle property paths

### DIFF
--- a/src/js/components/Data/DataForm.js
+++ b/src/js/components/Data/DataForm.js
@@ -79,7 +79,7 @@ const unflatten = (formValue) => {
       let parent = result;
       while (parts.length > 1) {
         const sub = parts.shift();
-        parent[sub] = {};
+        if (!parent[sub]) parent[sub] = {};
         parent = parent[sub];
       }
       parent[parts.shift()] = val;

--- a/src/js/components/Data/DataForm.js
+++ b/src/js/components/Data/DataForm.js
@@ -45,6 +45,48 @@ const viewFormKeyMap = {
   view: formViewNameKey,
 };
 
+// flatten nested objects. For example: { a: { b: v } } -> { 'a.b': v }
+const flatten = (formValue, options) => {
+  const result = JSON.parse(JSON.stringify(formValue));
+  Object.keys(result).forEach((k) => {
+    let name = k;
+    // flatten one level at a time, ignore _range situations
+    while (
+      typeof result[name] === 'object' &&
+      !Array.isArray(result[name]) &&
+      (options?.full || !result[name][formRangeKey])
+    ) {
+      const subPath = Object.keys(result[name])[0];
+      const path = `${name}.${subPath}`;
+      result[path] = result[name][subPath];
+      delete result[name];
+      name = path;
+    }
+  });
+  return result;
+};
+
+// unflatten nested objects. For example: { 'a.b': v } -> { a: { b: v } }
+const unflatten = (formValue) => {
+  const result = JSON.parse(JSON.stringify(formValue));
+  const specialKeys = Object.values(viewFormKeyMap);
+  Object.keys(result)
+    .filter((k) => !specialKeys.includes(k))
+    .forEach((k) => {
+      const parts = k.split('.');
+      const val = result[k];
+      delete result[k];
+      let parent = result;
+      while (parts.length > 1) {
+        const sub = parts.shift();
+        parent[sub] = {};
+        parent = parent[sub];
+      }
+      parent[parts.shift()] = val;
+    });
+  return result;
+};
+
 // converts from the external view format to the internal Form value format
 const viewToFormValue = (view) => {
   const result = { ...(view?.properties || {}) };
@@ -69,7 +111,7 @@ const viewToFormValue = (view) => {
   if (view?.name) result[formViewNameKey] = view.name;
   if (view?.columns) result[formColumnsKey] = view.columns;
 
-  return result;
+  return unflatten(result);
 };
 
 // converts from the internal Form value format to the external view format
@@ -91,7 +133,10 @@ const formValueToView = (value, views) => {
     delete valueCopy[viewFormKeyMap[key]];
   });
 
-  result.properties = { ...(result.properties || {}), ...valueCopy };
+  // flatten any nested objects
+  const flatValue = flatten(valueCopy);
+
+  result.properties = { ...(result.properties || {}), ...flatValue };
 
   // convert any ranges
   Object.keys(result.properties).forEach((key) => {
@@ -129,7 +174,7 @@ const transformTouched = (touched, value) => {
     // special case _range fields
     const parts = key.split('.');
     if (parts[1] === formRangeKey) result[key] = value[parts[0]];
-    else result[key] = value[key];
+    else result[key] = flatten(value, { full: true })[key];
   });
   return result;
 };
@@ -146,9 +191,11 @@ const normalizeValue = (nextValue, prevValue, views) => {
       views.find((v) => v.name === nextValue[formViewNameKey]),
     );
   }
+  // something else changed
 
-  // something else changed, clear empty propeties
+  // clear empty properties
   const result = clearEmpty(nextValue);
+
   // if we have a view and something related to it changed, clear the view
   if (result[formViewNameKey]) {
     const view = views.find((v) => v.name === result[formViewNameKey]);

--- a/src/js/components/Data/stories/Complex.js
+++ b/src/js/components/Data/stories/Complex.js
@@ -1,0 +1,71 @@
+import React from 'react';
+
+import { Grid, DataTable, Notification } from 'grommet';
+
+import { Data } from '../Data';
+
+const data = [
+  {
+    id: 1,
+    name: 'Alpha',
+    location: { city: 'Athens', country: 'Greece' },
+    economy: { GDP: 100 },
+  },
+  {
+    id: 2,
+    name: 'Beta',
+    location: { city: 'Bangkok', country: 'Thailand' },
+    economy: { GDP: 150 },
+  },
+];
+
+const properties = {
+  name: { label: 'Name', search: true },
+  'location.city': { label: 'City' },
+  'economy.GDP': { label: 'GDP' },
+};
+
+const columns = [
+  {
+    property: 'name',
+    header: 'Name',
+    primary: true,
+  },
+  {
+    property: 'location.city',
+    header: 'City',
+  },
+  {
+    property: 'economy.GDP',
+    header: 'GDP',
+  },
+];
+
+export const Complex = () => (
+  // Uncomment <Grommet> lines when using outside of storybook
+  // <Grommet theme={...}>
+  <Grid
+    flex={false}
+    pad="large"
+    columns={[['small', 'large']]}
+    justifyContent="center"
+    gap="large"
+  >
+    <Notification
+      status="info"
+      message="Data is in 'beta'. The API surface is subject to change."
+    />
+    <Data data={data} properties={properties} toolbar>
+      <DataTable columns={columns} />
+    </Data>
+  </Grid>
+  // </Grommet>
+);
+
+Complex.args = {
+  full: true,
+};
+
+export default {
+  title: 'Data/Data/Complex',
+};

--- a/src/js/components/DataFilter/DataFilter.js
+++ b/src/js/components/DataFilter/DataFilter.js
@@ -6,8 +6,15 @@ import { RangeSelector } from '../RangeSelector';
 import { SelectMultiple } from '../SelectMultiple';
 import { DataFilterPropTypes } from './propTypes';
 
+const getValueAt = (valueObject, pathArg) => {
+  if (valueObject === undefined) return undefined;
+  const path = Array.isArray(pathArg) ? pathArg : pathArg.split('.');
+  if (path.length === 1) return valueObject[path];
+  return getValueAt(valueObject[path.shift()], path);
+};
+
 const generateOptions = (data, property) =>
-  Array.from(new Set(data.map((d) => d[property])))
+  Array.from(new Set(data.map((d) => getValueAt(d, property))))
     .filter((v) => v !== undefined && v !== '')
     .sort();
 
@@ -42,57 +49,30 @@ export const DataFilter = ({
     unfilteredData,
   } = useContext(DataContext);
 
-  const options = useMemo(() => {
-    if (children) return undefined; // caller driving
-    if (optionsProp) return optionsProp; // caller setting
-    // Data properties setting
-    if (properties?.[property]?.options) return properties[property].options;
-    // skip if we have a range
-    if (rangeProp || properties?.[property]?.range) return undefined;
+  const [options, range] = useMemo(() => {
+    if (children) return [undefined, undefined]; // caller driving
+
+    const optionsIn = optionsProp || properties?.[property]?.options;
+    const rangeIn = rangeProp || properties?.[property]?.range;
+    if (optionsIn) return [optionsIn, undefined];
+    if (rangeIn) return [undefined, [rangeIn.min, rangeIn.max]];
 
     // generate options from all values for property
     const uniqueValues = generateOptions(unfilteredData || data, property);
     // if any values aren't numeric, treat as options
     if (uniqueValues.some((v) => v && typeof v !== 'number'))
-      return uniqueValues;
-    // if all values are numeric, let range take care of it
-    return undefined;
-  }, [
-    children,
-    data,
-    optionsProp,
-    properties,
-    property,
-    rangeProp,
-    unfilteredData,
-  ]);
-
-  const range = useMemo(() => {
-    if (children) return undefined; // caller driving
-    const anyRange = rangeProp || properties?.[property]?.range;
-    if (anyRange) {
-      // caller setting or Data properties setting
-      const { min, max } = anyRange;
-      return [min, max];
-    }
-    // skip if we have options
-    if (options) return undefined;
-
-    // generate range from all values for the property
-    const uniqueValues = generateOptions(
-      unfilteredData || data,
-      property,
-    ).sort();
+      return [uniqueValues, undefined];
+    // all values are numeric, treat as range
     // normalize to make it friendler, so [1.3, 4.895] becomes [1, 5]
     const delta = uniqueValues[uniqueValues.length - 1] - uniqueValues[0];
     const interval = Number.parseFloat((delta / 3).toPrecision(1));
     const min = alignMin(uniqueValues[0], interval);
     const max = alignMax(uniqueValues[uniqueValues.length - 1], interval);
-    return [min, max];
+    return [undefined, [min, max]];
   }, [
     children,
     data,
-    options,
+    optionsProp,
     properties,
     property,
     rangeProp,

--- a/src/js/components/DataFilters/__tests__/DataFilters-test.tsx
+++ b/src/js/components/DataFilters/__tests__/DataFilters-test.tsx
@@ -3,6 +3,7 @@ import { act, fireEvent, render } from '@testing-library/react';
 import 'jest-styled-components';
 
 import { Data } from '../../Data';
+import { DataTable } from '../../DataTable';
 import { Grommet } from '../../Grommet';
 import { DataFilters } from '..';
 import { createPortal, expectPortal } from '../../../utils/portal';
@@ -110,6 +111,39 @@ describe('DataFilters', () => {
       <Grommet>
         <Data data={data} view={{ search: 'a', properties: { name: ['a'] } }}>
           <DataFilters />
+        </Data>
+      </Grommet>,
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test('sub objects', () => {
+    const { container } = render(
+      <Grommet>
+        <Data
+          data={[
+            { location: { city: 'Paris', lat: 48 } },
+            { location: { city: 'Sydney', lat: -33 } },
+          ]}
+          properties={{
+            'location.city': { label: 'City' },
+            'location.lat': { label: 'Latitude', range: { min: -90, max: 90 } },
+          }}
+          view={{
+            properties: {
+              'location.city': ['Paris'],
+              'location.lat': { min: 10, max: 90 },
+            },
+          }}
+        >
+          <DataFilters />
+          <DataTable
+            columns={[
+              { property: 'location.city', header: 'City' },
+              { property: 'location.lat', header: 'Latitude' },
+            ]}
+          />
         </Data>
       </Grommet>,
     );

--- a/src/js/components/DataFilters/__tests__/__snapshots__/DataFilters-test.tsx.snap
+++ b/src/js/components/DataFilters/__tests__/__snapshots__/DataFilters-test.tsx.snap
@@ -4055,3 +4055,1096 @@ exports[`DataFilters renders 1`] = `
   </div>
 </div>
 `;
+
+exports[`DataFilters sub objects 1`] = `
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 100%;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  overflow: auto;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-bottom: 12px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 12px;
+}
+
+.c10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c12 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-right: 12px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c15 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: solid 2px #7D4CDB;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 24px;
+  width: 24px;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  border-radius: 4px;
+}
+
+.c18 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: solid 2px rgba(0,0,0,0.15);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 24px;
+  width: 24px;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  border-radius: 4px;
+}
+
+.c19 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  width: 100%;
+  height: 100%;
+}
+
+.c21 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  width: 100%;
+  height: 100%;
+  cursor: pointer;
+}
+
+.c23 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  width: 100%;
+  border-radius: 12px;
+}
+
+.c24 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  overflow: visible;
+}
+
+.c25 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex-basis: 100%;
+  -ms-flex-preferred-size: 100%;
+  flex-basis: 100%;
+  height: 100%;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c26 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  background-color: #7D4CDB;
+  color: #f8f8f8;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 12px;
+  width: 12px;
+  border-radius: 100%;
+}
+
+.c27 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  background-color: rgba(125,76,219,0.4);
+  color: #444444;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  width: 100%;
+  border-radius: 12px;
+}
+
+.c29 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-top: 12px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c37 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c17 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  height: 12px;
+}
+
+.c31 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  width: 12px;
+}
+
+.c8 {
+  margin-left: 12px;
+  margin-right: 12px;
+  margin-top: 6px;
+  margin-bottom: 6px;
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c20 {
+  margin-left: 12px;
+  margin-right: 12px;
+  font-size: 14px;
+  line-height: 20px;
+  text-align: right;
+}
+
+.c28 {
+  margin-left: 12px;
+  margin-right: 12px;
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.c38 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c41 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c30 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: 2px solid #7D4CDB;
+  border-radius: 18px;
+  color: #444444;
+  padding: 4px 22px;
+  font-size: 18px;
+  line-height: 24px;
+  background-color: #7D4CDB;
+  color: #f8f8f8;
+  border-radius: 18px;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+}
+
+.c30:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c30:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c30:focus > circle,
+.c30:focus > ellipse,
+.c30:focus > line,
+.c30:focus > path,
+.c30:focus > polygon,
+.c30:focus > polyline,
+.c30:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c30:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c30:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c30:focus:not(:focus-visible) > circle,
+.c30:focus:not(:focus-visible) > ellipse,
+.c30:focus:not(:focus-visible) > line,
+.c30:focus:not(:focus-visible) > path,
+.c30:focus:not(:focus-visible) > polygon,
+.c30:focus:not(:focus-visible) > polyline,
+.c30:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c30:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c32 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: 2px solid #7D4CDB;
+  border-radius: 18px;
+  color: #444444;
+  padding: 4px 22px;
+  font-size: 18px;
+  line-height: 24px;
+  opacity: 0.3;
+  cursor: default;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+}
+
+.c32:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c32:focus > circle,
+.c32:focus > ellipse,
+.c32:focus > line,
+.c32:focus > path,
+.c32:focus > polygon,
+.c32:focus > polyline,
+.c32:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c32:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c32:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c32:focus:not(:focus-visible) > circle,
+.c32:focus:not(:focus-visible) > ellipse,
+.c32:focus:not(:focus-visible) > line,
+.c32:focus:not(:focus-visible) > path,
+.c32:focus:not(:focus-visible) > polygon,
+.c32:focus:not(:focus-visible) > polyline,
+.c32:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c32:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c16 {
+  box-sizing: border-box;
+  stroke-width: 4px;
+  stroke: #7D4CDB;
+  width: 24px;
+  height: 24px;
+}
+
+.c11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  cursor: pointer;
+}
+
+.c11:hover input:not([disabled]) + div,
+.c11:hover input:not([disabled]) + span {
+  border-color: #000000;
+}
+
+.c14 {
+  opacity: 0;
+  -moz-appearance: none;
+  width: 0;
+  height: 0;
+  margin: 0;
+  cursor: pointer;
+}
+
+.c14:checked + span > span {
+  left: calc( 48px - 24px );
+  background: #7D4CDB;
+}
+
+.c13 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c22 {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c33 {
+  opacity: 0;
+}
+
+.c2 {
+  max-width: 100%;
+}
+
+.c6 {
+  margin: 0px;
+  font-size: 26px;
+  line-height: 32px;
+  max-width: 624px;
+  font-weight: 600;
+  overflow-wrap: break-word;
+}
+
+.c36 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c40 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c34 {
+  border-spacing: 0;
+  border-collapse: collapse;
+  width: inherit;
+}
+
+.c35 {
+  position: relative;
+  border-spacing: 0;
+  border-collapse: separate;
+}
+
+.c39:focus {
+  outline: 2px solid #6FFFB0;
+}
+
+.c39:focus:not(:focus-visible) {
+  outline: none;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    margin-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c9 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c9 {
+    padding: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c12 {
+    margin-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c15 {
+    border: solid 2px #7D4CDB;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c18 {
+    border: solid 2px rgba(0,0,0,0.15);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c23 {
+    border-radius: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c27 {
+    border-radius: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c29 {
+    margin-top: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c17 {
+    height: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c31 {
+    width: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    font-size: 22px;
+    line-height: 28px;
+    max-width: 528px;
+  }
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+    id="data"
+  >
+    <form
+      class="c2"
+    >
+      <div
+        class="c3"
+      >
+        <div
+          class="c4"
+        >
+          <header
+            class="c5"
+          >
+            <h2
+              class="c6"
+            >
+              Filters
+            </h2>
+          </header>
+          <div
+            class="c7 "
+          >
+            <label
+              class="c8"
+              for="data-location.city"
+            >
+              City
+            </label>
+            <div
+              class="c9 FormField__FormFieldContentBox-sc-m9hood-1"
+            >
+              <div
+                class="c10 StyledCheckBoxGroup-sc-2nhc5d-0"
+                id="data-location.city"
+                role="group"
+              >
+                <label
+                  class="c11"
+                  label="Paris"
+                >
+                  <div
+                    class="c12 c13"
+                  >
+                    <input
+                      checked=""
+                      class="c14"
+                      type="checkbox"
+                    />
+                    <div
+                      class="c15 "
+                    >
+                      <svg
+                        class="c16"
+                        preserveAspectRatio="xMidYMid meet"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M6,11.3 L10.3,16 L18,6.2"
+                          fill="none"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                  <span>
+                    Paris
+                  </span>
+                </label>
+                <div
+                  class="c17"
+                />
+                <label
+                  class="c11"
+                  label="Sydney"
+                >
+                  <div
+                    class="c12 c13"
+                  >
+                    <input
+                      class="c14"
+                      type="checkbox"
+                    />
+                    <div
+                      class="c18 "
+                    />
+                  </div>
+                  <span>
+                    Sydney
+                  </span>
+                </label>
+              </div>
+            </div>
+          </div>
+          <div
+            class="c7 "
+          >
+            <label
+              class="c8"
+              for="data-location.lat"
+            >
+              Latitude
+            </label>
+            <div
+              class="c9 FormField__FormFieldContentBox-sc-m9hood-1"
+            >
+              <div
+                class="c19"
+                id="data-location.lat"
+              >
+                <span
+                  class="c20"
+                  style="width: 0px;"
+                >
+                  10
+                </span>
+                <div
+                  class="c21 c22"
+                  tabindex="-1"
+                >
+                  <div
+                    class="c23"
+                    style="flex: 100 0 0px;"
+                  />
+                  <div
+                    class="c24"
+                    style="flex: 0 0 1px;"
+                  >
+                    <div
+                      aria-label="Lower Bounds"
+                      aria-valuemax="90"
+                      aria-valuemin="-90"
+                      aria-valuenow="10"
+                      class="c25"
+                      role="slider"
+                      style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 1;"
+                      tabindex="0"
+                    >
+                      <div
+                        class="c26 EdgeControl__StyledBox-sc-1xo2yt9-0"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="c27"
+                    style="flex: 81 0 0px; cursor: ew-resize;"
+                  />
+                  <div
+                    class="c24"
+                    style="flex: 0 0 1px;"
+                  >
+                    <div
+                      aria-label="Upper Bounds"
+                      aria-valuemax="90"
+                      aria-valuemin="-90"
+                      aria-valuenow="90"
+                      class="c25"
+                      role="slider"
+                      style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 1;"
+                      tabindex="0"
+                    >
+                      <div
+                        class="c26 EdgeControl__StyledBox-sc-1xo2yt9-0"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="c23"
+                    style="flex: 0 0 0px;"
+                  />
+                </div>
+                <span
+                  class="c28"
+                  style="width: 0px;"
+                >
+                  90
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <footer
+          class="c29"
+        >
+          <button
+            class="c30"
+            type="submit"
+          >
+            Apply filters
+          </button>
+          <div
+            class="c31"
+          />
+          <button
+            aria-hidden="true"
+            class="c32 c33"
+            disabled=""
+            tabindex="-1"
+            type="reset"
+          >
+            Undo changes
+          </button>
+        </footer>
+      </div>
+    </form>
+    <table
+      class="c34 c35"
+    >
+      <thead
+        class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
+      >
+        <tr
+          class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+        >
+          <th
+            class="c36 "
+            scope="col"
+          >
+            <div
+              class="c37"
+            >
+              <span
+                class="c38"
+              >
+                City
+              </span>
+            </div>
+          </th>
+          <th
+            class="c36 "
+            scope="col"
+          >
+            <div
+              class="c37"
+            >
+              <span
+                class="c38"
+              >
+                Latitude
+              </span>
+            </div>
+          </th>
+        </tr>
+      </thead>
+      <tbody
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c39"
+      >
+        <tr
+          class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+        >
+          <th
+            class="c40 "
+            scope="row"
+          >
+            <div
+              class="c10"
+            >
+              <span
+                class="c41"
+              >
+                Paris
+              </span>
+            </div>
+          </th>
+          <td
+            class="c40 "
+          >
+            <div
+              class="c10"
+            >
+              <span
+                class="c38"
+              >
+                48
+              </span>
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+`;


### PR DESCRIPTION
#### What does this PR do?

Changes Data to handle nested objects in the data as properties.
Now, you can use `properties={ 'location.city': { ...} }` and it will do what you might suspect.

Also, I combined `options` and `range` into a single `useMemo()` in DataFilter to be more efficient.

#### Where should the reviewer start?

Take a look at the new Complex story under Data.

#### What testing has been done on this PR?

Added the Complex story to test interaction with both range and options versions.

#### How should this be manually tested?

Complex story

#### Do Jest tests follow these best practices?

no jest changes

#### Any background context you want to provide?

#### What are the relevant issues?

#6638 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

yes

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
