### PR TITLE
DataTable onSelect fix datum argument undefined

### DIFF
--- a/src/js/components/DataTable/Body.js
+++ b/src/js/components/DataTable/Body.js
@@ -59,8 +59,11 @@ const Row = memo(
                     onClickRow(adjustedEvent);
                   } else if (onClickRow === 'select') {
                     if (isSelected) {
-                      onSelect(selected.filter((s) => s !== primaryValue));
-                    } else onSelect([...selected, primaryValue]);
+                      onSelect(
+                        selected.filter((s) => s !== primaryValue),
+                        primaryValue,
+                      );
+                    } else onSelect([...selected, primaryValue], primaryValue);
                   }
                 }
               }
@@ -95,8 +98,11 @@ const Row = memo(
                   disabled={isDisabled || !onSelect}
                   onChange={() => {
                     if (isSelected) {
-                      onSelect(selected.filter((s) => s !== primaryValue));
-                    } else onSelect([...selected, primaryValue]);
+                      onSelect(
+                        selected.filter((s) => s !== primaryValue),
+                        primaryValue,
+                      );
+                    } else onSelect([...selected, primaryValue], primaryValue);
                   }}
                   pad={cellProps.pad}
                 />

--- a/src/js/components/DataTable/__tests__/DataTable-test.tsx
+++ b/src/js/components/DataTable/__tests__/DataTable-test.tsx
@@ -1068,7 +1068,7 @@ describe('DataTable', () => {
     fireEvent.click(getByLabelText('select beta'));
     expect(onSelect).toBeCalledWith(
       expect.arrayContaining(['alpha', 'beta']),
-      undefined,
+      'beta',
     );
     expect(container.firstChild).toMatchSnapshot();
   });
@@ -1668,5 +1668,33 @@ describe('DataTable', () => {
       </Grommet>,
     );
     expect(asFragment()).toMatchSnapshot();
+  });
+
+  test('onSelect datum argument should be defined', () => {
+    const onSelect = jest.fn();
+    render(
+      <Grommet>
+        <DataTable
+          onSelect={onSelect}
+          data={[
+            { name: 'Alan', percent: 20 },
+            { name: 'Bryan', percent: 30 },
+          ]}
+          columns={[
+            {
+              property: 'name',
+              header: 'Name',
+              primary: true,
+            },
+            {
+              property: 'percent',
+              header: 'Percent Complete',
+            },
+          ]}
+        />
+      </Grommet>,
+    );
+    fireEvent.click(screen.getByRole('checkbox', { name: 'select Alan' }));
+    expect(onSelect).toBeCalledWith(['Alan'], 'Alan');
   });
 });


### PR DESCRIPTION
#### What does this PR do?
Fixes an issue where the second argument ('datum') passed to onSelect was always undefined.

#### Where should the reviewer start?

#### What testing has been done on this PR?
Added a jest test and tested with the following story:
```javascript
import React from 'react';
import { Box, DataTable, Text, Meter } from 'grommet';

export const Test = () => (
  <DataTable
    onSelect={(selected, datum) => console.log({ selected, datum })}
    onClickRow="select"
    columns={[
      {
        property: 'name',
        header: <Text>Name</Text>,
        primary: true,
      },
      {
        property: 'percent',
        header: 'Complete',
        render: (datum) => (
          <Box pad={{ vertical: 'xsmall' }}>
            <Meter
              values={[{ value: datum.percent }]}
              thickness="small"
              size="small"
            />
          </Box>
        ),
      },
    ]}
    data={[
      { name: 'Alan', percent: 20 },
      { name: 'Bryan', percent: 30 },
      { name: 'Chris', percent: 40 },
      { name: 'Eric', percent: 80 },
    ]}
  />
);

export default {
  title: 'Visualizations/DataTable/Test',
};
```

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes https://github.com/grommet/grommet/issues/6727
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible