### PR TITLE
Fix error when switching to the shadow dom in storybook

### DIFF
--- a/storybook/preview.js
+++ b/storybook/preview.js
@@ -17,15 +17,17 @@ export const decorators = [
   (Story, context) => {
     const [rootRef, setRootRef] = useState(null);
     const [state, setState] = useState('grommet');
-    useEffect(() => {
-      setState(context.globals.theme);
-    }, [context.globals.theme]);
+    const [root, setRoot] = useState('document');
     const full = context.allArgs?.full || 'min';
     const dir = context.allArgs?.dir;
     const options = context.allArgs?.options;
-    const {
-      globals: { root },
-    } = context;
+
+    useEffect(() => {
+      setState(context.globals.theme);
+    }, [context.globals.theme]);
+    useEffect(() => {
+      setRoot(context.globals.root);
+    }, [context.globals.root]);
 
     /**
      * This demonstrates that custom themed stories are driven off the "base"


### PR DESCRIPTION
#### What does this PR do?
Fixes the following error when trying to use the shadow dom on storybook.

To replicate this issue go to any storybook story and change root to 'shadow' then switch to a different story.

<img width="763" alt="Screen Shot 2023-04-18 at 2 52 13 PM" src="https://user-images.githubusercontent.com/54560994/232902401-c544ee55-8c45-448a-9f8a-d224f0ac9597.png">

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
backwards compatible