### PR TITLE
Suppress DOMExceptions on hiding Layer (#6888)

### DIFF
--- a/src/js/components/Layer/Layer.js
+++ b/src/js/components/Layer/Layer.js
@@ -58,12 +58,16 @@ const Layer = forwardRef((props, ref) => {
               .getRootNode()
               .getElementById('layerClone');
             if (clone) {
-              containerTarget.removeChild(clone);
+              if (containerTarget.contains(clone)) {
+                containerTarget.removeChild(clone);
+              }
               layerContainer.remove();
             }
           }, animationDuration);
         } else {
-          containerTarget.removeChild(layerContainer);
+          if (containerTarget.contains(layerContainer)) {
+            containerTarget.removeChild(layerContainer);
+          }
         }
       }
     },


### PR DESCRIPTION
#### What does this PR do?

Suppress DOMExceptions on hiding `Layer` (see #6888).

#### Where should the reviewer start?

Good question. There are only minor code changes which and this should not effect functionality. But maybe suppressing the DOMException unhides other problems. In my manual testing I didn't see this, but maybe I overlooked something.

#### What testing has been done on this PR?

Rerun automated tests. As well as manual tests.

#### How should this be manually tested?

Since this is hard to reproduce, just hiding a `Layer`.

#### What are the relevant issues?

#6888

#### Screenshots (if appropriate)

This screenshot shows that the error is gone using this PR:

![grommet3](https://github.com/grommet/grommet/assets/5190548/38191a09-b8f0-4aac-9629-f1ce9b6f57b1)

One the left side you can see the header and the menu which proofs that rendering is fine on using this PR.

#### Do the grommet docs need to be updated?

No

#### Should this PR be mentioned in the release notes?

Yes

#### Is this change backwards compatible or is it a breaking change?

It is backwards compatible