### PR TITLE
Prevent row focus style for unclickable rows with onSelect (#6719)

### DIFF
--- a/src/js/components/DataTable/Body.js
+++ b/src/js/components/DataTable/Body.js
@@ -196,7 +196,7 @@ const Body = forwardRef(
     const usingKeyboard = useKeyboard();
 
     const onFocusActive =
-      active ?? lastActive ?? (usingKeyboard ? 0 : undefined);
+      active ?? lastActive ?? (usingKeyboard && onClickRow ? 0 : undefined);
 
     const activePrimaryValue =
       active >= 0 ? datumValue(data[active], primaryProperty) : undefined;


### PR DESCRIPTION
Hello there,

This small change is intended to resolve #6719.

As I looked into this, I also discovered a variation to causing the unwanted highlighting of the first row. When keyboard navigation is initiated prior, any subsequent row checkbox click will re-highlight the first row. This is a more broad issue, affecting stories beyond "Controlled".

I did try to add a test, but wasn't able to arrive at a case that covers the unwanted highlighting scenario. The main problem I hit was emulating the keyboard navigation with the tab key in order to get the highlighting style to appear.

Finally, I do recognise this may not be the best remedy for the issue at hand. Hopefully I haven't misunderstood that the active row style should only be tied to the use of `onClickRow`.

---

#### What does this PR do?

Resolves unwanted highlighting of the first row in a DataTable after keyboard navigation occurs.

#### Where should the reviewer start?

Change only affects the DataTable component.

#### What testing has been done on this PR?

Only manual testing on my part using the available stories for DataTable.

#### How should this be manually tested?

Refer to the linked issue for the original reproduction steps.

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

None.

#### What are the relevant issues?

#6719

#### Screenshots (if appropriate)

DataTable "Controlled" story:

![demo1](https://github.com/grommet/grommet/assets/43751307/917e38c3-080f-45bf-9de4-c1744dec6ba7)

DataTable "Allow Select All" story:

![demo2](https://github.com/grommet/grommet/assets/43751307/916e6d84-c71d-4472-8659-73bd05c79289)

#### Do the grommet docs need to be updated?

Unsure. Maintainers to decide.

#### Should this PR be mentioned in the release notes?

Unsure. Maintainers to decide.

#### Is this change backwards compatible or is it a breaking change?

I'd like to think the change doesn't compromise any other DataTable behaviours I'm not aware of.