### PR TITLE
Anchor -- Align icon color to label color when theme.anchor.size.color is specified

### DIFF
--- a/src/js/components/Anchor/Anchor.js
+++ b/src/js/components/Anchor/Anchor.js
@@ -70,7 +70,12 @@ const Anchor = forwardRef(
     let coloredIcon = icon;
     if (icon && !icon.props.color) {
       coloredIcon = cloneElement(icon, {
-        color: normalizeColor(color || theme.anchor.color, theme),
+        color: normalizeColor(
+          color ||
+            theme.anchor?.size?.[sizeProp || size]?.color ||
+            theme.anchor.color,
+          theme,
+        ),
       });
     }
 

--- a/src/js/components/Anchor/__tests__/Anchor-test.tsx
+++ b/src/js/components/Anchor/__tests__/Anchor-test.tsx
@@ -11,6 +11,7 @@ import { Anchor } from '..';
 import { Box } from '../../Box';
 import { Paragraph } from '../../Paragraph';
 import { Text } from '../../Text';
+import { LinkNext } from 'grommet-icons';
 
 describe('Anchor', () => {
   test('should have no accessibility violations', async () => {
@@ -265,10 +266,10 @@ describe('Anchor', () => {
           Anchor should inherit <Anchor label="small" /> from Paragraph.
         </Paragraph>
         <Anchor label="Default anchor with no size prop should receive medium" />
-        <Anchor label="Anchor with icon" icon={<svg />} />
+        <Anchor label="Anchor with icon" icon={<LinkNext />} />
         <Anchor
-          label="Large anchor with icon should receive large color on icon"
-          icon={<svg />}
+          label="Large anchor with icon should receive color on icon"
+          icon={<LinkNext />}
           size="large"
         />
       </Grommet>,

--- a/src/js/components/Anchor/__tests__/Anchor-test.tsx
+++ b/src/js/components/Anchor/__tests__/Anchor-test.tsx
@@ -266,6 +266,11 @@ describe('Anchor', () => {
         </Paragraph>
         <Anchor label="Default anchor with no size prop should receive medium" />
         <Anchor label="Anchor with icon" icon={<svg />} />
+        <Anchor
+          label="Large anchor with icon should receive large color on icon"
+          icon={<svg />}
+          size="large"
+        />
       </Grommet>,
     );
 

--- a/src/js/components/Anchor/__tests__/__snapshots__/Anchor-test.tsx.snap
+++ b/src/js/components/Anchor/__tests__/__snapshots__/Anchor-test.tsx.snap
@@ -899,6 +899,22 @@ exports[`Anchor renders size specific theming 1`] = `
         Anchor with icon
       </span>
     </a>
+    <a
+      class="c8"
+    >
+      <span
+        class="c17"
+        style="display: inline-flex;"
+      >
+        <svg
+          color="#7D4CDB"
+        />
+        <span
+          class="c18"
+        />
+        Large anchor with icon should receive large color on icon
+      </span>
+    </a>
   </div>
 </DocumentFragment>
 `;

--- a/src/js/components/Anchor/__tests__/__snapshots__/Anchor-test.tsx.snap
+++ b/src/js/components/Anchor/__tests__/__snapshots__/Anchor-test.tsx.snap
@@ -528,7 +528,75 @@ exports[`Anchor renders a11yTitle and aria-label 1`] = `
 
 exports[`Anchor renders size specific theming 1`] = `
 <DocumentFragment>
-  .c0 {
+  .c18 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #000000;
+  stroke: #000000;
+}
+
+.c18 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c18 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c18 *[stroke*="#"],
+.c18 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c18 *[fill-rule],
+.c18 *[FILL-RULE],
+.c18 *[fill*="#"],
+.c18 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c20 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #7D4CDB;
+  stroke: #7D4CDB;
+}
+
+.c20 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c20 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c20 *[stroke*="#"],
+.c20 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c20 *[fill-rule],
+.c20 *[FILL-RULE],
+.c20 *[fill*="#"],
+.c20 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c0 {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -570,7 +638,7 @@ exports[`Anchor renders size specific theming 1`] = `
   flex-direction: row;
 }
 
-.c18 {
+.c19 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -891,10 +959,19 @@ exports[`Anchor renders size specific theming 1`] = `
         style="display: inline-flex;"
       >
         <svg
-          color="#000000"
-        />
-        <span
+          aria-label="LinkNext"
           class="c18"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M2 12h20m-9-9 9 9-9 9"
+            fill="none"
+            stroke="#000"
+            stroke-width="2"
+          />
+        </svg>
+        <span
+          class="c19"
         />
         Anchor with icon
       </span>
@@ -907,12 +984,21 @@ exports[`Anchor renders size specific theming 1`] = `
         style="display: inline-flex;"
       >
         <svg
-          color="#7D4CDB"
-        />
+          aria-label="LinkNext"
+          class="c20"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M2 12h20m-9-9 9 9-9 9"
+            fill="none"
+            stroke="#000"
+            stroke-width="2"
+          />
+        </svg>
         <span
-          class="c18"
+          class="c19"
         />
-        Large anchor with icon should receive large color on icon
+        Large anchor with icon should receive color on icon
       </span>
     </a>
   </div>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

To align with previous behavior, icon color should align with label color. With [recent theme enhancement](https://github.com/grommet/grommet/pull/6643), the theme size-specific styling wasn't coming through on icon. Updating iconColor logic to check for color specification.

#### Where should the reviewer start?
src/js/components/Anchor/Anchor.js

#### What testing has been done on this PR?
Tested in storybook, added a jest test.

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Related to #6636 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
No.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.