### PR TITLE
Add use client to index.js

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,3 +1,5 @@
+'use client';
+
 export * from './components';
 export * from './contexts';
 export * from './default-props';


### PR DESCRIPTION
#### What does this PR do?
For anyone using consuming Grommet with React Server Components, we should specify that Grommet components should be rendered on the client side.

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible