### PR TITLE
Tip stays open when the tip is hovered

### DIFF
--- a/src/js/components/Tip/Tip.js
+++ b/src/js/components/Tip/Tip.js
@@ -15,6 +15,7 @@ import { TipPropTypes } from './propTypes';
 const Tip = forwardRef(({ children, content, dropProps, plain }, tipRef) => {
   const theme = useContext(ThemeContext);
   const [over, setOver] = useState(false);
+  const [tooltipOver, setTooltipOver] = useState(false);
   const usingKeyboard = useKeyboard();
 
   const componentRef = useForwardedRef(tipRef);
@@ -68,13 +69,15 @@ const Tip = forwardRef(({ children, content, dropProps, plain }, tipRef) => {
 
   return [
     clonedChild,
-    over && (
+    (over || tooltipOver) && (
       <Drop
         target={componentRef.current}
         trapFocus={false}
         key="tip-drop"
         {...theme.tip.drop}
         {...dropProps}
+        onMouseEnter={() => setTooltipOver(true)}
+        onMouseLeave={() => setTooltipOver(false)}
       >
         {plain ? content : <Box {...theme.tip.content}>{content}</Box>}
       </Drop>


### PR DESCRIPTION
#### What does this PR do?
Fixes #6926
- Tip stays open when the tip is hovered.

#### Where should the reviewer start?
- In the stories

#### What testing has been done on this PR?
- Ran locally on storybook.

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
- Previously tooltip was disappearing when hovered 

#### What are the relevant issues?
- #6926 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
- yes
