### PR TITLE
Fix Button busy animation color for non primary buttons

### DIFF
--- a/src/js/components/Button/BusyAnimation.js
+++ b/src/js/components/Button/BusyAnimation.js
@@ -16,17 +16,16 @@ const bounceDelayRule = css`
 `;
 
 const Dot = styled(Box)`
+  background-color: currentColor;
   width: 8px;
   height: 8px;
-  background-color: ;
-  ${(props) => props.color && `background-color: ${props.color};`}
   border-radius: 100%;
   display: inline-block;
   ${bounceDelayRule}
   ${(props) => props.delay && `animation-delay: ${props.delay};`}
 `;
 
-export const EllipsisAnimation = ({ color }) => (
+export const EllipsisAnimation = () => (
   <Box
     style={{ position: 'absolute' }}
     fill
@@ -36,9 +35,9 @@ export const EllipsisAnimation = ({ color }) => (
     <Box alignSelf="center" direction="row" gap="small">
       {/* A negative delay starts the animation sooner. The first dot
       should begin animating before the second and so on. */}
-      <Dot color={color} delay="-0.32s" />
-      <Dot color={color} delay="-0.16s" />
-      <Dot color={color} />
+      <Dot delay="-0.32s" />
+      <Dot delay="-0.16s" />
+      <Dot />
     </Box>
   </Box>
 );

--- a/src/js/components/Button/Button.js
+++ b/src/js/components/Button/Button.js
@@ -461,7 +461,7 @@ const Button = forwardRef(
         // position relative is necessary to have the animation
         // display over the button content
         <RelativeBox flex={false}>
-          {busy && <EllipsisAnimation color={animationColor} />}
+          {busy && <EllipsisAnimation />}
           {success && (
             <Box
               style={{ position: 'absolute' }}


### PR DESCRIPTION
#### What does this PR do?
Fixes an issue with Button `busy` where the busy animation was not the right color for non primary buttons.

To fix this I used `background-color: currentColor;` on the busy animation dots so that they would use the same color as the button label text.

#### Where should the reviewer start?

#### What testing has been done on this PR?
Tested by changing the button busy story to use other button kinds

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no

#### Should this PR be mentioned in the release notes?
no

#### Is this change backwards compatible or is it a breaking change?
backwards compatible