### PR TITLE
Add level prop to Accordion

### DIFF
--- a/src/js/components/Accordion/Accordion.js
+++ b/src/js/components/Accordion/Accordion.js
@@ -9,7 +9,15 @@ const activeAsArray = (active) =>
 
 const Accordion = forwardRef(
   (
-    { activeIndex, animate = true, children, multiple, onActive, ...rest },
+    {
+      activeIndex,
+      animate = true,
+      children,
+      level,
+      multiple,
+      onActive,
+      ...rest
+    },
     ref,
   ) => {
     const [activeIndexes, setActiveIndexes] = useState([]);
@@ -50,10 +58,11 @@ const Accordion = forwardRef(
         return {
           active: activeIndexes.indexOf(index) > -1,
           animate,
+          level,
           onPanelChange: () => onPanelChange(index),
         };
       },
-      [activeIndexes, animate, multiple, onActive],
+      [activeIndexes, animate, level, multiple, onActive],
     );
 
     return (

--- a/src/js/components/Accordion/__tests__/Accordion-test.tsx
+++ b/src/js/components/Accordion/__tests__/Accordion-test.tsx
@@ -386,4 +386,21 @@ describe('Accordion', () => {
     await user.tab();
     expect(onBlur).toHaveBeenCalled();
   });
+
+  test('should apply level prop to headings', () => {
+    const { asFragment } = render(
+      <Grommet>
+        <Accordion level={2}>
+          <AccordionPanel label="Panel 1">Panel body 1</AccordionPanel>
+          <AccordionPanel label="Panel 2">Panel body 2</AccordionPanel>
+        </Accordion>
+      </Grommet>,
+    );
+
+    expect(
+      screen.getByRole('heading', { level: 2, name: 'Panel 1' }),
+    ).toBeTruthy();
+
+    expect(asFragment()).toMatchSnapshot();
+  });
 });

--- a/src/js/components/Accordion/__tests__/__snapshots__/Accordion-test.tsx.snap
+++ b/src/js/components/Accordion/__tests__/__snapshots__/Accordion-test.tsx.snap
@@ -7105,6 +7105,363 @@ exports[`Accordion no AccordionPanel 1`] = `
 </DocumentFragment>
 `;
 
+exports[`Accordion should apply level prop to headings 1`] = `
+<DocumentFragment>
+  .c8 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #7D4CDB;
+  stroke: #7D4CDB;
+}
+
+.c8 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c8 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c8 *[stroke*="#"],
+.c8 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c8 *[fill-rule],
+.c8 *[FILL-RULE],
+.c8 *[fill*="#"],
+.c8 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-left: 6px;
+  padding-right: 6px;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  min-width: -webkit-fit-content;
+  min-width: -moz-fit-content;
+  min-width: fit-content;
+  padding-left: 12px;
+  padding-right: 12px;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c3:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus > circle,
+.c3:focus > ellipse,
+.c3:focus > line,
+.c3:focus > path,
+.c3:focus > polygon,
+.c3:focus > polyline,
+.c3:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c3:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c3:focus:not(:focus-visible) > circle,
+.c3:focus:not(:focus-visible) > ellipse,
+.c3:focus:not(:focus-visible) > line,
+.c3:focus:not(:focus-visible) > path,
+.c3:focus:not(:focus-visible) > polygon,
+.c3:focus:not(:focus-visible) > polyline,
+.c3:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c3:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c10 {
+  -webkit-transition: max-height 200ms,opacity 200ms;
+  transition: max-height 200ms,opacity 200ms;
+  opacity: 0;
+  overflow: hidden;
+}
+
+.c6 {
+  font-size: 34px;
+  line-height: 40px;
+  max-width: 816px;
+  font-weight: 600;
+  overflow-wrap: break-word;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+@media only screen and (max-width:768px) {
+  .c5 {
+    padding-left: 3px;
+    padding-right: 3px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    padding-left: 6px;
+    padding-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c9 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    font-size: 26px;
+    line-height: 32px;
+    max-width: 624px;
+  }
+}
+
+<div
+    class="c0"
+  >
+    <div
+      class="c1"
+    >
+      <div
+        class="c2"
+      >
+        <button
+          aria-expanded="false"
+          class="c3"
+          type="button"
+        >
+          <div
+            class="c4"
+          >
+            <div
+              class="c5"
+            >
+              <h2
+                class="c6"
+              >
+                Panel 1
+              </h2>
+            </div>
+            <div
+              class="c7"
+            >
+              <svg
+                aria-label="FormDown"
+                class="c8"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m18 9-6 6-6-6"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
+          </div>
+        </button>
+        <div
+          class="c9"
+          role="region"
+        >
+          <div
+            aria-hidden="true"
+            class="c1 c10"
+          />
+        </div>
+      </div>
+      <div
+        class="c2"
+      >
+        <button
+          aria-expanded="false"
+          class="c3"
+          type="button"
+        >
+          <div
+            class="c4"
+          >
+            <div
+              class="c5"
+            >
+              <h2
+                class="c6"
+              >
+                Panel 2
+              </h2>
+            </div>
+            <div
+              class="c7"
+            >
+              <svg
+                aria-label="FormDown"
+                class="c8"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m18 9-6 6-6-6"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
+          </div>
+        </button>
+        <div
+          class="c9"
+          role="region"
+        >
+          <div
+            aria-hidden="true"
+            class="c1 c10"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`Accordion should have no accessibility violations 1`] = `
 <DocumentFragment>
   .c6 {

--- a/src/js/components/Accordion/index.d.ts
+++ b/src/js/components/Accordion/index.d.ts
@@ -5,6 +5,7 @@ import { BoxProps } from '../Box/index';
 export interface AccordionProps {
   activeIndex?: number | number[];
   animate?: AnimateType;
+  level?: number;
   onActive?: (activeIndexes: number[]) => void;
   multiple?: boolean;
   messages?: { tabContents?: string };

--- a/src/js/components/Accordion/propTypes.js
+++ b/src/js/components/Accordion/propTypes.js
@@ -11,6 +11,7 @@ if (process.env.NODE_ENV !== 'production') {
     ]),
     animate: PropTypes.bool,
     children: PropTypes.node,
+    level: PropTypes.number,
     onActive: PropTypes.func,
     multiple: PropTypes.bool,
     messages: PropTypes.shape({

--- a/src/js/components/AccordionPanel/AccordionPanel.js
+++ b/src/js/components/AccordionPanel/AccordionPanel.js
@@ -27,7 +27,8 @@ const AccordionPanel = forwardRef(
     ref,
   ) => {
     const theme = useContext(ThemeContext) || defaultProps.theme;
-    const { active, animate, onPanelChange } = useContext(AccordionContext);
+    const { active, animate, level, onPanelChange } =
+      useContext(AccordionContext);
     const [hover, setHover] = useState(undefined);
     const [focus, setFocus] = useState();
 
@@ -119,6 +120,7 @@ const AccordionPanel = forwardRef(
                 <Box pad={{ horizontal: 'xsmall' }}>
                   <Heading
                     level={
+                      level ||
                       (theme.accordion.heading &&
                         theme.accordion.heading.level) ||
                       4

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -11,6 +11,7 @@ exports[`Components loads 1`] = `
       "animate": [Function],
       "children": [Function],
       "gridArea": [Function],
+      "level": [Function],
       "margin": [Function],
       "messages": [Function],
       "multiple": [Function],


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Added `level` prop to Accordion to allow caller to control what semantic heading should be rendered in the accordion panel.

#### Where should the reviewer start?
src/js/components/Accordion/Accordion.js

#### What testing has been done on this PR?
Tested locally in a storybook example and added jest test.

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [x] `screen` is used for querying.
- [x] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [x] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #6654 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?
- Added `level` to Accordion

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.