### PR TITLE
Fix issue with Menu control showing twice

### DIFF
--- a/src/js/components/Menu/Menu.js
+++ b/src/js/components/Menu/Menu.js
@@ -444,7 +444,10 @@ const Menu = forwardRef((props, ref) => {
                 don't show controlMirror when window height has shrunk
               */}
               {!initialAlignTop &&
-              (alignControlMirror === 'bottom' || align.bottom === 'bottom')
+              // don't show controlMirror if caller is using
+              // align.bottom === 'top'
+              ((alignControlMirror === 'bottom' && !align.bottom === 'top') ||
+                align.bottom === 'bottom')
                 ? controlMirror
                 : undefined}
             </ContainerBox>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Fixes logic for Menu when `align.bottom === 'top'` so that Menu control is not shown twice.

#### Where should the reviewer start?
src/js/components/Menu/Menu.js

#### What testing has been done on this PR?

Local in storybook with:

```
<Menu
  label="Menu"
  dropProps={{ align: { bottom: 'top', right: 'right'}}}
  items={[
    { label: 'First Action', onClick: () => {} },
    { label: 'Second Action', onClick: () => {} },
  ]}
/>
```

#### How should this be manually tested?

Storybook locally with above config.

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

Closes #6778 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?
Yes. Fixed bug with Menu `dropProps` where control was repeated.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.