### PR TITLE
Fixed DataFilters to show all filter options

### DIFF
--- a/src/js/components/Data/__tests__/Data-test.tsx
+++ b/src/js/components/Data/__tests__/Data-test.tsx
@@ -30,6 +30,7 @@ const data = [
 ];
 
 describe('Data', () => {
+  window.scrollTo = jest.fn();
   beforeEach(createPortal);
 
   test('renders', () => {
@@ -383,7 +384,7 @@ describe('Data', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test('properties when property is an array', () => {
+  test('properties when property is an array', async () => {
     const user = userEvent.setup();
 
     const { asFragment } = render(
@@ -423,7 +424,8 @@ describe('Data', () => {
     expect(asFragment()).toMatchSnapshot();
     const filtersButton = screen.getByRole('button', { name: 'Open filters' });
     expect(filtersButton).toBeTruthy();
-    user.click(filtersButton);
+    await user.click(filtersButton);
+    expect(screen.getByRole('button', { name: 'Apply filters' })).toBeTruthy();
     expectPortal('data--filters-control').toMatchSnapshot();
   });
 });

--- a/src/js/components/Data/__tests__/__snapshots__/Data-test.tsx.snap
+++ b/src/js/components/Data/__tests__/__snapshots__/Data-test.tsx.snap
@@ -1368,251 +1368,6 @@ exports[`Data onView 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  margin-bottom: 12px;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c7 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding: 12px;
-}
-
-.c8 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c10 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  margin-right: 12px;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-}
-
-.c13 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border: solid 2px rgba(0,0,0,0.15);
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  height: 24px;
-  width: 24px;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  border-radius: 4px;
-}
-
-.c15 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  width: 100%;
-  height: 100%;
-}
-
-.c17 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  width: 100%;
-  height: 100%;
-  cursor: pointer;
-}
-
-.c19 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  -webkit-align-self: stretch;
-  -ms-flex-item-align: stretch;
-  align-self: stretch;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  width: 100%;
-  border-radius: 12px;
-}
-
-.c20 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  -webkit-align-self: stretch;
-  -ms-flex-item-align: stretch;
-  align-self: stretch;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  overflow: visible;
-}
-
-.c21 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-flex-basis: 100%;
-  -ms-flex-preferred-size: 100%;
-  flex-basis: 100%;
-  height: 100%;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-}
-
-.c22 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  background-color: #7D4CDB;
-  color: #f8f8f8;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  height: 12px;
-  width: 12px;
-  border-radius: 100%;
-}
-
-.c23 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  -webkit-align-self: stretch;
-  -ms-flex-item-align: stretch;
-  align-self: stretch;
-  background-color: rgba(125,76,219,0.4);
-  color: #444444;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  width: 100%;
-  border-radius: 12px;
-}
-
-.c25 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
   margin-top: 12px;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1632,7 +1387,7 @@ exports[`Data onView 1`] = `
   justify-content: space-between;
 }
 
-.c33 {
+.c13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1653,17 +1408,21 @@ exports[`Data onView 1`] = `
   justify-content: center;
 }
 
-.c14 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  -webkit-align-self: stretch;
-  -ms-flex-item-align: stretch;
-  align-self: stretch;
-  height: 12px;
+.c16 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
 }
 
-.c27 {
+.c7 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -1673,42 +1432,18 @@ exports[`Data onView 1`] = `
   width: 12px;
 }
 
-.c6 {
-  margin-left: 12px;
-  margin-right: 12px;
-  margin-top: 6px;
-  margin-bottom: 6px;
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c16 {
-  margin-left: 12px;
-  margin-right: 12px;
-  font-size: 14px;
-  line-height: 20px;
-  text-align: right;
-}
-
-.c24 {
-  margin-left: 12px;
-  margin-right: 12px;
-  font-size: 14px;
-  line-height: 20px;
-}
-
-.c36 {
+.c17 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
 }
 
-.c37 {
+.c18 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c26 {
+.c6 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -1736,51 +1471,51 @@ exports[`Data onView 1`] = `
   transition-timing-function: ease-in-out;
 }
 
-.c26:hover {
+.c6:hover {
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c26:focus {
+.c6:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c26:focus > circle,
-.c26:focus > ellipse,
-.c26:focus > line,
-.c26:focus > path,
-.c26:focus > polygon,
-.c26:focus > polyline,
-.c26:focus > rect {
+.c6:focus > circle,
+.c6:focus > ellipse,
+.c6:focus > line,
+.c6:focus > path,
+.c6:focus > polygon,
+.c6:focus > polyline,
+.c6:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c26:focus::-moz-focus-inner {
+.c6:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c26:focus:not(:focus-visible) {
+.c6:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c26:focus:not(:focus-visible) > circle,
-.c26:focus:not(:focus-visible) > ellipse,
-.c26:focus:not(:focus-visible) > line,
-.c26:focus:not(:focus-visible) > path,
-.c26:focus:not(:focus-visible) > polygon,
-.c26:focus:not(:focus-visible) > polyline,
-.c26:focus:not(:focus-visible) > rect {
+.c6:focus:not(:focus-visible) > circle,
+.c6:focus:not(:focus-visible) > ellipse,
+.c6:focus:not(:focus-visible) > line,
+.c6:focus:not(:focus-visible) > path,
+.c6:focus:not(:focus-visible) > polygon,
+.c6:focus:not(:focus-visible) > polyline,
+.c6:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c26:focus:not(:focus-visible)::-moz-focus-inner {
+.c6:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c28 {
+.c8 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -1807,47 +1542,47 @@ exports[`Data onView 1`] = `
   transition-timing-function: ease-in-out;
 }
 
-.c28:focus {
+.c8:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c28:focus > circle,
-.c28:focus > ellipse,
-.c28:focus > line,
-.c28:focus > path,
-.c28:focus > polygon,
-.c28:focus > polyline,
-.c28:focus > rect {
+.c8:focus > circle,
+.c8:focus > ellipse,
+.c8:focus > line,
+.c8:focus > path,
+.c8:focus > polygon,
+.c8:focus > polyline,
+.c8:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c28:focus::-moz-focus-inner {
+.c8:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c28:focus:not(:focus-visible) {
+.c8:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c28:focus:not(:focus-visible) > circle,
-.c28:focus:not(:focus-visible) > ellipse,
-.c28:focus:not(:focus-visible) > line,
-.c28:focus:not(:focus-visible) > path,
-.c28:focus:not(:focus-visible) > polygon,
-.c28:focus:not(:focus-visible) > polyline,
-.c28:focus:not(:focus-visible) > rect {
+.c8:focus:not(:focus-visible) > circle,
+.c8:focus:not(:focus-visible) > ellipse,
+.c8:focus:not(:focus-visible) > line,
+.c8:focus:not(:focus-visible) > path,
+.c8:focus:not(:focus-visible) > polygon,
+.c8:focus:not(:focus-visible) > polyline,
+.c8:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c28:focus:not(:focus-visible)::-moz-focus-inner {
+.c8:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c29 {
+.c9 {
   opacity: 0;
 }
 
@@ -1855,61 +1590,7 @@ exports[`Data onView 1`] = `
   max-width: 100%;
 }
 
-.c9 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
-  cursor: pointer;
-}
-
-.c9:hover input:not([disabled]) + div,
-.c9:hover input:not([disabled]) + span {
-  border-color: #000000;
-}
-
 .c12 {
-  opacity: 0;
-  -moz-appearance: none;
-  width: 0;
-  height: 0;
-  margin: 0;
-  cursor: pointer;
-}
-
-.c12:checked + span > span {
-  left: calc( 48px - 24px );
-  background: #7D4CDB;
-}
-
-.c11 {
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-}
-
-.c18 {
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-}
-
-.c32 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -1922,7 +1603,7 @@ exports[`Data onView 1`] = `
   padding-bottom: 6px;
 }
 
-.c35 {
+.c15 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -1934,82 +1615,34 @@ exports[`Data onView 1`] = `
   padding-bottom: 6px;
 }
 
-.c30 {
+.c10 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
 }
 
-.c31 {
+.c11 {
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
 }
 
-.c34:focus {
+.c14:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c34:focus:not(:focus-visible) {
+.c14:focus:not(:focus-visible) {
   outline: none;
 }
 
 @media only screen and (max-width:768px) {
   .c5 {
-    margin-bottom: 6px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c7 {
-    border-bottom: solid 1px rgba(0,0,0,0.33);
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c7 {
-    padding: 6px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c10 {
-    margin-right: 6px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c13 {
-    border: solid 2px rgba(0,0,0,0.15);
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c19 {
-    border-radius: 6px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c23 {
-    border-radius: 6px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c25 {
     margin-top: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c14 {
-    height: 6px;
-  }
-}
-
-@media only screen and (max-width:768px) {
-  .c27 {
+  .c7 {
     width: 6px;
   }
 }
@@ -2032,276 +1665,23 @@ exports[`Data onView 1`] = `
         >
           <div
             class="c1"
-          >
-            <div
-              class="c5 "
-            >
-              <label
-                class="c6"
-                for="data-name"
-              >
-                name
-              </label>
-              <div
-                class="c7 FormField__FormFieldContentBox-sc-m9hood-1"
-              >
-                <div
-                  class="c8 StyledCheckBoxGroup-sc-2nhc5d-0"
-                  id="data-name"
-                  role="group"
-                >
-                  <label
-                    class="c9"
-                    label="aa"
-                  >
-                    <div
-                      class="c10 c11"
-                    >
-                      <input
-                        class="c12"
-                        type="checkbox"
-                      />
-                      <div
-                        class="c13 "
-                      />
-                    </div>
-                    <span>
-                      aa
-                    </span>
-                  </label>
-                  <div
-                    class="c14"
-                  />
-                  <label
-                    class="c9"
-                    label="bb"
-                  >
-                    <div
-                      class="c10 c11"
-                    >
-                      <input
-                        class="c12"
-                        type="checkbox"
-                      />
-                      <div
-                        class="c13 "
-                      />
-                    </div>
-                    <span>
-                      bb
-                    </span>
-                  </label>
-                  <div
-                    class="c14"
-                  />
-                  <label
-                    class="c9"
-                    label="cc"
-                  >
-                    <div
-                      class="c10 c11"
-                    >
-                      <input
-                        class="c12"
-                        type="checkbox"
-                      />
-                      <div
-                        class="c13 "
-                      />
-                    </div>
-                    <span>
-                      cc
-                    </span>
-                  </label>
-                  <div
-                    class="c14"
-                  />
-                  <label
-                    class="c9"
-                    label="dd"
-                  >
-                    <div
-                      class="c10 c11"
-                    >
-                      <input
-                        class="c12"
-                        type="checkbox"
-                      />
-                      <div
-                        class="c13 "
-                      />
-                    </div>
-                    <span>
-                      dd
-                    </span>
-                  </label>
-                </div>
-              </div>
-            </div>
-            <div
-              class="c5 "
-            >
-              <label
-                class="c6"
-                for="data-enabled"
-              >
-                enabled
-              </label>
-              <div
-                class="c7 FormField__FormFieldContentBox-sc-m9hood-1"
-              >
-                <div
-                  class="c8 StyledCheckBoxGroup-sc-2nhc5d-0"
-                  id="data-enabled"
-                  role="group"
-                >
-                  <label
-                    class="c9"
-                    label="true"
-                  >
-                    <div
-                      class="c10 c11"
-                    >
-                      <input
-                        class="c12"
-                        type="checkbox"
-                      />
-                      <div
-                        class="c13 "
-                      />
-                    </div>
-                    <span>
-                      true
-                    </span>
-                  </label>
-                  <div
-                    class="c14"
-                  />
-                  <label
-                    class="c9"
-                    label="false"
-                  >
-                    <div
-                      class="c10 c11"
-                    >
-                      <input
-                        class="c12"
-                        type="checkbox"
-                      />
-                      <div
-                        class="c13 "
-                      />
-                    </div>
-                    <span>
-                      false
-                    </span>
-                  </label>
-                </div>
-              </div>
-            </div>
-            <div
-              class="c5 "
-            >
-              <label
-                class="c6"
-                for="data-rating"
-              >
-                rating
-              </label>
-              <div
-                class="c7 FormField__FormFieldContentBox-sc-m9hood-1"
-              >
-                <div
-                  class="c15"
-                  id="data-rating"
-                >
-                  <span
-                    class="c16"
-                    style="width: 0px;"
-                  >
-                    2.0999999999999996
-                  </span>
-                  <div
-                    class="c17 c18"
-                    tabindex="-1"
-                  >
-                    <div
-                      class="c19"
-                      style="flex: 0 0 0px;"
-                    />
-                    <div
-                      class="c20"
-                      style="flex: 0 0 1px;"
-                    >
-                      <div
-                        aria-label="Lower Bounds"
-                        aria-valuemax="4.8999999999999995"
-                        aria-valuemin="2.0999999999999996"
-                        aria-valuenow="2.0999999999999996"
-                        class="c21"
-                        role="slider"
-                        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 1;"
-                        tabindex="0"
-                      >
-                        <div
-                          class="c22 EdgeControl__StyledBox-sc-1xo2yt9-0"
-                        />
-                      </div>
-                    </div>
-                    <div
-                      class="c23"
-                      style="flex: 3.8 0 0px; cursor: ew-resize;"
-                    />
-                    <div
-                      class="c20"
-                      style="flex: 0 0 1px;"
-                    >
-                      <div
-                        aria-label="Upper Bounds"
-                        aria-valuemax="4.8999999999999995"
-                        aria-valuemin="2.0999999999999996"
-                        aria-valuenow="4.8999999999999995"
-                        class="c21"
-                        role="slider"
-                        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 1;"
-                        tabindex="0"
-                      >
-                        <div
-                          class="c22 EdgeControl__StyledBox-sc-1xo2yt9-0"
-                        />
-                      </div>
-                    </div>
-                    <div
-                      class="c19"
-                      style="flex: 0 0 0px;"
-                    />
-                  </div>
-                  <span
-                    class="c24"
-                    style="width: 0px;"
-                  >
-                    4.8999999999999995
-                  </span>
-                </div>
-              </div>
-            </div>
-          </div>
+          />
         </div>
         <footer
-          class="c25"
+          class="c5"
         >
           <button
-            class="c26"
+            class="c6"
             type="submit"
           >
             Apply filters
           </button>
           <div
-            class="c27"
+            class="c7"
           />
           <button
             aria-hidden="true"
-            class="c28 c29"
+            class="c8 c9"
             disabled=""
             tabindex="-1"
             type="reset"
@@ -2312,7 +1692,7 @@ exports[`Data onView 1`] = `
       </div>
     </form>
     <table
-      class="c30 c31"
+      class="c10 c11"
     >
       <thead
         class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -2321,99 +1701,99 @@ exports[`Data onView 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c32 "
+            class="c12 "
             scope="col"
           >
             <div
-              class="c33"
+              class="c13"
             />
           </th>
           <th
-            class="c32 "
+            class="c12 "
             scope="col"
           >
             <div
-              class="c33"
+              class="c13"
             />
           </th>
           <th
-            class="c32 "
+            class="c12 "
             scope="col"
           >
             <div
-              class="c33"
+              class="c13"
             />
           </th>
           <th
-            class="c32 "
+            class="c12 "
             scope="col"
           >
             <div
-              class="c33"
+              class="c13"
             />
           </th>
           <th
-            class="c32 "
+            class="c12 "
             scope="col"
           >
             <div
-              class="c33"
+              class="c13"
             />
           </th>
         </tr>
       </thead>
       <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c34"
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c14"
       >
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c35 "
+            class="c15 "
             scope="row"
           >
             <div
-              class="c8"
+              class="c16"
             >
               <span
-                class="c36"
+                class="c17"
               >
                 aa
               </span>
             </div>
           </th>
           <td
-            class="c35 "
+            class="c15 "
           >
             <div
-              class="c8"
+              class="c16"
             />
           </td>
           <td
-            class="c35 "
+            class="c15 "
           >
             <div
-              class="c8"
+              class="c16"
             >
               <span
-                class="c37"
+                class="c18"
               >
                 2.3
               </span>
             </div>
           </td>
           <td
-            class="c35 "
+            class="c15 "
           >
             <div
-              class="c8"
+              class="c16"
             />
           </td>
           <td
-            class="c35 "
+            class="c15 "
           >
             <div
-              class="c8"
+              class="c16"
             />
           </td>
         </tr>
@@ -2421,51 +1801,51 @@ exports[`Data onView 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c35 "
+            class="c15 "
             scope="row"
           >
             <div
-              class="c8"
+              class="c16"
             >
               <span
-                class="c36"
+                class="c17"
               >
                 bb
               </span>
             </div>
           </th>
           <td
-            class="c35 "
+            class="c15 "
           >
             <div
-              class="c8"
+              class="c16"
             />
           </td>
           <td
-            class="c35 "
+            class="c15 "
           >
             <div
-              class="c8"
+              class="c16"
             >
               <span
-                class="c37"
+                class="c18"
               >
                 4.3
               </span>
             </div>
           </td>
           <td
-            class="c35 "
+            class="c15 "
           >
             <div
-              class="c8"
+              class="c16"
             />
           </td>
           <td
-            class="c35 "
+            class="c15 "
           >
             <div
-              class="c8"
+              class="c16"
             />
           </td>
         </tr>
@@ -2473,45 +1853,45 @@ exports[`Data onView 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c35 "
+            class="c15 "
             scope="row"
           >
             <div
-              class="c8"
+              class="c16"
             >
               <span
-                class="c36"
+                class="c17"
               >
                 cc
               </span>
             </div>
           </th>
           <td
-            class="c35 "
+            class="c15 "
           >
             <div
-              class="c8"
+              class="c16"
             />
           </td>
           <td
-            class="c35 "
+            class="c15 "
           >
             <div
-              class="c8"
+              class="c16"
             />
           </td>
           <td
-            class="c35 "
+            class="c15 "
           >
             <div
-              class="c8"
+              class="c16"
             />
           </td>
           <td
-            class="c35 "
+            class="c15 "
           >
             <div
-              class="c8"
+              class="c16"
             />
           </td>
         </tr>
@@ -2519,45 +1899,45 @@ exports[`Data onView 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c35 "
+            class="c15 "
             scope="row"
           >
             <div
-              class="c8"
+              class="c16"
             >
               <span
-                class="c36"
+                class="c17"
               >
                 dd
               </span>
             </div>
           </th>
           <td
-            class="c35 "
+            class="c15 "
           >
             <div
-              class="c8"
+              class="c16"
             />
           </td>
           <td
-            class="c35 "
+            class="c15 "
           >
             <div
-              class="c8"
+              class="c16"
             />
           </td>
           <td
-            class="c35 "
+            class="c15 "
           >
             <div
-              class="c8"
+              class="c16"
             />
           </td>
           <td
-            class="c35 "
+            class="c15 "
           >
             <div
-              class="c8"
+              class="c16"
             />
           </td>
         </tr>
@@ -4401,10 +3781,88 @@ exports[`Data properties when property is an array 2`] = `
 
 }
 
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+
+}
+
 <button
   aria-label="Open filters"
   class="c0"
+  data-g-tabindex="none"
   id="data--filters-control"
+  tabindex="-1"
   type="button"
 >
   <svg

--- a/src/js/components/DataFilters/DataFilters.js
+++ b/src/js/components/DataFilters/DataFilters.js
@@ -26,10 +26,10 @@ const layerProps = {
 export const DataFilters = ({ drop, children, heading, layer, ...rest }) => {
   const {
     clearFilters,
-    data,
     id: dataId,
     messages,
     properties,
+    unfilteredData,
     view,
   } = useContext(DataContext);
   const { format } = useContext(MessageContext);
@@ -66,10 +66,10 @@ export const DataFilters = ({ drop, children, heading, layer, ...rest }) => {
   let content = children;
   if (Children.count(children) === 0) {
     let filtersFor;
-    if (!properties && data && data.length)
+    if (!properties && unfilteredData && unfilteredData.length)
       // build from a piece of data, ignore object values
-      filtersFor = Object.keys(data[0]).filter(
-        (k) => typeof data[0][k] !== 'object',
+      filtersFor = Object.keys(unfilteredData[0]).filter(
+        (k) => typeof unfilteredData[0][k] !== 'object',
       );
     else if (Array.isArray(properties)) filtersFor = properties;
     else if (typeof properties === 'object')

--- a/src/js/components/DataFilters/__tests__/__snapshots__/DataFilters-test.tsx.snap
+++ b/src/js/components/DataFilters/__tests__/__snapshots__/DataFilters-test.tsx.snap
@@ -1827,6 +1827,26 @@ exports[`DataFilters layer 2`] = `
 }
 
 @media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
   .c6 {
     padding-left: 12px;
     padding-right: 12px;
@@ -1904,6 +1924,10 @@ exports[`DataFilters layer 2`] = `
   .c25 {
     width: 6px;
   }
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+
 }
 
 @media only screen and (max-width:768px) {
@@ -3824,6 +3848,742 @@ exports[`DataFilters renders 1`] = `
     </form>
   </div>
 </div>
+`;
+
+exports[`DataFilters should display all filter options regardless of result set 1`] = `
+<DocumentFragment>
+  .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 100%;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+  overflow: auto;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-bottom: 12px;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 12px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-right: 12px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c13 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: solid 2px rgba(0,0,0,0.15);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 24px;
+  width: 24px;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  border-radius: 4px;
+}
+
+.c15 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-top: 12px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c21 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border-top: solid 1px rgba(0,0,0,0.33);
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  padding-left: 24px;
+  padding-right: 24px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+
+.c23 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  padding-left: 24px;
+  padding-right: 24px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+
+.c14 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  height: 12px;
+}
+
+.c17 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  width: 12px;
+}
+
+.c6 {
+  margin-left: 12px;
+  margin-right: 12px;
+  margin-top: 6px;
+  margin-bottom: 6px;
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c16 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: 2px solid #7D4CDB;
+  border-radius: 18px;
+  color: #444444;
+  padding: 4px 22px;
+  font-size: 18px;
+  line-height: 24px;
+  background-color: #7D4CDB;
+  color: #f8f8f8;
+  border-radius: 18px;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+}
+
+.c16:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c16:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c16:focus > circle,
+.c16:focus > ellipse,
+.c16:focus > line,
+.c16:focus > path,
+.c16:focus > polygon,
+.c16:focus > polyline,
+.c16:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c16:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c16:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c16:focus:not(:focus-visible) > circle,
+.c16:focus:not(:focus-visible) > ellipse,
+.c16:focus:not(:focus-visible) > line,
+.c16:focus:not(:focus-visible) > path,
+.c16:focus:not(:focus-visible) > polygon,
+.c16:focus:not(:focus-visible) > polyline,
+.c16:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c16:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c18 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: 2px solid #7D4CDB;
+  border-radius: 18px;
+  color: #444444;
+  padding: 4px 22px;
+  font-size: 18px;
+  line-height: 24px;
+  opacity: 0.3;
+  cursor: default;
+  -webkit-transition-property: color,background-color,border-color,box-shadow;
+  transition-property: color,background-color,border-color,box-shadow;
+  -webkit-transition-duration: 0.1s;
+  transition-duration: 0.1s;
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+}
+
+.c18:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c18:focus > circle,
+.c18:focus > ellipse,
+.c18:focus > line,
+.c18:focus > path,
+.c18:focus > polygon,
+.c18:focus > polyline,
+.c18:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c18:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c18:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c18:focus:not(:focus-visible) > circle,
+.c18:focus:not(:focus-visible) > ellipse,
+.c18:focus:not(:focus-visible) > line,
+.c18:focus:not(:focus-visible) > path,
+.c18:focus:not(:focus-visible) > polygon,
+.c18:focus:not(:focus-visible) > polyline,
+.c18:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c18:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c19 {
+  opacity: 0;
+}
+
+.c2 {
+  max-width: 100%;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  cursor: pointer;
+}
+
+.c9:hover input:not([disabled]) + div,
+.c9:hover input:not([disabled]) + span {
+  border-color: #000000;
+}
+
+.c12 {
+  opacity: 0;
+  -moz-appearance: none;
+  width: 0;
+  height: 0;
+  margin: 0;
+  cursor: pointer;
+}
+
+.c12:checked + span > span {
+  left: calc( 48px - 24px );
+  background: #7D4CDB;
+}
+
+.c11 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c20 {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.c22:focus {
+  outline: none;
+}
+
+@media only screen and (max-width:768px) {
+  .c5 {
+    margin-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c7 {
+    padding: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c10 {
+    margin-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c13 {
+    border: solid 2px rgba(0,0,0,0.15);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c15 {
+    margin-top: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c21 {
+    border-top: solid 1px rgba(0,0,0,0.33);
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c21 {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c21 {
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c23 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c23 {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c23 {
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c14 {
+    height: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c17 {
+    width: 6px;
+  }
+}
+
+<div
+    class="c0"
+  >
+    <div
+      class="c1"
+      id="data"
+    >
+      <form
+        class="c2"
+      >
+        <div
+          class="c3"
+        >
+          <div
+            class="c4"
+          >
+            <div
+              class="c1"
+            >
+              <div
+                class="c5 "
+              >
+                <label
+                  class="c6"
+                  for="data-name"
+                >
+                  name
+                </label>
+                <div
+                  class="c7 FormField__FormFieldContentBox-sc-m9hood-1"
+                >
+                  <div
+                    class="c8 StyledCheckBoxGroup-sc-2nhc5d-0"
+                    id="data-name"
+                    role="group"
+                  >
+                    <label
+                      class="c9"
+                      label="a"
+                    >
+                      <div
+                        class="c10 c11"
+                      >
+                        <input
+                          class="c12"
+                          type="checkbox"
+                        />
+                        <div
+                          class="c13 "
+                        />
+                      </div>
+                      <span>
+                        a
+                      </span>
+                    </label>
+                    <div
+                      class="c14"
+                    />
+                    <label
+                      class="c9"
+                      label="b"
+                    >
+                      <div
+                        class="c10 c11"
+                      >
+                        <input
+                          class="c12"
+                          type="checkbox"
+                        />
+                        <div
+                          class="c13 "
+                        />
+                      </div>
+                      <span>
+                        b
+                      </span>
+                    </label>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="c5 "
+              >
+                <label
+                  class="c6"
+                  for="data-color"
+                >
+                  color
+                </label>
+                <div
+                  class="c7 FormField__FormFieldContentBox-sc-m9hood-1"
+                >
+                  <div
+                    class="c8 StyledCheckBoxGroup-sc-2nhc5d-0"
+                    id="data-color"
+                    role="group"
+                  >
+                    <label
+                      class="c9"
+                      label="blue"
+                    >
+                      <div
+                        class="c10 c11"
+                      >
+                        <input
+                          class="c12"
+                          type="checkbox"
+                        />
+                        <div
+                          class="c13 "
+                        />
+                      </div>
+                      <span>
+                        blue
+                      </span>
+                    </label>
+                    <div
+                      class="c14"
+                    />
+                    <label
+                      class="c9"
+                      label="red"
+                    >
+                      <div
+                        class="c10 c11"
+                      >
+                        <input
+                          class="c12"
+                          type="checkbox"
+                        />
+                        <div
+                          class="c13 "
+                        />
+                      </div>
+                      <span>
+                        red
+                      </span>
+                    </label>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <footer
+            class="c15"
+          >
+            <button
+              class="c16"
+              type="submit"
+            >
+              Apply filters
+            </button>
+            <div
+              class="c17"
+            />
+            <button
+              aria-hidden="true"
+              class="c18 c19"
+              disabled=""
+              tabindex="-1"
+              type="reset"
+            >
+              Undo changes
+            </button>
+          </footer>
+        </div>
+      </form>
+      <ul
+        class="c20"
+        role="list"
+      >
+        <li
+          class="c21 c22"
+        >
+          a
+        </li>
+        <li
+          class="c23 c22"
+        >
+          b
+        </li>
+      </ul>
+    </div>
+  </div>
+</DocumentFragment>
 `;
 
 exports[`DataFilters sub objects 1`] = `


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Closes https://github.com/grommet/grommet/issues/6940.

Uses `unfilteredData` instead of `data` as source to build up default filter options. Previously, the logic was built up from `data`, however if `data` reached a length of zero, then no object was available to build up the options.

#### Where should the reviewer start?

- review issue
- DataFilters.js

#### What testing has been done on this PR?

- Storybook
- Added unit tests

#### How should this be manually tested?

Use the following stories:
- https://storybook.grommet.io/?path=/story/data-data-simple--simple
- Story 1 - when `properties` is not specified, [data provides default filters](https://v2.grommet.io/data#properties).
- Story 2 - when `properties` is specified, `properties` becomes [the schema definition for which properties are filterable](https://v2.grommet.io/data#properties) by filters.

For each:
1. Use a combination of filters to get zero results.
2. Re-open filters, all filter properties should be options.

Story w/out `properties` prop:
```
 <Data
    data={[
      {
        name: 'aa',
        enabled: true,
        rating: 2.3,
        sub: { note: 'ZZ' },
        tags: ['qa', 'staging', 'prod'],
      },
      {
        name: 'bb',
        enabled: false,
        rating: 4.3,
        sub: { note: 'YY' },
        tags: ['qa', 'staging'],
      },
      { name: 'cc', sub: {}, tags: ['qa'] },
      { name: 'dd' },
    ]}
    toolbar
  >
    <DataTable
      columns={[
        { property: 'name', header: 'Name' },
        { property: 'sub.note', header: 'Note' },
        {
          property: 'tags',
          header: 'Tags',
          render: ({ tags }) => (tags ? tags.join(', ') : null),
        },
      ]}
    />
  </Data>
```

Story with `properties` prop:
```
 <Data
    data={[
      {
        name: 'aa',
        enabled: true,
        rating: 2.3,
        sub: { note: 'ZZ' },
        tags: ['qa', 'staging', 'prod'],
      },
      {
        name: 'bb',
        enabled: false,
        rating: 4.3,
        sub: { note: 'YY' },
        tags: ['qa', 'staging'],
      },
      { name: 'cc', sub: {}, tags: ['qa'] },
      { name: 'dd' },
    ]}
    toolbar
    properties={{
      name: { label: 'Name' },
      'sub.note': { label: 'Note' },
      tags: {
        label: 'Tags',
        options: [
          { label: '01 - Development', value: 'dev' },
          { label: '02 - QA', value: 'qa' },
          { label: '03 - Staging', value: 'staging' },
          { label: '04 - Production', value: 'prod' },
        ],
      },
    }}
  >
    <DataTable
      columns={[
        { property: 'name', header: 'Name' },
        { property: 'sub.note', header: 'Note' },
        {
          property: 'tags',
          header: 'Tags',
          render: ({ tags }) => (tags ? tags.join(', ') : null),
        },
      ]}
    />
  </Data>
```

#### Do Jest tests follow these best practices?

- [x] `screen` is used for querying.
- [x] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [x] `userEvent` is used in place of `fireEvent`.
- [x] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

https://github.com/grommet/grommet/issues/6940

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

Yes.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.
