### PR TITLE
Reverted change in FormField to use flex={false}

### DIFF
--- a/src/js/components/Data/__tests__/__snapshots__/Data-test.tsx.snap
+++ b/src/js/components/Data/__tests__/__snapshots__/Data-test.tsx.snap
@@ -1489,9 +1489,6 @@ exports[`Data onView 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c9 {

--- a/src/js/components/DataFilter/__tests__/__snapshots__/DataFilter-test.tsx.snap
+++ b/src/js/components/DataFilter/__tests__/__snapshots__/DataFilter-test.tsx.snap
@@ -89,9 +89,6 @@ exports[`DataFilter children 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c9 {
@@ -573,9 +570,6 @@ exports[`DataFilter options 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c9 {
@@ -1335,9 +1329,6 @@ exports[`DataFilter range Data 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c9 {
@@ -2025,9 +2016,6 @@ exports[`DataFilter range prop 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c9 {
@@ -2715,9 +2703,6 @@ exports[`DataFilter renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c9 {

--- a/src/js/components/DataFilters/__tests__/__snapshots__/DataFilters-test.tsx.snap
+++ b/src/js/components/DataFilters/__tests__/__snapshots__/DataFilters-test.tsx.snap
@@ -89,9 +89,6 @@ exports[`DataFilters clear 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c9 {
@@ -874,7 +871,7 @@ exports[`DataFilters drop 2`] = `
 
 exports[`DataFilters drop 3`] = `
 "@media only screen and (max-width: 768px) {
-  .bkspar {
+  .jkVdVC {
     margin-bottom: 6px;
   }
 }
@@ -1392,9 +1389,6 @@ exports[`DataFilters layer 2`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c14 {
@@ -2149,7 +2143,7 @@ exports[`DataFilters layer 2`] = `
 
 exports[`DataFilters layer 3`] = `
 "@media only screen and (max-width: 768px) {
-  .bkspar {
+  .jkVdVC {
     margin-bottom: 6px;
   }
 }
@@ -2291,9 +2285,6 @@ exports[`DataFilters properties array 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c9 {
@@ -2909,9 +2900,6 @@ exports[`DataFilters properties object 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c9 {
@@ -3527,9 +3515,6 @@ exports[`DataFilters renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c9 {
@@ -4145,9 +4130,6 @@ exports[`DataFilters sub objects 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c9 {

--- a/src/js/components/DataSearch/__tests__/__snapshots__/DataSearch-test.tsx.snap
+++ b/src/js/components/DataSearch/__tests__/__snapshots__/DataSearch-test.tsx.snap
@@ -178,7 +178,7 @@ exports[`DataSearch drop 2`] = `
 
 exports[`DataSearch drop 3`] = `
 "@media only screen and (max-width: 768px) {
-  .bkspar {
+  .jkVdVC {
     margin-bottom: 6px;
   }
 }
@@ -334,9 +334,6 @@ exports[`DataSearch renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c9 {

--- a/src/js/components/DataSort/__tests__/__snapshots__/DataSort-test.tsx.snap
+++ b/src/js/components/DataSort/__tests__/__snapshots__/DataSort-test.tsx.snap
@@ -178,7 +178,7 @@ exports[`DataSort drop 2`] = `
 
 exports[`DataSort drop 3`] = `
 "@media only screen and (max-width: 768px) {
-  .bkspar {
+  .jkVdVC {
     margin-bottom: 6px;
   }
 }
@@ -365,9 +365,6 @@ exports[`DataSort renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c9 {

--- a/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.tsx.snap
+++ b/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.tsx.snap
@@ -8291,9 +8291,6 @@ exports[`DateInput handle focus in FormField 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c2 {
@@ -8582,9 +8579,6 @@ exports[`DateInput handle focus in FormField 2`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c2 {

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-controlled.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-controlled.js.snap
@@ -24,9 +24,6 @@ exports[`Form controlled controlled 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c2 {
@@ -216,7 +213,7 @@ exports[`Form controlled controlled 2`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 bkspar FormField__FormFieldBox-sc-m9hood-0 casIFC"
+      class="StyledBox-sc-13pk1d4-0 jkVdVC FormField__FormFieldBox-sc-m9hood-0 casIFC"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 iPSxqg FormField__FormFieldContentBox-sc-m9hood-1"
@@ -250,7 +247,7 @@ exports[`Form controlled controlled 3`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 bkspar FormField__FormFieldBox-sc-m9hood-0 casIFC"
+      class="StyledBox-sc-13pk1d4-0 jkVdVC FormField__FormFieldBox-sc-m9hood-0 casIFC"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 iPSxqg FormField__FormFieldContentBox-sc-m9hood-1"
@@ -324,9 +321,6 @@ exports[`Form controlled controlled Array of Form Fields 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c3 {
@@ -626,7 +620,7 @@ exports[`Form controlled controlled Array of Form Fields 2`] = `
       class="StyledBox-sc-13pk1d4-0 eVZuZv"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 bkspar FormField__FormFieldBox-sc-m9hood-0 casIFC"
+        class="StyledBox-sc-13pk1d4-0 jkVdVC FormField__FormFieldBox-sc-m9hood-0 casIFC"
       >
         <div
           class="StyledBox-sc-13pk1d4-0 iPSxqg FormField__FormFieldContentBox-sc-m9hood-1"
@@ -645,7 +639,7 @@ exports[`Form controlled controlled Array of Form Fields 2`] = `
         </div>
       </div>
       <div
-        class="StyledBox-sc-13pk1d4-0 bkspar FormField__FormFieldBox-sc-m9hood-0 casIFC"
+        class="StyledBox-sc-13pk1d4-0 jkVdVC FormField__FormFieldBox-sc-m9hood-0 casIFC"
       >
         <div
           class="StyledBox-sc-13pk1d4-0 iPSxqg FormField__FormFieldContentBox-sc-m9hood-1"
@@ -668,7 +662,7 @@ exports[`Form controlled controlled Array of Form Fields 2`] = `
       class="StyledBox-sc-13pk1d4-0 eVZuZv"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 bkspar FormField__FormFieldBox-sc-m9hood-0 casIFC"
+        class="StyledBox-sc-13pk1d4-0 jkVdVC FormField__FormFieldBox-sc-m9hood-0 casIFC"
       >
         <div
           class="StyledBox-sc-13pk1d4-0 iPSxqg FormField__FormFieldContentBox-sc-m9hood-1"
@@ -687,7 +681,7 @@ exports[`Form controlled controlled Array of Form Fields 2`] = `
         </div>
       </div>
       <div
-        class="StyledBox-sc-13pk1d4-0 bkspar FormField__FormFieldBox-sc-m9hood-0 casIFC"
+        class="StyledBox-sc-13pk1d4-0 jkVdVC FormField__FormFieldBox-sc-m9hood-0 casIFC"
       >
         <div
           class="StyledBox-sc-13pk1d4-0 iPSxqg FormField__FormFieldContentBox-sc-m9hood-1"
@@ -710,7 +704,7 @@ exports[`Form controlled controlled Array of Form Fields 2`] = `
       class="StyledBox-sc-13pk1d4-0 eVZuZv"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 bkspar FormField__FormFieldBox-sc-m9hood-0 casIFC"
+        class="StyledBox-sc-13pk1d4-0 jkVdVC FormField__FormFieldBox-sc-m9hood-0 casIFC"
       >
         <div
           class="StyledBox-sc-13pk1d4-0 iPSxqg FormField__FormFieldContentBox-sc-m9hood-1"
@@ -729,7 +723,7 @@ exports[`Form controlled controlled Array of Form Fields 2`] = `
         </div>
       </div>
       <div
-        class="StyledBox-sc-13pk1d4-0 bkspar FormField__FormFieldBox-sc-m9hood-0 casIFC"
+        class="StyledBox-sc-13pk1d4-0 jkVdVC FormField__FormFieldBox-sc-m9hood-0 casIFC"
       >
         <div
           class="StyledBox-sc-13pk1d4-0 iPSxqg FormField__FormFieldContentBox-sc-m9hood-1"
@@ -767,7 +761,7 @@ exports[`Form controlled controlled Array of Form Fields 3`] = `
       class="StyledBox-sc-13pk1d4-0 eVZuZv"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 bkspar FormField__FormFieldBox-sc-m9hood-0 casIFC"
+        class="StyledBox-sc-13pk1d4-0 jkVdVC FormField__FormFieldBox-sc-m9hood-0 casIFC"
       >
         <div
           class="StyledBox-sc-13pk1d4-0 iPSxqg FormField__FormFieldContentBox-sc-m9hood-1"
@@ -786,7 +780,7 @@ exports[`Form controlled controlled Array of Form Fields 3`] = `
         </div>
       </div>
       <div
-        class="StyledBox-sc-13pk1d4-0 bkspar FormField__FormFieldBox-sc-m9hood-0 casIFC"
+        class="StyledBox-sc-13pk1d4-0 jkVdVC FormField__FormFieldBox-sc-m9hood-0 casIFC"
       >
         <div
           class="StyledBox-sc-13pk1d4-0 iPSxqg FormField__FormFieldContentBox-sc-m9hood-1"
@@ -809,7 +803,7 @@ exports[`Form controlled controlled Array of Form Fields 3`] = `
       class="StyledBox-sc-13pk1d4-0 eVZuZv"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 bkspar FormField__FormFieldBox-sc-m9hood-0 casIFC"
+        class="StyledBox-sc-13pk1d4-0 jkVdVC FormField__FormFieldBox-sc-m9hood-0 casIFC"
       >
         <div
           class="StyledBox-sc-13pk1d4-0 iPSxqg FormField__FormFieldContentBox-sc-m9hood-1"
@@ -828,7 +822,7 @@ exports[`Form controlled controlled Array of Form Fields 3`] = `
         </div>
       </div>
       <div
-        class="StyledBox-sc-13pk1d4-0 bkspar FormField__FormFieldBox-sc-m9hood-0 casIFC"
+        class="StyledBox-sc-13pk1d4-0 jkVdVC FormField__FormFieldBox-sc-m9hood-0 casIFC"
       >
         <div
           class="StyledBox-sc-13pk1d4-0 iPSxqg FormField__FormFieldContentBox-sc-m9hood-1"
@@ -851,7 +845,7 @@ exports[`Form controlled controlled Array of Form Fields 3`] = `
       class="StyledBox-sc-13pk1d4-0 eVZuZv"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 bkspar FormField__FormFieldBox-sc-m9hood-0 casIFC"
+        class="StyledBox-sc-13pk1d4-0 jkVdVC FormField__FormFieldBox-sc-m9hood-0 casIFC"
       >
         <div
           class="StyledBox-sc-13pk1d4-0 iPSxqg FormField__FormFieldContentBox-sc-m9hood-1"
@@ -870,7 +864,7 @@ exports[`Form controlled controlled Array of Form Fields 3`] = `
         </div>
       </div>
       <div
-        class="StyledBox-sc-13pk1d4-0 bkspar FormField__FormFieldBox-sc-m9hood-0 casIFC"
+        class="StyledBox-sc-13pk1d4-0 jkVdVC FormField__FormFieldBox-sc-m9hood-0 casIFC"
       >
         <div
           class="StyledBox-sc-13pk1d4-0 iPSxqg FormField__FormFieldContentBox-sc-m9hood-1"
@@ -945,9 +939,6 @@ exports[`Form controlled controlled Array of Form Fields onValidate 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c3 {
@@ -1205,7 +1196,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate 2`] = `
       class="StyledBox-sc-13pk1d4-0 eVZuZv"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 bkspar FormField__FormFieldBox-sc-m9hood-0 casIFC"
+        class="StyledBox-sc-13pk1d4-0 jkVdVC FormField__FormFieldBox-sc-m9hood-0 casIFC"
       >
         <div
           class="StyledBox-sc-13pk1d4-0 eShBzY FormField__FormFieldContentBox-sc-m9hood-1"
@@ -1251,7 +1242,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate 2`] = `
         </span>
       </div>
       <div
-        class="StyledBox-sc-13pk1d4-0 bkspar FormField__FormFieldBox-sc-m9hood-0 casIFC"
+        class="StyledBox-sc-13pk1d4-0 jkVdVC FormField__FormFieldBox-sc-m9hood-0 casIFC"
       >
         <div
           class="StyledBox-sc-13pk1d4-0 iPSxqg FormField__FormFieldContentBox-sc-m9hood-1"
@@ -1274,7 +1265,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate 2`] = `
       class="StyledBox-sc-13pk1d4-0 eVZuZv"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 bkspar FormField__FormFieldBox-sc-m9hood-0 casIFC"
+        class="StyledBox-sc-13pk1d4-0 jkVdVC FormField__FormFieldBox-sc-m9hood-0 casIFC"
       >
         <div
           class="StyledBox-sc-13pk1d4-0 eShBzY FormField__FormFieldContentBox-sc-m9hood-1"
@@ -1320,7 +1311,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate 2`] = `
         </span>
       </div>
       <div
-        class="StyledBox-sc-13pk1d4-0 bkspar FormField__FormFieldBox-sc-m9hood-0 casIFC"
+        class="StyledBox-sc-13pk1d4-0 jkVdVC FormField__FormFieldBox-sc-m9hood-0 casIFC"
       >
         <div
           class="StyledBox-sc-13pk1d4-0 iPSxqg FormField__FormFieldContentBox-sc-m9hood-1"
@@ -1395,9 +1386,6 @@ exports[`Form controlled controlled Array of Form Fields onValidate custom error
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c3 {
@@ -1655,7 +1643,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate custom error
       class="StyledBox-sc-13pk1d4-0 eVZuZv"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 bkspar FormField__FormFieldBox-sc-m9hood-0 casIFC"
+        class="StyledBox-sc-13pk1d4-0 jkVdVC FormField__FormFieldBox-sc-m9hood-0 casIFC"
       >
         <div
           class="StyledBox-sc-13pk1d4-0 iPSxqg FormField__FormFieldContentBox-sc-m9hood-1"
@@ -1674,7 +1662,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate custom error
         </div>
       </div>
       <div
-        class="StyledBox-sc-13pk1d4-0 bkspar FormField__FormFieldBox-sc-m9hood-0 casIFC"
+        class="StyledBox-sc-13pk1d4-0 jkVdVC FormField__FormFieldBox-sc-m9hood-0 casIFC"
       >
         <div
           class="StyledBox-sc-13pk1d4-0 iPSxqg FormField__FormFieldContentBox-sc-m9hood-1"
@@ -1697,7 +1685,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate custom error
       class="StyledBox-sc-13pk1d4-0 eVZuZv"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 bkspar FormField__FormFieldBox-sc-m9hood-0 casIFC"
+        class="StyledBox-sc-13pk1d4-0 jkVdVC FormField__FormFieldBox-sc-m9hood-0 casIFC"
       >
         <div
           class="StyledBox-sc-13pk1d4-0 eShBzY FormField__FormFieldContentBox-sc-m9hood-1"
@@ -1743,7 +1731,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate custom error
         </span>
       </div>
       <div
-        class="StyledBox-sc-13pk1d4-0 bkspar FormField__FormFieldBox-sc-m9hood-0 casIFC"
+        class="StyledBox-sc-13pk1d4-0 jkVdVC FormField__FormFieldBox-sc-m9hood-0 casIFC"
       >
         <div
           class="StyledBox-sc-13pk1d4-0 iPSxqg FormField__FormFieldContentBox-sc-m9hood-1"
@@ -1796,9 +1784,6 @@ exports[`Form controlled controlled FormField deprecated 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c3 {
@@ -2003,7 +1988,7 @@ exports[`Form controlled controlled FormField deprecated 2`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 bkspar FormField__FormFieldBox-sc-m9hood-0 casIFC"
+      class="StyledBox-sc-13pk1d4-0 jkVdVC FormField__FormFieldBox-sc-m9hood-0 casIFC"
     >
       <label
         class="StyledText-sc-1sadyjn-0 jOYKvZ"
@@ -2043,7 +2028,7 @@ exports[`Form controlled controlled FormField deprecated 3`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 bkspar FormField__FormFieldBox-sc-m9hood-0 casIFC"
+      class="StyledBox-sc-13pk1d4-0 jkVdVC FormField__FormFieldBox-sc-m9hood-0 casIFC"
     >
       <label
         class="StyledText-sc-1sadyjn-0 jOYKvZ"
@@ -2101,9 +2086,6 @@ exports[`Form controlled controlled input 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c2 {
@@ -2293,7 +2275,7 @@ exports[`Form controlled controlled input 2`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 bkspar FormField__FormFieldBox-sc-m9hood-0 casIFC"
+      class="StyledBox-sc-13pk1d4-0 jkVdVC FormField__FormFieldBox-sc-m9hood-0 casIFC"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 iPSxqg FormField__FormFieldContentBox-sc-m9hood-1"
@@ -2327,7 +2309,7 @@ exports[`Form controlled controlled input 3`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 bkspar FormField__FormFieldBox-sc-m9hood-0 casIFC"
+      class="StyledBox-sc-13pk1d4-0 jkVdVC FormField__FormFieldBox-sc-m9hood-0 casIFC"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 iPSxqg FormField__FormFieldContentBox-sc-m9hood-1"
@@ -2379,9 +2361,6 @@ exports[`Form controlled controlled input lazy 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c2 {
@@ -2571,7 +2550,7 @@ exports[`Form controlled controlled input lazy 2`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 bkspar FormField__FormFieldBox-sc-m9hood-0 casIFC"
+      class="StyledBox-sc-13pk1d4-0 jkVdVC FormField__FormFieldBox-sc-m9hood-0 casIFC"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 iPSxqg FormField__FormFieldContentBox-sc-m9hood-1"
@@ -2605,7 +2584,7 @@ exports[`Form controlled controlled input lazy 3`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 bkspar FormField__FormFieldBox-sc-m9hood-0 casIFC"
+      class="StyledBox-sc-13pk1d4-0 jkVdVC FormField__FormFieldBox-sc-m9hood-0 casIFC"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 iPSxqg FormField__FormFieldContentBox-sc-m9hood-1"
@@ -2657,9 +2636,6 @@ exports[`Form controlled controlled lazy 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c2 {
@@ -2849,7 +2825,7 @@ exports[`Form controlled controlled lazy 2`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 bkspar FormField__FormFieldBox-sc-m9hood-0 casIFC"
+      class="StyledBox-sc-13pk1d4-0 jkVdVC FormField__FormFieldBox-sc-m9hood-0 casIFC"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 iPSxqg FormField__FormFieldContentBox-sc-m9hood-1"
@@ -2883,7 +2859,7 @@ exports[`Form controlled controlled lazy 3`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 bkspar FormField__FormFieldBox-sc-m9hood-0 casIFC"
+      class="StyledBox-sc-13pk1d4-0 jkVdVC FormField__FormFieldBox-sc-m9hood-0 casIFC"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 iPSxqg FormField__FormFieldContentBox-sc-m9hood-1"
@@ -2935,9 +2911,6 @@ exports[`Form controlled controlled onChange touched 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c2 {
@@ -3145,9 +3118,6 @@ exports[`Form controlled controlled onValidate 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c2 {
@@ -3337,7 +3307,7 @@ exports[`Form controlled controlled onValidate 2`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 bkspar FormField__FormFieldBox-sc-m9hood-0 casIFC"
+      class="StyledBox-sc-13pk1d4-0 jkVdVC FormField__FormFieldBox-sc-m9hood-0 casIFC"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 eShBzY FormField__FormFieldContentBox-sc-m9hood-1"
@@ -3416,9 +3386,6 @@ exports[`Form controlled controlled onValidate custom error 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c2 {
@@ -3608,7 +3575,7 @@ exports[`Form controlled controlled onValidate custom error 2`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 bkspar FormField__FormFieldBox-sc-m9hood-0 casIFC"
+      class="StyledBox-sc-13pk1d4-0 jkVdVC FormField__FormFieldBox-sc-m9hood-0 casIFC"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 eShBzY FormField__FormFieldContentBox-sc-m9hood-1"
@@ -3687,9 +3654,6 @@ exports[`Form controlled controlled onValidate custom info 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c2 {
@@ -3879,7 +3843,7 @@ exports[`Form controlled controlled onValidate custom info 2`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 bkspar FormField__FormFieldBox-sc-m9hood-0 casIFC"
+      class="StyledBox-sc-13pk1d4-0 jkVdVC FormField__FormFieldBox-sc-m9hood-0 casIFC"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 iPSxqg FormField__FormFieldContentBox-sc-m9hood-1"
@@ -3988,9 +3952,6 @@ exports[`Form controlled custom theme 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c3 {
@@ -4223,9 +4184,6 @@ exports[`Form controlled dynamicly removed fields using blur validation
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c2 {
@@ -4580,7 +4538,7 @@ exports[`Form controlled dynamicly removed fields using blur validation
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 bkspar FormField__FormFieldBox-sc-m9hood-0 casIFC"
+      class="StyledBox-sc-13pk1d4-0 jkVdVC FormField__FormFieldBox-sc-m9hood-0 casIFC"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 iPSxqg FormField__FormFieldContentBox-sc-m9hood-1"
@@ -4599,7 +4557,7 @@ exports[`Form controlled dynamicly removed fields using blur validation
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 bkspar FormField__FormFieldBox-sc-m9hood-0 casIFC"
+      class="StyledBox-sc-13pk1d4-0 jkVdVC FormField__FormFieldBox-sc-m9hood-0 casIFC"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 fpBxMF FormField__FormFieldContentBox-sc-m9hood-1"
@@ -4686,9 +4644,6 @@ exports[`Form controlled dynamicly removed fields using blur validation
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c1 {
@@ -4823,7 +4778,7 @@ exports[`Form controlled dynamicly removed fields using blur validation
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 bkspar FormField__FormFieldBox-sc-m9hood-0 casIFC"
+      class="StyledBox-sc-13pk1d4-0 jkVdVC FormField__FormFieldBox-sc-m9hood-0 casIFC"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 iPSxqg FormField__FormFieldContentBox-sc-m9hood-1"
@@ -4842,7 +4797,7 @@ exports[`Form controlled dynamicly removed fields using blur validation
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 bkspar FormField__FormFieldBox-sc-m9hood-0 casIFC"
+      class="StyledBox-sc-13pk1d4-0 jkVdVC FormField__FormFieldBox-sc-m9hood-0 casIFC"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 fpBxMF FormField__FormFieldContentBox-sc-m9hood-1 jyrxxG"

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
@@ -25,9 +25,6 @@ exports[`Form accessibility Box with TextInput in Form should
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c2 {
@@ -192,9 +189,6 @@ exports[`Form accessibility CheckBox in Form should have no accessibility violat
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c2 {
@@ -399,9 +393,6 @@ exports[`Form accessibility FormField with an explicit TextInput child
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c2 {
@@ -564,9 +555,6 @@ exports[`Form accessibility Select in Form should have no accessibility violatio
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c2 {
@@ -841,9 +829,6 @@ exports[`Form accessibility TextInput in Form should have
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c2 {
@@ -972,9 +957,6 @@ exports[`Form uncontrolled dynamicly removed fields should be removed from form 
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c2 {
@@ -1328,7 +1310,7 @@ exports[`Form uncontrolled dynamicly removed fields should be removed from form 
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 bkspar FormField__FormFieldBox-sc-m9hood-0 casIFC"
+      class="StyledBox-sc-13pk1d4-0 jkVdVC FormField__FormFieldBox-sc-m9hood-0 casIFC"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 iPSxqg FormField__FormFieldContentBox-sc-m9hood-1"
@@ -1347,7 +1329,7 @@ exports[`Form uncontrolled dynamicly removed fields should be removed from form 
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 bkspar FormField__FormFieldBox-sc-m9hood-0 casIFC"
+      class="StyledBox-sc-13pk1d4-0 jkVdVC FormField__FormFieldBox-sc-m9hood-0 casIFC"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 fpBxMF FormField__FormFieldContentBox-sc-m9hood-1"
@@ -1409,9 +1391,6 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c2 {
@@ -1766,7 +1745,7 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 bkspar FormField__FormFieldBox-sc-m9hood-0 casIFC"
+      class="StyledBox-sc-13pk1d4-0 jkVdVC FormField__FormFieldBox-sc-m9hood-0 casIFC"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 iPSxqg FormField__FormFieldContentBox-sc-m9hood-1"
@@ -1785,7 +1764,7 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 bkspar FormField__FormFieldBox-sc-m9hood-0 casIFC"
+      class="StyledBox-sc-13pk1d4-0 jkVdVC FormField__FormFieldBox-sc-m9hood-0 casIFC"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 fpBxMF FormField__FormFieldContentBox-sc-m9hood-1"
@@ -1872,9 +1851,6 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c1 {
@@ -2009,7 +1985,7 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 bkspar FormField__FormFieldBox-sc-m9hood-0 casIFC"
+      class="StyledBox-sc-13pk1d4-0 jkVdVC FormField__FormFieldBox-sc-m9hood-0 casIFC"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 iPSxqg FormField__FormFieldContentBox-sc-m9hood-1"
@@ -2028,7 +2004,7 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 bkspar FormField__FormFieldBox-sc-m9hood-0 casIFC"
+      class="StyledBox-sc-13pk1d4-0 jkVdVC FormField__FormFieldBox-sc-m9hood-0 casIFC"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 fpBxMF FormField__FormFieldContentBox-sc-m9hood-1 jyrxxG"
@@ -2107,9 +2083,6 @@ exports[`Form uncontrolled errors 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c2 {
@@ -2254,9 +2227,6 @@ exports[`Form uncontrolled infos 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c2 {
@@ -2545,9 +2515,6 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 1`] =
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c3 {
@@ -3380,7 +3347,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 bkspar FormField__FormFieldBox-sc-m9hood-0 casIFC"
+      class="StyledBox-sc-13pk1d4-0 jkVdVC FormField__FormFieldBox-sc-m9hood-0 casIFC"
     >
       <label
         class="StyledText-sc-1sadyjn-0 jOYKvZ"
@@ -3443,7 +3410,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 bkspar FormField__FormFieldBox-sc-m9hood-0 casIFC"
+      class="StyledBox-sc-13pk1d4-0 jkVdVC FormField__FormFieldBox-sc-m9hood-0 casIFC"
     >
       <label
         class="StyledText-sc-1sadyjn-0 jOYKvZ"
@@ -3479,7 +3446,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 bkspar FormField__FormFieldBox-sc-m9hood-0 casIFC"
+      class="StyledBox-sc-13pk1d4-0 jkVdVC FormField__FormFieldBox-sc-m9hood-0 casIFC"
     >
       <label
         class="StyledText-sc-1sadyjn-0 jOYKvZ"
@@ -3613,9 +3580,6 @@ exports[`Form uncontrolled uncontrolled 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c2 {
@@ -3805,7 +3769,7 @@ exports[`Form uncontrolled uncontrolled 2`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 bkspar FormField__FormFieldBox-sc-m9hood-0 casIFC"
+      class="StyledBox-sc-13pk1d4-0 jkVdVC FormField__FormFieldBox-sc-m9hood-0 casIFC"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 iPSxqg FormField__FormFieldContentBox-sc-m9hood-1"
@@ -3839,7 +3803,7 @@ exports[`Form uncontrolled uncontrolled 3`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 bkspar FormField__FormFieldBox-sc-m9hood-0 casIFC"
+      class="StyledBox-sc-13pk1d4-0 jkVdVC FormField__FormFieldBox-sc-m9hood-0 casIFC"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 iPSxqg FormField__FormFieldContentBox-sc-m9hood-1"
@@ -3891,9 +3855,6 @@ exports[`Form uncontrolled uncontrolled onValidate 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c2 {
@@ -4083,7 +4044,7 @@ exports[`Form uncontrolled uncontrolled onValidate 2`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 bkspar FormField__FormFieldBox-sc-m9hood-0 casIFC"
+      class="StyledBox-sc-13pk1d4-0 jkVdVC FormField__FormFieldBox-sc-m9hood-0 casIFC"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 eShBzY FormField__FormFieldContentBox-sc-m9hood-1"
@@ -4162,9 +4123,6 @@ exports[`Form uncontrolled uncontrolled onValidate custom error 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c2 {
@@ -4354,7 +4312,7 @@ exports[`Form uncontrolled uncontrolled onValidate custom error 2`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 bkspar FormField__FormFieldBox-sc-m9hood-0 casIFC"
+      class="StyledBox-sc-13pk1d4-0 jkVdVC FormField__FormFieldBox-sc-m9hood-0 casIFC"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 eShBzY FormField__FormFieldContentBox-sc-m9hood-1"
@@ -4433,9 +4391,6 @@ exports[`Form uncontrolled uncontrolled onValidate custom info 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c2 {
@@ -4625,7 +4580,7 @@ exports[`Form uncontrolled uncontrolled onValidate custom info 2`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 bkspar FormField__FormFieldBox-sc-m9hood-0 casIFC"
+      class="StyledBox-sc-13pk1d4-0 jkVdVC FormField__FormFieldBox-sc-m9hood-0 casIFC"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 iPSxqg FormField__FormFieldContentBox-sc-m9hood-1"
@@ -4700,9 +4655,6 @@ exports[`Form uncontrolled update 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c2 {
@@ -5068,9 +5020,6 @@ exports[`Form uncontrolled with field 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c2 {

--- a/src/js/components/FormField/FormField.js
+++ b/src/js/components/FormField/FormField.js
@@ -496,7 +496,6 @@ const FormField = forwardRef(
       <FormFieldBox
         ref={formFieldRef}
         className={className}
-        flex={false}
         background={outerBackground}
         margin={abut ? abutMargin : margin || { ...formFieldTheme.margin }}
         {...outerProps}

--- a/src/js/components/FormField/__tests__/__snapshots__/FormField-test.js.snap
+++ b/src/js/components/FormField/__tests__/__snapshots__/FormField-test.js.snap
@@ -25,9 +25,6 @@ exports[`FormField abut 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c2 {
@@ -94,9 +91,6 @@ exports[`FormField abut with margin 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c2 {
@@ -162,9 +156,6 @@ exports[`FormField checkbox pad is defined in formfield 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c3 {
@@ -432,9 +423,6 @@ exports[`FormField contentProps 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c3 {
@@ -603,9 +591,6 @@ exports[`FormField custom error and info icon and container 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c3 {
@@ -867,9 +852,6 @@ exports[`FormField custom formfield 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c3 {
@@ -940,9 +922,6 @@ exports[`FormField custom input margin 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c3 {
@@ -1093,9 +1072,6 @@ exports[`FormField custom label 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c3 {
@@ -1236,9 +1212,6 @@ exports[`FormField default 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c2 {
@@ -1371,9 +1344,6 @@ exports[`FormField disabled 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c2 {
@@ -1514,9 +1484,6 @@ exports[`FormField disabled with custom label 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c3 {
@@ -1662,9 +1629,6 @@ exports[`FormField empty margin 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c2 {
@@ -1731,9 +1695,6 @@ exports[`FormField error 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c2 {
@@ -1815,9 +1776,6 @@ exports[`FormField help 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c3 {
@@ -1896,9 +1854,6 @@ exports[`FormField htmlFor 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c2 {
@@ -1965,9 +1920,6 @@ exports[`FormField info 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c2 {
@@ -2049,9 +2001,6 @@ exports[`FormField label 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c3 {
@@ -2132,9 +2081,6 @@ exports[`FormField margin 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c2 {
@@ -2201,9 +2147,6 @@ exports[`FormField pad 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c2 {
@@ -2277,9 +2220,6 @@ exports[`FormField pad with border undefined 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c3 {
@@ -2421,9 +2361,6 @@ exports[`FormField required 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c2 {
@@ -2559,9 +2496,6 @@ exports[`FormField should have no accessibility violations 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c2 {
@@ -2628,9 +2562,6 @@ exports[`FormField should not render asterisk when required.indicator === false 
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c3 {
@@ -2772,9 +2703,6 @@ exports[`FormField should render asterisk when requiredIndicator === true 1`] = 
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c6 {
@@ -2985,9 +2913,6 @@ exports[`FormField should render custom indicator when requiredIndicator is
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c4 {

--- a/src/js/components/StarRating/__tests__/__snapshots__/StarRating-tests.tsx.snap
+++ b/src/js/components/StarRating/__tests__/__snapshots__/StarRating-tests.tsx.snap
@@ -655,9 +655,6 @@ exports[`StarRating value for rating 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c3 {

--- a/src/js/components/ThumbsRating/__tests__/__snapshots__/ThumbsRating.tsx.snap
+++ b/src/js/components/ThumbsRating/__tests__/__snapshots__/ThumbsRating.tsx.snap
@@ -453,9 +453,6 @@ exports[`ThumbsRating value for thumbs 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c3 {

--- a/src/js/components/Toolbar/__tests__/__snapshots__/Toolbar-test.js.snap
+++ b/src/js/components/Toolbar/__tests__/__snapshots__/Toolbar-test.js.snap
@@ -123,9 +123,6 @@ exports[`DataFilters renders 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
 }
 
 .c14 {


### PR DESCRIPTION
#### What does this PR do?

Reverts FormField `flex={false}`

#### Where should the reviewer start?

FormField.js

#### What testing has been done on this PR?

none

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

no test changes

#### Any background context you want to provide?

#### What are the relevant issues?

#6669 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
