### PR TITLE
Fix issue where valueLabel doesn't show if value is 0

### DIFF
--- a/src/js/components/Select/Select.js
+++ b/src/js/components/Select/Select.js
@@ -233,7 +233,7 @@ const Select = forwardRef(
     // element to show, trumps inputValue
     const selectValue = useMemo(() => {
       if (valueLabel instanceof Function) {
-        if (value || value === 0) return valueLabel(value);
+        if (value || value === 0 || value === false) return valueLabel(value);
       } else if (valueLabel) return valueLabel;
       else if (React.isValidElement(value)) return value; // deprecated
       return undefined;

--- a/src/js/components/Select/Select.js
+++ b/src/js/components/Select/Select.js
@@ -233,7 +233,7 @@ const Select = forwardRef(
     // element to show, trumps inputValue
     const selectValue = useMemo(() => {
       if (valueLabel instanceof Function) {
-        if (value) return valueLabel(value);
+        if (value !== '' && value !== null) return valueLabel(value);
       } else if (valueLabel) return valueLabel;
       else if (React.isValidElement(value)) return value; // deprecated
       return undefined;

--- a/src/js/components/Select/Select.js
+++ b/src/js/components/Select/Select.js
@@ -233,7 +233,7 @@ const Select = forwardRef(
     // element to show, trumps inputValue
     const selectValue = useMemo(() => {
       if (valueLabel instanceof Function) {
-        if (value !== '' && value !== null) return valueLabel(value);
+        if (value || value === 0) return valueLabel(value);
       } else if (valueLabel) return valueLabel;
       else if (React.isValidElement(value)) return value; // deprecated
       return undefined;

--- a/src/js/components/Select/__tests__/Select-test.js
+++ b/src/js/components/Select/__tests__/Select-test.js
@@ -1579,5 +1579,18 @@ describe('Select', () => {
     expect(select).toHaveAttribute('aria-expanded', 'true');
   });
 
+  test('valueLabel with value=0', () => {
+    const { asFragment } = render(
+      <Grommet>
+        <Select
+          options={[0, 1, 2]}
+          value={0}
+          valueLabel={(val) => `Value: ${val}`}
+        />
+      </Grommet>,
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
   window.scrollTo.mockRestore();
 });

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -19610,3 +19610,230 @@ exports[`Select small drop container height 1`] = `
 `;
 
 exports[`Select valueLabel 1`] = `undefined`;
+
+exports[`Select valueLabel with value=0 1`] = `
+<DocumentFragment>
+  .c7 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #7D4CDB;
+  stroke: #7D4CDB;
+}
+
+.c7 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c7 *:not([stroke])[fill="none"] {
+  stroke-width: 0;
+}
+
+.c7 *[stroke*="#"],
+.c7 *[STROKE*="#"] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c7 *[fill-rule],
+.c7 *[FILL-RULE],
+.c7 *[fill*="#"],
+.c7 *[FILL*="#"] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-left: 12px;
+  margin-right: 12px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c1 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c1:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c1:focus > circle,
+.c1:focus > ellipse,
+.c1:focus > line,
+.c1:focus > path,
+.c1:focus > polygon,
+.c1:focus > polyline,
+.c1:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c1:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c1:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c1:focus:not(:focus-visible) > circle,
+.c1:focus:not(:focus-visible) > ellipse,
+.c1:focus:not(:focus-visible) > line,
+.c1:focus:not(:focus-visible) > path,
+.c1:focus:not(:focus-visible) > polygon,
+.c1:focus:not(:focus-visible) > polyline,
+.c1:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c1:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c5 {
+  display: none;
+}
+
+.c2 {
+  border: 1px solid rgba(0,0,0,0.33);
+  border-radius: 4px;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    margin-left: 6px;
+    margin-right: 6px;
+  }
+}
+
+<div
+    class="c0"
+  >
+    <button
+      aria-expanded="false"
+      aria-haspopup="listbox"
+      aria-label="Open Drop"
+      class="c1 c2"
+      type="button"
+    >
+      <div
+        class="c3"
+      >
+        <div
+          class="c4"
+        >
+          Value: 0
+          <input
+            class="c5"
+            readonly=""
+            type="text"
+            value=""
+          />
+        </div>
+        <div
+          class="c6"
+          style="min-width: auto;"
+        >
+          <svg
+            aria-label="FormDown"
+            class="c7"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="m18 9-6 6-6-6"
+              fill="none"
+              stroke="#000"
+              stroke-width="2"
+            />
+          </svg>
+        </div>
+      </div>
+    </button>
+  </div>
+</DocumentFragment>
+`;


### PR DESCRIPTION
#### What does this PR do?
Resolves an issue where using `valueLabel` on Select and `value={0}` results in the valueLabel not being displayed correctly.

#### Where should the reviewer start?

#### What testing has been done on this PR?
Tested with the following storybook story and added a jest test.
```javascript
import React from 'react';

import { Box, Select } from 'grommet';

export const Test = () => {
  const [value, setValue] = React.useState(0);
  return (
    <Box fill align="center" justify="start" pad="large" gap="medium">
      <Select
        options={[0, 1, 2]}
        value={value}
        valueLabel={(val) => `Value: ${val}`}
        onChange={({ option }) => setValue(option)}
      />
    </Box>
  );
};

export default {
  title: 'Input/Select/Test',
};
```

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [x] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes https://github.com/grommet/grommet/issues/6829

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible