### PR TITLE
fix: box/round storybook accessibility violation

### DIFF
--- a/src/js/components/Box/stories/Round.js
+++ b/src/js/components/Box/stories/Round.js
@@ -22,7 +22,7 @@ export const RoundBox = () => (
           responsive={false}
           key={size}
           pad="large"
-          background="dark-4"
+          background="dark-2"
           round={{ size }}
         >
           {size} - Not responsive


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fix Storybook Accessibility Violations 

#### Where should the reviewer start?
- src/js/components/Box/Round.js
- storybook :- `Box/Round`

#### What testing has been done on this PR?
`yarn test` was run before committing

#### How should this be manually tested?
Check the accessibility tab in the Box/Round storybook

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### What are the relevant issues?
#6124 

#### Screenshots (if appropriate)
### Before
![before](https://github.com/grommet/grommet/assets/81921291/1bfec6e9-fa3b-4a00-affb-0c6feb8a9c85)

### After
![after](https://github.com/grommet/grommet/assets/81921291/6e4d9b0b-7d83-426b-820a-1790c64c878a)


#### Do the grommet docs need to be updated?
NO
#### Should this PR be mentioned in the release notes?
NO
#### Is this change backwards compatible or is it a breaking change?
NO
