### PR TITLE
Updated grommet icons version

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "styled-components": ">= 5.1"
   },
   "dependencies": {
-    "grommet-icons": "^4.8.0",
+    "grommet-icons": "^4.10.0",
     "hoist-non-react-statics": "^3.2.0",
     "markdown-to-jsx": "^7.1.5",
     "prop-types": "^15.8.1"

--- a/package.json
+++ b/package.json
@@ -207,7 +207,7 @@
   "bundlesize": [
     {
       "path": "./dist/grommet.min.js",
-      "maxSize": "157 kB"
+      "maxSize": "158 kB"
     }
   ],
   "keywords": [

--- a/src/js/components/Button/__tests__/__snapshots__/Button-kind-test.js.snap
+++ b/src/js/components/Button/__tests__/__snapshots__/Button-kind-test.js.snap
@@ -4347,7 +4347,7 @@ exports[`Button kind mouseOver and mouseOut events 2`] = `
     >
       <svg
         aria-label="Add"
-        class="StyledIcon-sc-ofa7kd-0 cMCkxw"
+        class="StyledIcon-sc-ofa7kd-0 fhGCWd"
         viewBox="0 0 24 24"
       >
         <path

--- a/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.tsx.snap
+++ b/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.tsx.snap
@@ -2443,7 +2443,7 @@ exports[`Calendar change months 2`] = `
           >
             <svg
               aria-label="Previous"
-              class="StyledIcon-sc-ofa7kd-0 jxjidg"
+              class="StyledIcon-sc-ofa7kd-0 bXBQEl"
               viewBox="0 0 24 24"
             >
               <path
@@ -2461,7 +2461,7 @@ exports[`Calendar change months 2`] = `
           >
             <svg
               aria-label="Next"
-              class="StyledIcon-sc-ofa7kd-0 jxjidg"
+              class="StyledIcon-sc-ofa7kd-0 bXBQEl"
               viewBox="0 0 24 24"
             >
               <path
@@ -17349,7 +17349,7 @@ exports[`Calendar select date 2`] = `
           >
             <svg
               aria-label="Previous"
-              class="StyledIcon-sc-ofa7kd-0 jxjidg"
+              class="StyledIcon-sc-ofa7kd-0 bXBQEl"
               viewBox="0 0 24 24"
             >
               <path
@@ -17367,7 +17367,7 @@ exports[`Calendar select date 2`] = `
           >
             <svg
               aria-label="Next"
-              class="StyledIcon-sc-ofa7kd-0 jxjidg"
+              class="StyledIcon-sc-ofa7kd-0 bXBQEl"
               viewBox="0 0 24 24"
             >
               <path
@@ -19376,7 +19376,7 @@ exports[`Calendar select dates 2`] = `
           >
             <svg
               aria-label="Previous"
-              class="StyledIcon-sc-ofa7kd-0 jxjidg"
+              class="StyledIcon-sc-ofa7kd-0 bXBQEl"
               viewBox="0 0 24 24"
             >
               <path
@@ -19394,7 +19394,7 @@ exports[`Calendar select dates 2`] = `
           >
             <svg
               aria-label="Next"
-              class="StyledIcon-sc-ofa7kd-0 jxjidg"
+              class="StyledIcon-sc-ofa7kd-0 bXBQEl"
               viewBox="0 0 24 24"
             >
               <path

--- a/src/js/components/Data/__tests__/__snapshots__/Data-test.tsx.snap
+++ b/src/js/components/Data/__tests__/__snapshots__/Data-test.tsx.snap
@@ -559,7 +559,7 @@ exports[`Data controlled search 2`] = `
           >
             <svg
               aria-label="Search"
-              class="StyledIcon-sc-ofa7kd-0 jxjidg"
+              class="StyledIcon-sc-ofa7kd-0 bXBQEl"
               viewBox="0 0 24 24"
             >
               <path
@@ -592,7 +592,7 @@ exports[`Data controlled search 2`] = `
         >
           <svg
             aria-label="Filter"
-            class="StyledIcon-sc-ofa7kd-0 jxjidg"
+            class="StyledIcon-sc-ofa7kd-0 bXBQEl"
             viewBox="0 0 24 24"
           >
             <path
@@ -5683,7 +5683,7 @@ exports[`Data uncontrolled search 2`] = `
           >
             <svg
               aria-label="Search"
-              class="StyledIcon-sc-ofa7kd-0 jxjidg"
+              class="StyledIcon-sc-ofa7kd-0 bXBQEl"
               viewBox="0 0 24 24"
             >
               <path
@@ -5716,7 +5716,7 @@ exports[`Data uncontrolled search 2`] = `
         >
           <svg
             aria-label="Filter"
-            class="StyledIcon-sc-ofa7kd-0 jxjidg"
+            class="StyledIcon-sc-ofa7kd-0 bXBQEl"
             viewBox="0 0 24 24"
           >
             <path

--- a/src/js/components/DataFilters/__tests__/__snapshots__/DataFilters-test.tsx.snap
+++ b/src/js/components/DataFilters/__tests__/__snapshots__/DataFilters-test.tsx.snap
@@ -860,7 +860,7 @@ exports[`DataFilters drop 2`] = `
 >
   <svg
     aria-label="Filter"
-    class="StyledIcon-sc-ofa7kd-0 jxjidg"
+    class="StyledIcon-sc-ofa7kd-0 bXBQEl"
     viewBox="0 0 24 24"
   >
     <path

--- a/src/js/components/DataSearch/__tests__/__snapshots__/DataSearch-test.tsx.snap
+++ b/src/js/components/DataSearch/__tests__/__snapshots__/DataSearch-test.tsx.snap
@@ -163,7 +163,7 @@ exports[`DataSearch drop 2`] = `
 >
   <svg
     aria-label="Search"
-    class="StyledIcon-sc-ofa7kd-0 jxjidg"
+    class="StyledIcon-sc-ofa7kd-0 bXBQEl"
     viewBox="0 0 24 24"
   >
     <path

--- a/src/js/components/DataSort/__tests__/__snapshots__/DataSort-test.tsx.snap
+++ b/src/js/components/DataSort/__tests__/__snapshots__/DataSort-test.tsx.snap
@@ -163,7 +163,7 @@ exports[`DataSort drop 2`] = `
 >
   <svg
     aria-label="Descend"
-    class="StyledIcon-sc-ofa7kd-0 jxjidg"
+    class="StyledIcon-sc-ofa7kd-0 bXBQEl"
     viewBox="0 0 24 24"
   >
     <path

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.tsx.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.tsx.snap
@@ -5688,7 +5688,7 @@ exports[`DataTable groupBy 2`] = `
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-sc-ofa7kd-0 iEfnSI"
+                  class="StyledIcon-sc-ofa7kd-0 gHlgBN"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -5755,7 +5755,7 @@ exports[`DataTable groupBy 2`] = `
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-sc-ofa7kd-0 iEfnSI"
+                  class="StyledIcon-sc-ofa7kd-0 gHlgBN"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -5811,7 +5811,7 @@ exports[`DataTable groupBy 2`] = `
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-sc-ofa7kd-0 iEfnSI"
+                  class="StyledIcon-sc-ofa7kd-0 gHlgBN"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -6994,7 +6994,7 @@ exports[`DataTable groupBy property 2`] = `
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-sc-ofa7kd-0 iEfnSI"
+                  class="StyledIcon-sc-ofa7kd-0 gHlgBN"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -7061,7 +7061,7 @@ exports[`DataTable groupBy property 2`] = `
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-sc-ofa7kd-0 iEfnSI"
+                  class="StyledIcon-sc-ofa7kd-0 gHlgBN"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -7117,7 +7117,7 @@ exports[`DataTable groupBy property 2`] = `
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-sc-ofa7kd-0 iEfnSI"
+                  class="StyledIcon-sc-ofa7kd-0 gHlgBN"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -11418,7 +11418,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-sc-ofa7kd-0 iEfnSI"
+                  class="StyledIcon-sc-ofa7kd-0 gHlgBN"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -11546,7 +11546,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-sc-ofa7kd-0 iEfnSI"
+                  class="StyledIcon-sc-ofa7kd-0 gHlgBN"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -11662,7 +11662,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-sc-ofa7kd-0 iEfnSI"
+                  class="StyledIcon-sc-ofa7kd-0 gHlgBN"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -11793,7 +11793,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-sc-ofa7kd-0 iEfnSI"
+                  class="StyledIcon-sc-ofa7kd-0 gHlgBN"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -11886,7 +11886,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-sc-ofa7kd-0 iEfnSI"
+                  class="StyledIcon-sc-ofa7kd-0 gHlgBN"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -11967,7 +11967,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-sc-ofa7kd-0 iEfnSI"
+                  class="StyledIcon-sc-ofa7kd-0 gHlgBN"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -34946,7 +34946,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             >
               <svg
                 aria-label="Previous"
-                class="StyledIcon-sc-ofa7kd-0 gNIOAA"
+                class="StyledIcon-sc-ofa7kd-0 eAbdrF"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -35002,7 +35002,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             >
               <svg
                 aria-label="Next"
-                class="StyledIcon-sc-ofa7kd-0 jxjidg"
+                class="StyledIcon-sc-ofa7kd-0 bXBQEl"
                 viewBox="0 0 24 24"
               >
                 <path

--- a/src/js/components/DataTableColumns/__tests__/__snapshots__/DataTableColumns-test.tsx.snap
+++ b/src/js/components/DataTableColumns/__tests__/__snapshots__/DataTableColumns-test.tsx.snap
@@ -498,7 +498,7 @@ exports[`DataTableColumns remove column 2`] = `
 >
   <svg
     aria-label="Splits"
-    class="StyledIcon-sc-ofa7kd-0 jxjidg"
+    class="StyledIcon-sc-ofa7kd-0 bXBQEl"
     viewBox="0 0 24 24"
   >
     <path
@@ -1731,7 +1731,7 @@ exports[`DataTableColumns search 2`] = `
 >
   <svg
     aria-label="Splits"
-    class="StyledIcon-sc-ofa7kd-0 jxjidg"
+    class="StyledIcon-sc-ofa7kd-0 bXBQEl"
     viewBox="0 0 24 24"
   >
     <path
@@ -1833,7 +1833,7 @@ exports[`DataTableColumns search 4`] = `
 >
   <svg
     aria-label="Splits"
-    class="StyledIcon-sc-ofa7kd-0 jxjidg"
+    class="StyledIcon-sc-ofa7kd-0 bXBQEl"
     viewBox="0 0 24 24"
   >
     <path

--- a/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.tsx.snap
+++ b/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.tsx.snap
@@ -1748,7 +1748,7 @@ exports[`DateInput controlled format inline 2`] = `
       >
         <svg
           aria-label="Calendar"
-          class="StyledIcon-sc-ofa7kd-0 jxjidg"
+          class="StyledIcon-sc-ofa7kd-0 bXBQEl"
           viewBox="0 0 24 24"
         >
           <path
@@ -1788,7 +1788,7 @@ exports[`DateInput controlled format inline 2`] = `
             >
               <svg
                 aria-label="Previous"
-                class="StyledIcon-sc-ofa7kd-0 jxjidg"
+                class="StyledIcon-sc-ofa7kd-0 bXBQEl"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -1806,7 +1806,7 @@ exports[`DateInput controlled format inline 2`] = `
             >
               <svg
                 aria-label="Next"
-                class="StyledIcon-sc-ofa7kd-0 jxjidg"
+                class="StyledIcon-sc-ofa7kd-0 bXBQEl"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -15429,7 +15429,7 @@ exports[`DateInput select format 2`] = `
     >
       <svg
         aria-label="Calendar"
-        class="StyledIcon-sc-ofa7kd-0 jxjidg"
+        class="StyledIcon-sc-ofa7kd-0 bXBQEl"
         viewBox="0 0 24 24"
       >
         <path
@@ -18203,7 +18203,7 @@ exports[`DateInput select format inline 2`] = `
       >
         <svg
           aria-label="Calendar"
-          class="StyledIcon-sc-ofa7kd-0 jxjidg"
+          class="StyledIcon-sc-ofa7kd-0 bXBQEl"
           viewBox="0 0 24 24"
         >
           <path
@@ -18243,7 +18243,7 @@ exports[`DateInput select format inline 2`] = `
             >
               <svg
                 aria-label="Previous"
-                class="StyledIcon-sc-ofa7kd-0 jxjidg"
+                class="StyledIcon-sc-ofa7kd-0 bXBQEl"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -18261,7 +18261,7 @@ exports[`DateInput select format inline 2`] = `
             >
               <svg
                 aria-label="Next"
-                class="StyledIcon-sc-ofa7kd-0 jxjidg"
+                class="StyledIcon-sc-ofa7kd-0 bXBQEl"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -23308,7 +23308,7 @@ exports[`DateInput select format inline range 2`] = `
       >
         <svg
           aria-label="Calendar"
-          class="StyledIcon-sc-ofa7kd-0 jxjidg"
+          class="StyledIcon-sc-ofa7kd-0 bXBQEl"
           viewBox="0 0 24 24"
         >
           <path
@@ -23348,7 +23348,7 @@ exports[`DateInput select format inline range 2`] = `
             >
               <svg
                 aria-label="Previous"
-                class="StyledIcon-sc-ofa7kd-0 jxjidg"
+                class="StyledIcon-sc-ofa7kd-0 bXBQEl"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -23366,7 +23366,7 @@ exports[`DateInput select format inline range 2`] = `
             >
               <svg
                 aria-label="Next"
-                class="StyledIcon-sc-ofa7kd-0 jxjidg"
+                class="StyledIcon-sc-ofa7kd-0 bXBQEl"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -32626,7 +32626,7 @@ exports[`DateInput type format inline 2`] = `
       >
         <svg
           aria-label="Calendar"
-          class="StyledIcon-sc-ofa7kd-0 jxjidg"
+          class="StyledIcon-sc-ofa7kd-0 bXBQEl"
           viewBox="0 0 24 24"
         >
           <path
@@ -32666,7 +32666,7 @@ exports[`DateInput type format inline 2`] = `
             >
               <svg
                 aria-label="Previous"
-                class="StyledIcon-sc-ofa7kd-0 jxjidg"
+                class="StyledIcon-sc-ofa7kd-0 bXBQEl"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -32684,7 +32684,7 @@ exports[`DateInput type format inline 2`] = `
             >
               <svg
                 aria-label="Next"
-                class="StyledIcon-sc-ofa7kd-0 jxjidg"
+                class="StyledIcon-sc-ofa7kd-0 bXBQEl"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -37652,7 +37652,7 @@ exports[`DateInput type format inline range 2`] = `
       >
         <svg
           aria-label="Calendar"
-          class="StyledIcon-sc-ofa7kd-0 jxjidg"
+          class="StyledIcon-sc-ofa7kd-0 bXBQEl"
           viewBox="0 0 24 24"
         >
           <path
@@ -37692,7 +37692,7 @@ exports[`DateInput type format inline range 2`] = `
             >
               <svg
                 aria-label="Previous"
-                class="StyledIcon-sc-ofa7kd-0 jxjidg"
+                class="StyledIcon-sc-ofa7kd-0 bXBQEl"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -37710,7 +37710,7 @@ exports[`DateInput type format inline range 2`] = `
             >
               <svg
                 aria-label="Next"
-                class="StyledIcon-sc-ofa7kd-0 jxjidg"
+                class="StyledIcon-sc-ofa7kd-0 bXBQEl"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -39912,7 +39912,7 @@ exports[`DateInput type format inline range partial 2`] = `
       >
         <svg
           aria-label="Calendar"
-          class="StyledIcon-sc-ofa7kd-0 jxjidg"
+          class="StyledIcon-sc-ofa7kd-0 bXBQEl"
           viewBox="0 0 24 24"
         >
           <path
@@ -39952,7 +39952,7 @@ exports[`DateInput type format inline range partial 2`] = `
             >
               <svg
                 aria-label="Previous"
-                class="StyledIcon-sc-ofa7kd-0 jxjidg"
+                class="StyledIcon-sc-ofa7kd-0 bXBQEl"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -39970,7 +39970,7 @@ exports[`DateInput type format inline range partial 2`] = `
             >
               <svg
                 aria-label="Next"
-                class="StyledIcon-sc-ofa7kd-0 jxjidg"
+                class="StyledIcon-sc-ofa7kd-0 bXBQEl"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -40772,7 +40772,7 @@ exports[`DateInput type format inline range partial 3`] = `
       >
         <svg
           aria-label="Calendar"
-          class="StyledIcon-sc-ofa7kd-0 jxjidg"
+          class="StyledIcon-sc-ofa7kd-0 bXBQEl"
           viewBox="0 0 24 24"
         >
           <path
@@ -40812,7 +40812,7 @@ exports[`DateInput type format inline range partial 3`] = `
             >
               <svg
                 aria-label="Previous"
-                class="StyledIcon-sc-ofa7kd-0 jxjidg"
+                class="StyledIcon-sc-ofa7kd-0 bXBQEl"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -40830,7 +40830,7 @@ exports[`DateInput type format inline range partial 3`] = `
             >
               <svg
                 aria-label="Next"
-                class="StyledIcon-sc-ofa7kd-0 jxjidg"
+                class="StyledIcon-sc-ofa7kd-0 bXBQEl"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -49988,7 +49988,7 @@ exports[`DateInput type format inline short 2`] = `
       >
         <svg
           aria-label="Calendar"
-          class="StyledIcon-sc-ofa7kd-0 jxjidg"
+          class="StyledIcon-sc-ofa7kd-0 bXBQEl"
           viewBox="0 0 24 24"
         >
           <path
@@ -50028,7 +50028,7 @@ exports[`DateInput type format inline short 2`] = `
             >
               <svg
                 aria-label="Previous"
-                class="StyledIcon-sc-ofa7kd-0 jxjidg"
+                class="StyledIcon-sc-ofa7kd-0 bXBQEl"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -50046,7 +50046,7 @@ exports[`DateInput type format inline short 2`] = `
             >
               <svg
                 aria-label="Next"
-                class="StyledIcon-sc-ofa7kd-0 jxjidg"
+                class="StyledIcon-sc-ofa7kd-0 bXBQEl"
                 viewBox="0 0 24 24"
               >
                 <path

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
@@ -3394,7 +3394,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
             >
               <svg
                 aria-label="FormDown"
-                class="StyledIcon-sc-ofa7kd-0 kwDoXo"
+                class="StyledIcon-sc-ofa7kd-0 kEyrVN"
                 viewBox="0 0 24 24"
               >
                 <path

--- a/src/js/components/List/__tests__/__snapshots__/List-test.js.snap
+++ b/src/js/components/List/__tests__/__snapshots__/List-test.js.snap
@@ -11827,7 +11827,7 @@ exports[`List events should render new data when page changes 2`] = `
             >
               <svg
                 aria-label="Previous"
-                class="StyledIcon-sc-ofa7kd-0 gNIOAA"
+                class="StyledIcon-sc-ofa7kd-0 eAbdrF"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -11883,7 +11883,7 @@ exports[`List events should render new data when page changes 2`] = `
             >
               <svg
                 aria-label="Next"
-                class="StyledIcon-sc-ofa7kd-0 jxjidg"
+                class="StyledIcon-sc-ofa7kd-0 bXBQEl"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -15505,7 +15505,7 @@ exports[`List onOrder Keyboard move down 2`] = `
         >
           <svg
             aria-label="FormUp"
-            class="StyledIcon-sc-ofa7kd-0 jxjidg"
+            class="StyledIcon-sc-ofa7kd-0 bXBQEl"
             viewBox="0 0 24 24"
           >
             <path
@@ -15525,7 +15525,7 @@ exports[`List onOrder Keyboard move down 2`] = `
         >
           <svg
             aria-label="FormDown"
-            class="StyledIcon-sc-ofa7kd-0 jxjidg"
+            class="StyledIcon-sc-ofa7kd-0 bXBQEl"
             viewBox="0 0 24 24"
           >
             <path
@@ -15574,7 +15574,7 @@ exports[`List onOrder Keyboard move down 2`] = `
         >
           <svg
             aria-label="FormUp"
-            class="StyledIcon-sc-ofa7kd-0 jxjidg"
+            class="StyledIcon-sc-ofa7kd-0 bXBQEl"
             viewBox="0 0 24 24"
           >
             <path
@@ -15595,7 +15595,7 @@ exports[`List onOrder Keyboard move down 2`] = `
         >
           <svg
             aria-label="FormDown"
-            class="StyledIcon-sc-ofa7kd-0 jxjidg"
+            class="StyledIcon-sc-ofa7kd-0 bXBQEl"
             viewBox="0 0 24 24"
           >
             <path
@@ -15659,7 +15659,7 @@ exports[`List onOrder Keyboard move down 3`] = `
         >
           <svg
             aria-label="FormUp"
-            class="StyledIcon-sc-ofa7kd-0 jxjidg"
+            class="StyledIcon-sc-ofa7kd-0 bXBQEl"
             viewBox="0 0 24 24"
           >
             <path
@@ -15679,7 +15679,7 @@ exports[`List onOrder Keyboard move down 3`] = `
         >
           <svg
             aria-label="FormDown"
-            class="StyledIcon-sc-ofa7kd-0 jxjidg"
+            class="StyledIcon-sc-ofa7kd-0 bXBQEl"
             viewBox="0 0 24 24"
           >
             <path
@@ -15728,7 +15728,7 @@ exports[`List onOrder Keyboard move down 3`] = `
         >
           <svg
             aria-label="FormUp"
-            class="StyledIcon-sc-ofa7kd-0 jxjidg"
+            class="StyledIcon-sc-ofa7kd-0 bXBQEl"
             viewBox="0 0 24 24"
           >
             <path
@@ -15749,7 +15749,7 @@ exports[`List onOrder Keyboard move down 3`] = `
         >
           <svg
             aria-label="FormDown"
-            class="StyledIcon-sc-ofa7kd-0 jxjidg"
+            class="StyledIcon-sc-ofa7kd-0 bXBQEl"
             viewBox="0 0 24 24"
           >
             <path
@@ -16275,7 +16275,7 @@ exports[`List onOrder Keyboard move up 2`] = `
         >
           <svg
             aria-label="FormUp"
-            class="StyledIcon-sc-ofa7kd-0 jxjidg"
+            class="StyledIcon-sc-ofa7kd-0 bXBQEl"
             viewBox="0 0 24 24"
           >
             <path
@@ -16295,7 +16295,7 @@ exports[`List onOrder Keyboard move up 2`] = `
         >
           <svg
             aria-label="FormDown"
-            class="StyledIcon-sc-ofa7kd-0 jxjidg"
+            class="StyledIcon-sc-ofa7kd-0 bXBQEl"
             viewBox="0 0 24 24"
           >
             <path
@@ -16344,7 +16344,7 @@ exports[`List onOrder Keyboard move up 2`] = `
         >
           <svg
             aria-label="FormUp"
-            class="StyledIcon-sc-ofa7kd-0 jxjidg"
+            class="StyledIcon-sc-ofa7kd-0 bXBQEl"
             viewBox="0 0 24 24"
           >
             <path
@@ -16365,7 +16365,7 @@ exports[`List onOrder Keyboard move up 2`] = `
         >
           <svg
             aria-label="FormDown"
-            class="StyledIcon-sc-ofa7kd-0 jxjidg"
+            class="StyledIcon-sc-ofa7kd-0 bXBQEl"
             viewBox="0 0 24 24"
           >
             <path
@@ -16429,7 +16429,7 @@ exports[`List onOrder Keyboard move up 3`] = `
         >
           <svg
             aria-label="FormUp"
-            class="StyledIcon-sc-ofa7kd-0 jxjidg"
+            class="StyledIcon-sc-ofa7kd-0 bXBQEl"
             viewBox="0 0 24 24"
           >
             <path
@@ -16449,7 +16449,7 @@ exports[`List onOrder Keyboard move up 3`] = `
         >
           <svg
             aria-label="FormDown"
-            class="StyledIcon-sc-ofa7kd-0 jxjidg"
+            class="StyledIcon-sc-ofa7kd-0 bXBQEl"
             viewBox="0 0 24 24"
           >
             <path
@@ -16498,7 +16498,7 @@ exports[`List onOrder Keyboard move up 3`] = `
         >
           <svg
             aria-label="FormUp"
-            class="StyledIcon-sc-ofa7kd-0 jxjidg"
+            class="StyledIcon-sc-ofa7kd-0 bXBQEl"
             viewBox="0 0 24 24"
           >
             <path
@@ -16519,7 +16519,7 @@ exports[`List onOrder Keyboard move up 3`] = `
         >
           <svg
             aria-label="FormDown"
-            class="StyledIcon-sc-ofa7kd-0 jxjidg"
+            class="StyledIcon-sc-ofa7kd-0 bXBQEl"
             viewBox="0 0 24 24"
           >
             <path
@@ -17044,7 +17044,7 @@ exports[`List onOrder Mouse move down 2`] = `
         >
           <svg
             aria-label="FormUp"
-            class="StyledIcon-sc-ofa7kd-0 jxjidg"
+            class="StyledIcon-sc-ofa7kd-0 bXBQEl"
             viewBox="0 0 24 24"
           >
             <path
@@ -17064,7 +17064,7 @@ exports[`List onOrder Mouse move down 2`] = `
         >
           <svg
             aria-label="FormDown"
-            class="StyledIcon-sc-ofa7kd-0 jxjidg"
+            class="StyledIcon-sc-ofa7kd-0 bXBQEl"
             viewBox="0 0 24 24"
           >
             <path
@@ -17113,7 +17113,7 @@ exports[`List onOrder Mouse move down 2`] = `
         >
           <svg
             aria-label="FormUp"
-            class="StyledIcon-sc-ofa7kd-0 jxjidg"
+            class="StyledIcon-sc-ofa7kd-0 bXBQEl"
             viewBox="0 0 24 24"
           >
             <path
@@ -17134,7 +17134,7 @@ exports[`List onOrder Mouse move down 2`] = `
         >
           <svg
             aria-label="FormDown"
-            class="StyledIcon-sc-ofa7kd-0 jxjidg"
+            class="StyledIcon-sc-ofa7kd-0 bXBQEl"
             viewBox="0 0 24 24"
           >
             <path

--- a/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
+++ b/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
@@ -3086,7 +3086,7 @@ exports[`Menu open and close on click 2`] = `
       />
       <svg
         aria-label="FormDown"
-        class="StyledIcon-sc-ofa7kd-0 kwDoXo"
+        class="StyledIcon-sc-ofa7kd-0 kEyrVN"
         viewBox="0 0 24 24"
       >
         <path

--- a/src/js/components/Notification/__tests__/__snapshots__/Notification-test.js.snap
+++ b/src/js/components/Notification/__tests__/__snapshots__/Notification-test.js.snap
@@ -172,7 +172,6 @@ exports[`Notification custom theme 1`] = `
           <svg
             aria-label="Status is critical"
             class="c4"
-            height="medium"
             viewBox="0 0 12 12"
           >
             <path
@@ -390,7 +389,6 @@ exports[`Notification global 1`] = `
           <svg
             aria-label="Status is unknown"
             class="c4"
-            height="medium"
             viewBox="0 0 12 12"
           >
             <rect
@@ -629,7 +627,6 @@ exports[`Notification multi actions 1`] = `
           <svg
             aria-label="Status is unknown"
             class="c4"
-            height="medium"
             viewBox="0 0 12 12"
           >
             <rect
@@ -920,7 +917,6 @@ exports[`Notification position bottom 1`] = `
           <svg
             aria-label="Status is unknown"
             class="c6"
-            height="medium"
             viewBox="0 0 12 12"
           >
             <rect
@@ -1222,7 +1218,6 @@ exports[`Notification position bottom-left 1`] = `
           <svg
             aria-label="Status is unknown"
             class="c6"
-            height="medium"
             viewBox="0 0 12 12"
           >
             <rect
@@ -1524,7 +1519,6 @@ exports[`Notification position bottom-right 1`] = `
           <svg
             aria-label="Status is unknown"
             class="c6"
-            height="medium"
             viewBox="0 0 12 12"
           >
             <rect
@@ -1826,7 +1820,6 @@ exports[`Notification position center 1`] = `
           <svg
             aria-label="Status is unknown"
             class="c6"
-            height="medium"
             viewBox="0 0 12 12"
           >
             <rect
@@ -2128,7 +2121,6 @@ exports[`Notification position end 1`] = `
           <svg
             aria-label="Status is unknown"
             class="c6"
-            height="medium"
             viewBox="0 0 12 12"
           >
             <rect
@@ -2430,7 +2422,6 @@ exports[`Notification position left 1`] = `
           <svg
             aria-label="Status is unknown"
             class="c6"
-            height="medium"
             viewBox="0 0 12 12"
           >
             <rect
@@ -2732,7 +2723,6 @@ exports[`Notification position right 1`] = `
           <svg
             aria-label="Status is unknown"
             class="c6"
-            height="medium"
             viewBox="0 0 12 12"
           >
             <rect
@@ -3034,7 +3024,6 @@ exports[`Notification position start 1`] = `
           <svg
             aria-label="Status is unknown"
             class="c6"
-            height="medium"
             viewBox="0 0 12 12"
           >
             <rect
@@ -3336,7 +3325,6 @@ exports[`Notification position top 1`] = `
           <svg
             aria-label="Status is unknown"
             class="c6"
-            height="medium"
             viewBox="0 0 12 12"
           >
             <rect
@@ -3638,7 +3626,6 @@ exports[`Notification position top-left 1`] = `
           <svg
             aria-label="Status is unknown"
             class="c6"
-            height="medium"
             viewBox="0 0 12 12"
           >
             <rect
@@ -3940,7 +3927,6 @@ exports[`Notification position top-right 1`] = `
           <svg
             aria-label="Status is unknown"
             class="c6"
-            height="medium"
             viewBox="0 0 12 12"
           >
             <rect
@@ -4165,7 +4151,6 @@ exports[`Notification should have no accessibility violations 1`] = `
           <svg
             aria-label="Status is unknown"
             class="c4"
-            height="medium"
             viewBox="0 0 12 12"
           >
             <rect
@@ -4604,7 +4589,6 @@ exports[`Notification should render custom template inside notification 1`] = `
           <svg
             aria-label="Status is unknown"
             class="c4"
-            height="medium"
             viewBox="0 0 12 12"
           >
             <rect
@@ -4814,7 +4798,6 @@ exports[`Notification should render the default icon if no icon is passed 1`] = 
           <svg
             aria-label="Home"
             class="c4"
-            height="medium"
             viewBox="0 0 24 24"
           >
             <path
@@ -5140,7 +5123,6 @@ exports[`Notification status 1`] = `
           <svg
             aria-label="Status is okay"
             class="c4"
-            height="medium"
             viewBox="0 0 12 12"
           >
             <circle
@@ -5189,7 +5171,6 @@ exports[`Notification status 1`] = `
           <svg
             aria-label="Status is warning"
             class="c11"
-            height="medium"
             viewBox="0 0 12 12"
           >
             <path
@@ -5237,7 +5218,6 @@ exports[`Notification status 1`] = `
           <svg
             aria-label="Status is critical"
             class="c13"
-            height="medium"
             viewBox="0 0 12 12"
           >
             <path

--- a/src/js/components/Pagination/__tests__/__snapshots__/Pagination-test.tsx.snap
+++ b/src/js/components/Pagination/__tests__/__snapshots__/Pagination-test.tsx.snap
@@ -7965,7 +7965,7 @@ exports[`Pagination should display next page of results when "next" is
           >
             <svg
               aria-label="Previous"
-              class="StyledIcon-sc-ofa7kd-0 gNIOAA"
+              class="StyledIcon-sc-ofa7kd-0 eAbdrF"
               viewBox="0 0 24 24"
             >
               <path
@@ -8087,7 +8087,7 @@ exports[`Pagination should display next page of results when "next" is
           >
             <svg
               aria-label="Next"
-              class="StyledIcon-sc-ofa7kd-0 gNIOAA"
+              class="StyledIcon-sc-ofa7kd-0 eAbdrF"
               viewBox="0 0 24 24"
             >
               <path
@@ -9238,7 +9238,7 @@ exports[`Pagination should display previous page of results when "previous" is
           >
             <svg
               aria-label="Previous"
-              class="StyledIcon-sc-ofa7kd-0 gNIOAA"
+              class="StyledIcon-sc-ofa7kd-0 eAbdrF"
               viewBox="0 0 24 24"
             >
               <path
@@ -9360,7 +9360,7 @@ exports[`Pagination should display previous page of results when "previous" is
           >
             <svg
               aria-label="Next"
-              class="StyledIcon-sc-ofa7kd-0 gNIOAA"
+              class="StyledIcon-sc-ofa7kd-0 eAbdrF"
               viewBox="0 0 24 24"
             >
               <path

--- a/src/js/components/Select/__tests__/__snapshots__/Select-multiple-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-multiple-test.js.snap
@@ -5438,7 +5438,7 @@ exports[`Select Controlled multiple values 2`] = `
     >
       <svg
         aria-label="FormDown"
-        class="StyledIcon-sc-ofa7kd-0 kwDoXo"
+        class="StyledIcon-sc-ofa7kd-0 kEyrVN"
         viewBox="0 0 24 24"
       >
         <path

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -2939,7 +2939,7 @@ exports[`Select complex options and children 2`] = `
     >
       <svg
         aria-label="FormDown"
-        class="StyledIcon-sc-ofa7kd-0 kwDoXo"
+        class="StyledIcon-sc-ofa7kd-0 kEyrVN"
         viewBox="0 0 24 24"
       >
         <path
@@ -4740,7 +4740,7 @@ exports[`Select disabled 2`] = `
     >
       <svg
         aria-label="FormDown"
-        class="StyledIcon-sc-ofa7kd-0 kwDoXo"
+        class="StyledIcon-sc-ofa7kd-0 kEyrVN"
         viewBox="0 0 24 24"
       >
         <path
@@ -12602,7 +12602,7 @@ exports[`Select prop: onOpen 2`] = `
     >
       <svg
         aria-label="FormDown"
-        class="StyledIcon-sc-ofa7kd-0 kwDoXo"
+        class="StyledIcon-sc-ofa7kd-0 kEyrVN"
         viewBox="0 0 24 24"
       >
         <path
@@ -18093,7 +18093,7 @@ exports[`Select select option by typing should not break if caller passes JSX 2`
       >
         <svg
           aria-label="FormDown"
-          class="StyledIcon-sc-ofa7kd-0 kwDoXo"
+          class="StyledIcon-sc-ofa7kd-0 kEyrVN"
           viewBox="0 0 24 24"
         >
           <path

--- a/src/js/components/SelectMultiple/__tests__/__snapshots__/SelectMultiple-test.tsx.snap
+++ b/src/js/components/SelectMultiple/__tests__/__snapshots__/SelectMultiple-test.tsx.snap
@@ -2949,7 +2949,7 @@ exports[`SelectMultiple select all and clear 3`] = `
     >
       <svg
         aria-label="FormDown"
-        class="StyledIcon-sc-ofa7kd-0 kwDoXo"
+        class="StyledIcon-sc-ofa7kd-0 kEyrVN"
         viewBox="0 0 24 24"
       >
         <path
@@ -4624,7 +4624,7 @@ exports[`SelectMultiple showSelectionInline with children 2`] = `
           >
             <svg
               aria-label="FormDown"
-              class="StyledIcon-sc-ofa7kd-0 kwDoXo"
+              class="StyledIcon-sc-ofa7kd-0 kEyrVN"
               viewBox="0 0 24 24"
             >
               <path

--- a/src/js/components/Video/__tests__/__snapshots__/Video-test.tsx.snap
+++ b/src/js/components/Video/__tests__/__snapshots__/Video-test.tsx.snap
@@ -1744,7 +1744,7 @@ exports[`Video Play and Pause event handlers 2`] = `
             />
             <svg
               aria-label="Actions"
-              class="StyledIcon-sc-ofa7kd-0 cMCkxw"
+              class="StyledIcon-sc-ofa7kd-0 fhGCWd"
               viewBox="0 0 24 24"
             >
               <path
@@ -6021,7 +6021,7 @@ exports[`Video mouse events handlers of controls 2`] = `
         >
           <svg
             aria-label="play"
-            class="StyledIcon-sc-ofa7kd-0 cMCkxw"
+            class="StyledIcon-sc-ofa7kd-0 fhGCWd"
             viewBox="0 0 24 24"
           >
             <path
@@ -6098,7 +6098,7 @@ exports[`Video mouse events handlers of controls 2`] = `
             />
             <svg
               aria-label="Actions"
-              class="StyledIcon-sc-ofa7kd-0 cMCkxw"
+              class="StyledIcon-sc-ofa7kd-0 fhGCWd"
               viewBox="0 0 24 24"
             >
               <path
@@ -6145,7 +6145,7 @@ exports[`Video mouse events handlers of controls 3`] = `
         >
           <svg
             aria-label="play"
-            class="StyledIcon-sc-ofa7kd-0 cMCkxw"
+            class="StyledIcon-sc-ofa7kd-0 fhGCWd"
             viewBox="0 0 24 24"
           >
             <path
@@ -6222,7 +6222,7 @@ exports[`Video mouse events handlers of controls 3`] = `
             />
             <svg
               aria-label="Actions"
-              class="StyledIcon-sc-ofa7kd-0 cMCkxw"
+              class="StyledIcon-sc-ofa7kd-0 fhGCWd"
               viewBox="0 0 24 24"
             >
               <path
@@ -8381,7 +8381,7 @@ exports[`Video scrubber 2`] = `
         >
           <svg
             aria-label="play"
-            class="StyledIcon-sc-ofa7kd-0 cMCkxw"
+            class="StyledIcon-sc-ofa7kd-0 fhGCWd"
             viewBox="0 0 24 24"
           >
             <path
@@ -8458,7 +8458,7 @@ exports[`Video scrubber 2`] = `
             />
             <svg
               aria-label="Actions"
-              class="StyledIcon-sc-ofa7kd-0 cMCkxw"
+              class="StyledIcon-sc-ofa7kd-0 fhGCWd"
               viewBox="0 0 24 24"
             >
               <path

--- a/yarn.lock
+++ b/yarn.lock
@@ -7837,10 +7837,10 @@ graphlib@^2.1.5:
   dependencies:
     lodash "^4.17.15"
 
-grommet-icons@^4.8.0:
-  version "4.8.0"
-  resolved "https://registry.yarnpkg.com/grommet-icons/-/grommet-icons-4.8.0.tgz#3c9922b3662d0b9e22913ecbaa7b1101031b554b"
-  integrity sha512-8cS1zVib88SIyLfsWFFazMzYz/8k5MvXZqopUjN/Bnl8HvQBUe0Z87F+JXRb1AMMYkuqXQW9Pg6XfBB3Ro9VdQ==
+grommet-icons@^4.10.0:
+  version "4.10.0"
+  resolved "https://registry.yarnpkg.com/grommet-icons/-/grommet-icons-4.10.0.tgz#a56bc083f7d52502a12871c031a6746c61164cce"
+  integrity sha512-f3Re6jFRh93n2Cn2hyrJUANG7wOsv3wlEuyW/A1kIYzamDWnNfoZLgDQZXbAmMUMb1NdN7OU/0JrINxTCUOAEA==
   dependencies:
     grommet-styles "^0.2.0"
 


### PR DESCRIPTION
#### What does this PR do?
Upgrade to use the latest version of grommet-icons

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
https://github.com/grommet/grommet/issues/6658

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No
#### Should this PR be mentioned in the release notes?
Maybe?
#### Is this change backwards compatible or is it a breaking change?
Backwards compatible