### PR TITLE
Fix focus issue on RadioButtonGroup

### DIFF
--- a/src/js/components/RadioButtonGroup/RadioButtonGroup.js
+++ b/src/js/components/RadioButtonGroup/RadioButtonGroup.js
@@ -1,10 +1,4 @@
-import React, {
-  forwardRef,
-  useContext,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import React, { forwardRef, useContext, useRef, useState } from 'react';
 
 import { ThemeContext } from 'styled-components';
 import { FormContext } from '../Form/FormContext';
@@ -67,14 +61,6 @@ const RadioButtonGroup = forwardRef(
       });
       return result;
     }, [options, value]);
-
-    useEffect(() => {
-      // if tab comes back to RadioButtonGroup when there still is no selection,
-      // we want focus to be on the first RadioButton
-      if (focus && !valueIndex) {
-        optionRefs.current[0].focus();
-      }
-    }, [focus, valueIndex]);
 
     const onNext = () => {
       if (valueIndex !== undefined && valueIndex < options.length - 1) {


### PR DESCRIPTION
#### What does this PR do?
Resolves an issue with RadioButtonGroup. When using a screenreader and navigating through the RadioButtonGroup options sometimes the focus jumps back to the first radio button.

This PR removes an unnecessary useEffect. The useEffect was added to ensure that when a RadioButtonGroup doesn't have a value and it is focused, the first option will receive focus. This behavior is already covered here: https://github.com/grommet/grommet/blob/master/src/js/components/RadioButtonGroup/RadioButtonGroup.js#L156-L158. The useEffect is unnecessary and introduces the screenreader issue.

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes https://github.com/grommet/grommet/issues/7002

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible