### PR TITLE
Fix groupHeader theming properties for DataTable (#6925)

### DIFF
--- a/src/js/components/DataTable/DataTable.js
+++ b/src/js/components/DataTable/DataTable.js
@@ -419,7 +419,10 @@ const DataTable = ({
   const bodyContent = groups ? (
     <GroupedBody
       ref={bodyRef}
-      cellProps={{ body: cellProps.body, groupHeader: cellProps.groupHeader }}
+      cellProps={{
+        body: cellProps.body,
+        groupHeader: { ...cellProps.body, ...cellProps.groupHeader },
+      }}
       columns={columns}
       disabled={disabled}
       groupBy={typeof groupBy === 'string' ? { property: groupBy } : groupBy}

--- a/src/js/components/DataTable/DataTable.js
+++ b/src/js/components/DataTable/DataTable.js
@@ -419,7 +419,7 @@ const DataTable = ({
   const bodyContent = groups ? (
     <GroupedBody
       ref={bodyRef}
-      cellProps={cellProps.body}
+      cellProps={{ body: cellProps.body, groupHeader: cellProps.groupHeader }}
       columns={columns}
       disabled={disabled}
       groupBy={typeof groupBy === 'string' ? { property: groupBy } : groupBy}

--- a/src/js/components/DataTable/GroupedBody.js
+++ b/src/js/components/DataTable/GroupedBody.js
@@ -165,7 +165,9 @@ export const GroupedBody = forwardRef(
             } = row;
             const cellProps = normalizeRowCellProps(
               rowProps,
-              cellPropsProp,
+              context === 'groupHeader'
+                ? cellPropsProp.groupHeader
+                : cellPropsProp.body,
               primaryValue,
               index,
             );

--- a/src/js/components/DataTable/__tests__/DataTable-test.tsx
+++ b/src/js/components/DataTable/__tests__/DataTable-test.tsx
@@ -1186,6 +1186,39 @@ describe('DataTable', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  test('should apply custom theme for groupHeader', () => {
+    const theme = {
+      dataTable: {
+        groupHeader: {
+          background: 'tomato',
+          border: {
+            side: 'top',
+            size: 'medium',
+          },
+          pad: 'medium',
+        },
+      },
+    };
+    const { asFragment } = render(
+      <Grommet theme={theme}>
+        <DataTable
+          columns={[
+            { header: 'Group', property: 'group' },
+            { header: 'Value', primary: true, property: 'value' },
+          ]}
+          data={[
+            { group: 1, value: 1 },
+            { group: 1, value: 2 },
+            { group: 2, value: 3 },
+            { group: 2, value: 4 },
+          ]}
+          groupBy="group"
+        />
+      </Grommet>,
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
   test('units', () => {
     const { container } = render(
       <Grommet>

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.tsx.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.tsx.snap
@@ -5742,7 +5742,7 @@ exports[`DataTable groupBy 0 value 1`] = `
   stroke: none;
 }
 
-.c15 {
+.c16 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -5753,25 +5753,25 @@ exports[`DataTable groupBy 0 value 1`] = `
   stroke: #666666;
 }
 
-.c15 g {
+.c16 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c15 *:not([stroke])[fill='none'] {
+.c16 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c15 *[stroke*='#'],
-.c15 *[STROKE*='#'] {
+.c16 *[stroke*='#'],
+.c16 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c15 *[fill-rule],
-.c15 *[FILL-RULE],
-.c15 *[fill*='#'],
-.c15 *[FILL*='#'] {
+.c16 *[fill-rule],
+.c16 *[FILL-RULE],
+.c16 *[fill*='#'],
+.c16 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -5973,9 +5973,39 @@ exports[`DataTable groupBy 0 value 1`] = `
   overflow: hidden;
   vertical-align: top;
   text-align: start;
+  background-color: #F2F2F2;
+  color: #444444;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
 }
 
 .c13 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  background-color: #F2F2F2;
+  color: #444444;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c15 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  width: 48px;
+  max-width: 48px;
+  overflow: hidden;
+  vertical-align: top;
+  text-align: start;
+}
+
+.c17 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -6178,7 +6208,7 @@ exports[`DataTable groupBy 0 value 1`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
       >
         <td
-          class="c12"
+          class="c15"
         >
           <div
             class="c4"
@@ -6189,14 +6219,14 @@ exports[`DataTable groupBy 0 value 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="c15"
+                class="c16"
                 viewBox="0 0 24 24"
               />
             </div>
           </div>
         </td>
         <td
-          class="c13 "
+          class="c17 "
         >
           <div
             class="c14"
@@ -6209,7 +6239,7 @@ exports[`DataTable groupBy 0 value 1`] = `
           </div>
         </td>
         <td
-          class="c13 "
+          class="c17 "
         >
           <div
             class="c14"
@@ -6222,7 +6252,7 @@ exports[`DataTable groupBy 0 value 1`] = `
           </div>
         </td>
         <td
-          class="c13 "
+          class="c17 "
         >
           <div
             class="c14"
@@ -6239,7 +6269,7 @@ exports[`DataTable groupBy 0 value 1`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
       >
         <td
-          class="c12"
+          class="c15"
         >
           <div
             class="c4"
@@ -6250,14 +6280,14 @@ exports[`DataTable groupBy 0 value 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="c15"
+                class="c16"
                 viewBox="0 0 24 24"
               />
             </div>
           </div>
         </td>
         <td
-          class="c13 "
+          class="c17 "
         >
           <div
             class="c14"
@@ -6270,7 +6300,7 @@ exports[`DataTable groupBy 0 value 1`] = `
           </div>
         </td>
         <td
-          class="c13 "
+          class="c17 "
         >
           <div
             class="c14"
@@ -6283,7 +6313,7 @@ exports[`DataTable groupBy 0 value 1`] = `
           </div>
         </td>
         <td
-          class="c13 "
+          class="c17 "
         >
           <div
             class="c14"
@@ -6533,6 +6563,9 @@ exports[`DataTable groupBy 1`] = `
   overflow: hidden;
   vertical-align: top;
   text-align: start;
+  background-color: #F2F2F2;
+  color: #444444;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
 }
 
 .c13 {
@@ -6541,6 +6574,9 @@ exports[`DataTable groupBy 1`] = `
   font-weight: inherit;
   text-align: inherit;
   text-align: start;
+  background-color: #F2F2F2;
+  color: #444444;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
   padding-left: 12px;
   padding-right: 12px;
   padding-top: 6px;
@@ -6855,7 +6891,7 @@ exports[`DataTable groupBy 2`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gbGTHA"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 NpttR"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 fYclLf"
@@ -6886,7 +6922,7 @@ exports[`DataTable groupBy 2`] = `
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 fiyHEw StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
           scope="row"
         >
           <div
@@ -6900,7 +6936,7 @@ exports[`DataTable groupBy 2`] = `
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 fiyHEw StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 kqmDKi"
@@ -6911,7 +6947,7 @@ exports[`DataTable groupBy 2`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gbGTHA"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 NpttR"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 fYclLf"
@@ -6942,7 +6978,7 @@ exports[`DataTable groupBy 2`] = `
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 fiyHEw StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
           scope="row"
         >
           <div
@@ -6956,7 +6992,7 @@ exports[`DataTable groupBy 2`] = `
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 fiyHEw StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 kqmDKi"
@@ -7003,7 +7039,7 @@ exports[`DataTable groupBy expand 1`] = `
   stroke: none;
 }
 
-.c15 {
+.c16 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -7014,25 +7050,25 @@ exports[`DataTable groupBy expand 1`] = `
   stroke: #666666;
 }
 
-.c15 g {
+.c16 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c15 *:not([stroke])[fill='none'] {
+.c16 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c15 *[stroke*='#'],
-.c15 *[STROKE*='#'] {
+.c16 *[stroke*='#'],
+.c16 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c15 *[fill-rule],
-.c15 *[FILL-RULE],
-.c15 *[fill*='#'],
-.c15 *[FILL*='#'] {
+.c16 *[fill-rule],
+.c16 *[FILL-RULE],
+.c16 *[fill*='#'],
+.c16 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -7124,7 +7160,7 @@ exports[`DataTable groupBy expand 1`] = `
   flex-direction: column;
 }
 
-.c17 {
+.c19 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7252,9 +7288,39 @@ exports[`DataTable groupBy expand 1`] = `
   overflow: hidden;
   vertical-align: top;
   text-align: start;
+  background-color: #F2F2F2;
+  color: #444444;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
 }
 
 .c13 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  background-color: #F2F2F2;
+  color: #444444;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c15 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  width: 48px;
+  max-width: 48px;
+  overflow: hidden;
+  vertical-align: top;
+  text-align: start;
+}
+
+.c17 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -7266,7 +7332,7 @@ exports[`DataTable groupBy expand 1`] = `
   padding-bottom: 6px;
 }
 
-.c16 {
+.c18 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -7448,7 +7514,7 @@ exports[`DataTable groupBy expand 1`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
       >
         <td
-          class="c12"
+          class="c15"
         >
           <div
             class="c4"
@@ -7459,14 +7525,14 @@ exports[`DataTable groupBy expand 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="c15"
+                class="c16"
                 viewBox="0 0 24 24"
               />
             </div>
           </div>
         </td>
         <td
-          class="c13 "
+          class="c17 "
         >
           <div
             class="c14"
@@ -7479,7 +7545,7 @@ exports[`DataTable groupBy expand 1`] = `
           </div>
         </td>
         <td
-          class="c13 "
+          class="c17 "
         >
           <div
             class="c14"
@@ -7496,10 +7562,10 @@ exports[`DataTable groupBy expand 1`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
       >
         <td
-          class="c16"
+          class="c18"
         >
           <div
-            class="c17"
+            class="c19"
             style="height: 0px;"
           >
             <div
@@ -7507,14 +7573,14 @@ exports[`DataTable groupBy expand 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="c15"
+                class="c16"
                 viewBox="0 0 24 24"
               />
             </div>
           </div>
         </td>
         <td
-          class="c13 "
+          class="c17 "
         >
           <div
             class="c14"
@@ -7527,7 +7593,7 @@ exports[`DataTable groupBy expand 1`] = `
           </div>
         </td>
         <td
-          class="c13 "
+          class="c17 "
         >
           <div
             class="c14"
@@ -7839,6 +7905,9 @@ exports[`DataTable groupBy property 1`] = `
   overflow: hidden;
   vertical-align: top;
   text-align: start;
+  background-color: #F2F2F2;
+  color: #444444;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
 }
 
 .c13 {
@@ -7847,6 +7916,9 @@ exports[`DataTable groupBy property 1`] = `
   font-weight: inherit;
   text-align: inherit;
   text-align: start;
+  background-color: #F2F2F2;
+  color: #444444;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
   padding-left: 12px;
   padding-right: 12px;
   padding-top: 6px;
@@ -8161,7 +8233,7 @@ exports[`DataTable groupBy property 2`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gbGTHA"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 NpttR"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 fYclLf"
@@ -8192,7 +8264,7 @@ exports[`DataTable groupBy property 2`] = `
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 fiyHEw StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
           scope="row"
         >
           <div
@@ -8206,7 +8278,7 @@ exports[`DataTable groupBy property 2`] = `
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 fiyHEw StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 kqmDKi"
@@ -8217,7 +8289,7 @@ exports[`DataTable groupBy property 2`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gbGTHA"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 NpttR"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 fYclLf"
@@ -8248,7 +8320,7 @@ exports[`DataTable groupBy property 2`] = `
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 fiyHEw StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
           scope="row"
         >
           <div
@@ -8262,7 +8334,7 @@ exports[`DataTable groupBy property 2`] = `
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 fiyHEw StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 kqmDKi"
@@ -8970,18 +9042,6 @@ exports[`DataTable groupBy toggle 2`] = `
   border: 0;
 }
 
-.c6 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
 .c1 {
   margin: 0;
   padding: 0;
@@ -8992,6 +9052,24 @@ exports[`DataTable groupBy toggle 2`] = `
   overflow: hidden;
   vertical-align: top;
   text-align: start;
+  background-color: #F2F2F2;
+  color: #444444;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+}
+
+.c6 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  background-color: #F2F2F2;
+  color: #444444;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
 }
 
 .c0:focus {
@@ -9405,7 +9483,7 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
   stroke: none;
 }
 
-.c24 {
+.c25 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -9416,25 +9494,25 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
   stroke: #666666;
 }
 
-.c24 g {
+.c25 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c24 *:not([stroke])[fill='none'] {
+.c25 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c24 *[stroke*='#'],
-.c24 *[STROKE*='#'] {
+.c25 *[stroke*='#'],
+.c25 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c24 *[fill-rule],
-.c24 *[FILL-RULE],
-.c24 *[fill*='#'],
-.c24 *[FILL*='#'] {
+.c25 *[fill-rule],
+.c25 *[FILL-RULE],
+.c25 *[fill*='#'],
+.c25 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -9592,7 +9670,7 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
   flex-direction: column;
 }
 
-.c27 {
+.c30 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -9618,7 +9696,7 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
   border-radius: 4px;
 }
 
-.c26 {
+.c29 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -9812,6 +9890,9 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
   overflow: hidden;
   vertical-align: top;
   text-align: start;
+  background-color: #F2F2F2;
+  color: #444444;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
 }
 
 .c21 {
@@ -9822,9 +9903,49 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
   width: 1px;
   overflow: hidden;
   text-align: start;
+  background-color: #F2F2F2;
+  color: #444444;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
 }
 
 .c22 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  background-color: #F2F2F2;
+  color: #444444;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c24 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  width: 48px;
+  max-width: 48px;
+  overflow: hidden;
+  vertical-align: top;
+  text-align: start;
+}
+
+.c26 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  width: 1px;
+  overflow: hidden;
+  text-align: start;
+}
+
+.c27 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -9836,7 +9957,7 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
   padding-bottom: 6px;
 }
 
-.c25 {
+.c28 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -9889,7 +10010,7 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
 }
 
 @media only screen and (max-width:768px) {
-  .c27 {
+  .c30 {
     border: solid 2px #7D4CDB;
   }
 }
@@ -10103,7 +10224,7 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
       >
         <td
-          class="c20"
+          class="c24"
         >
           <div
             class="c4"
@@ -10114,14 +10235,14 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
             >
               <svg
                 aria-hidden="true"
-                class="c24"
+                class="c25"
                 viewBox="0 0 24 24"
               />
             </div>
           </div>
         </td>
         <td
-          class="c21"
+          class="c26"
         >
           <div
             class="c9"
@@ -10147,7 +10268,7 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
           </div>
         </td>
         <td
-          class="c22 "
+          class="c27 "
         >
           <div
             class="c23"
@@ -10160,7 +10281,7 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
           </div>
         </td>
         <td
-          class="c22 "
+          class="c27 "
         >
           <div
             class="c23"
@@ -10177,10 +10298,10 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
       >
         <td
-          class="c25"
+          class="c28"
         >
           <div
-            class="c26"
+            class="c29"
             style="height: 0px;"
           >
             <div
@@ -10188,14 +10309,14 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
             >
               <svg
                 aria-hidden="true"
-                class="c24"
+                class="c25"
                 viewBox="0 0 24 24"
               />
             </div>
           </div>
         </td>
         <td
-          class="c21"
+          class="c26"
         >
           <div
             class="c9"
@@ -10214,7 +10335,7 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
                   type="checkbox"
                 />
                 <div
-                  class="c27 "
+                  class="c30 "
                 >
                   <svg
                     class="c15"
@@ -10232,7 +10353,7 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
           </div>
         </td>
         <td
-          class="c22 "
+          class="c27 "
         >
           <div
             class="c23"
@@ -10245,7 +10366,7 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
           </div>
         </td>
         <td
-          class="c22 "
+          class="c27 "
         >
           <div
             class="c23"
@@ -10709,6 +10830,9 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
   overflow: hidden;
   vertical-align: top;
   text-align: start;
+  background-color: #F2F2F2;
+  color: #444444;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
 }
 
 .c21 {
@@ -10719,6 +10843,9 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
   width: 1px;
   overflow: hidden;
   text-align: start;
+  background-color: #F2F2F2;
+  color: #444444;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
 }
 
 .c22 {
@@ -10727,6 +10854,9 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
   font-weight: inherit;
   text-align: inherit;
   text-align: start;
+  background-color: #F2F2F2;
+  color: #444444;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
   padding-left: 12px;
   padding-right: 12px;
   padding-top: 6px;
@@ -11454,6 +11584,9 @@ exports[`DataTable onSelect + groupBy should select all items within a group 1`]
   overflow: hidden;
   vertical-align: top;
   text-align: start;
+  background-color: #F2F2F2;
+  color: #444444;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
 }
 
 .c21 {
@@ -11464,6 +11597,9 @@ exports[`DataTable onSelect + groupBy should select all items within a group 1`]
   width: 1px;
   overflow: hidden;
   text-align: start;
+  background-color: #F2F2F2;
+  color: #444444;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
 }
 
 .c23 {
@@ -11472,6 +11608,9 @@ exports[`DataTable onSelect + groupBy should select all items within a group 1`]
   font-weight: inherit;
   text-align: inherit;
   text-align: start;
+  background-color: #F2F2F2;
+  color: #444444;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
   padding-left: 12px;
   padding-right: 12px;
   padding-top: 6px;
@@ -12171,6 +12310,9 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 1`
   overflow: hidden;
   vertical-align: top;
   text-align: start;
+  background-color: #F2F2F2;
+  color: #444444;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
 }
 
 .c20 {
@@ -12181,6 +12323,9 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 1`
   width: 1px;
   overflow: hidden;
   text-align: start;
+  background-color: #F2F2F2;
+  color: #444444;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
 }
 
 .c21 {
@@ -12189,6 +12334,9 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 1`
   font-weight: inherit;
   text-align: inherit;
   text-align: start;
+  background-color: #F2F2F2;
+  color: #444444;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
   padding-left: 12px;
   padding-right: 12px;
   padding-top: 6px;
@@ -12646,7 +12794,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gbGTHA"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 NpttR"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 fYclLf"
@@ -12677,7 +12825,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jgBFZZ"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hGsKfY"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 dlUdOy"
@@ -12737,7 +12885,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 fiyHEw StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
           scope="row"
         >
           <div
@@ -12751,7 +12899,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 fiyHEw StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 kqmDKi"
@@ -12762,7 +12910,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gbGTHA"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 NpttR"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 fYclLf"
@@ -12793,7 +12941,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jgBFZZ"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hGsKfY"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 dlUdOy"
@@ -12853,7 +13001,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 fiyHEw StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
           scope="row"
         >
           <div
@@ -12867,7 +13015,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 fiyHEw StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 kqmDKi"
@@ -12986,7 +13134,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gbGTHA"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 NpttR"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 fYclLf"
@@ -13017,7 +13165,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jgBFZZ"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hGsKfY"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 dlUdOy"
@@ -13042,7 +13190,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 fiyHEw StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
           scope="row"
         >
           <div
@@ -13056,7 +13204,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 fiyHEw StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 kqmDKi"
@@ -13067,7 +13215,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gbGTHA"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 NpttR"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 fYclLf"
@@ -13098,7 +13246,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jgBFZZ"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hGsKfY"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 dlUdOy"
@@ -13123,7 +13271,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 fiyHEw StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
           scope="row"
         >
           <div
@@ -13137,7 +13285,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 fiyHEw StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 kqmDKi"
@@ -21559,6 +21707,7 @@ exports[`DataTable rowProps on group header rows 1`] = `
   vertical-align: top;
   text-align: start;
   background: yellow;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
 }
 
 .c13 {
@@ -21568,6 +21717,7 @@ exports[`DataTable rowProps on group header rows 1`] = `
   text-align: inherit;
   text-align: start;
   background: yellow;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
   padding-left: 12px;
   padding-right: 12px;
   padding-top: 6px;
@@ -23601,6 +23751,509 @@ exports[`DataTable select with allowSelectAll={false} 2`] = `
     </tbody>
   </table>
 </div>
+`;
+
+exports[`DataTable should apply custom theme for groupHeader 1`] = `
+<DocumentFragment>
+  .c7 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: rgba(0,0,0,0.33);
+  stroke: rgba(0,0,0,0.33);
+}
+
+.c7 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c7 *:not([stroke])[fill='none'] {
+  stroke-width: 0;
+}
+
+.c7 *[stroke*='#'],
+.c7 *[STROKE*='#'] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c7 *[fill-rule],
+.c7 *[FILL-RULE],
+.c7 *[fill*='#'],
+.c7 *[FILL*='#'] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c13 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  padding: 24px;
+}
+
+.c15 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c10 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c5 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c5:hover {
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
+}
+
+.c5:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c5:focus > circle,
+.c5:focus > ellipse,
+.c5:focus > line,
+.c5:focus > path,
+.c5:focus > polygon,
+.c5:focus > polyline,
+.c5:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c5:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c5:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c5:focus:not(:focus-visible) > circle,
+.c5:focus:not(:focus-visible) > ellipse,
+.c5:focus:not(:focus-visible) > line,
+.c5:focus:not(:focus-visible) > path,
+.c5:focus:not(:focus-visible) > polygon,
+.c5:focus:not(:focus-visible) > polyline,
+.c5:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c5:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c3 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  width: 48px;
+  max-width: 48px;
+  overflow: hidden;
+  vertical-align: top;
+  text-align: start;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+}
+
+.c8 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c12 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  width: 48px;
+  max-width: 48px;
+  overflow: hidden;
+  vertical-align: top;
+  text-align: start;
+  background: tomato;
+  border-top: solid 4px rgba(0,0,0,0.33);
+}
+
+.c14 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  background: tomato;
+  border-top: solid 4px rgba(0,0,0,0.33);
+  padding: 24px;
+}
+
+.c1 {
+  border-spacing: 0;
+  border-collapse: collapse;
+  width: inherit;
+}
+
+.c2 {
+  position: relative;
+  border-spacing: 0;
+  border-collapse: separate;
+}
+
+.c11:focus {
+  outline: 2px solid #6FFFB0;
+}
+
+.c11:focus:not(:focus-visible) {
+  outline: none;
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    padding-left: 6px;
+    padding-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    padding-top: 3px;
+    padding-bottom: 3px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c13 {
+    padding: 12px;
+  }
+}
+
+<div
+    class="c0"
+  >
+    <table
+      class="c1 c2"
+    >
+      <thead
+        class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
+      >
+        <tr
+          class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+        >
+          <td
+            class="c3"
+          >
+            <div
+              class="c4"
+              style="height: 0px;"
+            >
+              <button
+                aria-label="expand"
+                class="c5"
+                type="button"
+              >
+                <div
+                  class="c6"
+                >
+                  <svg
+                    aria-label="FormDown"
+                    class="c7"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="m18 9-6 6-6-6"
+                      fill="none"
+                      stroke="#000"
+                      stroke-width="2"
+                    />
+                  </svg>
+                </div>
+              </button>
+            </div>
+          </td>
+          <th
+            class="c8 "
+            scope="col"
+          >
+            <div
+              class="c9"
+            >
+              <span
+                class="c10"
+              >
+                Group
+              </span>
+            </div>
+          </th>
+          <th
+            class="c8 "
+            scope="col"
+          >
+            <div
+              class="c9"
+            >
+              <span
+                class="c10"
+              >
+                Value
+              </span>
+            </div>
+          </th>
+        </tr>
+      </thead>
+      <tbody
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c11"
+      >
+        <tr
+          class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+        >
+          <td
+            class="c12"
+          >
+            <div
+              class="c4"
+              style="height: 0px;"
+            >
+              <button
+                aria-label="expand"
+                class="c5"
+                type="button"
+              >
+                <div
+                  class="c13"
+                >
+                  <svg
+                    aria-label="FormDown"
+                    class="c7"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="m18 9-6 6-6-6"
+                      fill="none"
+                      stroke="#000"
+                      stroke-width="2"
+                    />
+                  </svg>
+                </div>
+              </button>
+            </div>
+          </td>
+          <th
+            class="c14 "
+            scope="row"
+          >
+            <div
+              class="c15"
+            >
+              <span
+                class="c10"
+              >
+                1
+              </span>
+            </div>
+          </th>
+          <td
+            class="c14 "
+          >
+            <div
+              class="c15"
+            />
+          </td>
+        </tr>
+        <tr
+          class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+        >
+          <td
+            class="c12"
+          >
+            <div
+              class="c4"
+              style="height: 0px;"
+            >
+              <button
+                aria-label="expand"
+                class="c5"
+                type="button"
+              >
+                <div
+                  class="c13"
+                >
+                  <svg
+                    aria-label="FormDown"
+                    class="c7"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="m18 9-6 6-6-6"
+                      fill="none"
+                      stroke="#000"
+                      stroke-width="2"
+                    />
+                  </svg>
+                </div>
+              </button>
+            </div>
+          </td>
+          <th
+            class="c14 "
+            scope="row"
+          >
+            <div
+              class="c15"
+            >
+              <span
+                class="c10"
+              >
+                2
+              </span>
+            </div>
+          </th>
+          <td
+            class="c14 "
+          >
+            <div
+              class="c15"
+            />
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</DocumentFragment>
 `;
 
 exports[`DataTable should apply pagination styling 1`] = `

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.tsx.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.tsx.snap
@@ -5742,7 +5742,7 @@ exports[`DataTable groupBy 0 value 1`] = `
   stroke: none;
 }
 
-.c16 {
+.c15 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -5753,25 +5753,25 @@ exports[`DataTable groupBy 0 value 1`] = `
   stroke: #666666;
 }
 
-.c16 g {
+.c15 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c16 *:not([stroke])[fill='none'] {
+.c15 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c16 *[stroke*='#'],
-.c16 *[STROKE*='#'] {
+.c15 *[stroke*='#'],
+.c15 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c16 *[fill-rule],
-.c16 *[FILL-RULE],
-.c16 *[fill*='#'],
-.c16 *[FILL*='#'] {
+.c15 *[fill-rule],
+.c15 *[FILL-RULE],
+.c15 *[fill*='#'],
+.c15 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -5973,39 +5973,9 @@ exports[`DataTable groupBy 0 value 1`] = `
   overflow: hidden;
   vertical-align: top;
   text-align: start;
-  background-color: #F2F2F2;
-  color: #444444;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
 }
 
 .c13 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  background-color: #F2F2F2;
-  color: #444444;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-.c15 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  width: 48px;
-  max-width: 48px;
-  overflow: hidden;
-  vertical-align: top;
-  text-align: start;
-}
-
-.c17 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -6208,7 +6178,7 @@ exports[`DataTable groupBy 0 value 1`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
       >
         <td
-          class="c15"
+          class="c12"
         >
           <div
             class="c4"
@@ -6219,14 +6189,14 @@ exports[`DataTable groupBy 0 value 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="c16"
+                class="c15"
                 viewBox="0 0 24 24"
               />
             </div>
           </div>
         </td>
         <td
-          class="c17 "
+          class="c13 "
         >
           <div
             class="c14"
@@ -6239,7 +6209,7 @@ exports[`DataTable groupBy 0 value 1`] = `
           </div>
         </td>
         <td
-          class="c17 "
+          class="c13 "
         >
           <div
             class="c14"
@@ -6252,7 +6222,7 @@ exports[`DataTable groupBy 0 value 1`] = `
           </div>
         </td>
         <td
-          class="c17 "
+          class="c13 "
         >
           <div
             class="c14"
@@ -6269,7 +6239,7 @@ exports[`DataTable groupBy 0 value 1`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
       >
         <td
-          class="c15"
+          class="c12"
         >
           <div
             class="c4"
@@ -6280,14 +6250,14 @@ exports[`DataTable groupBy 0 value 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="c16"
+                class="c15"
                 viewBox="0 0 24 24"
               />
             </div>
           </div>
         </td>
         <td
-          class="c17 "
+          class="c13 "
         >
           <div
             class="c14"
@@ -6300,7 +6270,7 @@ exports[`DataTable groupBy 0 value 1`] = `
           </div>
         </td>
         <td
-          class="c17 "
+          class="c13 "
         >
           <div
             class="c14"
@@ -6313,7 +6283,7 @@ exports[`DataTable groupBy 0 value 1`] = `
           </div>
         </td>
         <td
-          class="c17 "
+          class="c13 "
         >
           <div
             class="c14"
@@ -6563,9 +6533,6 @@ exports[`DataTable groupBy 1`] = `
   overflow: hidden;
   vertical-align: top;
   text-align: start;
-  background-color: #F2F2F2;
-  color: #444444;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
 }
 
 .c13 {
@@ -6574,9 +6541,6 @@ exports[`DataTable groupBy 1`] = `
   font-weight: inherit;
   text-align: inherit;
   text-align: start;
-  background-color: #F2F2F2;
-  color: #444444;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
   padding-left: 12px;
   padding-right: 12px;
   padding-top: 6px;
@@ -6891,7 +6855,7 @@ exports[`DataTable groupBy 2`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 NpttR"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gbGTHA"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 fYclLf"
@@ -6922,7 +6886,7 @@ exports[`DataTable groupBy 2`] = `
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 fiyHEw StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
           scope="row"
         >
           <div
@@ -6936,7 +6900,7 @@ exports[`DataTable groupBy 2`] = `
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 fiyHEw StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 kqmDKi"
@@ -6947,7 +6911,7 @@ exports[`DataTable groupBy 2`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 NpttR"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gbGTHA"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 fYclLf"
@@ -6978,7 +6942,7 @@ exports[`DataTable groupBy 2`] = `
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 fiyHEw StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
           scope="row"
         >
           <div
@@ -6992,7 +6956,7 @@ exports[`DataTable groupBy 2`] = `
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 fiyHEw StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 kqmDKi"
@@ -7039,7 +7003,7 @@ exports[`DataTable groupBy expand 1`] = `
   stroke: none;
 }
 
-.c16 {
+.c15 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -7050,25 +7014,25 @@ exports[`DataTable groupBy expand 1`] = `
   stroke: #666666;
 }
 
-.c16 g {
+.c15 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c16 *:not([stroke])[fill='none'] {
+.c15 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c16 *[stroke*='#'],
-.c16 *[STROKE*='#'] {
+.c15 *[stroke*='#'],
+.c15 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c16 *[fill-rule],
-.c16 *[FILL-RULE],
-.c16 *[fill*='#'],
-.c16 *[FILL*='#'] {
+.c15 *[fill-rule],
+.c15 *[FILL-RULE],
+.c15 *[fill*='#'],
+.c15 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -7160,7 +7124,7 @@ exports[`DataTable groupBy expand 1`] = `
   flex-direction: column;
 }
 
-.c19 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7288,9 +7252,6 @@ exports[`DataTable groupBy expand 1`] = `
   overflow: hidden;
   vertical-align: top;
   text-align: start;
-  background-color: #F2F2F2;
-  color: #444444;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
 }
 
 .c13 {
@@ -7299,40 +7260,13 @@ exports[`DataTable groupBy expand 1`] = `
   font-weight: inherit;
   text-align: inherit;
   text-align: start;
-  background-color: #F2F2F2;
-  color: #444444;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
   padding-left: 12px;
   padding-right: 12px;
   padding-top: 6px;
   padding-bottom: 6px;
 }
 
-.c15 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  width: 48px;
-  max-width: 48px;
-  overflow: hidden;
-  vertical-align: top;
-  text-align: start;
-}
-
-.c17 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-.c18 {
+.c16 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -7514,7 +7448,7 @@ exports[`DataTable groupBy expand 1`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
       >
         <td
-          class="c15"
+          class="c12"
         >
           <div
             class="c4"
@@ -7525,14 +7459,14 @@ exports[`DataTable groupBy expand 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="c16"
+                class="c15"
                 viewBox="0 0 24 24"
               />
             </div>
           </div>
         </td>
         <td
-          class="c17 "
+          class="c13 "
         >
           <div
             class="c14"
@@ -7545,7 +7479,7 @@ exports[`DataTable groupBy expand 1`] = `
           </div>
         </td>
         <td
-          class="c17 "
+          class="c13 "
         >
           <div
             class="c14"
@@ -7562,10 +7496,10 @@ exports[`DataTable groupBy expand 1`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
       >
         <td
-          class="c18"
+          class="c16"
         >
           <div
-            class="c19"
+            class="c17"
             style="height: 0px;"
           >
             <div
@@ -7573,14 +7507,14 @@ exports[`DataTable groupBy expand 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="c16"
+                class="c15"
                 viewBox="0 0 24 24"
               />
             </div>
           </div>
         </td>
         <td
-          class="c17 "
+          class="c13 "
         >
           <div
             class="c14"
@@ -7593,7 +7527,7 @@ exports[`DataTable groupBy expand 1`] = `
           </div>
         </td>
         <td
-          class="c17 "
+          class="c13 "
         >
           <div
             class="c14"
@@ -7905,9 +7839,6 @@ exports[`DataTable groupBy property 1`] = `
   overflow: hidden;
   vertical-align: top;
   text-align: start;
-  background-color: #F2F2F2;
-  color: #444444;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
 }
 
 .c13 {
@@ -7916,9 +7847,6 @@ exports[`DataTable groupBy property 1`] = `
   font-weight: inherit;
   text-align: inherit;
   text-align: start;
-  background-color: #F2F2F2;
-  color: #444444;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
   padding-left: 12px;
   padding-right: 12px;
   padding-top: 6px;
@@ -8233,7 +8161,7 @@ exports[`DataTable groupBy property 2`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 NpttR"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gbGTHA"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 fYclLf"
@@ -8264,7 +8192,7 @@ exports[`DataTable groupBy property 2`] = `
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 fiyHEw StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
           scope="row"
         >
           <div
@@ -8278,7 +8206,7 @@ exports[`DataTable groupBy property 2`] = `
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 fiyHEw StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 kqmDKi"
@@ -8289,7 +8217,7 @@ exports[`DataTable groupBy property 2`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 NpttR"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gbGTHA"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 fYclLf"
@@ -8320,7 +8248,7 @@ exports[`DataTable groupBy property 2`] = `
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 fiyHEw StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
           scope="row"
         >
           <div
@@ -8334,7 +8262,7 @@ exports[`DataTable groupBy property 2`] = `
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 fiyHEw StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 kqmDKi"
@@ -9042,6 +8970,18 @@ exports[`DataTable groupBy toggle 2`] = `
   border: 0;
 }
 
+.c6 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
 .c1 {
   margin: 0;
   padding: 0;
@@ -9052,24 +8992,6 @@ exports[`DataTable groupBy toggle 2`] = `
   overflow: hidden;
   vertical-align: top;
   text-align: start;
-  background-color: #F2F2F2;
-  color: #444444;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
-}
-
-.c6 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  background-color: #F2F2F2;
-  color: #444444;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
 }
 
 .c0:focus {
@@ -9483,7 +9405,7 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
   stroke: none;
 }
 
-.c25 {
+.c24 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -9494,25 +9416,25 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
   stroke: #666666;
 }
 
-.c25 g {
+.c24 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c25 *:not([stroke])[fill='none'] {
+.c24 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c25 *[stroke*='#'],
-.c25 *[STROKE*='#'] {
+.c24 *[stroke*='#'],
+.c24 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c25 *[fill-rule],
-.c25 *[FILL-RULE],
-.c25 *[fill*='#'],
-.c25 *[FILL*='#'] {
+.c24 *[fill-rule],
+.c24 *[FILL-RULE],
+.c24 *[fill*='#'],
+.c24 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -9670,7 +9592,7 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
   flex-direction: column;
 }
 
-.c30 {
+.c27 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -9696,7 +9618,7 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
   border-radius: 4px;
 }
 
-.c29 {
+.c26 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -9890,9 +9812,6 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
   overflow: hidden;
   vertical-align: top;
   text-align: start;
-  background-color: #F2F2F2;
-  color: #444444;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
 }
 
 .c21 {
@@ -9903,9 +9822,6 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
   width: 1px;
   overflow: hidden;
   text-align: start;
-  background-color: #F2F2F2;
-  color: #444444;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
 }
 
 .c22 {
@@ -9914,50 +9830,13 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
   font-weight: inherit;
   text-align: inherit;
   text-align: start;
-  background-color: #F2F2F2;
-  color: #444444;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
   padding-left: 12px;
   padding-right: 12px;
   padding-top: 6px;
   padding-bottom: 6px;
 }
 
-.c24 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  width: 48px;
-  max-width: 48px;
-  overflow: hidden;
-  vertical-align: top;
-  text-align: start;
-}
-
-.c26 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  width: 1px;
-  overflow: hidden;
-  text-align: start;
-}
-
-.c27 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-.c28 {
+.c25 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -10010,7 +9889,7 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
 }
 
 @media only screen and (max-width:768px) {
-  .c30 {
+  .c27 {
     border: solid 2px #7D4CDB;
   }
 }
@@ -10224,7 +10103,7 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
       >
         <td
-          class="c24"
+          class="c20"
         >
           <div
             class="c4"
@@ -10235,14 +10114,14 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
             >
               <svg
                 aria-hidden="true"
-                class="c25"
+                class="c24"
                 viewBox="0 0 24 24"
               />
             </div>
           </div>
         </td>
         <td
-          class="c26"
+          class="c21"
         >
           <div
             class="c9"
@@ -10268,7 +10147,7 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
           </div>
         </td>
         <td
-          class="c27 "
+          class="c22 "
         >
           <div
             class="c23"
@@ -10281,7 +10160,7 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
           </div>
         </td>
         <td
-          class="c27 "
+          class="c22 "
         >
           <div
             class="c23"
@@ -10298,10 +10177,10 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
       >
         <td
-          class="c28"
+          class="c25"
         >
           <div
-            class="c29"
+            class="c26"
             style="height: 0px;"
           >
             <div
@@ -10309,14 +10188,14 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
             >
               <svg
                 aria-hidden="true"
-                class="c25"
+                class="c24"
                 viewBox="0 0 24 24"
               />
             </div>
           </div>
         </td>
         <td
-          class="c26"
+          class="c21"
         >
           <div
             class="c9"
@@ -10335,7 +10214,7 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
                   type="checkbox"
                 />
                 <div
-                  class="c30 "
+                  class="c27 "
                 >
                   <svg
                     class="c15"
@@ -10353,7 +10232,7 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
           </div>
         </td>
         <td
-          class="c27 "
+          class="c22 "
         >
           <div
             class="c23"
@@ -10366,7 +10245,7 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
           </div>
         </td>
         <td
-          class="c27 "
+          class="c22 "
         >
           <div
             class="c23"
@@ -10830,9 +10709,6 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
   overflow: hidden;
   vertical-align: top;
   text-align: start;
-  background-color: #F2F2F2;
-  color: #444444;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
 }
 
 .c21 {
@@ -10843,9 +10719,6 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
   width: 1px;
   overflow: hidden;
   text-align: start;
-  background-color: #F2F2F2;
-  color: #444444;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
 }
 
 .c22 {
@@ -10854,9 +10727,6 @@ exports[`DataTable onSelect + groupBy should render indeterminate checkbox on ta
   font-weight: inherit;
   text-align: inherit;
   text-align: start;
-  background-color: #F2F2F2;
-  color: #444444;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
   padding-left: 12px;
   padding-right: 12px;
   padding-top: 6px;
@@ -11584,9 +11454,6 @@ exports[`DataTable onSelect + groupBy should select all items within a group 1`]
   overflow: hidden;
   vertical-align: top;
   text-align: start;
-  background-color: #F2F2F2;
-  color: #444444;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
 }
 
 .c21 {
@@ -11597,9 +11464,6 @@ exports[`DataTable onSelect + groupBy should select all items within a group 1`]
   width: 1px;
   overflow: hidden;
   text-align: start;
-  background-color: #F2F2F2;
-  color: #444444;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
 }
 
 .c23 {
@@ -11608,9 +11472,6 @@ exports[`DataTable onSelect + groupBy should select all items within a group 1`]
   font-weight: inherit;
   text-align: inherit;
   text-align: start;
-  background-color: #F2F2F2;
-  color: #444444;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
   padding-left: 12px;
   padding-right: 12px;
   padding-top: 6px;
@@ -12310,9 +12171,6 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 1`
   overflow: hidden;
   vertical-align: top;
   text-align: start;
-  background-color: #F2F2F2;
-  color: #444444;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
 }
 
 .c20 {
@@ -12323,9 +12181,6 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 1`
   width: 1px;
   overflow: hidden;
   text-align: start;
-  background-color: #F2F2F2;
-  color: #444444;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
 }
 
 .c21 {
@@ -12334,9 +12189,6 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 1`
   font-weight: inherit;
   text-align: inherit;
   text-align: start;
-  background-color: #F2F2F2;
-  color: #444444;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
   padding-left: 12px;
   padding-right: 12px;
   padding-top: 6px;
@@ -12794,7 +12646,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 NpttR"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gbGTHA"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 fYclLf"
@@ -12825,7 +12677,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hGsKfY"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jgBFZZ"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 dlUdOy"
@@ -12885,7 +12737,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 fiyHEw StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
           scope="row"
         >
           <div
@@ -12899,7 +12751,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 fiyHEw StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 kqmDKi"
@@ -12910,7 +12762,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 NpttR"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gbGTHA"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 fYclLf"
@@ -12941,7 +12793,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hGsKfY"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jgBFZZ"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 dlUdOy"
@@ -13001,7 +12853,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 fiyHEw StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
           scope="row"
         >
           <div
@@ -13015,7 +12867,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 fiyHEw StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 kqmDKi"
@@ -13134,7 +12986,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 NpttR"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gbGTHA"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 fYclLf"
@@ -13165,7 +13017,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hGsKfY"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jgBFZZ"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 dlUdOy"
@@ -13190,7 +13042,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 fiyHEw StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
           scope="row"
         >
           <div
@@ -13204,7 +13056,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 fiyHEw StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 kqmDKi"
@@ -13215,7 +13067,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 eymRHp"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 NpttR"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gbGTHA"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 fYclLf"
@@ -13246,7 +13098,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hGsKfY"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jgBFZZ"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 dlUdOy"
@@ -13271,7 +13123,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 fiyHEw StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
           scope="row"
         >
           <div
@@ -13285,7 +13137,7 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 fiyHEw StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 eYGrCx StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 htfSia"
         >
           <div
             class="StyledBox-sc-13pk1d4-0 kqmDKi"
@@ -21707,7 +21559,6 @@ exports[`DataTable rowProps on group header rows 1`] = `
   vertical-align: top;
   text-align: start;
   background: yellow;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
 }
 
 .c13 {
@@ -21717,7 +21568,6 @@ exports[`DataTable rowProps on group header rows 1`] = `
   text-align: inherit;
   text-align: start;
   background: yellow;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
   padding-left: 12px;
   padding-right: 12px;
   padding-top: 6px;

--- a/src/js/components/DataTable/buildState.js
+++ b/src/js/components/DataTable/buildState.js
@@ -253,7 +253,7 @@ export const normalizeRowProp = (name, rowProp, prop) => {
   return prop;
 };
 
-const tableContextNames = ['header', 'body', 'footer'];
+const tableContextNames = ['header', 'body', 'footer', 'groupHeader'];
 const cellPropertyNames = ['background', 'border', 'pad'];
 
 // Convert property specific cell props to context specific cell props.

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -1176,20 +1176,7 @@ exports[`Components loads 1`] = `
               "size": "xsmall",
             },
           },
-          "groupHeader": {
-            "background": {
-              "dark": "dark-2",
-              "light": "light-2",
-            },
-            "border": {
-              "side": "bottom",
-              "size": "xsmall",
-            },
-            "pad": {
-              "horizontal": "small",
-              "vertical": "xsmall",
-            },
-          },
+          "groupHeader": {},
           "header": {
             "gap": "small",
             "units": {
@@ -3178,20 +3165,7 @@ exports[`Components loads 1`] = `
               "size": "xsmall",
             },
           },
-          "groupHeader": {
-            "background": {
-              "dark": "dark-2",
-              "light": "light-2",
-            },
-            "border": {
-              "side": "bottom",
-              "size": "xsmall",
-            },
-            "pad": {
-              "horizontal": "small",
-              "vertical": "xsmall",
-            },
-          },
+          "groupHeader": {},
           "header": {
             "gap": "small",
             "units": {

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -818,12 +818,9 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         // extend: undefined,
       },
       groupHeader: {
-        background: {
-          dark: 'dark-2',
-          light: 'light-2',
-        },
-        border: { side: 'bottom', size: 'xsmall' },
-        pad: { horizontal: 'small', vertical: 'xsmall' },
+        // background: undefined,
+        // border: undefined,
+        // pad: undefined,
       },
       groupEnd: {
         border: { side: 'bottom', size: 'xsmall' },


### PR DESCRIPTION
Hello there,

Another pull request, this time aimed at addressing #6925.

A noteworthy side effect of my proposed fix involved updating existing test snapshots for DataTable. In particular, those which used `groupBy` for row grouping. I can only guess that this was because theme properties relating to `groupHeader` were never fed through properly.

---

#### What does this PR do?

Ensures that any theme properties (e.g. https://v2.grommet.io/datatable#dataTable.groupHeader.background) used to customise a DataTable component are incorporated for rendering.

#### Where should the reviewer start?

Making sure that the test snapshots I updated are within reason.

#### What testing has been done on this PR?

I used the available DataTable stories in addition to adding an extra test that covers the provision of `groupHeader` theme properties.

#### How should this be manually tested?

Any DataTable story that involves `groupBy` would be affected by this change (i.e. because even the default `groupHeader` theme properties didn't appear to be passed along).

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

None.

#### What are the relevant issues?

#6925

#### Screenshots (if appropriate)

This should now be the default appearance when using `groupBy`:

![image](https://github.com/grommet/grommet/assets/43751307/260def30-f56e-4fa1-ae5b-59c1ef141090)

Edited the custom theme story for DataTable to demonstrate `groupHeader` theme properties being changed:

![image](https://github.com/grommet/grommet/assets/43751307/c54d2fe8-bdec-44b0-aff3-e64f6791a0c9)

#### Do the grommet docs need to be updated?

Unsure. Maintainers to decide.

#### Should this PR be mentioned in the release notes?

Likely, as it involves a visual change that would immediately affect anybody using `groupBy` with DataTable.

#### Is this change backwards compatible or is it a breaking change?

As mentioned above, this change will alter the default look of DataTable when using `groupBy`, but it's in the interest of allowing people the ability to customise the appearance of row groups if they don't want the default.