### PR TITLE
Adjust empty search message styling on Select

### DIFF
--- a/src/js/components/Select/EmptySearchOption.js
+++ b/src/js/components/Select/EmptySearchOption.js
@@ -1,24 +1,20 @@
 import React from 'react';
 import { Box } from '../Box';
 import { Text } from '../Text';
-import { SelectOption } from './StyledSelect';
 
 export const EmptySearchOption = ({
   emptySearchMessage,
   selectOptionsStyle,
   theme,
 }) => (
-  <SelectOption
-    key="search_empty"
-    tabIndex="0"
-    role="menuitem"
-    hoverIndicator="background"
-    disabled
+  <Box
+    {...{
+      ...selectOptionsStyle,
+      pad: selectOptionsStyle?.pad || theme.button?.option?.pad,
+    }}
   >
-    <Box {...selectOptionsStyle}>
-      <Text aria-live="polite" role="alert" {...theme.select.container.text}>
-        {emptySearchMessage}
-      </Text>
-    </Box>
-  </SelectOption>
+    <Text aria-live="polite" role="alert" {...theme.select?.options?.text}>
+      {emptySearchMessage}
+    </Text>
+  </Box>
 );

--- a/src/js/components/Select/SelectContainer.js
+++ b/src/js/components/Select/SelectContainer.js
@@ -390,14 +390,14 @@ const SelectContainer = forwardRef(
               theme={theme}
             />
           )}
-          <OptionsContainer
-            role="listbox"
-            tabIndex="-1"
-            ref={optionsRef}
-            aria-multiselectable={multiple}
-            onMouseMove={() => setKeyboardNavigation(false)}
-          >
-            {options.length > 0 ? (
+          {options.length > 0 ? (
+            <OptionsContainer
+              role="listbox"
+              tabIndex="-1"
+              ref={optionsRef}
+              aria-multiselectable={multiple}
+              onMouseMove={() => setKeyboardNavigation(false)}
+            >
               <InfiniteScroll
                 items={options}
                 step={theme.select.step}
@@ -482,14 +482,14 @@ const SelectContainer = forwardRef(
                   );
                 }}
               </InfiniteScroll>
-            ) : (
-              <EmptySearchOption
-                emptySearchMessage={emptySearchMessage}
-                selectOptionsStyle={selectOptionsStyle}
-                theme={theme}
-              />
-            )}
-          </OptionsContainer>
+            </OptionsContainer>
+          ) : (
+            <EmptySearchOption
+              emptySearchMessage={emptySearchMessage}
+              selectOptionsStyle={selectOptionsStyle}
+              theme={theme}
+            />
+          )}
           {shouldShowClearButton('bottom') && (
             <ClearButton
               ref={clearRef}


### PR DESCRIPTION
#### What does this PR do?
This PR changes the 'no options found' container in Select and SelectMultiple so that it is no longer a disabled Button and is instead just Text within a Box. The Text and Box can be styled with `theme.select.options.container` and `theme.select.options.text`. 

For themes that do not have any padding defined in `theme.select.options.container` and have a `button kind='option'` defined, the padding defined by `button kind='option'` is used on the Box around the 'no options found' text. The options in the Select are styled as `button kind='option'` so this ensures that the options in the select and the 'no options found' text have the same amount of padding applied.

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible