### PR TITLE
Convert Stack to use transient props

### DIFF
--- a/src/js/components/Stack/Stack.js
+++ b/src/js/components/Stack/Stack.js
@@ -2,6 +2,7 @@ import React, { Children, forwardRef } from 'react';
 
 import { StyledStack, StyledStackLayer } from './StyledStack';
 import { StackPropTypes } from './propTypes';
+import { convertRestToTransientProps } from '../../utils';
 
 const buildStyledChildren =
   ({ anchor, fill, guidingIndex, interactiveChild, interactiveIndex }) =>
@@ -9,12 +10,16 @@ const buildStyledChildren =
     const interactive =
       interactiveChild === undefined || interactiveIndex === index;
     const isGuidingIndex = index === guidingIndex;
-    const props = isGuidingIndex
-      ? { guiding: true, fillContainer: fill }
-      : { anchor };
+    const transientProps = isGuidingIndex
+      ? { $guiding: true, $fillContainer: fill }
+      : { $anchor: anchor };
 
     return (
-      <StyledStackLayer key={index} interactive={interactive} {...props}>
+      <StyledStackLayer
+        key={index}
+        $interactive={interactive}
+        {...transientProps}
+      >
         {child}
       </StyledStackLayer>
     );
@@ -25,6 +30,7 @@ const Stack = forwardRef(
     { anchor, children, fill, guidingChild, interactiveChild, ...rest },
     ref,
   ) => {
+    const transientRest = convertRestToTransientProps(rest);
     const prunedChildren = Children.toArray(children).filter((c) => c);
     const toChildIndex = (child) => {
       let index = child;
@@ -47,7 +53,7 @@ const Stack = forwardRef(
     );
 
     return (
-      <StyledStack ref={ref} fillContainer={fill} {...rest}>
+      <StyledStack ref={ref} $fillContainer={fill} {...transientRest}>
         {styledChildren}
       </StyledStack>
     );

--- a/src/js/components/Stack/StyledStack.js
+++ b/src/js/components/Stack/StyledStack.js
@@ -4,15 +4,15 @@ import { genericStyles } from '../../utils';
 import { defaultProps } from '../../default-props';
 
 const fillStyle = css`
-  ${props =>
-    props.fillContainer === true || props.fillContainer === 'horizontal'
+  ${(props) =>
+    props.$fillContainer === true || props.$fillContainer === 'horizontal'
       ? `
         width: 100%;
         max-width: none;
       `
       : ''}
-  ${props =>
-    props.fillContainer === true || props.fillContainer === 'vertical'
+  ${(props) =>
+    props.$fillContainer === true || props.$fillContainer === 'vertical'
       ? 'height: 100%;'
       : ''}
   flex-grow: 1;
@@ -22,8 +22,8 @@ const fillStyle = css`
 const StyledStack = styled.div`
   position: relative;
   ${genericStyles}
-  ${props => props.fillContainer && fillStyle}
-  ${props => props.theme.stack && props.theme.stack.extend}
+  ${(props) => props.$fillContainer && fillStyle}
+  ${(props) => props.theme.stack && props.theme.stack.extend}
 `;
 
 StyledStack.defaultProps = {};
@@ -80,16 +80,16 @@ const styleMap = {
 };
 
 const StyledStackLayer = styled.div`
-  position: ${props => (props.guiding ? 'relative' : 'absolute')};
-  ${props => props.guiding && 'display: block;'}
-  ${props => !props.guiding && `${styleMap[props.anchor || 'fill']};`}
-  ${props =>
-    props.fillContainer &&
+  position: ${(props) => (props.$guiding ? 'relative' : 'absolute')};
+  ${(props) => props.$guiding && 'display: block;'}
+  ${(props) => !props.$guiding && `${styleMap[props.$anchor || 'fill']};`}
+  ${(props) =>
+    props.$fillContainer &&
     `
     width: 100%;
     height: 100%;
   `}
-  ${props => !props.interactive && `pointer-events: none;`}
+  ${(props) => !props.$interactive && `pointer-events: none;`}
 `;
 
 StyledStackLayer.defaultProps = {};

--- a/src/js/components/Stack/__tests__/__snapshots__/Stack-test.tsx.snap
+++ b/src/js/components/Stack/__tests__/__snapshots__/Stack-test.tsx.snap
@@ -24,17 +24,13 @@ exports[`Stack anchor 1`] = `
   position: absolute;
   top: 50%;
   left: 50%;
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
-  transform: translate(-50%,-50%);
+  transform: translate(-50%, -50%);
 }
 
 .c4 {
   position: absolute;
   top: 0;
   left: 50%;
-  -webkit-transform: translateX(-50%);
-  -ms-transform: translateX(-50%);
   transform: translateX(-50%);
 }
 
@@ -42,8 +38,6 @@ exports[`Stack anchor 1`] = `
   position: absolute;
   top: 50%;
   left: 0;
-  -webkit-transform: translateY(-50%);
-  -ms-transform: translateY(-50%);
   transform: translateY(-50%);
 }
 
@@ -51,8 +45,6 @@ exports[`Stack anchor 1`] = `
   position: absolute;
   bottom: 0;
   left: 50%;
-  -webkit-transform: translateX(-50%);
-  -ms-transform: translateX(-50%);
   transform: translateX(-50%);
 }
 
@@ -60,8 +52,6 @@ exports[`Stack anchor 1`] = `
   position: absolute;
   top: 50%;
   right: 0;
-  -webkit-transform: translateY(-50%);
-  -ms-transform: translateY(-50%);
   transform: translateY(-50%);
 }
 
@@ -325,13 +315,7 @@ exports[`Stack fill 1`] = `
   width: 100%;
   max-width: none;
   height: 100%;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
   flex-grow: 1;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
@@ -343,26 +327,14 @@ exports[`Stack fill 1`] = `
   position: relative;
   width: 100%;
   max-width: none;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
   flex-grow: 1;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 
 .c7 {
   position: relative;
   height: 100%;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
   flex-grow: 1;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Converts Stack to use transient props.

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
