### PR TITLE
Fix flatten function to allow filtering on multiple sub properties of same parent property

### DIFF
--- a/src/js/components/Data/DataForm.js
+++ b/src/js/components/Data/DataForm.js
@@ -47,22 +47,31 @@ const viewFormKeyMap = {
   view: formViewNameKey,
 };
 
-// flatten nested objects. For example: { a: { b: v } } -> { 'a.b': v }
+// flatten nested objects.
+// For example: { a: { b: v, c: z } } -> { 'a.b': v, 'a.c': z }
 const flatten = (formValue, options) => {
   const result = JSON.parse(JSON.stringify(formValue));
-  Object.keys(result).forEach((k) => {
-    let name = k;
-    // flatten one level at a time, ignore _range situations
-    while (
-      typeof result[name] === 'object' &&
-      !Array.isArray(result[name]) &&
-      (options?.full || !result[name][formRangeKey])
+  Object.keys(result).forEach((i) => {
+    // We check the type of the i using
+    // typeof() function and recursively
+    // call the function again
+    // ignore _range situations
+    if (
+      typeof result[i] === 'object' &&
+      !Array.isArray(result[i]) &&
+      (options?.full || !result[i][formRangeKey])
     ) {
-      const subPath = Object.keys(result[name])[0];
-      const path = `${name}.${subPath}`;
-      result[path] = result[name][subPath];
-      delete result[name];
-      name = path;
+      const temp = flatten(result[i]);
+      Object.keys(temp).forEach((j) => {
+        // Store temp in result
+        // ignore empty arrays
+        if (
+          !Array.isArray(temp[j]) ||
+          (Array.isArray(temp[j]) && temp[j].length)
+        )
+          result[`${i}.${j}`] = temp[j];
+      });
+      delete result[i];
     }
   });
   return result;

--- a/src/js/components/DataFilter/__tests__/DataFilter-test.tsx
+++ b/src/js/components/DataFilter/__tests__/DataFilter-test.tsx
@@ -254,4 +254,65 @@ describe('DataFilter', () => {
 
     expect(container.firstChild).toMatchSnapshot();
   });
+
+  test('should allow filtering on multiple sub-properties from same parent property', async () => {
+    const user = userEvent.setup();
+    const { asFragment } = render(
+      <Grommet>
+        <Data
+          data={data}
+          properties={{
+            'type.name': {
+              label: 'Type',
+            },
+            'type.id': {
+              label: 'ID',
+            },
+          }}
+        >
+          <DataFilters drop>
+            <DataFilter
+              property="type.name"
+              options={['ZZ', 'YY', 'aa', 'bb', 'cc']}
+            />
+            <DataFilter property="type.id" options={['1', '2']} />
+          </DataFilters>
+        </Data>
+      </Grommet>,
+    );
+
+    const { getByRole, getByLabelText } = screen;
+
+    const filterButton = getByRole('button', { name: 'Open filters' });
+    expect(filterButton).toBeTruthy();
+    await user.click(filterButton);
+
+    // open SelectMultiple
+    const selectInput = getByRole('button', { name: /Open Drop/i });
+    expect(selectInput).toBeTruthy();
+    await user.click(selectInput);
+
+    // click the first option 'ZZ'
+    await user.click(getByRole('option', { name: /ZZ/i }));
+
+    // close SelectMultiple
+    await user.click(getByRole('button', { name: /Close Select/i }));
+
+    const checkBox = getByLabelText(1);
+
+    await user.click(checkBox);
+
+    // click Apply Filters button
+    const applyFiltersButton = getByRole('button', { name: 'Apply filters' });
+    expect(applyFiltersButton).toBeTruthy();
+    await user.click(applyFiltersButton);
+
+    const updatedFilterButton = getByRole('button', {
+      name: 'Open filters, 2 filters applied',
+    });
+
+    expect(updatedFilterButton).toBeTruthy();
+    // snapshot on selected filter
+    expect(asFragment()).toMatchSnapshot();
+  });
 });

--- a/src/js/components/DataFilter/__tests__/__snapshots__/DataFilter-test.tsx.snap
+++ b/src/js/components/DataFilter/__tests__/__snapshots__/DataFilter-test.tsx.snap
@@ -5728,3 +5728,460 @@ exports[`DataFilter select multiple options search 3`] = `
   }
 }"
 `;
+
+exports[`DataFilter should allow filtering on multiple sub-properties from same parent property 1`] = `
+<DocumentFragment>
+  .c6 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #666666;
+  stroke: #666666;
+}
+
+.c6 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c6 *:not([stroke])[fill='none'] {
+  stroke-width: 0;
+}
+
+.c6 *[stroke*='#'],
+.c6 *[STROKE*='#'] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c6 *[fill-rule],
+.c6 *[FILL-RULE],
+.c6 *[fill*='#'],
+.c6 *[FILL*='#'] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: #7D4CDB;
+  color: #f8f8f8;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  border-radius: 24px;
+}
+
+.c10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-inline-start: 12px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c4 {
+  position: relative;
+}
+
+.c5 {
+  position: relative;
+  display: block;
+}
+
+.c7 {
+  position: absolute;
+  top: 0;
+  right: 0;
+}
+
+.c9 {
+  font-size: 14px;
+  line-height: 20px;
+  color: #FFFFFF;
+  font-weight: normal;
+}
+
+.c3 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  line-height: 0;
+  padding: 12px;
+}
+
+.c3:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus > circle,
+.c3:focus > ellipse,
+.c3:focus > line,
+.c3:focus > path,
+.c3:focus > polygon,
+.c3:focus > polyline,
+.c3:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c3:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c3:focus:not(:focus-visible) > circle,
+.c3:focus:not(:focus-visible) > ellipse,
+.c3:focus:not(:focus-visible) > line,
+.c3:focus:not(:focus-visible) > path,
+.c3:focus:not(:focus-visible) > polygon,
+.c3:focus:not(:focus-visible) > polyline,
+.c3:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c3:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c11 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: 2px solid #7D4CDB;
+  border-radius: 18px;
+  color: #444444;
+  padding: 4px 22px;
+  font-size: 18px;
+  line-height: 24px;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+}
+
+.c11:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c11:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus > circle,
+.c11:focus > ellipse,
+.c11:focus > line,
+.c11:focus > path,
+.c11:focus > polygon,
+.c11:focus > polyline,
+.c11:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c11:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c11:focus:not(:focus-visible) > circle,
+.c11:focus:not(:focus-visible) > ellipse,
+.c11:focus:not(:focus-visible) > line,
+.c11:focus:not(:focus-visible) > path,
+.c11:focus:not(:focus-visible) > polygon,
+.c11:focus:not(:focus-visible) > polyline,
+.c11:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c11:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+  .c8 {
+    border-radius: 12px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c10 {
+    margin-inline-start: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+
+}
+
+<div
+    class="c0"
+  >
+    <div
+      class="c1"
+      id="data"
+    >
+      <div
+        class="c2"
+      >
+        <button
+          aria-label="Open filters, 2 filters applied"
+          class="c3"
+          id="data--filters-control"
+          type="button"
+        >
+          <div
+            class="c4"
+          >
+            <div
+              class="c5"
+            >
+              <svg
+                aria-label="Filter"
+                class="c6"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m3 6 7 7v8h4v-8l7-7V3H3z"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
+            <div
+              class="c7"
+              style="top: 0px; right: 0px; transform: translate(50%, -50%); transform-origin: 100% 0%;"
+            >
+              <div
+                class="c8 Badge__StyledBadgeContainer-sc-1es4ws1-0"
+                style="min-height: 24px; min-width: 24px;"
+              >
+                <span
+                  class="c9"
+                >
+                  2
+                </span>
+              </div>
+            </div>
+          </div>
+        </button>
+        <div
+          class="c10"
+        >
+          <button
+            class="c11"
+            type="button"
+          >
+            Clear filters
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Adjust `flatten` function in data form which was only accounting for the first nested property under a given key as opposed to all.

#### Where should the reviewer start?

DataForm.js

#### What testing has been done on this PR?


https://github.com/grommet/grommet/assets/12522275/50895916-2813-4c9e-9d0e-2035ce3ed2a9


Tested in storybook using this code:

```
import React from 'react';

import { Grid, DataTable, Notification } from 'grommet';

import { Data } from '../Data';
// import { columns, DATA } from '../../DataTable/stories/data';

const data = [
  {
    id: 0,
    location: 'San Francisco',
    favorites: {
      fruit: 'apple',
      candy: 'chocolate',
    },
  },
  {
    id: 1,
    location: 'Fort Collins',
    favorites: {
      fruit: 'apple',
      candy: 'chocolate',
    },
  },
  {
    id: 2,
    location: 'San Francisco',
    favorites: {
      fruit: 'pear',
      candy: 'chocolate',
    },
  },
  {
    id: 3,
    location: 'Fort Collins',
    favorites: {
      fruit: 'apple',
      candy: 'twix',
    },
  },
  {
    id: 4,
    location: 'San Diego',
    favorites: {
      fruit: 'banana',
      candy: 'snickers',
    },
  },
];

export const Simple = () => (
  // Uncomment <Grommet> lines when using outside of storybook
  // <Grommet theme={...}>
  <Data
    data={data}
    toolbar
    properties={{
      location: { label: 'Location' },
      'favorites.fruit': { label: 'Favorite fruit' },
      'favorites.candy': { label: 'Favorite candy' },
    }}
  >
    <DataTable
      columns={[
        {
          property: 'id',
          header: 'ID',
        },
        {
          property: 'location',
          header: 'Location',
        },
        {
          property: 'favorites.fruit',
          header: 'Favorite fruit',
        },
        {
          property: 'favorites.candy',
          header: 'Favorite candy',
        },
      ]}
    />
  </Data>
  // </Grommet>
);

Simple.args = {
  full: true,
};

export default {
  title: 'Data/Data/Simple',
};
```

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [x] `screen` is used for querying.
- [x] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [x] `userEvent` is used in place of `fireEvent`.
- [x] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

Closes #6918 

#### Screenshots (if appropriate)

See video above.

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
Yes. Fixed DataForm bug which was only allowing filtering on a single nested key of a property.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.