### PR TITLE
Changed DataTable to use a primaryKey value as the row key

### DIFF
--- a/src/js/components/DataTable/Body.js
+++ b/src/js/components/DataTable/Body.js
@@ -281,7 +281,7 @@ const Body = forwardRef(
               );
               return (
                 <Row
-                  key={index}
+                  key={primaryValue ?? index}
                   setActive={setActive}
                   rowRef={rowRef}
                   cellProps={cellProps}

--- a/src/js/components/DataTable/__tests__/DataTable-test.tsx
+++ b/src/js/components/DataTable/__tests__/DataTable-test.tsx
@@ -602,7 +602,7 @@ describe('DataTable', () => {
           <DataTable
             columns={[
               { property: 'a', header: 'A' },
-              { property: 'b', header: 'B' },
+              { property: 'b', header: 'B', primary: true },
             ]}
             data={[
               { a: 'one', b: 1.1 },

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.tsx.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.tsx.snap
@@ -7835,6 +7835,19 @@ exports[`DataTable groupBy toggle 1`] = `
       <tr
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
       >
+        <td
+          class="c7 "
+        >
+          <div
+            class="c8"
+          >
+            <span
+              class="c5"
+            >
+              one
+            </span>
+          </div>
+        </td>
         <th
           class="c7 "
           scope="row"
@@ -7844,59 +7857,59 @@ exports[`DataTable groupBy toggle 1`] = `
           >
             <span
               class="c9"
-            >
-              one
-            </span>
-          </div>
-        </th>
-        <td
-          class="c7 "
-        >
-          <div
-            class="c8"
-          >
-            <span
-              class="c5"
             >
               1.1
             </span>
           </div>
-        </td>
+        </th>
       </tr>
       <tr
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
       >
-        <th
+        <td
           class="c7 "
-          scope="row"
         >
           <div
             class="c8"
           >
             <span
-              class="c9"
+              class="c5"
             >
               one
             </span>
           </div>
-        </th>
-        <td
+        </td>
+        <th
           class="c7 "
+          scope="row"
         >
           <div
             class="c8"
           >
             <span
-              class="c5"
+              class="c9"
             >
               1.2
             </span>
           </div>
-        </td>
+        </th>
       </tr>
       <tr
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
       >
+        <td
+          class="c7 "
+        >
+          <div
+            class="c8"
+          >
+            <span
+              class="c5"
+            >
+              two
+            </span>
+          </div>
+        </td>
         <th
           class="c7 "
           scope="row"
@@ -7906,28 +7919,28 @@ exports[`DataTable groupBy toggle 1`] = `
           >
             <span
               class="c9"
-            >
-              two
-            </span>
-          </div>
-        </th>
-        <td
-          class="c7 "
-        >
-          <div
-            class="c8"
-          >
-            <span
-              class="c5"
             >
               2.1
             </span>
           </div>
-        </td>
+        </th>
       </tr>
       <tr
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
       >
+        <td
+          class="c7 "
+        >
+          <div
+            class="c8"
+          >
+            <span
+              class="c5"
+            >
+              two
+            </span>
+          </div>
+        </td>
         <th
           class="c7 "
           scope="row"
@@ -7938,23 +7951,10 @@ exports[`DataTable groupBy toggle 1`] = `
             <span
               class="c9"
             >
-              two
-            </span>
-          </div>
-        </th>
-        <td
-          class="c7 "
-        >
-          <div
-            class="c8"
-          >
-            <span
-              class="c5"
-            >
               2.2
             </span>
           </div>
-        </td>
+        </th>
       </tr>
     </tbody>
   </table>
@@ -8604,12 +8604,12 @@ exports[`DataTable groupBy toggle 3`] = `
   flex-direction: column;
 }
 
-.c4 {
+.c3 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c3 {
+.c4 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
@@ -8649,9 +8649,8 @@ exports[`DataTable groupBy toggle 3`] = `
       <tr
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
       >
-        <th
+        <td
           class="c1 "
-          scope="row"
         >
           <div
             class="c2"
@@ -8662,9 +8661,10 @@ exports[`DataTable groupBy toggle 3`] = `
               one
             </span>
           </div>
-        </th>
-        <td
+        </td>
+        <th
           class="c1 "
+          scope="row"
         >
           <div
             class="c2"
@@ -8675,14 +8675,13 @@ exports[`DataTable groupBy toggle 3`] = `
               1.1
             </span>
           </div>
-        </td>
+        </th>
       </tr>
       <tr
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
       >
-        <th
+        <td
           class="c1 "
-          scope="row"
         >
           <div
             class="c2"
@@ -8693,9 +8692,10 @@ exports[`DataTable groupBy toggle 3`] = `
               one
             </span>
           </div>
-        </th>
-        <td
+        </td>
+        <th
           class="c1 "
+          scope="row"
         >
           <div
             class="c2"
@@ -8706,14 +8706,13 @@ exports[`DataTable groupBy toggle 3`] = `
               1.2
             </span>
           </div>
-        </td>
+        </th>
       </tr>
       <tr
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
       >
-        <th
+        <td
           class="c1 "
-          scope="row"
         >
           <div
             class="c2"
@@ -8724,9 +8723,10 @@ exports[`DataTable groupBy toggle 3`] = `
               two
             </span>
           </div>
-        </th>
-        <td
+        </td>
+        <th
           class="c1 "
+          scope="row"
         >
           <div
             class="c2"
@@ -8737,14 +8737,13 @@ exports[`DataTable groupBy toggle 3`] = `
               2.1
             </span>
           </div>
-        </td>
+        </th>
       </tr>
       <tr
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
       >
-        <th
+        <td
           class="c1 "
-          scope="row"
         >
           <div
             class="c2"
@@ -8755,9 +8754,10 @@ exports[`DataTable groupBy toggle 3`] = `
               two
             </span>
           </div>
-        </th>
-        <td
+        </td>
+        <th
           class="c1 "
+          scope="row"
         >
           <div
             class="c2"
@@ -8768,7 +8768,7 @@ exports[`DataTable groupBy toggle 3`] = `
               2.2
             </span>
           </div>
-        </td>
+        </th>
       </tr>
     </tbody>
   </table>
@@ -34047,1395 +34047,3780 @@ exports[`DataTable should render new data when page changes 2`] = `
         <tbody
           class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-3 jwnbCl"
         >
-          <tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
+          .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c2 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
               scope="row"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 hUfGMB"
+                  class="c2"
                 >
                   entry-50
                 </span>
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 lhOBjf"
+                  class="c3"
                 >
                   50
                 </span>
               </div>
             </td>
           </tr>
-          <tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
+          .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c2 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
               scope="row"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 hUfGMB"
+                  class="c2"
                 >
                   entry-51
                 </span>
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 lhOBjf"
+                  class="c3"
                 >
                   51
                 </span>
               </div>
             </td>
           </tr>
-          <tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
+          .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c2 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
               scope="row"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 hUfGMB"
+                  class="c2"
                 >
                   entry-52
                 </span>
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 lhOBjf"
+                  class="c3"
                 >
                   52
                 </span>
               </div>
             </td>
           </tr>
-          <tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
+          .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c2 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
               scope="row"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 hUfGMB"
+                  class="c2"
                 >
                   entry-53
                 </span>
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 lhOBjf"
+                  class="c3"
                 >
                   53
                 </span>
               </div>
             </td>
           </tr>
-          <tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
+          .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c2 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
               scope="row"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 hUfGMB"
+                  class="c2"
                 >
                   entry-54
                 </span>
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 lhOBjf"
+                  class="c3"
                 >
                   54
                 </span>
               </div>
             </td>
           </tr>
-          <tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
+          .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c2 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
               scope="row"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 hUfGMB"
+                  class="c2"
                 >
                   entry-55
                 </span>
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 lhOBjf"
+                  class="c3"
                 >
                   55
                 </span>
               </div>
             </td>
           </tr>
-          <tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
+          .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c2 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
               scope="row"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 hUfGMB"
+                  class="c2"
                 >
                   entry-56
                 </span>
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 lhOBjf"
+                  class="c3"
                 >
                   56
                 </span>
               </div>
             </td>
           </tr>
-          <tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
+          .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c2 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
               scope="row"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 hUfGMB"
+                  class="c2"
                 >
                   entry-57
                 </span>
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 lhOBjf"
+                  class="c3"
                 >
                   57
                 </span>
               </div>
             </td>
           </tr>
-          <tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
+          .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c2 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
               scope="row"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 hUfGMB"
+                  class="c2"
                 >
                   entry-58
                 </span>
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 lhOBjf"
+                  class="c3"
                 >
                   58
                 </span>
               </div>
             </td>
           </tr>
-          <tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
+          .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c2 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
               scope="row"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 hUfGMB"
+                  class="c2"
                 >
                   entry-59
                 </span>
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 lhOBjf"
+                  class="c3"
                 >
                   59
                 </span>
               </div>
             </td>
           </tr>
-          <tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
+          .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c2 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
               scope="row"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 hUfGMB"
+                  class="c2"
                 >
                   entry-60
                 </span>
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 lhOBjf"
+                  class="c3"
                 >
                   60
                 </span>
               </div>
             </td>
           </tr>
-          <tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
+          .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c2 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
               scope="row"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 hUfGMB"
+                  class="c2"
                 >
                   entry-61
                 </span>
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 lhOBjf"
+                  class="c3"
                 >
                   61
                 </span>
               </div>
             </td>
           </tr>
-          <tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
+          .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c2 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
               scope="row"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 hUfGMB"
+                  class="c2"
                 >
                   entry-62
                 </span>
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 lhOBjf"
+                  class="c3"
                 >
                   62
                 </span>
               </div>
             </td>
           </tr>
-          <tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
+          .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c2 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
               scope="row"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 hUfGMB"
+                  class="c2"
                 >
                   entry-63
                 </span>
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 lhOBjf"
+                  class="c3"
                 >
                   63
                 </span>
               </div>
             </td>
           </tr>
-          <tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
+          .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c2 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
               scope="row"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 hUfGMB"
+                  class="c2"
                 >
                   entry-64
                 </span>
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 lhOBjf"
+                  class="c3"
                 >
                   64
                 </span>
               </div>
             </td>
           </tr>
-          <tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
+          .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c2 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
               scope="row"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 hUfGMB"
+                  class="c2"
                 >
                   entry-65
                 </span>
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 lhOBjf"
+                  class="c3"
                 >
                   65
                 </span>
               </div>
             </td>
           </tr>
-          <tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
+          .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c2 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
               scope="row"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 hUfGMB"
+                  class="c2"
                 >
                   entry-66
                 </span>
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 lhOBjf"
+                  class="c3"
                 >
                   66
                 </span>
               </div>
             </td>
           </tr>
-          <tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
+          .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c2 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
               scope="row"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 hUfGMB"
+                  class="c2"
                 >
                   entry-67
                 </span>
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 lhOBjf"
+                  class="c3"
                 >
                   67
                 </span>
               </div>
             </td>
           </tr>
-          <tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
+          .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c2 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
               scope="row"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 hUfGMB"
+                  class="c2"
                 >
                   entry-68
                 </span>
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 lhOBjf"
+                  class="c3"
                 >
                   68
                 </span>
               </div>
             </td>
           </tr>
-          <tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
+          .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c2 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
               scope="row"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 hUfGMB"
+                  class="c2"
                 >
                   entry-69
                 </span>
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 lhOBjf"
+                  class="c3"
                 >
                   69
                 </span>
               </div>
             </td>
           </tr>
-          <tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
+          .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c2 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
               scope="row"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 hUfGMB"
+                  class="c2"
                 >
                   entry-70
                 </span>
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 lhOBjf"
+                  class="c3"
                 >
                   70
                 </span>
               </div>
             </td>
           </tr>
-          <tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
+          .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c2 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
               scope="row"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 hUfGMB"
+                  class="c2"
                 >
                   entry-71
                 </span>
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 lhOBjf"
+                  class="c3"
                 >
                   71
                 </span>
               </div>
             </td>
           </tr>
-          <tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
+          .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c2 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
               scope="row"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 hUfGMB"
+                  class="c2"
                 >
                   entry-72
                 </span>
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 lhOBjf"
+                  class="c3"
                 >
                   72
                 </span>
               </div>
             </td>
           </tr>
-          <tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
+          .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c2 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
               scope="row"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 hUfGMB"
+                  class="c2"
                 >
                   entry-73
                 </span>
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 lhOBjf"
+                  class="c3"
                 >
                   73
                 </span>
               </div>
             </td>
           </tr>
-          <tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
+          .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c2 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
               scope="row"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 hUfGMB"
+                  class="c2"
                 >
                   entry-74
                 </span>
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 lhOBjf"
+                  class="c3"
                 >
                   74
                 </span>
               </div>
             </td>
           </tr>
-          <tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
+          .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c2 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
               scope="row"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 hUfGMB"
+                  class="c2"
                 >
                   entry-75
                 </span>
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 lhOBjf"
+                  class="c3"
                 >
                   75
                 </span>
               </div>
             </td>
           </tr>
-          <tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
+          .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c2 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
               scope="row"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 hUfGMB"
+                  class="c2"
                 >
                   entry-76
                 </span>
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 lhOBjf"
+                  class="c3"
                 >
                   76
                 </span>
               </div>
             </td>
           </tr>
-          <tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
+          .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c2 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
               scope="row"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 hUfGMB"
+                  class="c2"
                 >
                   entry-77
                 </span>
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 lhOBjf"
+                  class="c3"
                 >
                   77
                 </span>
               </div>
             </td>
           </tr>
-          <tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
+          .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c2 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
               scope="row"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 hUfGMB"
+                  class="c2"
                 >
                   entry-78
                 </span>
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 lhOBjf"
+                  class="c3"
                 >
                   78
                 </span>
               </div>
             </td>
           </tr>
-          <tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
+          .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c2 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
               scope="row"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 hUfGMB"
+                  class="c2"
                 >
                   entry-79
                 </span>
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 lhOBjf"
+                  class="c3"
                 >
                   79
                 </span>
               </div>
             </td>
           </tr>
-          <tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
+          .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c2 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
               scope="row"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 hUfGMB"
+                  class="c2"
                 >
                   entry-80
                 </span>
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 lhOBjf"
+                  class="c3"
                 >
                   80
                 </span>
               </div>
             </td>
           </tr>
-          <tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
+          .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c2 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
               scope="row"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 hUfGMB"
+                  class="c2"
                 >
                   entry-81
                 </span>
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 lhOBjf"
+                  class="c3"
                 >
                   81
                 </span>
               </div>
             </td>
           </tr>
-          <tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
+          .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c2 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
               scope="row"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 hUfGMB"
+                  class="c2"
                 >
                   entry-82
                 </span>
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 lhOBjf"
+                  class="c3"
                 >
                   82
                 </span>
               </div>
             </td>
           </tr>
-          <tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
+          .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c2 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
               scope="row"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 hUfGMB"
+                  class="c2"
                 >
                   entry-83
                 </span>
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 lhOBjf"
+                  class="c3"
                 >
                   83
                 </span>
               </div>
             </td>
           </tr>
-          <tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
+          .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c2 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
               scope="row"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 hUfGMB"
+                  class="c2"
                 >
                   entry-84
                 </span>
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 lhOBjf"
+                  class="c3"
                 >
                   84
                 </span>
               </div>
             </td>
           </tr>
-          <tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
+          .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c2 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
               scope="row"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 hUfGMB"
+                  class="c2"
                 >
                   entry-85
                 </span>
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 lhOBjf"
+                  class="c3"
                 >
                   85
                 </span>
               </div>
             </td>
           </tr>
-          <tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
+          .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c2 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
               scope="row"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 hUfGMB"
+                  class="c2"
                 >
                   entry-86
                 </span>
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 lhOBjf"
+                  class="c3"
                 >
                   86
                 </span>
               </div>
             </td>
           </tr>
-          <tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
+          .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c2 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
               scope="row"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 hUfGMB"
+                  class="c2"
                 >
                   entry-87
                 </span>
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 lhOBjf"
+                  class="c3"
                 >
                   87
                 </span>
               </div>
             </td>
           </tr>
-          <tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
+          .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c2 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
               scope="row"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 hUfGMB"
+                  class="c2"
                 >
                   entry-88
                 </span>
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 lhOBjf"
+                  class="c3"
                 >
                   88
                 </span>
               </div>
             </td>
           </tr>
-          <tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
+          .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c2 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
               scope="row"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 hUfGMB"
+                  class="c2"
                 >
                   entry-89
                 </span>
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 lhOBjf"
+                  class="c3"
                 >
                   89
                 </span>
               </div>
             </td>
           </tr>
-          <tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
+          .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c2 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
               scope="row"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 hUfGMB"
+                  class="c2"
                 >
                   entry-90
                 </span>
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 lhOBjf"
+                  class="c3"
                 >
                   90
                 </span>
               </div>
             </td>
           </tr>
-          <tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
+          .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c2 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
               scope="row"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 hUfGMB"
+                  class="c2"
                 >
                   entry-91
                 </span>
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 lhOBjf"
+                  class="c3"
                 >
                   91
                 </span>
               </div>
             </td>
           </tr>
-          <tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
+          .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c2 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
               scope="row"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 hUfGMB"
+                  class="c2"
                 >
                   entry-92
                 </span>
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 lhOBjf"
+                  class="c3"
                 >
                   92
                 </span>
               </div>
             </td>
           </tr>
-          <tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
+          .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c2 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
               scope="row"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 hUfGMB"
+                  class="c2"
                 >
                   entry-93
                 </span>
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 lhOBjf"
+                  class="c3"
                 >
                   93
                 </span>
               </div>
             </td>
           </tr>
-          <tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
+          .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c2 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
               scope="row"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 hUfGMB"
+                  class="c2"
                 >
                   entry-94
                 </span>
               </div>
             </th>
             <td
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+              class="c0 "
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kqmDKi"
+                class="c1"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 lhOBjf"
+                  class="c3"
                 >
                   94
                 </span>
@@ -43376,54 +45761,80 @@ exports[`DataTable sort null data 2`] = `
           </div>
         </td>
       </tr>
-      <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
-      >
-        <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
-          scope="row"
-        >
-          <div
-            class="StyledBox-sc-13pk1d4-0 kqmDKi"
-          />
-        </th>
-        <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
-        >
-          <div
-            class="StyledBox-sc-13pk1d4-0 kqmDKi"
-          >
-            <span
-              class="StyledText-sc-1sadyjn-0 lhOBjf"
-            >
-              3
-            </span>
-          </div>
-        </td>
-        <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
-        >
-          <div
-            class="StyledBox-sc-13pk1d4-0 kqmDKi"
-          />
-        </td>
-        <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
-        >
-          <div
-            class="StyledBox-sc-13pk1d4-0 kqmDKi"
-          >
-            .c0 {
+      .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c2 {
   font-size: 18px;
   line-height: 24px;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
 }
 
 @media only screen and (max-width:768px) {
 
 }
 
-<span
-              class="c0"
+<tr
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+      >
+        <th
+          class="c0 "
+          scope="row"
+        >
+          <div
+            class="c1"
+          />
+        </th>
+        <td
+          class="c0 "
+        >
+          <div
+            class="c1"
+          >
+            <span
+              class="c2"
+            >
+              3
+            </span>
+          </div>
+        </td>
+        <td
+          class="c0 "
+        >
+          <div
+            class="c1"
+          />
+        </td>
+        <td
+          class="c0 "
+        >
+          <div
+            class="c1"
+          >
+            <span
+              class="c2"
             >
               z
             </span>
@@ -43485,18 +45896,8 @@ exports[`DataTable sort null data 2`] = `
           <div
             class="StyledBox-sc-13pk1d4-0 kqmDKi"
           >
-            .c0 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-<span
-              class="c0"
+            <span
+              class="StyledText-sc-1sadyjn-0 hUfGMB"
             >
               two
             </span>
@@ -43521,17 +45922,8 @@ exports[`DataTable sort null data 2`] = `
           <div
             class="StyledBox-sc-13pk1d4-0 kqmDKi"
           >
-            .c0 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-<span
-              class="c0"
+            <span
+              class="StyledText-sc-1sadyjn-0 lhOBjf"
             >
               second
             </span>
@@ -43739,18 +46131,8 @@ exports[`DataTable sort null data 3`] = `
           <div
             class="StyledBox-sc-13pk1d4-0 kqmDKi"
           >
-            .c0 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-<span
-              class="c0"
+            <span
+              class="StyledText-sc-1sadyjn-0 hUfGMB"
             >
               one
             </span>
@@ -43829,69 +46211,86 @@ exports[`DataTable sort null data 3`] = `
           </div>
         </td>
       </tr>
-      <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
+      .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c2 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<tr
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+          class="c0 "
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 kqmDKi"
+            class="c1"
           />
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+          class="c0 "
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 kqmDKi"
+            class="c1"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 lhOBjf"
+              class="c2"
             >
               0
             </span>
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+          class="c0 "
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 kqmDKi"
+            class="c1"
           >
-            .c0 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-<span
-              class="c0"
+            <span
+              class="c2"
             >
               first
             </span>
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+          class="c0 "
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 kqmDKi"
+            class="c1"
           >
-            .c0 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-<span
-              class="c0"
+            <span
+              class="c2"
             >
               y
             </span>
@@ -44188,18 +46587,8 @@ exports[`DataTable sort null data 4`] = `
           <div
             class="StyledBox-sc-13pk1d4-0 kqmDKi"
           >
-            .c0 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-<span
-              class="c0"
+            <span
+              class="StyledText-sc-1sadyjn-0 hUfGMB"
             >
               two
             </span>
@@ -44224,17 +46613,8 @@ exports[`DataTable sort null data 4`] = `
           <div
             class="StyledBox-sc-13pk1d4-0 kqmDKi"
           >
-            .c0 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-<span
-              class="c0"
+            <span
+              class="StyledText-sc-1sadyjn-0 lhOBjf"
             >
               second
             </span>
@@ -44299,54 +46679,80 @@ exports[`DataTable sort null data 4`] = `
           </div>
         </td>
       </tr>
-      <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
-      >
-        <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
-          scope="row"
-        >
-          <div
-            class="StyledBox-sc-13pk1d4-0 kqmDKi"
-          />
-        </th>
-        <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
-        >
-          <div
-            class="StyledBox-sc-13pk1d4-0 kqmDKi"
-          >
-            <span
-              class="StyledText-sc-1sadyjn-0 lhOBjf"
-            >
-              3
-            </span>
-          </div>
-        </td>
-        <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
-        >
-          <div
-            class="StyledBox-sc-13pk1d4-0 kqmDKi"
-          />
-        </td>
-        <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
-        >
-          <div
-            class="StyledBox-sc-13pk1d4-0 kqmDKi"
-          >
-            .c0 {
+      .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c2 {
   font-size: 18px;
   line-height: 24px;
+}
+
+.c0 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
 }
 
 @media only screen and (max-width:768px) {
 
 }
 
-<span
-              class="c0"
+<tr
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+      >
+        <th
+          class="c0 "
+          scope="row"
+        >
+          <div
+            class="c1"
+          />
+        </th>
+        <td
+          class="c0 "
+        >
+          <div
+            class="c1"
+          >
+            <span
+              class="c2"
+            >
+              3
+            </span>
+          </div>
+        </td>
+        <td
+          class="c0 "
+        >
+          <div
+            class="c1"
+          />
+        </td>
+        <td
+          class="c0 "
+        >
+          <div
+            class="c1"
+          >
+            <span
+              class="c2"
             >
               z
             </span>

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.tsx.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.tsx.snap
@@ -51,12 +51,6 @@ exports[`DataTable !primaryKey 1`] = `
   line-height: 24px;
 }
 
-.c9 {
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: bold;
-}
-
 .c3 {
   margin: 0;
   padding: 0;
@@ -150,20 +144,19 @@ exports[`DataTable !primaryKey 1`] = `
       <tr
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
       >
-        <th
+        <td
           class="c7 "
-          scope="row"
         >
           <div
             class="c8"
           >
             <span
-              class="c9"
+              class="c5"
             >
               one
             </span>
           </div>
-        </th>
+        </td>
         <td
           class="c7 "
         >
@@ -181,20 +174,19 @@ exports[`DataTable !primaryKey 1`] = `
       <tr
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
       >
-        <th
+        <td
           class="c7 "
-          scope="row"
         >
           <div
             class="c8"
           >
             <span
-              class="c9"
+              class="c5"
             >
               two
             </span>
           </div>
-        </th>
+        </td>
         <td
           class="c7 "
         >

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.tsx.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.tsx.snap
@@ -51,6 +51,12 @@ exports[`DataTable !primaryKey 1`] = `
   line-height: 24px;
 }
 
+.c9 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
 .c3 {
   margin: 0;
   padding: 0;
@@ -144,19 +150,20 @@ exports[`DataTable !primaryKey 1`] = `
       <tr
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
       >
-        <td
+        <th
           class="c7 "
+          scope="row"
         >
           <div
             class="c8"
           >
             <span
-              class="c5"
+              class="c9"
             >
               one
             </span>
           </div>
-        </td>
+        </th>
         <td
           class="c7 "
         >
@@ -174,19 +181,20 @@ exports[`DataTable !primaryKey 1`] = `
       <tr
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
       >
-        <td
+        <th
           class="c7 "
+          scope="row"
         >
           <div
             class="c8"
           >
             <span
-              class="c5"
+              class="c9"
             >
               two
             </span>
           </div>
-        </td>
+        </th>
         <td
           class="c7 "
         >

--- a/src/js/components/DataTable/buildState.js
+++ b/src/js/components/DataTable/buildState.js
@@ -28,17 +28,17 @@ export const datumValue = (datum, property) => {
 
 // get the primary property name
 export const normalizePrimaryProperty = (columns, primaryKey) => {
-  let result;
-  columns.forEach((column) => {
-    // remember the first key property
-    if (column.primary && !result) {
-      result = column.property;
-    }
-  });
+  let result = primaryKey;
   if (!result) {
-    if (primaryKey === false) result = undefined;
-    else if (primaryKey) result = primaryKey;
-    else if (columns.length > 0) result = columns[0].property;
+    columns.forEach((column) => {
+      // remember the first key property
+      if (column.primary && !result) {
+        result = column.property;
+      }
+    });
+  }
+  if (!result && columns.length > 0) {
+    result = columns[0].property;
   }
   return result;
 };

--- a/src/js/components/DataTable/buildState.js
+++ b/src/js/components/DataTable/buildState.js
@@ -29,7 +29,7 @@ export const datumValue = (datum, property) => {
 // get the primary property name
 export const normalizePrimaryProperty = (columns, primaryKey) => {
   let result = primaryKey;
-  if (!result) {
+  if (result === undefined) {
     columns.forEach((column) => {
       // remember the first key property
       if (column.primary && !result) {
@@ -37,7 +37,7 @@ export const normalizePrimaryProperty = (columns, primaryKey) => {
       }
     });
   }
-  if (!result && columns.length > 0) {
+  if (result === undefined && columns.length > 0) {
     result = columns[0].property;
   }
   return result;

--- a/src/js/components/DataTableColumns/stories/Simple.js
+++ b/src/js/components/DataTableColumns/stories/Simple.js
@@ -23,7 +23,7 @@ export const Simple = () => (
       <Toolbar>
         <DataTableColumns drop options={options} />
       </Toolbar>
-      <DataTable columns={columns} />
+      <DataTable columns={columns} primaryKey="name" />
     </Data>
   </Box>
   // </Grommet>


### PR DESCRIPTION
#### What does this PR do?

Changed DataTable to use a primaryKey value as the row key

#### Where should the reviewer start?

one line changed

#### What testing has been done on this PR?

unit tests

#### How should this be manually tested?

storybook?

#### Do Jest tests follow these best practices?

no change to test structure

#### Any background context you want to provide?

#### What are the relevant issues?

#6688 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible when using primaryKey
if the caller has no column.primary or primaryKey and the first value in the data objects is not unique, the browser will display a warning. This is expected given the inputs.