### PR TITLE
[Type] remove `onClick` from types of Box props

### DIFF
--- a/src/js/components/Box/index.d.ts
+++ b/src/js/components/Box/index.d.ts
@@ -52,7 +52,6 @@ export interface BoxProps {
     | 'evenly'
     | 'start'
     | 'stretch';
-  onClick?: (event: React.MouseEvent) => void;
   overflow?:
     | 'auto'
     | 'hidden'

--- a/src/js/components/CheckBoxGroup/index.d.ts
+++ b/src/js/components/CheckBoxGroup/index.d.ts
@@ -27,7 +27,7 @@ export interface CheckBoxGroupProps {
 export interface CheckBoxGroupExtendedProps
   extends CheckBoxGroupProps,
     BoxProps,
-    Omit<JSX.IntrinsicElements['div'], 'onClick' | keyof CheckBoxGroupProps> {}
+    Omit<JSX.IntrinsicElements['div'], keyof CheckBoxGroupProps> {}
 
 declare const CheckBoxGroup: React.FC<CheckBoxGroupExtendedProps>;
 


### PR DESCRIPTION


<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
`onClick` type is inherited generically from IntrinsicElements and grommet is currently limiting the type.

#### Where should the reviewer start?
TS file
#### What testing has been done on this PR?
local
#### How should this be manually tested?
storybook
#### Do Jest tests follow these best practices?
N/A
- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
Fix a regression https://github.com/grommet/grommet/pull/6983#issuecomment-1810580064

#### What are the relevant issues?
https://github.com/grommet/grommet/issues/7016

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
TS
#### Should this PR be mentioned in the release notes?
Yes
#### Is this change backwards compatible or is it a breaking change?
yes