### PR TITLE
Apply line-height 0 to pagination controls

### DIFF
--- a/src/js/components/Data/__tests__/__snapshots__/Data-test.tsx.snap
+++ b/src/js/components/Data/__tests__/__snapshots__/Data-test.tsx.snap
@@ -2931,7 +2931,7 @@ exports[`Data pagination 1`] = `
 
 .c13 {
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
 }
 
 .c13 > svg {
@@ -3462,7 +3462,7 @@ exports[`Data pagination step 1`] = `
 
 .c13 {
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
 }
 
 .c13 > svg {

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.tsx.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.tsx.snap
@@ -22493,7 +22493,7 @@ exports[`DataTable should apply pagination styling 1`] = `
 
 .c17 {
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
 }
 
 .c17 > svg {
@@ -25736,7 +25736,7 @@ exports[`DataTable should paginate 1`] = `
 
 .c17 {
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
 }
 
 .c17 > svg {
@@ -28086,7 +28086,7 @@ exports[`DataTable should pin and paginate 1`] = `
 
 .c18 {
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
 }
 
 .c18 > svg {
@@ -30427,7 +30427,7 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
 
 .c17 {
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
 }
 
 .c17 > svg {
@@ -31722,7 +31722,7 @@ exports[`DataTable should render new data when page changes 1`] = `
 
 .c17 {
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
 }
 
 .c17 > svg {
@@ -34941,7 +34941,7 @@ exports[`DataTable should render new data when page changes 2`] = `
           >
             <button
               aria-label="Go to previous page"
-              class="StyledButtonKind-sc-1vhfpnt-0 gBbBJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iEGxtK"
+              class="StyledButtonKind-sc-1vhfpnt-0 gBbBJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 gIpmVc"
               type="button"
             >
               <svg
@@ -34966,7 +34966,7 @@ exports[`DataTable should render new data when page changes 2`] = `
           >
             <button
               aria-label="Go to page 1"
-              class="StyledButtonKind-sc-1vhfpnt-0 dPZONJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iEGxtK"
+              class="StyledButtonKind-sc-1vhfpnt-0 dPZONJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 gIpmVc"
               type="button"
             >
               1
@@ -34981,7 +34981,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             <button
               aria-current="page"
               aria-label="Go to page 2"
-              class="StyledButtonKind-sc-1vhfpnt-0 clvxmb StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iEGxtK"
+              class="StyledButtonKind-sc-1vhfpnt-0 clvxmb StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 gIpmVc"
               type="button"
             >
               2
@@ -34996,7 +34996,7 @@ exports[`DataTable should render new data when page changes 2`] = `
             <button
               aria-disabled="true"
               aria-label="Go to next page"
-              class="StyledButtonKind-sc-1vhfpnt-0 bxrgft StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iEGxtK"
+              class="StyledButtonKind-sc-1vhfpnt-0 bxrgft StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 gIpmVc"
               disabled=""
               type="button"
             >
@@ -35611,7 +35611,7 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
 
 .c17 {
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
 }
 
 .c17 > svg {
@@ -37952,7 +37952,7 @@ exports[`DataTable should show correct page when "show" is { page: # } 1`] = `
 
 .c17 {
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
 }
 
 .c17 > svg {

--- a/src/js/components/List/__tests__/__snapshots__/List-test.js.snap
+++ b/src/js/components/List/__tests__/__snapshots__/List-test.js.snap
@@ -4723,7 +4723,7 @@ exports[`List events should apply pagination styling 1`] = `
 
 .c12 {
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
 }
 
 .c12 > svg {
@@ -5882,7 +5882,7 @@ exports[`List events should paginate 1`] = `
 
 .c12 {
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
 }
 
 .c12 > svg {
@@ -6884,7 +6884,7 @@ exports[`List events should render correct num items per page (step) 1`] = `
 
 .c12 {
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
 }
 
 .c12 > svg {
@@ -7776,7 +7776,7 @@ exports[`List events should render new data when page changes 1`] = `
 
 .c12 {
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
 }
 
 .c12 > svg {
@@ -11822,7 +11822,7 @@ exports[`List events should render new data when page changes 2`] = `
           >
             <button
               aria-label="Go to previous page"
-              class="StyledButtonKind-sc-1vhfpnt-0 gBbBJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iEGxtK"
+              class="StyledButtonKind-sc-1vhfpnt-0 gBbBJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 gIpmVc"
               type="button"
             >
               <svg
@@ -11847,7 +11847,7 @@ exports[`List events should render new data when page changes 2`] = `
           >
             <button
               aria-label="Go to page 1"
-              class="StyledButtonKind-sc-1vhfpnt-0 dPZONJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iEGxtK"
+              class="StyledButtonKind-sc-1vhfpnt-0 dPZONJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 gIpmVc"
               type="button"
             >
               1
@@ -11862,7 +11862,7 @@ exports[`List events should render new data when page changes 2`] = `
             <button
               aria-current="page"
               aria-label="Go to page 2"
-              class="StyledButtonKind-sc-1vhfpnt-0 clvxmb StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iEGxtK"
+              class="StyledButtonKind-sc-1vhfpnt-0 clvxmb StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 gIpmVc"
               type="button"
             >
               2
@@ -11877,7 +11877,7 @@ exports[`List events should render new data when page changes 2`] = `
             <button
               aria-disabled="true"
               aria-label="Go to next page"
-              class="StyledButtonKind-sc-1vhfpnt-0 bxrgft StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iEGxtK"
+              class="StyledButtonKind-sc-1vhfpnt-0 bxrgft StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 gIpmVc"
               disabled=""
               type="button"
             >
@@ -12445,7 +12445,7 @@ exports[`List events should show correct item index when "show" is a number 1`] 
 
 .c12 {
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
 }
 
 .c12 > svg {
@@ -13447,7 +13447,7 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
 
 .c12 {
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
 }
 
 .c12 > svg {

--- a/src/js/components/Pagination/StyledPageControl.js
+++ b/src/js/components/Pagination/StyledPageControl.js
@@ -13,7 +13,9 @@ const sizeStyle = (props) => {
     ? {
         content: {
           fontSize: style.font && style.font.size,
-          lineHeight: style.font && style.font.height,
+          // fix for safari, apply line-height 0 on next/previous
+          // icon-only buttons
+          lineHeight: style.font && props.hasLabel ? style.font.height : 0,
         },
         container: {
           height: style.height,

--- a/src/js/components/Pagination/__tests__/__snapshots__/Pagination-test.tsx.snap
+++ b/src/js/components/Pagination/__tests__/__snapshots__/Pagination-test.tsx.snap
@@ -342,7 +342,7 @@ exports[`Pagination should allow user to control page via state with page +
 
 .c5 {
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
 }
 
 .c5 > svg {
@@ -370,7 +370,7 @@ exports[`Pagination should allow user to control page via state with page +
 .c11 {
   font-weight: bold;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
 }
 
 @media only screen and (max-width:768px) {
@@ -1013,7 +1013,7 @@ exports[`Pagination should apply a11yTitle and aria-label 1`] = `
 
 .c5 {
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
 }
 
 .c5 > svg {
@@ -1041,7 +1041,7 @@ exports[`Pagination should apply a11yTitle and aria-label 1`] = `
 .c11 {
   font-weight: bold;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
 }
 
 @media only screen and (max-width:768px) {
@@ -2487,7 +2487,7 @@ exports[`Pagination should apply custom theme 1`] = `
 
 .c6 {
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
 }
 
 .c6 > svg {
@@ -2515,7 +2515,7 @@ exports[`Pagination should apply custom theme 1`] = `
 .c12 {
   font-weight: bold;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
 }
 
 .c2 {
@@ -3826,7 +3826,7 @@ exports[`Pagination should apply size 1`] = `
 
 .c5 {
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
 }
 
 .c5 > svg {
@@ -3835,7 +3835,7 @@ exports[`Pagination should apply size 1`] = `
 
 .c16 {
   font-size: 14px;
-  line-height: 20px;
+  line-height: 0;
 }
 
 .c16 > svg {
@@ -3844,7 +3844,7 @@ exports[`Pagination should apply size 1`] = `
 
 .c24 {
   font-size: 22px;
-  line-height: 28px;
+  line-height: 0;
 }
 
 .c24 > svg {
@@ -3908,19 +3908,19 @@ exports[`Pagination should apply size 1`] = `
 .c11 {
   font-weight: bold;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
 }
 
 .c20 {
   font-weight: bold;
   font-size: 14px;
-  line-height: 20px;
+  line-height: 0;
 }
 
 .c28 {
   font-weight: bold;
   font-size: 22px;
-  line-height: 28px;
+  line-height: 0;
 }
 
 @media only screen and (max-width:768px) {
@@ -4765,7 +4765,7 @@ exports[`Pagination should change the page on prop change 1`] = `
 
 .c5 {
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
 }
 
 .c5 > svg {
@@ -4793,7 +4793,7 @@ exports[`Pagination should change the page on prop change 1`] = `
 .c11 {
   font-weight: bold;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
 }
 
 @media only screen and (max-width:768px) {
@@ -5436,7 +5436,7 @@ exports[`Pagination should disable next button if on last page 1`] = `
 
 .c5 {
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
 }
 
 .c5 > svg {
@@ -5464,7 +5464,7 @@ exports[`Pagination should disable next button if on last page 1`] = `
 .c10 {
   font-weight: bold;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
 }
 
 @media only screen and (max-width:768px) {
@@ -5908,7 +5908,7 @@ exports[`Pagination should disable previous and next controls when numberItems
 
 .c5 {
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
 }
 
 .c5 > svg {
@@ -6215,7 +6215,7 @@ exports[`Pagination should disable previous and next controls when numberItems
 
 .c5 {
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
 }
 
 .c5 > svg {
@@ -6585,7 +6585,7 @@ exports[`Pagination should disable previous and next controls when numberItems
 
 .c5 {
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
 }
 
 .c5 > svg {
@@ -7172,7 +7172,7 @@ exports[`Pagination should disable previous button if on first page 1`] = `
 
 .c5 {
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
 }
 
 .c5 > svg {
@@ -7200,7 +7200,7 @@ exports[`Pagination should disable previous button if on first page 1`] = `
 .c11 {
   font-weight: bold;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
 }
 
 @media only screen and (max-width:768px) {
@@ -7728,7 +7728,7 @@ exports[`Pagination should display next page of results when "next" is
 
 .c5 {
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
 }
 
 .c5 > svg {
@@ -7756,7 +7756,7 @@ exports[`Pagination should display next page of results when "next" is
 .c11 {
   font-weight: bold;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
 }
 
 @media only screen and (max-width:768px) {
@@ -7960,7 +7960,7 @@ exports[`Pagination should display next page of results when "next" is
         >
           <button
             aria-label="Go to previous page"
-            class="StyledButtonKind-sc-1vhfpnt-0 gBbBJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iEGxtK"
+            class="StyledButtonKind-sc-1vhfpnt-0 gBbBJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 gIpmVc"
             type="button"
           >
             <svg
@@ -7985,7 +7985,7 @@ exports[`Pagination should display next page of results when "next" is
         >
           <button
             aria-label="Go to page 1"
-            class="StyledButtonKind-sc-1vhfpnt-0 dPZONJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iEGxtK"
+            class="StyledButtonKind-sc-1vhfpnt-0 dPZONJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 gIpmVc"
             type="button"
           >
             1
@@ -8000,7 +8000,7 @@ exports[`Pagination should display next page of results when "next" is
           <button
             aria-current="page"
             aria-label="Go to page 2"
-            class="StyledButtonKind-sc-1vhfpnt-0 clvxmb StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iEGxtK"
+            class="StyledButtonKind-sc-1vhfpnt-0 clvxmb StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 gIpmVc"
             type="button"
           >
             2
@@ -8014,7 +8014,7 @@ exports[`Pagination should display next page of results when "next" is
         >
           <button
             aria-label="Go to page 3"
-            class="StyledButtonKind-sc-1vhfpnt-0 dPZONJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iEGxtK"
+            class="StyledButtonKind-sc-1vhfpnt-0 dPZONJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 gIpmVc"
             type="button"
           >
             3
@@ -8028,7 +8028,7 @@ exports[`Pagination should display next page of results when "next" is
         >
           <button
             aria-label="Go to page 4"
-            class="StyledButtonKind-sc-1vhfpnt-0 dPZONJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iEGxtK"
+            class="StyledButtonKind-sc-1vhfpnt-0 dPZONJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 gIpmVc"
             type="button"
           >
             4
@@ -8042,7 +8042,7 @@ exports[`Pagination should display next page of results when "next" is
         >
           <button
             aria-label="Go to page 5"
-            class="StyledButtonKind-sc-1vhfpnt-0 dPZONJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iEGxtK"
+            class="StyledButtonKind-sc-1vhfpnt-0 dPZONJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 gIpmVc"
             type="button"
           >
             5
@@ -8055,7 +8055,7 @@ exports[`Pagination should display next page of results when "next" is
           class="StyledPageControl__StyledContainer-sc-1vlfaez-1 dcsBDI"
         >
           <span
-            class="StyledText-sc-1sadyjn-0 lhOBjf StyledPageControl__StyledSeparator-sc-1vlfaez-2 fqjoiP"
+            class="StyledText-sc-1sadyjn-0 lhOBjf StyledPageControl__StyledSeparator-sc-1vlfaez-2 jxDSVl"
           >
             …
           </span>
@@ -8068,7 +8068,7 @@ exports[`Pagination should display next page of results when "next" is
         >
           <button
             aria-label="Go to page 24"
-            class="StyledButtonKind-sc-1vhfpnt-0 dPZONJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iEGxtK"
+            class="StyledButtonKind-sc-1vhfpnt-0 dPZONJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 gIpmVc"
             type="button"
           >
             24
@@ -8082,7 +8082,7 @@ exports[`Pagination should display next page of results when "next" is
         >
           <button
             aria-label="Go to next page"
-            class="StyledButtonKind-sc-1vhfpnt-0 gBbBJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iEGxtK"
+            class="StyledButtonKind-sc-1vhfpnt-0 gBbBJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 gIpmVc"
             type="button"
           >
             <svg
@@ -8447,7 +8447,7 @@ exports[`Pagination should display page 'n' of results when "page n" is
 
 .c5 {
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
 }
 
 .c5 > svg {
@@ -8475,7 +8475,7 @@ exports[`Pagination should display page 'n' of results when "page n" is
 .c11 {
   font-weight: bold;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
 }
 
 @media only screen and (max-width:768px) {
@@ -9001,7 +9001,7 @@ exports[`Pagination should display previous page of results when "previous" is
 
 .c5 {
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
 }
 
 .c5 > svg {
@@ -9029,7 +9029,7 @@ exports[`Pagination should display previous page of results when "previous" is
 .c11 {
   font-weight: bold;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
 }
 
 @media only screen and (max-width:768px) {
@@ -9233,7 +9233,7 @@ exports[`Pagination should display previous page of results when "previous" is
         >
           <button
             aria-label="Go to previous page"
-            class="StyledButtonKind-sc-1vhfpnt-0 gBbBJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iEGxtK"
+            class="StyledButtonKind-sc-1vhfpnt-0 gBbBJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 gIpmVc"
             type="button"
           >
             <svg
@@ -9258,7 +9258,7 @@ exports[`Pagination should display previous page of results when "previous" is
         >
           <button
             aria-label="Go to page 1"
-            class="StyledButtonKind-sc-1vhfpnt-0 dPZONJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iEGxtK"
+            class="StyledButtonKind-sc-1vhfpnt-0 dPZONJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 gIpmVc"
             type="button"
           >
             1
@@ -9273,7 +9273,7 @@ exports[`Pagination should display previous page of results when "previous" is
           <button
             aria-current="page"
             aria-label="Go to page 2"
-            class="StyledButtonKind-sc-1vhfpnt-0 clvxmb StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iEGxtK"
+            class="StyledButtonKind-sc-1vhfpnt-0 clvxmb StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 gIpmVc"
             type="button"
           >
             2
@@ -9287,7 +9287,7 @@ exports[`Pagination should display previous page of results when "previous" is
         >
           <button
             aria-label="Go to page 3"
-            class="StyledButtonKind-sc-1vhfpnt-0 dPZONJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iEGxtK"
+            class="StyledButtonKind-sc-1vhfpnt-0 dPZONJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 gIpmVc"
             type="button"
           >
             3
@@ -9301,7 +9301,7 @@ exports[`Pagination should display previous page of results when "previous" is
         >
           <button
             aria-label="Go to page 4"
-            class="StyledButtonKind-sc-1vhfpnt-0 dPZONJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iEGxtK"
+            class="StyledButtonKind-sc-1vhfpnt-0 dPZONJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 gIpmVc"
             type="button"
           >
             4
@@ -9315,7 +9315,7 @@ exports[`Pagination should display previous page of results when "previous" is
         >
           <button
             aria-label="Go to page 5"
-            class="StyledButtonKind-sc-1vhfpnt-0 dPZONJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iEGxtK"
+            class="StyledButtonKind-sc-1vhfpnt-0 dPZONJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 gIpmVc"
             type="button"
           >
             5
@@ -9328,7 +9328,7 @@ exports[`Pagination should display previous page of results when "previous" is
           class="StyledPageControl__StyledContainer-sc-1vlfaez-1 dcsBDI"
         >
           <span
-            class="StyledText-sc-1sadyjn-0 lhOBjf StyledPageControl__StyledSeparator-sc-1vlfaez-2 fqjoiP"
+            class="StyledText-sc-1sadyjn-0 lhOBjf StyledPageControl__StyledSeparator-sc-1vlfaez-2 jxDSVl"
           >
             …
           </span>
@@ -9341,7 +9341,7 @@ exports[`Pagination should display previous page of results when "previous" is
         >
           <button
             aria-label="Go to page 24"
-            class="StyledButtonKind-sc-1vhfpnt-0 dPZONJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iEGxtK"
+            class="StyledButtonKind-sc-1vhfpnt-0 dPZONJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 gIpmVc"
             type="button"
           >
             24
@@ -9355,7 +9355,7 @@ exports[`Pagination should display previous page of results when "previous" is
         >
           <button
             aria-label="Go to next page"
-            class="StyledButtonKind-sc-1vhfpnt-0 gBbBJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iEGxtK"
+            class="StyledButtonKind-sc-1vhfpnt-0 gBbBJ StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 gIpmVc"
             type="button"
           >
             <svg
@@ -9838,7 +9838,7 @@ exports[`Pagination should display the correct last page based on items length
 
 .c5 {
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
 }
 
 .c5 > svg {
@@ -9866,7 +9866,7 @@ exports[`Pagination should display the correct last page based on items length
 .c11 {
   font-weight: bold;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
 }
 
 @media only screen and (max-width:768px) {
@@ -10393,7 +10393,7 @@ exports[`Pagination should render correct numberEdgePages 1`] = `
 
 .c5 {
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
 }
 
 .c5 > svg {
@@ -10421,7 +10421,7 @@ exports[`Pagination should render correct numberEdgePages 1`] = `
 .c10 {
   font-weight: bold;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
 }
 
 @media only screen and (max-width:768px) {
@@ -11000,7 +11000,7 @@ exports[`Pagination should render correct numberMiddlePages when even 1`] = `
 
 .c5 {
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
 }
 
 .c5 > svg {
@@ -11028,7 +11028,7 @@ exports[`Pagination should render correct numberMiddlePages when even 1`] = `
 .c10 {
   font-weight: bold;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
 }
 
 @media only screen and (max-width:768px) {
@@ -11565,7 +11565,7 @@ exports[`Pagination should render correct numberMiddlePages when odd 1`] = `
 
 .c5 {
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
 }
 
 .c5 > svg {
@@ -11593,7 +11593,7 @@ exports[`Pagination should render correct numberMiddlePages when odd 1`] = `
 .c10 {
   font-weight: bold;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
 }
 
 @media only screen and (max-width:768px) {
@@ -12262,7 +12262,7 @@ exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 
 
 .c5 {
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
 }
 
 .c5 > svg {
@@ -12290,7 +12290,7 @@ exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 
 .c11 {
   font-weight: bold;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
 }
 
 @media only screen and (max-width:768px) {
@@ -12908,7 +12908,7 @@ exports[`Pagination should set page to last page if page prop > total possible
 
 .c5 {
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
 }
 
 .c5 > svg {
@@ -12936,7 +12936,7 @@ exports[`Pagination should set page to last page if page prop > total possible
 .c10 {
   font-weight: bold;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
 }
 
 @media only screen and (max-width:768px) {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Mirrors approach from #6666 on pagination buttons which have a slightly custom button implementation which was overriding the line-height 0 from the underlying button.

Fixes rendering of next/previous icons on Safari.

#### Where should the reviewer start?

src/js/components/Pagination/StyledPageControl.js

#### What testing has been done on this PR?

Tested in storybook with HPE NEXT theme on Safari.

resolved
<img width="382" alt="Screen Shot 2023-03-21 at 5 51 19 PM" src="https://user-images.githubusercontent.com/12522275/226775289-97136c9d-f935-4b06-8f77-2610ada93d93.png">

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.