### PR TITLE
Fixed issue where border was not applied to CheckBox cells in DataTable

### DIFF
--- a/src/js/components/DataTable/Body.js
+++ b/src/js/components/DataTable/Body.js
@@ -78,6 +78,7 @@ const Row = memo(
                 cellProps.pinned.background) ||
               cellProps.background
             }
+            border={cellProps.pinned.border || cellProps.border}
             pinnedOffset={pinnedOffset?._grommetDataTableSelect}
             aria-disabled={isDisabled || !onSelect || undefined}
             column={{

--- a/src/js/components/DataTable/GroupedBody.js
+++ b/src/js/components/DataTable/GroupedBody.js
@@ -186,6 +186,7 @@ export const GroupedBody = forwardRef(
                 {(selected || onSelect) && (
                   <TableCell
                     background={cellProps.background}
+                    border={cellProps.pinned.border || cellProps.border}
                     plain="noPad"
                     size="auto"
                     verticalAlign={verticalAlign}

--- a/src/js/components/DataTable/__tests__/DataTable-test.tsx
+++ b/src/js/components/DataTable/__tests__/DataTable-test.tsx
@@ -1640,4 +1640,33 @@ describe('DataTable', () => {
     );
     expect(container.firstChild).toMatchSnapshot();
   });
+
+  test('border on CheckBox cell', () => {
+    const { asFragment } = render(
+      <Grommet>
+        <DataTable
+          data={[
+            { name: 'Alan', percent: 20 },
+            { name: 'Bryan', percent: 30 },
+            { name: 'Chris', percent: 20 },
+            { name: 'Eric', percent: 80 },
+          ]}
+          columns={[
+            {
+              property: 'name',
+              header: 'Name',
+              primary: true,
+            },
+            {
+              property: 'percent',
+              header: 'Percent Complete',
+            },
+          ]}
+          border={{ body: { side: 'bottom' } }}
+          onSelect={() => {}}
+        />
+      </Grommet>,
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
 });

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.tsx.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.tsx.snap
@@ -2470,6 +2470,528 @@ exports[`DataTable border 1`] = `
 </div>
 `;
 
+exports[`DataTable border on CheckBox cell 1`] = `
+<DocumentFragment>
+  .c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: solid 2px rgba(0,0,0,0.15);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 24px;
+  width: 24px;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  border-radius: 4px;
+}
+
+.c11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c14 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c12 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c15 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+  cursor: pointer;
+}
+
+.c5:hover input:not([disabled]) + div,
+.c5:hover input:not([disabled]) + span {
+  border-color: #000000;
+}
+
+.c8 {
+  opacity: 0;
+  -moz-appearance: none;
+  width: 0;
+  height: 0;
+  margin: 0;
+  cursor: pointer;
+}
+
+.c8:checked + span > span {
+  left: calc( 48px - 24px );
+  background: #7D4CDB;
+}
+
+.c7 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c3 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  width: 1px;
+  overflow: hidden;
+  text-align: start;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+}
+
+.c10 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c1 {
+  border-spacing: 0;
+  border-collapse: collapse;
+  width: inherit;
+}
+
+.c2 {
+  position: relative;
+  border-spacing: 0;
+  border-collapse: separate;
+}
+
+.c13:focus {
+  outline: 2px solid #6FFFB0;
+}
+
+.c13:focus:not(:focus-visible) {
+  outline: none;
+}
+
+@media only screen and (max-width:768px) {
+  .c9 {
+    border: solid 2px rgba(0,0,0,0.15);
+  }
+}
+
+<div
+    class="c0"
+  >
+    <table
+      class="c1 c2"
+    >
+      <thead
+        class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
+      >
+        <tr
+          class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+        >
+          <th
+            class="c3 "
+            scope="col"
+          >
+            <div
+              class="c4"
+              style="height: 0px;"
+            >
+              <label
+                class="c5"
+              >
+                <div
+                  class="c6 c7"
+                >
+                  <input
+                    aria-label="select all"
+                    class="c8"
+                    type="checkbox"
+                  />
+                  <div
+                    class="c9 "
+                  />
+                </div>
+              </label>
+            </div>
+          </th>
+          <th
+            class="c10 "
+            scope="col"
+          >
+            <div
+              class="c11"
+            >
+              <span
+                class="c12"
+              >
+                Name
+              </span>
+            </div>
+          </th>
+          <th
+            class="c10 "
+            scope="col"
+          >
+            <div
+              class="c11"
+            >
+              <span
+                class="c12"
+              >
+                Percent Complete
+              </span>
+            </div>
+          </th>
+        </tr>
+      </thead>
+      <tbody
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c13"
+      >
+        <tr
+          class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+        >
+          <td
+            class="c3 "
+          >
+            <div
+              class="c4"
+              style="height: 0px;"
+            >
+              <label
+                class="c5"
+              >
+                <div
+                  class="c6 c7"
+                >
+                  <input
+                    aria-label="select Alan"
+                    class="c8"
+                    type="checkbox"
+                  />
+                  <div
+                    class="c9 "
+                  />
+                </div>
+              </label>
+            </div>
+          </td>
+          <th
+            class="c10 "
+            scope="row"
+          >
+            <div
+              class="c14"
+            >
+              <span
+                class="c15"
+              >
+                Alan
+              </span>
+            </div>
+          </th>
+          <td
+            class="c10 "
+          >
+            <div
+              class="c14"
+            >
+              <span
+                class="c12"
+              >
+                20
+              </span>
+            </div>
+          </td>
+        </tr>
+        <tr
+          class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+        >
+          <td
+            class="c3 "
+          >
+            <div
+              class="c4"
+              style="height: 0px;"
+            >
+              <label
+                class="c5"
+              >
+                <div
+                  class="c6 c7"
+                >
+                  <input
+                    aria-label="select Bryan"
+                    class="c8"
+                    type="checkbox"
+                  />
+                  <div
+                    class="c9 "
+                  />
+                </div>
+              </label>
+            </div>
+          </td>
+          <th
+            class="c10 "
+            scope="row"
+          >
+            <div
+              class="c14"
+            >
+              <span
+                class="c15"
+              >
+                Bryan
+              </span>
+            </div>
+          </th>
+          <td
+            class="c10 "
+          >
+            <div
+              class="c14"
+            >
+              <span
+                class="c12"
+              >
+                30
+              </span>
+            </div>
+          </td>
+        </tr>
+        <tr
+          class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+        >
+          <td
+            class="c3 "
+          >
+            <div
+              class="c4"
+              style="height: 0px;"
+            >
+              <label
+                class="c5"
+              >
+                <div
+                  class="c6 c7"
+                >
+                  <input
+                    aria-label="select Chris"
+                    class="c8"
+                    type="checkbox"
+                  />
+                  <div
+                    class="c9 "
+                  />
+                </div>
+              </label>
+            </div>
+          </td>
+          <th
+            class="c10 "
+            scope="row"
+          >
+            <div
+              class="c14"
+            >
+              <span
+                class="c15"
+              >
+                Chris
+              </span>
+            </div>
+          </th>
+          <td
+            class="c10 "
+          >
+            <div
+              class="c14"
+            >
+              <span
+                class="c12"
+              >
+                20
+              </span>
+            </div>
+          </td>
+        </tr>
+        <tr
+          class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+        >
+          <td
+            class="c3 "
+          >
+            <div
+              class="c4"
+              style="height: 0px;"
+            >
+              <label
+                class="c5"
+              >
+                <div
+                  class="c6 c7"
+                >
+                  <input
+                    aria-label="select Eric"
+                    class="c8"
+                    type="checkbox"
+                  />
+                  <div
+                    class="c9 "
+                  />
+                </div>
+              </label>
+            </div>
+          </td>
+          <th
+            class="c10 "
+            scope="row"
+          >
+            <div
+              class="c14"
+            >
+              <span
+                class="c15"
+              >
+                Eric
+              </span>
+            </div>
+          </th>
+          <td
+            class="c10 "
+          >
+            <div
+              class="c14"
+            >
+              <span
+                class="c12"
+              >
+                80
+              </span>
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`DataTable click 1`] = `
 .c0 {
   font-size: 18px;


### PR DESCRIPTION
#### What does this PR do?
Fixed issue in DataTable when the rows are selectable and have a border the border was not showing up on the CheckBox cell.

#### Where should the reviewer start?

#### What testing has been done on this PR?
Added a jest test and tested with the following story:
```javascript
import React from 'react';

import { Box, DataTable } from 'grommet';

export const Test = () => (
  <Box align="center" pad="large">
    <DataTable
        data={[
          { name: "Alan", percent: 20 },
          { name: "Bryan", percent: 30 },
          { name: "Chris", percent: 20 },
          { name: "Eric", percent: 80 }
        ]}
        columns={[
          {
            property: "name",
            header: "Name",
            primary: true
          },
          {
            property: "percent",
            header: "Percent Complete"
          }
        ]}
        border={{ body: { side: "bottom" } }}
        onSelect={() => {}}
        groupBy={{ property: 'percent' }}
      />
  </Box>
);

export default {
  title: 'Visualizations/DataTable/Test',
};

```

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes https://github.com/grommet/grommet/issues/6657

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No
#### Should this PR be mentioned in the release notes?
Yes
#### Is this change backwards compatible or is it a breaking change?
Backwards compatible