### PR TITLE
Changed DataFilter to handle properties with zero or one values

### DIFF
--- a/src/js/components/DataFilter/DataFilter.js
+++ b/src/js/components/DataFilter/DataFilter.js
@@ -62,8 +62,10 @@ export const DataFilter = ({
 
     // generate options from all values for property
     const uniqueValues = generateOptions(unfilteredData || data, property);
+    // if less than two values, nothing to filter
+    if (uniqueValues.length < 2) return [undefined, undefined];
     // if any values aren't numeric, treat as options
-    if (uniqueValues.some((v) => v && typeof v !== 'number'))
+    if (uniqueValues.some((v) => v !== undefined && typeof v !== 'number'))
       return [uniqueValues, undefined];
     // all values are numeric, treat as range
     // normalize to make it friendler, so [1.3, 4.895] becomes [1, 5]
@@ -100,28 +102,28 @@ export const DataFilter = ({
           round="small"
         />
       );
-    } else if (
-      options.length === 2 &&
-      options[1] === true &&
-      options[0] === false
-    ) {
-      // special case boolean properties
-      content = (
-        <CheckBoxGroup id={id} name={property} options={booleanOptions} />
-      );
-    } else if (options.length < 7) {
-      content = <CheckBoxGroup id={id} name={property} options={options} />;
-    } else {
-      content = (
-        <SelectMultiple
-          id={id}
-          name={property}
-          showSelectedInline
-          options={options}
-        />
-      );
+    } else if (options) {
+      if (options.length === 2 && options[1] === true && options[0] === false) {
+        // special case boolean properties
+        content = (
+          <CheckBoxGroup id={id} name={property} options={booleanOptions} />
+        );
+      } else if (options.length < 7) {
+        content = <CheckBoxGroup id={id} name={property} options={options} />;
+      } else {
+        content = (
+          <SelectMultiple
+            id={id}
+            name={property}
+            showSelectedInline
+            options={options}
+          />
+        );
+      }
     }
   }
+
+  if (!content) return null;
 
   if (noForm)
     // likely in Toolbar

--- a/src/js/components/DataFilter/__tests__/DataFilter-test.tsx
+++ b/src/js/components/DataFilter/__tests__/DataFilter-test.tsx
@@ -9,9 +9,23 @@ import { DataFilter } from '..';
 import { Toolbar } from '../../Toolbar';
 
 const data = [
-  { name: 'aa', enabled: true, rating: 2.3, type: { name: 'ZZ', id: 1 } },
-  { name: 'bb', enabled: false, rating: 4.3, type: { name: 'YY', id: 2 } },
-  { name: 'cc', type: { name: 'ZZ', id: 1 } },
+  {
+    name: 'aa',
+    enabled: true,
+    rating: 2.3,
+    type: { name: 'ZZ', id: 1 },
+    blank: '',
+    zero: 0,
+  },
+  {
+    name: 'bb',
+    enabled: false,
+    rating: 4.3,
+    type: { name: 'YY', id: 2 },
+    blank: '',
+    zero: 0,
+  },
+  { name: 'cc', type: { name: 'ZZ', id: 1 }, blank: '', zero: 0 },
 ];
 
 describe('DataFilter', () => {
@@ -24,6 +38,8 @@ describe('DataFilter', () => {
             <DataFilter property="name" />
             <DataFilter property="enabled" />
             <DataFilter property="rating" />
+            <DataFilter property="blank" />
+            <DataFilter property="zero" />
           </DataFilters>
         </Data>
       </Grommet>,
@@ -84,9 +100,7 @@ describe('DataFilter', () => {
           <DataFilters drop>
             <DataFilter
               property="type.name"
-              options={[
-                'ZZ', 'YY', 'aa', 'bb', 'cc', 'dd', 'ee', 'ff'
-              ]}
+              options={['ZZ', 'YY', 'aa', 'bb', 'cc', 'dd', 'ee', 'ff']}
             />
           </DataFilters>
         </Data>
@@ -107,13 +121,13 @@ describe('DataFilter', () => {
     act(() => jest.advanceTimersByTime(200));
 
     // close SelectMultiple
-    fireEvent.click(getByRole('button', { name: /Close Select/i }));     
+    fireEvent.click(getByRole('button', { name: /Close Select/i }));
     act(() => jest.advanceTimersByTime(200));
-  
+
     // click Apply Filters button
     expect(getByRole('button', { name: 'Apply filters' })).toBeTruthy();
-    fireEvent.click(getByRole('button', {name: 'Apply filters'}));
-    
+    fireEvent.click(getByRole('button', { name: 'Apply filters' }));
+
     // advance timers so filters can be applied
     act(() => jest.advanceTimersByTime(200));
 


### PR DESCRIPTION
#### What does this PR do?

Changed DataFilter to handle properties with zero or one values.

Of note, there is a change to the unit test but not a snapshot change. This is because the "blank" and "zero" properties are not rendered by DataFilter. Before the change to DataFilter.js here, the snapshots would have changed to show awkward filter controls that didn't do anything.

#### Where should the reviewer start?

DataFilter.js

#### What testing has been done on this PR?

Manually used a data set provided by @samuelgoff.
Enhanced a unit test to include these cases.

#### How should this be manually tested?

Try with more variations of data.

#### Do Jest tests follow these best practices?

no change to existing test patterns

#### Any background context you want to provide?

See notes above.

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

no

#### Should this PR be mentioned in the release notes?

yes

#### Is this change backwards compatible or is it a breaking change?

backwards compatible, since filtering on properties with less than two possible values is meaningless.
