### PR TITLE
Fix types for Grommet messages

### DIFF
--- a/src/js/components/Grommet/index.d.ts
+++ b/src/js/components/Grommet/index.d.ts
@@ -17,15 +17,83 @@ export interface GrommetProps {
     };
     drop?: {
       checkContainingBlock?: boolean;
-    }
+    };
   };
   messages?: {
     messages?: {
+      button?: {
+        busy?: string;
+        success?: string;
+      };
+      calendar?: {
+        previousMove?: string;
+        previous?: string;
+        nextMove?: string;
+        next?: string;
+      };
+      carousel?: {
+        previous?: string;
+        next?: string;
+        jump?: string;
+      };
+      dateInput?: {
+        openCalendar?: string;
+        enterCalendar?: string;
+        exitCalendar?: string;
+      };
+      dataFilters?: {
+        clear?: string;
+        heading?: string;
+        open?: string;
+        openSet?: {
+          singular?: string;
+          plural?: string;
+        };
+      };
+      dataForm?: {
+        reset?: string;
+        submit?: string;
+      };
+      dataSearch?: {
+        label?: string;
+        open?: string;
+      };
+      dataSort?: {
+        ascending?: string;
+        by?: string;
+        descending?: string;
+        direction?: string;
+        open?: string;
+      };
+      dataSummary?: {
+        filtered?: string;
+        filteredSingle?: string;
+        total?: string;
+      };
+      dataTableColumns?: {
+        open?: string;
+        order?: string;
+        select?: string;
+        tip?: string;
+      };
+      dataTableGroupBy?: {
+        clear?: string;
+        label?: string;
+      };
+      dataView?: {
+        label?: string;
+      };
       fileInput?: {
         browse?: string;
         dropPrompt?: string;
         dropPromptMultiple?: string;
         files?: string;
+        maxFile?: string;
+        maxSizeSingle?: string;
+        maxSizeMultiple?: {
+          singular?: string;
+          plural?: string;
+        };
         remove?: string;
         removeAll?: string;
       };
@@ -43,6 +111,7 @@ export interface GrommetProps {
       };
       select?: {
         multiple?: string;
+        selected?: string;
       };
       skipLinks?: {
         skipTo?: string;
@@ -57,7 +126,10 @@ export interface GrommetProps {
         suggestionIsOpen?: string;
       };
       video?: {
+        audioDescriptions?: string;
+        captions?: string;
         closeMenu?: string;
+        description?: string;
         fullScreen?: string;
         progressMeter?: string;
         scrubber?: string;

--- a/src/js/components/Grommet/propTypes.js
+++ b/src/js/components/Grommet/propTypes.js
@@ -20,11 +20,79 @@ if (process.env.NODE_ENV !== 'production') {
     messages: PropTypes.shape({
       format: PropTypes.func,
       messages: PropTypes.shape({
+        button: PropTypes.shape({
+          busy: PropTypes.string,
+          success: PropTypes.string,
+        }),
+        calendar: PropTypes.shape({
+          previousMove: PropTypes.string,
+          previous: PropTypes.string,
+          nextMove: PropTypes.string,
+          next: PropTypes.string,
+        }),
+        carousel: PropTypes.shape({
+          previous: PropTypes.string,
+          next: PropTypes.string,
+          jump: PropTypes.string,
+        }),
+        dateInput: PropTypes.shape({
+          openCalendar: PropTypes.string,
+          enterCalendar: PropTypes.string,
+          exitCalendar: PropTypes.string,
+        }),
+        dataFilters: PropTypes.shape({
+          clear: PropTypes.string,
+          heading: PropTypes.string,
+          open: PropTypes.string,
+          openSet: PropTypes.shape({
+            singular: PropTypes.string,
+            plural: PropTypes.string,
+          }),
+        }),
+        dataForm: PropTypes.shape({
+          reset: PropTypes.string,
+          submit: PropTypes.string,
+        }),
+        dataSearch: PropTypes.shape({
+          label: PropTypes.string,
+          open: PropTypes.string,
+        }),
+        dataSort: PropTypes.shape({
+          ascending: PropTypes.string,
+          by: PropTypes.string,
+          descending: PropTypes.string,
+          direction: PropTypes.string,
+          open: PropTypes.string,
+        }),
+        dataSummary: PropTypes.shape({
+          filtered: PropTypes.string,
+          filteredSingle: PropTypes.string,
+          total: PropTypes.string,
+        }),
+        dataTableColumns: PropTypes.shape({
+          open: PropTypes.string,
+          order: PropTypes.string,
+          select: PropTypes.string,
+          tip: PropTypes.string,
+        }),
+        dataTableGroupBy: PropTypes.shape({
+          clear: PropTypes.string,
+          label: PropTypes.string,
+        }),
+        dataView: PropTypes.shape({
+          label: PropTypes.string,
+        }),
         fileInput: PropTypes.shape({
           browse: PropTypes.string,
           dropPrompt: PropTypes.string,
           dropPromptMultiple: PropTypes.string,
           files: PropTypes.string,
+          maxFile: PropTypes.string,
+          maxSizeSingle: PropTypes.string,
+          maxSizeMultiple: PropTypes.shape({
+            singular: PropTypes.string,
+            plural: PropTypes.string,
+          }),
           remove: PropTypes.string,
           removeAll: PropTypes.string,
         }),
@@ -42,6 +110,7 @@ if (process.env.NODE_ENV !== 'production') {
         }),
         select: PropTypes.shape({
           multiple: PropTypes.string,
+          selected: PropTypes.string,
         }),
         skipLinks: PropTypes.shape({
           skipTo: PropTypes.string,
@@ -56,7 +125,10 @@ if (process.env.NODE_ENV !== 'production') {
           suggestionIsOpen: PropTypes.string,
         }),
         video: PropTypes.shape({
+          audioDescriptions: PropTypes.string,
+          captions: PropTypes.string,
           closeMenu: PropTypes.string,
+          description: PropTypes.string,
           fullScreen: PropTypes.string,
           progressMeter: PropTypes.string,
           scrubber: PropTypes.string,

--- a/src/js/languages/default.json
+++ b/src/js/languages/default.json
@@ -66,14 +66,14 @@
     "dropPrompt": "Drop file here or",
     "dropPromptMultiple": "Drop files here or",
     "files": "files",
+    "maxFile": "Attach a maximum of {max} files only.",
     "maxSizeSingle": "The file is too large. Select a file no larger than {maxSize}.",
     "maxSizeMultiple": {
       "singular": "One file is too large. Select files which are no larger than {maxSize}.",
       "plural": "{numOfFiles} files are too large. Select files which are no larger than {maxSize}."
     },
     "remove": "remove",
-    "removeAll": "remove all",
-    "maxFile": "Attach a maximum of {max} files only."
+    "removeAll": "remove all"
   },
   "form": {
     "invalid": "invalid",
@@ -104,9 +104,10 @@
     "suggestionIsOpen": "Suggestions drop is open, continue to use arrow keys to navigate"
   },
   "video": {
+    "audioDescriptions": "video audio description",
     "captions": "closed captions",
     "closeMenu": "close menu",
-    "audioDescriptions": "video audio description",
+    "description": "video audio description",
     "fullScreen": "full screen",
     "progressMeter": "video progress",
     "scrubber": "scrubber",
@@ -114,7 +115,6 @@
     "pauseButton": "pause",
     "playButton": "play",
     "volumeDown": "volume down",
-    "volumeUp": "volume up",
-    "description": "video audio description"
+    "volumeUp": "volume up"
   }
 }


### PR DESCRIPTION
#### What does this PR do?
Fixes type definitions from Grommet `messages` prop.

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes https://github.com/grommet/grommet/issues/6822

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible