### PR TITLE
Added tests for Data with property values as an array

### DIFF
--- a/src/js/components/Data/__tests__/Data-test.tsx
+++ b/src/js/components/Data/__tests__/Data-test.tsx
@@ -9,9 +9,21 @@ import { Pagination } from '../../Pagination';
 import { Data } from '..';
 
 const data = [
-  { name: 'aa', enabled: true, rating: 2.3, sub: { note: 'ZZ' } },
-  { name: 'bb', enabled: false, rating: 4.3, sub: { note: 'YY' } },
-  { name: 'cc', sub: {} },
+  {
+    name: 'aa',
+    enabled: true,
+    rating: 2.3,
+    sub: { note: 'ZZ' },
+    tags: ['qa', 'staging', 'prod'],
+  },
+  {
+    name: 'bb',
+    enabled: false,
+    rating: 4.3,
+    sub: { note: 'YY' },
+    tags: ['qa', 'staging'],
+  },
+  { name: 'cc', sub: {}, tags: ['qa'] },
   { name: 'dd' },
 ];
 

--- a/src/js/components/Data/__tests__/Data-test.tsx
+++ b/src/js/components/Data/__tests__/Data-test.tsx
@@ -385,7 +385,6 @@ describe('Data', () => {
 
   test('properties when property is an array', () => {
     const user = userEvent.setup();
-    // jest.useFakeTimers();
 
     const { asFragment } = render(
       <Grommet>
@@ -425,9 +424,6 @@ describe('Data', () => {
     const filtersButton = screen.getByRole('button', { name: 'Open filters' });
     expect(filtersButton).toBeTruthy();
     user.click(filtersButton);
-
-    // wait for animation
-    // act(() => jest.advanceTimersByTime(200));
     expectPortal('data--filters-control').toMatchSnapshot();
   });
 });

--- a/src/js/components/Data/__tests__/__snapshots__/Data-test.tsx.snap
+++ b/src/js/components/Data/__tests__/__snapshots__/Data-test.tsx.snap
@@ -3686,6 +3686,801 @@ exports[`Data pagination step 1`] = `
 </div>
 `;
 
+exports[`Data properties when property is an array 1`] = `
+<DocumentFragment>
+  .c6 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #666666;
+  stroke: #666666;
+}
+
+.c6 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c6 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c6 *[stroke*="#"],
+.c6 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c6 *[fill-rule],
+.c6 *[FILL-RULE],
+.c6 *[fill*="#"],
+.c6 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c14 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c18 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-column-gap: 12px;
+  column-gap: 12px;
+  row-gap: 12px;
+}
+
+.c10 {
+  margin-top: 6px;
+  margin-bottom: 6px;
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c15 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c19 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c9 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  line-height: 0;
+  padding: 12px;
+}
+
+.c9:hover {
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
+}
+
+.c9:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9:focus > circle,
+.c9:focus > ellipse,
+.c9:focus > line,
+.c9:focus > path,
+.c9:focus > polygon,
+.c9:focus > polyline,
+.c9:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c9:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c9:focus:not(:focus-visible) > circle,
+.c9:focus:not(:focus-visible) > ellipse,
+.c9:focus:not(:focus-visible) > line,
+.c9:focus:not(:focus-visible) > path,
+.c9:focus:not(:focus-visible) > polygon,
+.c9:focus:not(:focus-visible) > polyline,
+.c9:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c9:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c7 {
+  box-sizing: border-box;
+  font-size: inherit;
+  font-family: inherit;
+  border: none;
+  -webkit-appearance: none;
+  background: transparent;
+  color: inherit;
+  width: 100%;
+  padding: 11px;
+  font-weight: 600;
+  margin: 0;
+  border: 1px solid rgba(0,0,0,0.33);
+  border-radius: 4px;
+  padding-left: 48px;
+}
+
+.c7:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c7:focus > circle,
+.c7:focus > ellipse,
+.c7:focus > line,
+.c7:focus > path,
+.c7:focus > polygon,
+.c7:focus > polyline,
+.c7:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c7:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c7::-webkit-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c7::-moz-placeholder {
+  color: #AAAAAA;
+}
+
+.c7:-ms-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c7::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+.c7::-moz-focus-inner {
+  border: none;
+  outline: none;
+}
+
+.c7:-moz-placeholder,
+.c7::-moz-placeholder {
+  opacity: 1;
+}
+
+.c4 {
+  position: relative;
+  width: 100%;
+}
+
+.c5 {
+  position: absolute;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-packjustify: center;
+  -webkit-justify: center;
+  -ms-flex-packjustify: center;
+  justify: center;
+  top: 50%;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  pointer-events: none;
+  left: 12px;
+}
+
+.c3 {
+  max-width: 100%;
+}
+
+.c13 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c17 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c11 {
+  border-spacing: 0;
+  border-collapse: collapse;
+  width: inherit;
+}
+
+.c12 {
+  position: relative;
+  border-spacing: 0;
+  border-collapse: separate;
+}
+
+.c16:focus {
+  outline: 2px solid #6FFFB0;
+}
+
+.c16:focus:not(:focus-visible) {
+  outline: none;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    -webkit-column-gap: 6px;
+    column-gap: 6px;
+  }
+}
+
+<div
+    class="c0"
+  >
+    <div
+      class="c1"
+      id="data"
+    >
+      <div
+        class="c2"
+      >
+        <form
+          class="c3"
+        >
+          <div
+            class="c4"
+          >
+            <div
+              class="c5"
+            >
+              <svg
+                aria-label="Search"
+                class="c6"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
+            <input
+              aria-label="Search"
+              autocomplete="off"
+              class="c7"
+              id="data--search"
+              name="_search"
+              type="search"
+              value=""
+            />
+          </div>
+        </form>
+        <div
+          class="c8"
+        >
+          <button
+            aria-label="Open filters"
+            class="c9"
+            id="data--filters-control"
+            type="button"
+          >
+            <svg
+              aria-label="Filter"
+              class="c6"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m3 6 7 7v8h4v-8l7-7V3H3z"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+      <span
+        class="c10"
+      >
+        4 items
+      </span>
+      <table
+        class="c11 c12"
+      >
+        <thead
+          class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
+        >
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c13 "
+              scope="col"
+            >
+              <div
+                class="c14"
+              >
+                <span
+                  class="c15"
+                >
+                  Name
+                </span>
+              </div>
+            </th>
+            <th
+              class="c13 "
+              scope="col"
+            >
+              <div
+                class="c14"
+              >
+                <span
+                  class="c15"
+                >
+                  Note
+                </span>
+              </div>
+            </th>
+            <th
+              class="c13 "
+              scope="col"
+            >
+              <div
+                class="c14"
+              >
+                <span
+                  class="c15"
+                >
+                  Tags
+                </span>
+              </div>
+            </th>
+          </tr>
+        </thead>
+        <tbody
+          class="StyledTable__StyledTableBody-sc-1m3u5g-3 c16"
+        >
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c17 "
+              scope="row"
+            >
+              <div
+                class="c18"
+              >
+                <span
+                  class="c19"
+                >
+                  aa
+                </span>
+              </div>
+            </th>
+            <td
+              class="c17 "
+            >
+              <div
+                class="c18"
+              >
+                <span
+                  class="c15"
+                >
+                  ZZ
+                </span>
+              </div>
+            </td>
+            <td
+              class="c17 "
+            >
+              <div
+                class="c18"
+              >
+                <span
+                  class="c15"
+                >
+                  qa, staging, prod
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c17 "
+              scope="row"
+            >
+              <div
+                class="c18"
+              >
+                <span
+                  class="c19"
+                >
+                  bb
+                </span>
+              </div>
+            </th>
+            <td
+              class="c17 "
+            >
+              <div
+                class="c18"
+              >
+                <span
+                  class="c15"
+                >
+                  YY
+                </span>
+              </div>
+            </td>
+            <td
+              class="c17 "
+            >
+              <div
+                class="c18"
+              >
+                <span
+                  class="c15"
+                >
+                  qa, staging
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c17 "
+              scope="row"
+            >
+              <div
+                class="c18"
+              >
+                <span
+                  class="c19"
+                >
+                  cc
+                </span>
+              </div>
+            </th>
+            <td
+              class="c17 "
+            >
+              <div
+                class="c18"
+              />
+            </td>
+            <td
+              class="c17 "
+            >
+              <div
+                class="c18"
+              >
+                <span
+                  class="c15"
+                >
+                  qa
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c17 "
+              scope="row"
+            >
+              <div
+                class="c18"
+              >
+                <span
+                  class="c19"
+                >
+                  dd
+                </span>
+              </div>
+            </th>
+            <td
+              class="c17 "
+            >
+              <div
+                class="c18"
+              />
+            </td>
+            <td
+              class="c17 "
+            >
+              <div
+                class="c18"
+              />
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Data properties when property is an array 2`] = `
+.c1 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #666666;
+  stroke: #666666;
+}
+
+.c1 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c1 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c1 *[stroke*="#"],
+.c1 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c1 *[fill-rule],
+.c1 *[FILL-RULE],
+.c1 *[fill*="#"],
+.c1 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c0 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  line-height: 0;
+  padding: 12px;
+}
+
+.c0:hover {
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
+}
+
+.c0:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c0:focus > circle,
+.c0:focus > ellipse,
+.c0:focus > line,
+.c0:focus > path,
+.c0:focus > polygon,
+.c0:focus > polyline,
+.c0:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c0:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c0:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c0:focus:not(:focus-visible) > circle,
+.c0:focus:not(:focus-visible) > ellipse,
+.c0:focus:not(:focus-visible) > line,
+.c0:focus:not(:focus-visible) > path,
+.c0:focus:not(:focus-visible) > polygon,
+.c0:focus:not(:focus-visible) > polyline,
+.c0:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c0:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+<button
+  aria-label="Open filters"
+  class="c0"
+  id="data--filters-control"
+  type="button"
+>
+  <svg
+    aria-label="Filter"
+    class="c1"
+    viewBox="0 0 24 24"
+  >
+    <path
+      d="m3 6 7 7v8h4v-8l7-7V3H3z"
+      fill="none"
+      stroke="#000"
+      stroke-width="2"
+    />
+  </svg>
+</button>
+`;
+
+exports[`Data properties when property is an array 3`] = `""`;
+
 exports[`Data renders 1`] = `
 .c0 {
   font-size: 18px;

--- a/src/js/components/Data/__tests__/__snapshots__/Data-test.tsx.snap
+++ b/src/js/components/Data/__tests__/__snapshots__/Data-test.tsx.snap
@@ -2409,6 +2409,14 @@ exports[`Data onView 1`] = `
               class="c35"
             />
           </th>
+          <th
+            class="c34 "
+            scope="col"
+          >
+            <div
+              class="c35"
+            />
+          </th>
         </tr>
       </thead>
       <tbody
@@ -2450,6 +2458,13 @@ exports[`Data onView 1`] = `
                 2.3
               </span>
             </div>
+          </td>
+          <td
+            class="c37 "
+          >
+            <div
+              class="c10"
+            />
           </td>
           <td
             class="c37 "
@@ -2503,6 +2518,13 @@ exports[`Data onView 1`] = `
               class="c10"
             />
           </td>
+          <td
+            class="c37 "
+          >
+            <div
+              class="c10"
+            />
+          </td>
         </tr>
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
@@ -2542,6 +2564,13 @@ exports[`Data onView 1`] = `
               class="c10"
             />
           </td>
+          <td
+            class="c37 "
+          >
+            <div
+              class="c10"
+            />
+          </td>
         </tr>
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
@@ -2560,6 +2589,13 @@ exports[`Data onView 1`] = `
               </span>
             </div>
           </th>
+          <td
+            class="c37 "
+          >
+            <div
+              class="c10"
+            />
+          </td>
           <td
             class="c37 "
           >

--- a/src/js/components/Data/__tests__/__snapshots__/Data-test.tsx.snap
+++ b/src/js/components/Data/__tests__/__snapshots__/Data-test.tsx.snap
@@ -2353,11 +2353,11 @@ exports[`Data onView 1`] = `
             />
           </th>
           <th
-            class="c34 "
+            class="c32 "
             scope="col"
           >
             <div
-              class="c35"
+              class="c33"
             />
           </th>
         </tr>
@@ -2410,10 +2410,10 @@ exports[`Data onView 1`] = `
             />
           </td>
           <td
-            class="c37 "
+            class="c35 "
           >
             <div
-              class="c10"
+              class="c8"
             />
           </td>
         </tr>
@@ -2462,10 +2462,10 @@ exports[`Data onView 1`] = `
             />
           </td>
           <td
-            class="c37 "
+            class="c35 "
           >
             <div
-              class="c10"
+              class="c8"
             />
           </td>
         </tr>
@@ -2508,10 +2508,10 @@ exports[`Data onView 1`] = `
             />
           </td>
           <td
-            class="c37 "
+            class="c35 "
           >
             <div
-              class="c10"
+              class="c8"
             />
           </td>
         </tr>
@@ -2554,10 +2554,10 @@ exports[`Data onView 1`] = `
             />
           </td>
           <td
-            class="c37 "
+            class="c35 "
           >
             <div
-              class="c10"
+              class="c8"
             />
           </td>
         </tr>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Adds tests covering https://github.com/grommet/grommet/issues/6701 and https://github.com/grommet/grommet/pull/6704 by supplying Data with data containing property values as an array.

#### Where should the reviewer start?

Data-test.tsx

#### What testing has been done on this PR?

New Jest test added.

#### How should this be manually tested?

N/A

#### Do Jest tests follow these best practices?

- [x] `screen` is used for querying.
- [x] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [x] `userEvent` is used in place of `fireEvent`.
- [x] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

https://github.com/grommet/hpe-design-system/issues/3164

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

No.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible
