### PR TITLE
Allow align of Tab controls to be theme driven

### DIFF
--- a/src/js/components/Tabs/Tabs.js
+++ b/src/js/components/Tabs/Tabs.js
@@ -331,6 +331,7 @@ const Tabs = forwardRef(
         background={theme.tabs.background}
       >
         <Box
+          alignSelf={alignControls || theme.tabs.header?.alignSelf}
           role="tablist"
           flex={false}
           direction={overflow ? 'row' : 'column'}
@@ -360,7 +361,6 @@ const Tabs = forwardRef(
             as={Box}
             direction="row"
             justify={overflow ? 'start' : justify}
-            alignSelf={alignControls}
             flex={!!overflow}
             wrap={false}
             overflow={overflow ? 'hidden' : 'visible'}

--- a/src/js/components/Tabs/__tests__/Tabs-test.tsx
+++ b/src/js/components/Tabs/__tests__/Tabs-test.tsx
@@ -5,7 +5,7 @@ import 'jest-axe/extend-expect';
 import 'regenerator-runtime/runtime';
 
 import { axe } from 'jest-axe';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
 
 import { Grommet, Tab, Tabs } from '../..';
 import { ThemeType } from '../../../themes';
@@ -335,5 +335,30 @@ describe('Tabs', () => {
 
     fireEvent.click(getByText('Tab 2'));
     expect(onClick).toBeCalled();
+  });
+
+  test('should apply theme alignSelf to tab controls', () => {
+    const customTheme = {
+      tabs: {
+        header: {
+          alignSelf: 'start',
+        },
+      },
+    };
+
+    const { asFragment } = render(
+      <Grommet theme={customTheme}>
+        <Tabs>
+          <Tab title="Tab 1">This tab is first</Tab>
+          <Tab title="Tab 2">This tab is second</Tab>
+        </Tabs>
+      </Grommet>,
+    );
+
+    expect(asFragment()).toMatchSnapshot();
+
+    const tabsHeader = screen.getByRole('tablist')!;
+    const tabsHeaderStyle = window.getComputedStyle(tabsHeader);
+    expect(tabsHeaderStyle.alignSelf).toBe('flex-start');
   });
 });

--- a/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.tsx.snap
+++ b/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.tsx.snap
@@ -634,6 +634,9 @@ exports[`Tabs alignControls 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: column;
@@ -651,9 +654,6 @@ exports[`Tabs alignControls 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
   min-width: 0;
   min-height: 0;
   -webkit-flex-direction: row;
@@ -3821,6 +3821,317 @@ exports[`Tabs should apply custom theme disabled style when theme.button.default
     </div>
   </div>
 </div>
+`;
+
+exports[`Tabs should apply theme alignSelf to tab controls 1`] = `
+<DocumentFragment>
+  .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: start;
+  align-self: flex-start;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  overflow: visible;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-left: 12px;
+  margin-right: 12px;
+  margin-top: 3px;
+  margin-bottom: 3px;
+  border-bottom: solid 2px #000000;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-bottom: 6px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-left: 12px;
+  margin-right: 12px;
+  margin-top: 3px;
+  margin-bottom: 3px;
+  border-bottom: solid 2px #7D4CDB;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-bottom: 6px;
+}
+
+.c7 {
+  font-size: 18px;
+  line-height: 24px;
+  color: #444444;
+}
+
+.c9 {
+  font-size: 18px;
+  line-height: 24px;
+  color: #7D4CDB;
+}
+
+.c4 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c4:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus > circle,
+.c4:focus > ellipse,
+.c4:focus > line,
+.c4:focus > path,
+.c4:focus > polygon,
+.c4:focus > polyline,
+.c4:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c4:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c4:focus:not(:focus-visible) > circle,
+.c4:focus:not(:focus-visible) > ellipse,
+.c4:focus:not(:focus-visible) > line,
+.c4:focus:not(:focus-visible) > path,
+.c4:focus:not(:focus-visible) > polygon,
+.c4:focus:not(:focus-visible) > polyline,
+.c4:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c4:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c6 {
+  white-space: nowrap;
+  margin-left: 12px;
+  margin-right: 12px;
+  margin-top: 3px;
+  margin-bottom: 3px;
+}
+
+.c6:hover {
+  color: #000000;
+}
+
+.c6:focus {
+  z-index: 1;
+}
+
+.c10 {
+  min-height: 0;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+@media only screen and (max-width:768px) {
+  .c5 {
+    margin-left: 6px;
+    margin-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c5 {
+    margin-top: 2px;
+    margin-bottom: 2px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c5 {
+    border-bottom: solid 2px #000000;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c5 {
+    padding-bottom: 3px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c8 {
+    margin-left: 6px;
+    margin-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c8 {
+    margin-top: 2px;
+    margin-bottom: 2px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c8 {
+    border-bottom: solid 2px #7D4CDB;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c8 {
+    padding-bottom: 3px;
+  }
+}
+
+<div
+    class="c0"
+  >
+    <div
+      class="c1 "
+    >
+      <div
+        class="c2"
+        role="tablist"
+      >
+        <div
+          class="c3 "
+        >
+          <button
+            aria-expanded="true"
+            aria-selected="true"
+            class="c4"
+            role="tab"
+            type="button"
+          >
+            <div
+              class="c5 c6"
+            >
+              <span
+                class="c7"
+              >
+                Tab 1
+              </span>
+            </div>
+          </button>
+          <button
+            aria-expanded="false"
+            aria-selected="false"
+            class="c4"
+            role="tab"
+            type="button"
+          >
+            <div
+              class="c8 c6"
+            >
+              <span
+                class="c9"
+              >
+                Tab 2
+              </span>
+            </div>
+          </button>
+        </div>
+      </div>
+      <div
+        aria-label="Tab 1 Tab Contents"
+        class="c10"
+        role="tabpanel"
+      >
+        This tab is first
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
 `;
 
 exports[`Tabs should have no accessibility violations 1`] = `

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -25,6 +25,7 @@ import {
   PropsOf,
   AlignContentType,
   SkeletonColorsType,
+  AlignSelfType,
 } from '../utils';
 
 import { AnchorProps } from '../components/Anchor/index';
@@ -1519,6 +1520,7 @@ export interface ThemeType {
     extend?: ExtendType;
     gap?: GapType;
     header?: {
+      alignSelf?: AlignSelfType;
       background?: BackgroundType;
       border?: {
         side?: string;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1778,6 +1778,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       // extend: undefined,
       // gap: undefined,
       header: {
+        // alignSelf: undefined,
         // background: undefined,
         // border: {
         //   side: undefined,

--- a/src/js/utils/index.d.ts
+++ b/src/js/utils/index.d.ts
@@ -128,7 +128,13 @@ export type AlignContentType =
   | 'start'
   | 'stretch'
   | string;
-export type AlignSelfType = 'start' | 'center' | 'end' | 'stretch' | 'baseline';
+export type AlignSelfType =
+  | 'start'
+  | 'center'
+  | 'end'
+  | 'stretch'
+  | 'baseline'
+  | string;
 export type AnimateType = boolean;
 export interface BackgroundObject {
   color?: ColorType;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Adds `theme.tabs.header.alignSelf` to allow theme to drive alignment of Tabs header along axis. This moves where `alignControls` property applies to fix a bug from when responsive tabs was added.

#### Where should the reviewer start?
src/js/components/Tabs/Tabs.js

#### What testing has been done on this PR?
Tested in a storybook, added a test.

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [x] `screen` is used for querying.
- [x] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [x] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Related to https://github.com/grommet/grommet-theme-hpe/issues/308

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Yes.

#### Should this PR be mentioned in the release notes?
Yes. Added `theme.tabs.header.alignSelf` to theme.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.