### PR TITLE
Add innerRef as useImperativeHandle dependency to avoid infinite loop (#6792)

### DIFF
--- a/src/js/utils/refs.js
+++ b/src/js/utils/refs.js
@@ -2,6 +2,6 @@ import { useImperativeHandle, useRef } from 'react';
 
 export const useForwardedRef = (ref) => {
   const innerRef = useRef(null);
-  useImperativeHandle(ref, () => innerRef.current);
+  useImperativeHandle(ref, () => innerRef.current, [innerRef]);
   return innerRef;
 };


### PR DESCRIPTION
#### What does this PR do?

Solve infinite loop from issue #6792 

#### Where should the reviewer start?

Start reading the issue #6792 and go to the associated Codesandbox to see broken code since 2.29.0.

#### What testing has been done on this PR?

Verified ref callback value on component mount/re-render.

#### How should this be manually tested?

1. Go to codesandbox
2. Change the grommet version to : `npm:@lcdp/grommet@2.32.0-fix-infinite-loop-6792.1`
Codesandbox with version modified available here : https://codesandbox.io/s/grommet-v2-template-forked-clv6l7?file=/CustomComponent.js
3. Everything is working, go to console to see the correct DOM node passed in ref callback

#### Do Jest tests follow these best practices?

NO TESTS

#### Any background context you want to provide?

#### What are the relevant issues?

Issue #6792

#### Screenshots (if appropriate)

No

#### Do the grommet docs need to be updated?

No

#### Should this PR be mentioned in the release notes?

Yes

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible