### PR TITLE
Add line height 0 to plain icon only buttons

### DIFF
--- a/src/js/components/Button/StyledButtonKind.js
+++ b/src/js/components/Button/StyledButtonKind.js
@@ -244,6 +244,7 @@ const plainStyle = (props) => css`
       vertical-align: middle;
     }
   `}
+  ${props.hasIcon && !props.hasLabel && `line-height: 0;`}
 `;
 
 const StyledButtonKind = styled.button.withConfig({

--- a/src/js/components/Button/__tests__/__snapshots__/Button-kind-test.js.snap
+++ b/src/js/components/Button/__tests__/__snapshots__/Button-kind-test.js.snap
@@ -4777,6 +4777,7 @@ exports[`Button kind plain with icon 1`] = `
   padding: 0;
   text-align: inherit;
   color: inherit;
+  line-height: 0;
 }
 
 .c1 > svg {


### PR DESCRIPTION
#### What does this PR do?
Applies that same fix in https://github.com/grommet/grommet/pull/6666 to icon only plain buttons.

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
https://github.com/grommet/grommet-theme-hpe/issues/319

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No
#### Should this PR be mentioned in the release notes?
Yes
#### Is this change backwards compatible or is it a breaking change?
Backwards compatible