### PR TITLE
fix box/simple storybook accessibility violation

### DIFF
--- a/src/js/components/Box/stories/Simple.js
+++ b/src/js/components/Box/stories/Simple.js
@@ -17,16 +17,16 @@ export const SimpleBox = () => (
     <Box
       pad="large"
       align="center"
-      background={{ color: 'light-2', opacity: 'strong' }}
+      background={{ color: 'light-4', opacity: 'strong' }}
       round
       gap="small"
     >
       <Attraction size="large" />
       <Text>Party</Text>
-      <Anchor href="" label="Link" />
+      <Anchor href="" label="Link" color="blue-4" />
       <Button label="Button" onClick={() => {}} />
     </Box>
-    <Box pad="large" align="center" background="dark-3" round gap="small">
+    <Box pad="large" align="center" background="dark-1" round gap="small">
       <Car size="large" color="light-2" />
       <Text>Travel</Text>
       <Anchor href="" label="Link" />

--- a/src/js/components/Box/stories/Simple.js
+++ b/src/js/components/Box/stories/Simple.js
@@ -23,7 +23,7 @@ export const SimpleBox = () => (
     >
       <Attraction size="large" />
       <Text>Party</Text>
-      <Anchor href="" label="Link" color="blue-4" />
+      <Anchor href="" label="Link" color="dark-1" />
       <Button label="Button" onClick={() => {}} />
     </Box>
     <Box pad="large" align="center" background="dark-1" round gap="small">


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fix Storybook Accessibility Violations

#### Where should the reviewer start?
- src/js/components/Box/Simple.js
- storybook :- `Box/Simple`

#### What testing has been done on this PR?
`yarn test` was run before committing

#### How should this be manually tested?
Check the accessibility tab in the Box/Simple storybook

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.


#### What are the relevant issues? 
#6124 

#### Screenshots (if appropriate)
## brfore
![before](https://github.com/grommet/grommet/assets/81921291/c03623df-6c98-45f8-8969-d9641c32fc8d)

## after
![after](https://github.com/grommet/grommet/assets/81921291/f67bf565-bd0f-4e0e-a0a8-5260b7057566)

#### Do the grommet docs need to be updated?
NO

#### Should this PR be mentioned in the release notes?
NO

#### Is this change backwards compatible or is it a breaking change?
NO