### PR TITLE
feat: Arrow for Diagram Component

### DIFF
--- a/src/js/components/Diagram/__tests__/__snapshots__/Diagram-test.tsx.snap
+++ b/src/js/components/Diagram/__tests__/__snapshots__/Diagram-test.tsx.snap
@@ -103,6 +103,8 @@ exports[`Diagram anchor 1`] = `
           <path
             d="M 0,0 Q 0,0 0,0 T 0,0"
             fill="none"
+            marker-end="url("#openArrowEnd-0")"
+            marker-start="url("#openArrowStart-0")"
             stroke="#6FFFB0"
             stroke-linecap="butt"
             stroke-linejoin="miter"
@@ -111,6 +113,8 @@ exports[`Diagram anchor 1`] = `
           <path
             d="M 0,0 Q 0,0 0,0 T 0,0"
             fill="none"
+            marker-end="url("#openArrowEnd-1")"
+            marker-start="url("#openArrowStart-1")"
             stroke="#6FFFB0"
             stroke-linecap="butt"
             stroke-linejoin="miter"
@@ -119,6 +123,8 @@ exports[`Diagram anchor 1`] = `
           <path
             d="M 0,0 Q 0,0 0,0 T 0,0"
             fill="none"
+            marker-end="url("#openArrowEnd-2")"
+            marker-start="url("#openArrowStart-2")"
             stroke="#6FFFB0"
             stroke-linecap="butt"
             stroke-linejoin="miter"
@@ -234,6 +240,8 @@ exports[`Diagram basic 1`] = `
           <path
             d="M 0,0 Q 0,0 0,0 T 0,0"
             fill="none"
+            marker-end="url("#openArrowEnd-0")"
+            marker-start="url("#openArrowStart-0")"
             stroke="#6FFFB0"
             stroke-linecap="butt"
             stroke-linejoin="miter"
@@ -349,6 +357,8 @@ exports[`Diagram color 1`] = `
           <path
             d="M 0,0 Q 0,0 0,0 T 0,0"
             fill="none"
+            marker-end="url("#openArrowEnd-0")"
+            marker-start="url("#openArrowStart-0")"
             stroke="#7D4CDB"
             stroke-linecap="butt"
             stroke-linejoin="miter"
@@ -464,6 +474,8 @@ exports[`Diagram offset 1`] = `
           <path
             d="M 6,6 Q 6,6 6,6 T 6,6"
             fill="none"
+            marker-end="url("#openArrowEnd-0")"
+            marker-start="url("#openArrowStart-0")"
             stroke="#6FFFB0"
             stroke-linecap="butt"
             stroke-linejoin="miter"
@@ -472,6 +484,8 @@ exports[`Diagram offset 1`] = `
           <path
             d="M 12,12 Q 12,12 12,12 T 12,12"
             fill="none"
+            marker-end="url("#openArrowEnd-1")"
+            marker-start="url("#openArrowStart-1")"
             stroke="#6FFFB0"
             stroke-linecap="butt"
             stroke-linejoin="miter"
@@ -480,6 +494,8 @@ exports[`Diagram offset 1`] = `
           <path
             d="M 24,24 Q 24,24 24,24 T 24,24"
             fill="none"
+            marker-end="url("#openArrowEnd-2")"
+            marker-start="url("#openArrowStart-2")"
             stroke="#6FFFB0"
             stroke-linecap="butt"
             stroke-linejoin="miter"
@@ -595,6 +611,8 @@ exports[`Diagram thickness 1`] = `
           <path
             d="M 0,0 Q 0,0 0,0 T 0,0"
             fill="none"
+            marker-end="url("#openArrowEnd-0")"
+            marker-start="url("#openArrowStart-0")"
             stroke="#6FFFB0"
             stroke-linecap="butt"
             stroke-linejoin="miter"
@@ -603,6 +621,8 @@ exports[`Diagram thickness 1`] = `
           <path
             d="M 0,0 Q 0,0 0,0 T 0,0"
             fill="none"
+            marker-end="url("#openArrowEnd-1")"
+            marker-start="url("#openArrowStart-1")"
             stroke="#6FFFB0"
             stroke-linecap="butt"
             stroke-linejoin="miter"
@@ -611,6 +631,8 @@ exports[`Diagram thickness 1`] = `
           <path
             d="M 0,0 Q 0,0 0,0 T 0,0"
             fill="none"
+            marker-end="url("#openArrowEnd-2")"
+            marker-start="url("#openArrowStart-2")"
             stroke="#6FFFB0"
             stroke-linecap="butt"
             stroke-linejoin="miter"
@@ -619,6 +641,8 @@ exports[`Diagram thickness 1`] = `
           <path
             d="M 0,0 Q 0,0 0,0 T 0,0"
             fill="none"
+            marker-end="url("#openArrowEnd-3")"
+            marker-start="url("#openArrowStart-3")"
             stroke="#6FFFB0"
             stroke-linecap="butt"
             stroke-linejoin="miter"
@@ -627,6 +651,8 @@ exports[`Diagram thickness 1`] = `
           <path
             d="M 0,0 Q 0,0 0,0 T 0,0"
             fill="none"
+            marker-end="url("#openArrowEnd-4")"
+            marker-start="url("#openArrowStart-4")"
             stroke="#6FFFB0"
             stroke-linecap="butt"
             stroke-linejoin="miter"
@@ -635,6 +661,8 @@ exports[`Diagram thickness 1`] = `
           <path
             d="M 0,0 Q 0,0 0,0 T 0,0"
             fill="none"
+            marker-end="url("#openArrowEnd-5")"
+            marker-start="url("#openArrowStart-5")"
             stroke="#6FFFB0"
             stroke-linecap="butt"
             stroke-linejoin="miter"
@@ -750,6 +778,8 @@ exports[`Diagram type 1`] = `
           <path
             d="M 0,0 L 0,0"
             fill="none"
+            marker-end="url("#openArrowEnd-0")"
+            marker-start="url("#openArrowStart-0")"
             stroke="#6FFFB0"
             stroke-linecap="butt"
             stroke-linejoin="miter"
@@ -758,6 +788,8 @@ exports[`Diagram type 1`] = `
           <path
             d="M 0,0 Q 0,0 0,0 T 0,0"
             fill="none"
+            marker-end="url("#openArrowEnd-1")"
+            marker-start="url("#openArrowStart-1")"
             stroke="#6FFFB0"
             stroke-linecap="butt"
             stroke-linejoin="miter"
@@ -766,6 +798,8 @@ exports[`Diagram type 1`] = `
           <path
             d="M 0,0 L 0,0 L 0,0 L 0,0"
             fill="none"
+            marker-end="url("#openArrowEnd-2")"
+            marker-start="url("#openArrowStart-2")"
             stroke="#6FFFB0"
             stroke-linecap="butt"
             stroke-linejoin="miter"

--- a/src/js/components/Diagram/index.d.ts
+++ b/src/js/components/Diagram/index.d.ts
@@ -20,6 +20,7 @@ export interface DiagramProps {
   connections: {
     anchor?: DiagramConnectionAnchor;
     animation?: DiagramAnimationType;
+    arrow?: 'from' | 'to' | boolean;
     color?: ColorType;
     fromTarget: string | object;
     label?: string;

--- a/src/js/components/Diagram/propTypes.js
+++ b/src/js/components/Diagram/propTypes.js
@@ -42,6 +42,7 @@ if (process.env.NODE_ENV !== 'production') {
         toTarget: PropTypes.oneOfType([PropTypes.string, PropTypes.object])
           .isRequired,
         type: PropTypes.oneOf(['direct', 'curved', 'rectilinear']),
+        arrow: PropTypes.oneOf(['from', 'to', PropTypes.bool]),
       }),
     ).isRequired,
   };

--- a/src/js/components/Diagram/stories/Animated.js
+++ b/src/js/components/Diagram/stories/Animated.js
@@ -13,6 +13,7 @@ const connection = (fromTarget, toTarget, { ...rest } = {}) => ({
   thickness: 'xsmall',
   round: true,
   type: 'curved',
+  arrow: 'to',
   ...rest,
 });
 

--- a/src/js/components/Diagram/stories/Arrow.js
+++ b/src/js/components/Diagram/stories/Arrow.js
@@ -1,0 +1,46 @@
+import React from 'react';
+
+import { Gremlin, IceCream } from 'grommet-icons';
+import { Stack, Box, Diagram } from 'grommet';
+
+const anchor = 'vertical';
+const type = 'curved';
+
+const connection = {
+  id: 'shimi',
+  anchor,
+  color: 'accent-1',
+  thickness: 'xsmall',
+  type,
+  toTarget: 'yummy',
+  fromTarget: 'gremlin',
+  round: true,
+  arrow: 'to',
+};
+
+const connections = [connection];
+
+export const Arrow = () => (
+  // Uncomment <Grommet> lines when using outside of storybook
+  // <Grommet theme={...}>
+  <Stack>
+    <Box fill pad="xlarge">
+      <Box align="start">
+        <Gremlin id="gremlin" color="neutral-2" size="xlarge" />
+      </Box>
+      <Box
+        align="start"
+        pad={{ vertical: 'large' }}
+        style={{ marginTop: '5rem' }}
+      >
+        <IceCream id="yummy" color="neutral-2" size="xlarge" />
+      </Box>
+    </Box>
+    <Diagram connections={connections} />
+  </Stack>
+  // </Grommet>
+);
+
+export default {
+  title: 'Visualizations/Diagram/Arrow',
+};


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
- Added `arrow` prop for the connection of Diagram component
- API of arrow: `from` | `to` | true
- This is the initial design which is coming from my earlier pr - https://github.com/grommet/grommet/pull/5950

#### Where should the reviewer start?
Diagram.js

#### What testing has been done on this PR?
Currently, only manually tested using Arrow.js and Animated.js files

#### How should this be manually tested?
- Arrow.js and Animated.js files

#### Do Jest tests follow these best practices?
- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
N/A

#### What are the relevant issues?
#5882 

#### Screenshots (if appropriate)
![154091194-1c155fed-f663-48e0-9626-e8f4c6d39f04](https://github.com/grommet/grommet/assets/61521805/61a804d3-6325-4793-92d7-1ebb0325453c)


#### Do the grommet docs need to be updated?
Yes, after this pr is merged

#### Should this PR be mentioned in the release notes?
Yes, please

#### Is this change backwards compatible or is it a breaking change?
backwards compatible