### PR TITLE
Fix issue of check mark exceeding parent bounds when padding applied with fill and reverse styles.

### DIFF
--- a/src/js/components/CheckBox/StyledCheckBox.js
+++ b/src/js/components/CheckBox/StyledCheckBox.js
@@ -85,7 +85,7 @@ const StyledCheckBoxContainer = styled.label`
         props.theme,
       )};
     }
-     
+
     background-color: ${normalizeColor(
       !props.disabled && props.theme.checkBox.hover?.background?.color,
       props.theme,

--- a/src/js/components/CheckBox/StyledCheckBox.js
+++ b/src/js/components/CheckBox/StyledCheckBox.js
@@ -7,7 +7,7 @@ import { defaultProps } from '../../default-props';
 // added to it to simplify its logic. If this is ever reused somewhere else,
 // consider the need of separating those once again.
 const fillStyle = () => `
-      width: 100%;
+      width: auto;
       height: 100%;
       max-width: none;
       flex: 1 0 auto;

--- a/src/js/components/CheckBox/__tests__/__snapshots__/CheckBox-test.tsx.snap
+++ b/src/js/components/CheckBox/__tests__/__snapshots__/CheckBox-test.tsx.snap
@@ -2080,7 +2080,7 @@ exports[`CheckBox reverse toggle fill 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  width: 100%;
+  width: auto;
   height: 100%;
   max-width: none;
   -webkit-flex: 1 0 auto;

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-controlled.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-controlled.js.snap
@@ -4803,7 +4803,7 @@ exports[`Form controlled dynamicly removed fields using blur validation
         class="StyledBox-sc-13pk1d4-0 gkHEjs FormField__FormFieldContentBox-sc-m9hood-1 fdkHPz"
       >
         <label
-          class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fomtlz"
+          class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hhVOvb"
           label="toggle"
         >
           <div

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
@@ -2010,7 +2010,7 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation
         class="StyledBox-sc-13pk1d4-0 gkHEjs FormField__FormFieldContentBox-sc-m9hood-1 fdkHPz"
       >
         <label
-          class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fomtlz"
+          class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hhVOvb"
           label="toggle"
         >
           <div


### PR DESCRIPTION


<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fix issue [6803](https://github.com/grommet/grommet/issues/6803) of check mark exceeding parent bounds when padding applied with fill and reverse styles. 
#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
