### PR TITLE
Apply line-height 0 for iconOnly buttons

### DIFF
--- a/src/js/components/Button/StyledButtonKind.js
+++ b/src/js/components/Button/StyledButtonKind.js
@@ -33,7 +33,9 @@ const fontStyle = (props) => {
   const data = props.theme.text[size];
   return css`
     font-size: ${data.size};
-    line-height: ${data.height};
+    // fix for safari, when button is icon-only, apply line-height 0
+    // to ensure no extra height is applied above svg
+    line-height: ${props.hasIcon && !props.hasLabel ? 0 : data.height};
   `;
 };
 

--- a/src/js/components/Button/__tests__/__snapshots__/Button-kind-test.js.snap
+++ b/src/js/components/Button/__tests__/__snapshots__/Button-kind-test.js.snap
@@ -960,7 +960,7 @@ exports[`Button kind badge should render relative to contents when button has no
   border-radius: 18px;
   padding: 4px 22px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
   transition-property: color,background-color,border-color,box-shadow;
@@ -1219,7 +1219,7 @@ exports[`Button kind button icon colors 1`] = `
   border-radius: 18px;
   padding: 4px 22px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   background-color: #000;
   border-color: #666666;
   text-align: center;
@@ -1365,7 +1365,7 @@ exports[`Button kind button with icon and align 1`] = `
   border-radius: 18px;
   padding: 4px 22px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   text-align: start;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
   transition-property: color,background-color,border-color,box-shadow;
@@ -2928,7 +2928,7 @@ exports[`Button kind icon only pad should apply when icon but no label 1`] = `
   border-radius: 18px;
   padding: 5px 5px;
   font-size: 14px;
-  line-height: 20px;
+  line-height: 0;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
   transition-property: color,background-color,border-color,box-shadow;
@@ -3069,7 +3069,7 @@ exports[`Button kind icon only pad should apply when icon but no label 1`] = `
   border-radius: 18px;
   padding: 8px 12px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
   transition-property: color,background-color,border-color,box-shadow;
@@ -3210,7 +3210,7 @@ exports[`Button kind icon only pad should apply when icon but no label 1`] = `
   border-radius: 24px;
   padding: 18px 18px;
   font-size: 22px;
-  line-height: 28px;
+  line-height: 0;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
   transition-property: color,background-color,border-color,box-shadow;

--- a/src/js/components/Data/__tests__/__snapshots__/Data-test.tsx.snap
+++ b/src/js/components/Data/__tests__/__snapshots__/Data-test.tsx.snap
@@ -2825,7 +2825,7 @@ exports[`Data pagination 1`] = `
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   color: #000000;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
@@ -3356,7 +3356,7 @@ exports[`Data pagination step 1`] = `
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   color: #000000;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.tsx.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.tsx.snap
@@ -22135,7 +22135,7 @@ exports[`DataTable should apply pagination styling 1`] = `
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   text-align: center;
   opacity: 0.3;
   cursor: default;
@@ -22374,7 +22374,7 @@ exports[`DataTable should apply pagination styling 1`] = `
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   color: #000000;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
@@ -25378,7 +25378,7 @@ exports[`DataTable should paginate 1`] = `
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   text-align: center;
   opacity: 0.3;
   cursor: default;
@@ -25617,7 +25617,7 @@ exports[`DataTable should paginate 1`] = `
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   color: #000000;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
@@ -27719,7 +27719,7 @@ exports[`DataTable should pin and paginate 1`] = `
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   text-align: center;
   opacity: 0.3;
   cursor: default;
@@ -27958,7 +27958,7 @@ exports[`DataTable should pin and paginate 1`] = `
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   color: #000000;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
@@ -30069,7 +30069,7 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   text-align: center;
   opacity: 0.3;
   cursor: default;
@@ -30308,7 +30308,7 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   color: #000000;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
@@ -31364,7 +31364,7 @@ exports[`DataTable should render new data when page changes 1`] = `
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   text-align: center;
   opacity: 0.3;
   cursor: default;
@@ -31603,7 +31603,7 @@ exports[`DataTable should render new data when page changes 1`] = `
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   color: #000000;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
@@ -34941,7 +34941,7 @@ exports[`DataTable should render new data when page changes 2`] = `
           >
             <button
               aria-label="Go to previous page"
-              class="StyledButtonKind-sc-1vhfpnt-0 eVDbKr StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 fxwLKX"
+              class="StyledButtonKind-sc-1vhfpnt-0 ypLIx StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 fxwLKX"
               type="button"
             >
               <svg
@@ -34996,7 +34996,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             <button
               aria-disabled="true"
               aria-label="Go to next page"
-              class="StyledButtonKind-sc-1vhfpnt-0 klETIr StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 fxwLKX"
+              class="StyledButtonKind-sc-1vhfpnt-0 jLwgvt StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 fxwLKX"
               disabled=""
               type="button"
             >
@@ -35253,7 +35253,7 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   text-align: center;
   opacity: 0.3;
   cursor: default;
@@ -35492,7 +35492,7 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   color: #000000;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
@@ -37594,7 +37594,7 @@ exports[`DataTable should show correct page when "show" is { page: # } 1`] = `
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   color: #000000;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
@@ -37836,7 +37836,7 @@ exports[`DataTable should show correct page when "show" is { page: # } 1`] = `
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   text-align: center;
   opacity: 0.3;
   cursor: default;

--- a/src/js/components/List/__tests__/__snapshots__/List-test.js.snap
+++ b/src/js/components/List/__tests__/__snapshots__/List-test.js.snap
@@ -4410,7 +4410,7 @@ exports[`List events should apply pagination styling 1`] = `
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   text-align: center;
   opacity: 0.3;
   cursor: default;
@@ -4649,7 +4649,7 @@ exports[`List events should apply pagination styling 1`] = `
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   color: #000000;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
@@ -5569,7 +5569,7 @@ exports[`List events should paginate 1`] = `
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   text-align: center;
   opacity: 0.3;
   cursor: default;
@@ -5808,7 +5808,7 @@ exports[`List events should paginate 1`] = `
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   color: #000000;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
@@ -6571,7 +6571,7 @@ exports[`List events should render correct num items per page (step) 1`] = `
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   text-align: center;
   opacity: 0.3;
   cursor: default;
@@ -6810,7 +6810,7 @@ exports[`List events should render correct num items per page (step) 1`] = `
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   color: #000000;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
@@ -7463,7 +7463,7 @@ exports[`List events should render new data when page changes 1`] = `
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   text-align: center;
   opacity: 0.3;
   cursor: default;
@@ -7702,7 +7702,7 @@ exports[`List events should render new data when page changes 1`] = `
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   color: #000000;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
@@ -11822,7 +11822,7 @@ exports[`List events should render new data when page changes 2`] = `
           >
             <button
               aria-label="Go to previous page"
-              class="StyledButtonKind-sc-1vhfpnt-0 eVDbKr StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 fxwLKX"
+              class="StyledButtonKind-sc-1vhfpnt-0 ypLIx StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 fxwLKX"
               type="button"
             >
               <svg
@@ -11877,7 +11877,7 @@ exports[`List events should render new data when page changes 2`] = `
             <button
               aria-disabled="true"
               aria-label="Go to next page"
-              class="StyledButtonKind-sc-1vhfpnt-0 klETIr StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 fxwLKX"
+              class="StyledButtonKind-sc-1vhfpnt-0 jLwgvt StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 fxwLKX"
               disabled=""
               type="button"
             >
@@ -12132,7 +12132,7 @@ exports[`List events should show correct item index when "show" is a number 1`] 
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   text-align: center;
   opacity: 0.3;
   cursor: default;
@@ -12371,7 +12371,7 @@ exports[`List events should show correct item index when "show" is a number 1`] 
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   color: #000000;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
@@ -13134,7 +13134,7 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   color: #000000;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
@@ -13376,7 +13376,7 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   text-align: center;
   opacity: 0.3;
   cursor: default;

--- a/src/js/components/Pagination/__tests__/__snapshots__/Pagination-test.tsx.snap
+++ b/src/js/components/Pagination/__tests__/__snapshots__/Pagination-test.tsx.snap
@@ -268,7 +268,7 @@ exports[`Pagination should allow user to control page via state with page +
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   color: #000000;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
@@ -700,7 +700,7 @@ exports[`Pagination should apply a11yTitle and aria-label 1`] = `
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   text-align: center;
   opacity: 0.3;
   cursor: default;
@@ -939,7 +939,7 @@ exports[`Pagination should apply a11yTitle and aria-label 1`] = `
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   color: #000000;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
@@ -1498,7 +1498,7 @@ exports[`Pagination should apply button kind style when referenced by a string 1
   border-radius: 18px;
   padding: 4px 22px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   color: #000000;
   border-style: solid;
   border-width: 2px;
@@ -1747,7 +1747,7 @@ exports[`Pagination should apply button kind style when referenced by a string 1
   border-radius: 18px;
   padding: 4px 22px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   color: #000000;
   border-style: solid;
   border-width: 2px;
@@ -2174,7 +2174,7 @@ exports[`Pagination should apply custom theme 1`] = `
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   text-align: center;
   opacity: 0.3;
   cursor: default;
@@ -2413,7 +2413,7 @@ exports[`Pagination should apply custom theme 1`] = `
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   color: #000000;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
@@ -2861,7 +2861,7 @@ exports[`Pagination should apply size 1`] = `
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   text-align: center;
   opacity: 0.3;
   cursor: default;
@@ -3100,7 +3100,7 @@ exports[`Pagination should apply size 1`] = `
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   color: #000000;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
@@ -3187,7 +3187,7 @@ exports[`Pagination should apply size 1`] = `
   border-radius: 3px;
   padding: 4px 4px;
   font-size: 14px;
-  line-height: 20px;
+  line-height: 0;
   text-align: center;
   opacity: 0.3;
   cursor: default;
@@ -3426,7 +3426,7 @@ exports[`Pagination should apply size 1`] = `
   border-radius: 3px;
   padding: 4px 4px;
   font-size: 14px;
-  line-height: 20px;
+  line-height: 0;
   color: #000000;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
@@ -3513,7 +3513,7 @@ exports[`Pagination should apply size 1`] = `
   border-radius: 6px;
   padding: 4px 4px;
   font-size: 22px;
-  line-height: 28px;
+  line-height: 0;
   text-align: center;
   opacity: 0.3;
   cursor: default;
@@ -3752,7 +3752,7 @@ exports[`Pagination should apply size 1`] = `
   border-radius: 6px;
   padding: 4px 4px;
   font-size: 22px;
-  line-height: 28px;
+  line-height: 0;
   color: #000000;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
@@ -4691,7 +4691,7 @@ exports[`Pagination should change the page on prop change 1`] = `
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   color: #000000;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
@@ -5123,7 +5123,7 @@ exports[`Pagination should disable next button if on last page 1`] = `
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   color: #000000;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
@@ -5365,7 +5365,7 @@ exports[`Pagination should disable next button if on last page 1`] = `
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   text-align: center;
   opacity: 0.3;
   cursor: default;
@@ -5758,7 +5758,7 @@ exports[`Pagination should disable previous and next controls when numberItems
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   text-align: center;
   opacity: 0.3;
   cursor: default;
@@ -6144,7 +6144,7 @@ exports[`Pagination should disable previous and next controls when numberItems
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   text-align: center;
   opacity: 0.3;
   cursor: default;
@@ -6435,7 +6435,7 @@ exports[`Pagination should disable previous and next controls when numberItems
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   text-align: center;
   opacity: 0.3;
   cursor: default;
@@ -6859,7 +6859,7 @@ exports[`Pagination should disable previous button if on first page 1`] = `
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   text-align: center;
   opacity: 0.3;
   cursor: default;
@@ -7098,7 +7098,7 @@ exports[`Pagination should disable previous button if on first page 1`] = `
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   color: #000000;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
@@ -7654,7 +7654,7 @@ exports[`Pagination should display next page of results when "next" is
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   color: #000000;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
@@ -7960,7 +7960,7 @@ exports[`Pagination should display next page of results when "next" is
         >
           <button
             aria-label="Go to previous page"
-            class="StyledButtonKind-sc-1vhfpnt-0 eVDbKr StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 fxwLKX"
+            class="StyledButtonKind-sc-1vhfpnt-0 ypLIx StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 fxwLKX"
             type="button"
           >
             <svg
@@ -8082,7 +8082,7 @@ exports[`Pagination should display next page of results when "next" is
         >
           <button
             aria-label="Go to next page"
-            class="StyledButtonKind-sc-1vhfpnt-0 eVDbKr StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 fxwLKX"
+            class="StyledButtonKind-sc-1vhfpnt-0 ypLIx StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 fxwLKX"
             type="button"
           >
             <svg
@@ -8373,7 +8373,7 @@ exports[`Pagination should display page 'n' of results when "page n" is
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   color: #000000;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
@@ -8772,7 +8772,7 @@ exports[`Pagination should display previous page of results when "previous" is
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   color: #000000;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
@@ -9233,7 +9233,7 @@ exports[`Pagination should display previous page of results when "previous" is
         >
           <button
             aria-label="Go to previous page"
-            class="StyledButtonKind-sc-1vhfpnt-0 eVDbKr StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 fxwLKX"
+            class="StyledButtonKind-sc-1vhfpnt-0 ypLIx StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 fxwLKX"
             type="button"
           >
             <svg
@@ -9355,7 +9355,7 @@ exports[`Pagination should display previous page of results when "previous" is
         >
           <button
             aria-label="Go to next page"
-            class="StyledButtonKind-sc-1vhfpnt-0 eVDbKr StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 fxwLKX"
+            class="StyledButtonKind-sc-1vhfpnt-0 ypLIx StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 fxwLKX"
             type="button"
           >
             <svg
@@ -9525,7 +9525,7 @@ exports[`Pagination should display the correct last page based on items length
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   text-align: center;
   opacity: 0.3;
   cursor: default;
@@ -9764,7 +9764,7 @@ exports[`Pagination should display the correct last page based on items length
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   color: #000000;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
@@ -10164,7 +10164,7 @@ exports[`Pagination should render correct numberEdgePages 1`] = `
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   color: #000000;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
@@ -10771,7 +10771,7 @@ exports[`Pagination should render correct numberMiddlePages when even 1`] = `
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   color: #000000;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
@@ -11336,7 +11336,7 @@ exports[`Pagination should render correct numberMiddlePages when odd 1`] = `
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   color: #000000;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
@@ -11949,7 +11949,7 @@ exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   text-align: center;
   opacity: 0.3;
   cursor: default;
@@ -12188,7 +12188,7 @@ exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   color: #000000;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
@@ -12595,7 +12595,7 @@ exports[`Pagination should set page to last page if page prop > total possible
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   color: #000000;
   text-align: center;
   -webkit-transition-property: color,background-color,border-color,box-shadow;
@@ -12837,7 +12837,7 @@ exports[`Pagination should set page to last page if page prop > total possible
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   text-align: center;
   opacity: 0.3;
   cursor: default;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Applies `line-height: 0` for icon-only buttons. This is a required fix for Safari and does not have any visual effects on other browsers. Safari improperly determined a button's dimensions in cases where only icon property was applied, no label.

#### Where should the reviewer start?
src/js/components/Button/StyledButtonKind.js

#### What testing has been done on this PR?
See screenshots below. Tested locally in storybook using NEXT branch of grommet-theme-hpe. This can also be tested directly in a browser (current HPE Design System site exhibits this bug. For example, the "Search" button in main header has 39px height as opposed to 36px). Applying line-height 0 to the button fixes it.

#### How should this be manually tested?
See above notes.

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

Closes https://github.com/grommet/grommet/issues/6667

#### Screenshots (if appropriate)

BEFORE
<img width="498" alt="Screen Shot 2023-03-06 at 10 08 04 AM" src="https://user-images.githubusercontent.com/12522275/223197075-037eb925-2a51-40f5-bff8-b19f88cf945b.png">

AFTER
<img width="495" alt="Screen Shot 2023-03-06 at 10 07 52 AM" src="https://user-images.githubusercontent.com/12522275/223197112-8720a118-ad3c-45a7-8961-3638a1a83d85.png">

BEFORE (grommet-theme-hpe NEXT)
<img width="250" alt="Screen Shot 2023-03-06 at 9 54 29 AM" src="https://user-images.githubusercontent.com/12522275/223197128-cb82f8a2-c8ec-4c44-9461-5c9f3e9b07f5.png">

AFTER
<img width="275" alt="Screen Shot 2023-03-06 at 9 54 42 AM" src="https://user-images.githubusercontent.com/12522275/223197168-53100293-4380-4386-95f1-bf307becb502.png">

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
Yes.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.