### PR TITLE
Update DataTable primaryKey behavior to align behavior for undefined and null

### DIFF
--- a/src/js/components/DataTable/buildState.js
+++ b/src/js/components/DataTable/buildState.js
@@ -28,7 +28,14 @@ export const datumValue = (datum, property) => {
 
 // get the primary property name
 export const normalizePrimaryProperty = (columns, primaryKey) => {
-  let result = primaryKey;
+  let result;
+  if (typeof primaryKey === 'string' || typeof primaryKey === 'boolean') {
+    result = primaryKey;
+  } else if (primaryKey === null) {
+    console.warn(
+      'null is not a supported value for primaryKey. See supported values: https://v2.grommet.io/datatable#primaryKey',
+    );
+  }
   if (result === undefined) {
     columns.forEach((column) => {
       // remember the first key property


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Update logic of `normalizePrimaryProperty` to treat `null` like `undefined`. Therefore, if a DataTable has `primaryKey={null}` it will first see if any columns have `primary: true` defined and lastly will fallback to the first column.

While primaryKey doesn't technically support `null` as a value (see DataTable index.d.ts), this provides a more useful default behavior since propTypes loosely equates `null` and `undefined`. Having a primary key is important for certain DataTable behaviors such as `onSelect` that needs a primaryKey to identify a record.

To prompt people towards the desired values for `primaryKey`, I have added a console.warn statement with a link to the grommet docs.

Some notes:
- Typescript treats `null` differently than `undefined`. We do not want to extend the Typescript types for primaryKey to include since Typescript suggests using `undefined`: https://github.com/Microsoft/TypeScript/wiki/Coding-guidelines#null-and-undefined
- This helps for non-Typescript projects by adding a console.warn statement. Since propTypes equates `undefined` and `null` then this gives a console warning to help nudge towards the supported values.

#### Where should the reviewer start?

#### What testing has been done on this PR?

Tested locally in storybook with this code:

```
import React from 'react';

import { Box, DataTable } from 'grommet';

// Source code for the data can be found here
// https://github.com/grommet/grommet/blob/master/src/js/components/DataTable/stories/data.js
import { columns, DATA } from './data';

export const Simple = () => (
  // Uncomment <Grommet> lines when using outside of storybook
  // <Grommet theme={grommet}>
  <Box align="center" pad="large">
    <DataTable columns={columns} data={DATA} step={10} primaryKey={null} />
    <DataTable columns={columns} data={DATA} step={10} primaryKey={undefined} />
    <DataTable columns={columns} data={DATA} step={10} primaryKey={false} />
  </Box>
  // </Grommet>
);

export default {
  title: 'Visualizations/DataTable/Simple',
};
```

#### How should this be manually tested?

With the above code.

#### Do Jest tests follow these best practices?

I cannot add a test for this since the Typescript test will not allow me to pass `null` as a value to `primaryKey`.

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #6854 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
Yes.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.