### PR TITLE
Provide default responsive subtitle behavior for PageHeader

### DIFF
--- a/src/js/components/PageHeader/PageHeader.js
+++ b/src/js/components/PageHeader/PageHeader.js
@@ -8,11 +8,15 @@ import { Grid } from '../Grid';
 import { Paragraph } from '../Paragraph';
 import { ResponsiveContext } from '../../contexts/ResponsiveContext';
 
-const sizeStyle = (size, feature, theme) => {
+const sizeStyle = (size, feature, theme, breakpoint) => {
   const style = {
     ...theme.pageHeader[feature],
     ...((size && theme.pageHeader.size[size]?.[feature]) ??
       theme.pageHeader[feature]),
+    ...((!size || size === 'medium') &&
+      feature === 'subtitle' &&
+      theme.global.breakpoints[breakpoint]?.value <=
+        theme.global.breakpoints.small?.value && { size: 'medium' }),
   };
 
   return style;
@@ -79,7 +83,7 @@ const PageHeader = forwardRef(
           </Box>
           <Box gridArea="subtitle">
             {typeof subtitle === 'string' ? (
-              <Paragraph {...sizeStyle(size, 'subtitle', theme)}>
+              <Paragraph {...sizeStyle(size, 'subtitle', theme, breakpoint)}>
                 {subtitle}
               </Paragraph>
             ) : (


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

This PR adds functionality that automatically reduces the PageHeader subtitle size to `medium`. This is a reasonable value for HPE theme to ensure the subtitle remains smaller than the Heading (see screenshots below). `large` was not chosen because it would have the same font-size as the heading.

This does not effect Grommet theme which already uses a value of `medium`.

This only applies to the default size of PageHeader which is the main use case in HPE applications currently.

#### Where should the reviewer start?
src/js/components/PageHeader/PageHeader.js

#### What testing has been done on this PR?

Local storybook with HPE next branch.

DESKTOP
<img width="1371" alt="Screen Shot 2023-03-16 at 9 19 00 PM" src="https://user-images.githubusercontent.com/12522275/225812634-26af935c-d275-4a87-b906-047c5578cb89.png">

MOBILE
<img width="679" alt="Screen Shot 2023-03-16 at 9 19 06 PM" src="https://user-images.githubusercontent.com/12522275/225812629-9567d7de-6433-4d69-b0cc-e6779364ec68.png">
#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
Yes.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.