### PR TITLE
Update StyledCheckBox width and snapshots

### DIFF
--- a/src/js/components/CheckBox/StyledCheckBox.js
+++ b/src/js/components/CheckBox/StyledCheckBox.js
@@ -58,7 +58,7 @@ const StyledCheckBoxContainer = styled.label`
       ? props.theme.checkBox.label.align
       : undefined};
   user-select: none;
-  ${(props) => (props.fillProp ? fillStyle() : 'width: fit-content;')}
+  ${(props) => (props.fillProp ? fillStyle() : 'width: auto;')}
   ${(props) =>
     (props.pad || props.theme.checkBox.pad) &&
     edgeStyle(

--- a/src/js/components/CheckBox/__tests__/__snapshots__/CheckBox-test.tsx.snap
+++ b/src/js/components/CheckBox/__tests__/__snapshots__/CheckBox-test.tsx.snap
@@ -79,9 +79,7 @@ exports[`CheckBox checked renders 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
+  width: auto;
   cursor: pointer;
 }
 
@@ -233,9 +231,7 @@ exports[`CheckBox controlled 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
+  width: auto;
   cursor: pointer;
 }
 
@@ -318,7 +314,7 @@ exports[`CheckBox controlled 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 gIiCYk"
 >
   <label
-    class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 gVeQxx"
+    class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fXbqBx"
     label="test-label"
   >
     <div
@@ -427,9 +423,7 @@ exports[`CheckBox custom theme 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
+  width: auto;
   padding-left: 12px;
   padding-right: 12px;
   padding-top: 6px;
@@ -578,9 +572,7 @@ exports[`CheckBox defaultChecked 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
+  width: auto;
   cursor: pointer;
 }
 
@@ -753,9 +745,7 @@ exports[`CheckBox disabled renders 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
+  width: auto;
   opacity: 0.5;
   cursor: default;
 }
@@ -959,9 +949,7 @@ exports[`CheckBox indeterminate renders 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
+  width: auto;
   cursor: pointer;
 }
 
@@ -986,9 +974,7 @@ exports[`CheckBox indeterminate renders 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
+  width: auto;
   cursor: pointer;
 }
 
@@ -1167,9 +1153,7 @@ exports[`CheckBox label renders 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
+  width: auto;
   cursor: pointer;
 }
 
@@ -1190,9 +1174,7 @@ exports[`CheckBox label renders 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
+  width: auto;
   cursor: pointer;
 }
 
@@ -1353,9 +1335,7 @@ exports[`CheckBox label should not have accessibility violations 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
+  width: auto;
   cursor: pointer;
 }
 
@@ -1492,9 +1472,7 @@ exports[`CheckBox renders 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
+  width: auto;
   cursor: pointer;
 }
 
@@ -1639,9 +1617,7 @@ exports[`CheckBox renders a11yTitle and aria-label 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
+  width: auto;
   cursor: pointer;
 }
 
@@ -1790,9 +1766,7 @@ exports[`CheckBox renders custom checked icon 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
+  width: auto;
   cursor: pointer;
 }
 
@@ -1939,9 +1913,7 @@ exports[`CheckBox reverse renders 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
+  width: auto;
   cursor: pointer;
 }
 
@@ -2279,9 +2251,7 @@ exports[`CheckBox should not have accessibility violations 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
+  width: auto;
   cursor: pointer;
 }
 
@@ -2406,9 +2376,7 @@ exports[`CheckBox toggle renders 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
+  width: auto;
   cursor: pointer;
 }
 
@@ -2433,9 +2401,7 @@ exports[`CheckBox toggle renders 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
+  width: auto;
   cursor: pointer;
 }
 

--- a/src/js/components/CheckBoxGroup/__tests__/__snapshots__/CheckBoxGroup-test.tsx.snap
+++ b/src/js/components/CheckBoxGroup/__tests__/__snapshots__/CheckBoxGroup-test.tsx.snap
@@ -9,7 +9,7 @@ exports[`CheckBoxGroup custom theme 1`] = `
     role="group"
   >
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 gVeQxx"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fXbqBx"
       label="first-label"
     >
       <div
@@ -31,7 +31,7 @@ exports[`CheckBoxGroup custom theme 1`] = `
       class="StyledBox__StyledBoxGap-sc-13pk1d4-1 dRbQGU"
     />
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 gVeQxx"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fXbqBx"
       label="second-label"
     >
       <div
@@ -63,7 +63,7 @@ exports[`CheckBoxGroup defaultValue renders 1`] = `
       role="group"
     >
       <label
-        class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 gVeQxx"
+        class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fXbqBx"
         label="First"
       >
         <div
@@ -97,7 +97,7 @@ exports[`CheckBoxGroup defaultValue renders 1`] = `
         class="StyledBox__StyledBoxGap-sc-13pk1d4-1 biJsVL"
       />
       <label
-        class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 gVeQxx"
+        class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fXbqBx"
         label="Second"
       >
         <div
@@ -129,7 +129,7 @@ exports[`CheckBoxGroup disabled renders 1`] = `
     role="group"
   >
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dvTzMc"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 gsSrzw"
       disabled=""
       label="First"
     >
@@ -155,7 +155,7 @@ exports[`CheckBoxGroup disabled renders 1`] = `
       class="StyledBox__StyledBoxGap-sc-13pk1d4-1 biJsVL"
     />
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dvTzMc"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 gsSrzw"
       disabled=""
       label="Second"
     >
@@ -183,7 +183,7 @@ exports[`CheckBoxGroup disabled renders 1`] = `
     role="group"
   >
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dvTzMc"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 gsSrzw"
       disabled=""
       label="First"
     >
@@ -211,7 +211,7 @@ exports[`CheckBoxGroup disabled renders 1`] = `
     role="group"
   >
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dvTzMc"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 gsSrzw"
       disabled=""
       label="First"
     >
@@ -246,7 +246,7 @@ exports[`CheckBoxGroup initial value renders 1`] = `
     role="group"
   >
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 gVeQxx"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fXbqBx"
       label="Maui"
     >
       <div
@@ -268,7 +268,7 @@ exports[`CheckBoxGroup initial value renders 1`] = `
       class="StyledBox__StyledBoxGap-sc-13pk1d4-1 biJsVL"
     />
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 gVeQxx"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fXbqBx"
       label="Jerusalem"
     >
       <div
@@ -302,7 +302,7 @@ exports[`CheckBoxGroup initial value renders 1`] = `
       class="StyledBox__StyledBoxGap-sc-13pk1d4-1 biJsVL"
     />
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 gVeQxx"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fXbqBx"
       label="Wuhan"
     >
       <div
@@ -345,7 +345,7 @@ exports[`CheckBoxGroup labelKey 1`] = `
     role="group"
   >
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 gVeQxx"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fXbqBx"
       label="first-label"
     >
       <div
@@ -367,7 +367,7 @@ exports[`CheckBoxGroup labelKey 1`] = `
       class="StyledBox__StyledBoxGap-sc-13pk1d4-1 biJsVL"
     />
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 gVeQxx"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fXbqBx"
       label="second-label"
     >
       <div
@@ -398,7 +398,7 @@ exports[`CheckBoxGroup onChange 1`] = `
     role="group"
   >
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 gVeQxx"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fXbqBx"
       label="first-label"
     >
       <div
@@ -431,7 +431,7 @@ exports[`CheckBoxGroup onChange 1`] = `
       class="StyledBox__StyledBoxGap-sc-13pk1d4-1 biJsVL"
     />
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 gVeQxx"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fXbqBx"
       label="second-label"
     >
       <div
@@ -463,7 +463,7 @@ exports[`CheckBoxGroup onClick for check and uncheck a CheckBox 1`] = `
     tabindex="0"
   >
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 gVeQxx"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fXbqBx"
       label="first-label"
     >
       <div
@@ -496,7 +496,7 @@ exports[`CheckBoxGroup onClick for check and uncheck a CheckBox 1`] = `
       class="StyledBox__StyledBoxGap-sc-13pk1d4-1 biJsVL"
     />
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 gVeQxx"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fXbqBx"
       label="second-label"
     >
       <div
@@ -528,7 +528,7 @@ exports[`CheckBoxGroup onClick for check and uncheck a CheckBox 2`] = `
     tabindex="0"
   >
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 gVeQxx"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fXbqBx"
       label="first-label"
     >
       <div
@@ -550,7 +550,7 @@ exports[`CheckBoxGroup onClick for check and uncheck a CheckBox 2`] = `
       class="StyledBox__StyledBoxGap-sc-13pk1d4-1 biJsVL"
     />
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 gVeQxx"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fXbqBx"
       label="second-label"
     >
       <div
@@ -581,7 +581,7 @@ exports[`CheckBoxGroup options renders 1`] = `
     role="group"
   >
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 gVeQxx"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fXbqBx"
       label="First"
     >
       <div
@@ -603,7 +603,7 @@ exports[`CheckBoxGroup options renders 1`] = `
       class="StyledBox__StyledBoxGap-sc-13pk1d4-1 biJsVL"
     />
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 gVeQxx"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fXbqBx"
       label="Second"
     >
       <div
@@ -634,7 +634,7 @@ exports[`CheckBoxGroup value renders 1`] = `
     role="group"
   >
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 gVeQxx"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fXbqBx"
       label="First"
     >
       <div
@@ -668,7 +668,7 @@ exports[`CheckBoxGroup value renders 1`] = `
       class="StyledBox__StyledBoxGap-sc-13pk1d4-1 biJsVL"
     />
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 gVeQxx"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fXbqBx"
       label="Second"
     >
       <div
@@ -699,7 +699,7 @@ exports[`CheckBoxGroup valueKey 1`] = `
     role="group"
   >
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 gVeQxx"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fXbqBx"
       label="first-label"
     >
       <div
@@ -721,7 +721,7 @@ exports[`CheckBoxGroup valueKey 1`] = `
       class="StyledBox__StyledBoxGap-sc-13pk1d4-1 biJsVL"
     />
     <label
-      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 gVeQxx"
+      class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fXbqBx"
       label="second-label"
     >
       <div


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Update StyledCheckBox.js width to `auto` instead of `fit-content`. This was specifically meant to address the issue in this PR: https://github.com/grommet/hpe-design-system/pull/3225 where the CheckBox focus indicators were not aligned with one another.

#### Where should the reviewer start?
StyledCheckBox.js

#### What testing has been done on this PR?

#### How should this be manually tested?
Ensure that previous code that uses StyledCheckBox.js maintains functionality and styling.

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Related to https://github.com/grommet/hpe-design-system/pull/3225.

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
BREAKING CHANGE - DO NOT MERGE YET
