### PR TITLE
Changed SelectMultiple `showSelectedInline` icon to use icon specified in the theme

### DIFF
--- a/src/js/components/SelectMultiple/SelectMultiple.js
+++ b/src/js/components/SelectMultiple/SelectMultiple.js
@@ -322,6 +322,20 @@ const SelectMultiple = forwardRef(
 
     const iconColor = getIconColor(theme);
 
+    const displaySelectIcon = SelectIcon && (
+      <Box
+        alignSelf="center"
+        margin={theme.select.icons.margin}
+        width={{ min: 'auto' }}
+      >
+        {isValidElement(SelectIcon) ? (
+          SelectIcon
+        ) : (
+          <SelectIcon color={iconColor} size={size} />
+        )}
+      </Box>
+    );
+
     const dropContent = (
       <SelectMultipleContainer
         allOptions={allOptions}
@@ -330,6 +344,7 @@ const SelectMultiple = forwardRef(
         dropHeight={dropHeight}
         emptySearchMessage={emptySearchMessage}
         help={help}
+        icon={displaySelectIcon}
         id={id}
         labelKey={labelKey}
         limit={limit}
@@ -377,20 +392,6 @@ const SelectMultiple = forwardRef(
       dropContent,
       theme,
     };
-
-    const displaySelectIcon = SelectIcon && (
-      <Box
-        alignSelf="center"
-        margin={theme.select.icons.margin}
-        width={{ min: 'auto' }}
-      >
-        {isValidElement(SelectIcon) ? (
-          SelectIcon
-        ) : (
-          <SelectIcon color={iconColor} size={size} />
-        )}
-      </Box>
-    );
 
     return (
       <Keyboard onDown={onRequestOpen} onUp={onRequestOpen}>

--- a/src/js/components/SelectMultiple/SelectMultipleContainer.js
+++ b/src/js/components/SelectMultiple/SelectMultipleContainer.js
@@ -7,7 +7,6 @@ import React, {
   useState,
 } from 'react';
 import { ThemeContext } from 'styled-components';
-import { FormUp } from 'grommet-icons/icons/FormUp';
 
 import { setFocusWithoutScroll } from '../../utils';
 
@@ -46,6 +45,7 @@ const SelectMultipleContainer = forwardRef(
       dropHeight,
       emptySearchMessage = 'No matches found',
       help,
+      icon,
       id,
       labelKey,
       limit,
@@ -358,11 +358,11 @@ const SelectMultipleContainer = forwardRef(
       summaryContent = (
         <Box direction="row" justify="between" flex={false}>
           {summaryContent}
-          <Button onClick={onClose} a11yTitle="Close Select">
-            <Box fill alignSelf="start" pad={{ right: 'small', top: 'small' }}>
-              <FormUp />
-            </Box>
-          </Button>
+          <Box>
+            <Button fill="vertical" onClick={onClose} a11yTitle="Close Select">
+              {icon}
+            </Button>
+          </Box>
         </Box>
       );
 

--- a/src/js/components/SelectMultiple/__tests__/__snapshots__/SelectMultiple-test.tsx.snap
+++ b/src/js/components/SelectMultiple/__tests__/__snapshots__/SelectMultiple-test.tsx.snap
@@ -3773,14 +3773,6 @@ exports[`SelectMultiple showSelectionInline 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
   .c15 {
     margin-right: 6px;
   }
@@ -4353,14 +4345,6 @@ exports[`SelectMultiple showSelectionInline with children 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
   .c14 {
     padding: 6px;
   }
@@ -4568,14 +4552,6 @@ exports[`SelectMultiple showSelectionInline with children 2`] = `
 
 .c2 {
   cursor: pointer;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
 }
 
 @media only screen and (max-width:768px) {


### PR DESCRIPTION
#### What does this PR do?
Remove the use of the `FormUp` icon and change SelectMultiple's icon when the drop is open to work better with the new version of the HPE theme.

Before (using NEXT-stable of hpe theme):
<img width="384" alt="Screen Shot 2023-03-13 at 2 06 49 PM" src="https://user-images.githubusercontent.com/54560994/224820114-f943c6ba-4f88-40e4-bba5-e592e7100b2a.png">

After (using NEXT-stable of hpe theme):
<img width="284" alt="Screen Shot 2023-03-13 at 1 48 49 PM" src="https://user-images.githubusercontent.com/54560994/224820180-6433187a-21a2-40c9-84d3-96c4f4b9d8c3.png">

#### Where should the reviewer start?

#### What testing has been done on this PR?
Pointed package.json to use NEXT-stable version of the hpe theme, added in changes from https://github.com/grommet/grommet-theme-hpe/pull/328 and tested with SelectMultiple/showSelectedInline story

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
https://github.com/grommet/grommet-theme-hpe/pull/328
https://github.com/grommet/grommet-theme-hpe/issues/319

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No
#### Should this PR be mentioned in the release notes?
Yes
#### Is this change backwards compatible or is it a breaking change?
Backwards compatible