### PR TITLE
Updates type of onChange of RangeSelector

### DIFF
--- a/src/js/components/RangeSelector/index.d.ts
+++ b/src/js/components/RangeSelector/index.d.ts
@@ -10,7 +10,7 @@ export interface RangeSelectorProps {
   max?: number;
   messages?: { lower?: string; upper?: string };
   min?: number;
-  onChange?: (...args: any[]) => void;
+  onChange?: (range: [number, number]) => void;
   opacity?: 'weak' | 'medium' | 'strong' | string | boolean;
   round?: 'xsmall' | 'small' | 'medium' | 'large' | 'full' | string;
   size?:


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->
Improves event handler type for `RageSelector` component.

#### What does this PR do?
Improves event handler type for `RageSelector` component.

#### Where should the reviewer start?
index.d.ts of  RangeSelector

#### What testing has been done on this PR?
Checked the types locally

#### How should this be manually tested?
Verify the typing

#### Do Jest tests follow these best practices?
Not applicable

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
#3165 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
May be breaking for people using typescript. Because we are now making the type stricter.
