### PR TITLE
Adds type of onChange to RangeInput

### DIFF
--- a/src/js/components/RangeInput/index.d.ts
+++ b/src/js/components/RangeInput/index.d.ts
@@ -16,11 +16,15 @@ export interface RangeInputProps {
   step?: number;
   color?: ColorType | ColorInterface[];
   value?: number | string;
+  onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
 export interface RangeInputExtendedProps
   extends RangeInputProps,
-    Omit<JSX.IntrinsicElements['input'], 'color' | 'step' | 'value'> {}
+    Omit<
+      JSX.IntrinsicElements['input'],
+      'color' | 'step' | 'value' | 'onChange'
+    > {}
 
 declare const RangeInput: React.FC<RangeInputExtendedProps>;
 


### PR DESCRIPTION
Improves event handler type for RangeInput component.

What does this PR do?
Improves event handler type for RageInput component.

Where should the reviewer start?
index.d.ts of RangeInput

What testing has been done on this PR?
Checked the types locally

How should this be manually tested?
Verify the typing

Do Jest tests follow these best practices?
Not applicable

- [ ] screen is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] userEvent is used in place of fireEvent.
- [ ] asFragment() is used for snapshot testing.

Any background context you want to provide?

What are the relevant issues?
#3165 

Screenshots (if appropriate)

Do the grommet docs need to be updated?

Should this PR be mentioned in the release notes?

Is this change backwards compatible or is it a breaking change?
May be breaking for people using typescript. Because we are now making the type stricter.