### PR TITLE
Locked styled-components peer dependency to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "peerDependencies": {
     "react": "^16.6.1 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.6.1 || ^17.0.0 || ^18.0.0",
-    "styled-components": ">= 5.1"
+    "styled-components": "^5.1.0"
   },
   "dependencies": {
     "grommet-icons": "^4.10.0",


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Specifies styled-components peer dependency of v5 as [Grommet is not yet compatible with v6](https://github.com/grommet/grommet/issues/6857).

#### Where should the reviewer start?

package.json

#### What testing has been done on this PR?

N/A

#### How should this be manually tested?

N/A

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

https://github.com/grommet/grommet/issues/6857

#### What are the relevant issues?

https://github.com/grommet/grommet/issues/6857
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

No.

#### Is this change backwards compatible or is it a breaking change?

Backwards.