### PR TITLE
update prop type for select

### DIFF
--- a/src/js/components/Select/index.d.ts
+++ b/src/js/components/Select/index.d.ts
@@ -42,7 +42,7 @@ export interface BasicSelectProps {
   placeholder?: PlaceHolderType;
   plain?: boolean;
   replace?: boolean;
-  searchPlaceholder?: string;
+  searchPlaceholder?: PlaceHolderType;
   size?: 'small' | 'medium' | 'large' | 'xlarge' | string;
   valueKey?:
     | string

--- a/src/js/components/Select/propTypes.js
+++ b/src/js/components/Select/propTypes.js
@@ -62,7 +62,11 @@ export const genericSelectProps = {
   ]),
   plain: PropTypes.bool,
   replace: PropTypes.bool,
-  searchPlaceholder: PropTypes.string,
+  searchPlaceholder: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.element,
+    PropTypes.node,
+  ]),
   size: PropTypes.oneOfType([
     PropTypes.oneOf(['small', 'medium', 'large', 'xlarge']),
     PropTypes.string,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
update `searchPlaceholder` to take a node as well as a `string`
#### Where should the reviewer start?
select/index.d.ts
#### What testing has been done on this PR?

#### How should this be manually tested?
`searchPlaceholder` functionally takes a node as well as a string so should we support this? 
#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
```
I want search icon and placeholder text in search input field.
But searchPlaceholder accept only string value and I want both search Icon and placeholder both like below screenshot
How to do that? (edited) 

```

https://codesandbox.io/s/competent-merkle-q908cc?file=/src/App.js
#### What are the relevant issues?
none
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
yes
#### Should this PR be mentioned in the release notes?
maybe
#### Is this change backwards compatible or is it a breaking change?
backwards compatible 