### PR TITLE
Fix tip truncate mode for Text using dynamic content (#6910)

### DIFF
--- a/src/js/components/Text/Text.js
+++ b/src/js/components/Text/Text.js
@@ -53,7 +53,7 @@ const Text = forwardRef(
         window.removeEventListener('resize', updateTip);
         window.removeEventListener('pagechange', updateTip);
       };
-    }, [textRef, truncate]);
+    }, [textRef, children, truncate]);
 
     if (skeleton) {
       return (


### PR DESCRIPTION
Hello,

This is a minor adjustment that's intended to resolve #6910.

My understanding of why this particular issue happens is because the truncation testing logic inside Text isn't being triggered when it should be (i.e. when text content gets updated).

Note that even without my proposed change here, the problem resolves itself when a user triggers a viewport resize event. That's because the latter is another way the truncation testing logic may be retriggered.

(I should also add that at this time of writing, tests on `master` are failing, even without my proposed change.)

---

#### What does this PR do?

Ensures that Text usages with `truncate="tip"` display a tooltip when its content changes (e.g. stateful text being updated).

#### Where should the reviewer start?

By having a look at the Text component implementation.

#### What testing has been done on this PR?

I sunk a big chunk of time into investigating how to write a test to replicate the problematic scenario. Alas, I wasn't able to arrive at something satisfactory. I saw two sticking points:

1. Truncation testing logic inside Text relies on layout properties (e.g. `textRef.current.scrollWidth`), which I don't believe jsdom copes with.
2. It's not clear to me where the tooltip (i.e. Drop) attaches, and it looks too difficult to hijack and mock refs that deep down.

The best assurance I can provide with my change is through attempting to reproduce the issue with a custom story (see below).

Otherwise, I'm happy to be schooled on how might to get a test going for this.

#### How should this be manually tested?

I'm unsure the following story merits a permanent place, which is why I've not included it with the fix.

However, one should be able to copy and paste the story to test locally if desired:

```js
import React from 'react';

import { Box, Text } from 'grommet';

export const DynamicTruncateTip = () => {
  const [text, setText] = React.useState('');
  React.useEffect(() => {
    setText('expecting this text to be truncated');
  });
  return (
    <Box width="small">
      <Text truncate="tip">{text}</Text>
    </Box>
  );
};

DynamicTruncateTip.parameters = {
  chromatic: { disable: true },
};

export default {
  title: `Type/Text/DynamicTruncateTip`,
};
```

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

N/A.

#### What are the relevant issues?

#6910

#### Screenshots (if appropriate)

![1](https://github.com/grommet/grommet/assets/43751307/ce654f6f-f378-4b0d-a863-6a6daeef220c)

#### Do the grommet docs need to be updated?

Don't think so, it's a bug fix.

#### Should this PR be mentioned in the release notes?

As above.

#### Is this change backwards compatible or is it a breaking change?

I don't believe there should be compatibility issues.