### PR TITLE
Check that dropRef is defined before trying to access dropRef style

### DIFF
--- a/src/js/components/Drop/DropContainer.js
+++ b/src/js/components/Drop/DropContainer.js
@@ -98,8 +98,8 @@ const DropContainer = forwardRef(
 
     useEffect(() => {
       const notifyAlign = () => {
-        const styleCurrent = dropRef.current.style;
-        const alignControl = styleCurrent.top !== '' ? 'top' : 'bottom';
+        const styleCurrent = dropRef?.current?.style;
+        const alignControl = styleCurrent?.top !== '' ? 'top' : 'bottom';
 
         onAlign(alignControl);
       };


### PR DESCRIPTION
#### What does this PR do?
Fixes an issue where the app would crash because we tried to access dropRef.current.style without first checking if dropRef.current is defined.

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible