### PR TITLE
fix datachart bug for single chart data

### DIFF
--- a/src/js/components/DataChart/DataChart.js
+++ b/src/js/components/DataChart/DataChart.js
@@ -527,7 +527,7 @@ const DataChart = forwardRef(
       series.forEach(({ property, render }) => {
         if (
           !render &&
-          data.length > 1 &&
+          data.length >= 1 &&
           typeof data[0][property] === 'string'
         ) {
           result[property] = createDateFormat(
@@ -547,7 +547,8 @@ const DataChart = forwardRef(
         if (!property || (!horizontal && y) || (horizontal && !y)) {
           if (render) return render(value);
         } else {
-          const datum = data[axisValue];
+          // const datum = data[axisValue];
+          const datum = data[0];
           value = datum[property];
           if (render) return render(value, datum, property);
         }

--- a/src/js/components/DataChart/utils.js
+++ b/src/js/components/DataChart/utils.js
@@ -78,7 +78,13 @@ export const createDateFormat = (firstValue, lastValue, full) => {
   ) {
     const delta = Math.abs(endDate - startDate);
     let options;
-    if (delta < 60000)
+    if (delta === 0)
+      // equal 0 - single data point
+      options = {
+        month: full ? 'short' : 'numeric',
+        day: 'numeric',
+      };
+    else if (delta < 60000)
       // less than 1 minute
       options = full
         ? {
@@ -96,7 +102,7 @@ export const createDateFormat = (firstValue, lastValue, full) => {
     else if (delta < 86400000)
       // less than 1 day
       options = { hour: 'numeric' };
-    else if (delta < 2592000000)
+    else if (delta < 2592000000 || delta === 0)
       // less than 30 days
       options = {
         month: full ? 'short' : 'numeric',


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This pull request is meant to fix datachart bug with single data item

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `userEvent` is used in place of `fireEvent`.
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
closes #6991

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Yes

#### Is this change backwards compatible or is it a breaking change?
Backward compatible
