### PR TITLE
Added a test for Box border between in an array

### DIFF
--- a/src/js/components/Box/__tests__/Box-style-test.tsx
+++ b/src/js/components/Box/__tests__/Box-style-test.tsx
@@ -228,6 +228,10 @@ describe('Box', () => {
           <Box>one</Box>
           <Box>two</Box>
         </Box>
+        <Box border={[{ side: 'between' }, { side: 'top' }]} gap="small">
+          <Box>one</Box>
+          <Box>two</Box>
+        </Box>
       </Grommet>,
     );
 

--- a/src/js/components/Box/__tests__/__snapshots__/Box-style-test.tsx.snap
+++ b/src/js/components/Box/__tests__/__snapshots__/Box-style-test.tsx.snap
@@ -1511,6 +1511,23 @@ exports[`Box border 1`] = `
       two
     </div>
   </div>
+  <div
+    class="c4"
+  >
+    <div
+      class="c17"
+    >
+      one
+    </div>
+    <div
+      class="c18"
+    />
+    <div
+      class="c17"
+    >
+      two
+    </div>
+  </div>
 </div>
 `;
 


### PR DESCRIPTION
#### What does this PR do?
Adds a jest test for having a Box border array with 'between' as one of the values.
Functionality added in this pr: https://github.com/grommet/grommet/pull/6642

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
backwards compatible