### PR TITLE
Fix DataTableColumns search filter

### DIFF
--- a/src/js/components/DataTableColumns/DataTableColumns.js
+++ b/src/js/components/DataTableColumns/DataTableColumns.js
@@ -76,7 +76,7 @@ const Content = ({ drop, options, ...rest }) => {
       if (nextSearch) {
         const lowerSearch = nextSearch.toLowerCase();
         nextFilteredOptions = options.filter((o) =>
-          (o.property ?? o.label ?? o)?.toLowerCase().includes(lowerSearch),
+          (o.label ?? o.property ?? o)?.toLowerCase().includes(lowerSearch),
         );
       }
       setSearch(nextSearch);


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR has a fix for the DataTableColumns filter functionality where it will look at the label first to match the searchTerm.
Initially, it was looking at the property and this was causing the search filter to improperly filter the options.

Issue example: https://f4phv2.sse.codesandbox.io/datatable

#### What testing has been done on this PR?
- Storybook

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
