### PR TITLE
DataTable 'Select All' does not overwrites previously selected

### DIFF
--- a/src/js/components/DataTable/DataTable.js
+++ b/src/js/components/DataTable/DataTable.js
@@ -546,8 +546,19 @@ const DataTable = ({
             onSelect={
               onSelect
                 ? (nextSelected) => {
-                    setSelected(nextSelected);
-                    if (onSelect) onSelect(nextSelected);
+                    const selectedItems = [
+                      ...nextSelected.filter(
+                        (item) => !selected.includes(item),
+                      ),
+                      ...selected,
+                    ];
+                    setSelected(
+                      nextSelected.length ? selectedItems : nextSelected,
+                    );
+                    if (onSelect)
+                      onSelect(
+                        nextSelected.length ? selectedItems : nextSelected,
+                      );
                   }
                 : undefined
             }

--- a/src/js/components/DataTable/Header.js
+++ b/src/js/components/DataTable/Header.js
@@ -69,24 +69,20 @@ const buttonStyle = ({ pad, theme, verticalAlign }) => {
     // CSS for this sub-object in the theme
     const partStyles = kindPartStyles(layoutProps.hover, theme);
     if (partStyles.length > 0)
-      styles.push(
-        css`
-          &:hover {
-            ${partStyles}
-          }
-        `,
-      );
+      styles.push(css`
+        &:hover {
+          ${partStyles}
+        }
+      `);
   }
 
   if (iconProps.color) {
-    styles.push(
-      css`
-        svg {
-          stroke: ${normalizeColor(iconProps.color, theme)};
-          fill: ${normalizeColor(iconProps.color, theme)};
-        }
-      `,
-    );
+    styles.push(css`
+      svg {
+        stroke: ${normalizeColor(iconProps.color, theme)};
+        fill: ${normalizeColor(iconProps.color, theme)};
+      }
+    `);
   }
 
   let align = 'center';
@@ -94,12 +90,10 @@ const buttonStyle = ({ pad, theme, verticalAlign }) => {
   if (verticalAlign === 'top') align = 'start';
 
   if (verticalAlign) {
-    styles.push(
-      css`
-        display: inline-flex;
-        align-items: ${align};
-      `,
-    );
+    styles.push(css`
+      display: inline-flex;
+      align-items: ${align};
+    `);
   }
 
   return styles;
@@ -271,7 +265,9 @@ const Header = forwardRef(
                   indeterminate={
                     groupBy?.select
                       ? groupBy.select[''] === 'some'
-                      : totalSelected > 0 && totalSelected < data.length
+                      : totalSelected > 0 &&
+                        (totalSelected < data.length ||
+                          totalSelected > data.length)
                   }
                   onChange={onChangeSelection}
                   pad={cellProps.pad}


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fixes #6946
- DataTable 'Select All' does not overwrites previously selected items

#### Where should the reviewer start?
- Create a test story with the code provided in https://codesandbox.io/s/grommet-filtered-datatable-3b37fe?file=/src/App.js and execute the steps.

#### What testing has been done on this PR?
- Ran locally on storybook

#### How should this be manually tested?
- By Creating a test story with the code provided in https://codesandbox.io/s/grommet-filtered-datatable-3b37fe?file=/src/App.js and executing the steps.

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
#6946

#### Screenshots (if appropriate)

https://github.com/grommet/grommet/assets/126149345/0c14dcbc-6a3d-4c01-91e9-f530c83015a7


#### Do the grommet docs need to be updated?
- NO
#### Should this PR be mentioned in the release notes?
- No
#### Is this change backwards compatible or is it a breaking change?
- Yes