### PR TITLE
Fix #6981

### DIFF
--- a/src/js/utils/DOM.js
+++ b/src/js/utils/DOM.js
@@ -157,7 +157,7 @@ export const makeNodeFocusable = (node) => {
   }
 };
 
-const autoFocusingTags = /(a|area|input|select|textarea|button|iframe)$/;
+const autoFocusingTags = /(a|area|input|select|textarea|button|iframe)(?![\w-])$/;
 
 export const makeNodeUnfocusable = (node) => {
   // do not touch aria live containers so that announcements work


### PR DESCRIPTION
changed const autoFocusingTags = /(a|area|input|select|textarea|button|iframe)$/; to  const autoFocusingTags = /(a|area|input|select|textarea|button|iframe)(?![\w-])$/;

hacktoberfest



