### PR TITLE
Fix 'undefined' value in MaskedInput

### DIFF
--- a/src/js/components/MaskedInput/MaskedInput.js
+++ b/src/js/components/MaskedInput/MaskedInput.js
@@ -185,6 +185,7 @@ const MaskedInput = forwardRef(
     const [value, setValue] = formContext.useFormInput({
       name,
       value: valueProp,
+      initialValue: '',
     });
 
     const valueParts = useMemo(() => parseValue(mask, value), [mask, value]);

--- a/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.js.snap
+++ b/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.js.snap
@@ -1062,7 +1062,7 @@ exports[`MaskedInput event target props are available option via mouse 4`] = `
     id="item"
     name="item"
     placeholder="!"
-    value=""
+    value="aa!"
   />
 </div>
 `;
@@ -2519,7 +2519,7 @@ exports[`MaskedInput option via mouse 4`] = `
     id="item"
     name="item"
     placeholder="!"
-    value=""
+    value="aa!"
   />
 </div>
 `;


### PR DESCRIPTION
#### What does this PR do?
Fixes an issue where the MaskedInput value shows as `undefined` when the `value` property isn't supplied and an non-matching character is input.

Fixes #6884

#### Where should the reviewer start?
MaskedInput.js

#### What testing has been done on this PR?
Manual, storybook and jest

#### How should this be manually tested?
```jsx
export const Barcode = () => {
  const mask = [
    {
      length: [1, 14],
      regexp: /^(3|38|38[0,1]|38[0,1][0-9]{1,11})$/,
    },
  ];

  return (
    // Uncomment <Grommet> lines when using outside of storybook
    // <Grommet theme={...}>
    <Box fill align="center" justify="start" pad="large">
      <Box width="medium">
        <MaskedInput
          mask={mask} 

       />
      </Box>
    </Box>
    // </Grommet>
  );
};
```
#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
#6884

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Yes

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible