### PR TITLE
Changed DataTable to fix an issue with disabled rows and lazy loading.

### DIFF
--- a/src/js/components/DataTable/Body.js
+++ b/src/js/components/DataTable/Body.js
@@ -191,18 +191,23 @@ const Body = forwardRef(
     const onFocusActive =
       active ?? lastActive ?? (usingKeyboard ? 0 : undefined);
 
+    const activePrimaryValue =
+      active >= 0 ? datumValue(data[active], primaryProperty) : undefined;
+
     const selectRow = () => {
-      const primaryValue = data[active]?.[primaryProperty];
-      if (selected && selected.includes(primaryValue)) {
-        onSelect(selected.filter((s) => s !== primaryValue));
-      } else onSelect([...selected, primaryValue]);
+      if (activePrimaryValue !== undefined) {
+        if (selected && selected.includes(activePrimaryValue)) {
+          onSelect(selected.filter((s) => s !== activePrimaryValue));
+        } else onSelect([...selected, activePrimaryValue]);
+      }
     };
 
     const clickableRow =
       onClickRow &&
       active >= 0 &&
       (!disabled ||
-        !disabled.includes(datumValue(data[active], primaryProperty)));
+        (activePrimaryValue !== undefined &&
+          !disabled.includes(activePrimaryValue)));
 
     return (
       <Keyboard

--- a/src/js/components/DataTable/buildState.js
+++ b/src/js/components/DataTable/buildState.js
@@ -19,7 +19,7 @@ export const set = (obj, path, value) => {
 
 // get the value for the property in the datum object
 export const datumValue = (datum, property) => {
-  if (!property) return undefined;
+  if (!property || !datum) return undefined;
   const parts = property.split('.');
   if (parts.length === 1) return datum[property];
   if (!datum[parts[0]]) return undefined;


### PR DESCRIPTION
#### What does this PR do?

Changed DataTable to fix an issue with disabled rows and lazy loading.

#### Where should the reviewer start?

anywhere

#### What testing has been done on this PR?

Hand crafted a story to align with the description in the issue. To reproduce it requires:
- pagination controlled by the caller
- lazy loading of data
- disabled property presence
- onClick property
- interacting with the last row after changing the page but before the next page's data is set and the next page has fewer data items than the previous page

#### How should this be manually tested?

^^^

#### Do Jest tests follow these best practices?

no test changes, hard to build this in jest

#### Any background context you want to provide?

#### What are the relevant issues?

#6703 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible
