### PR TITLE
Update DataTableColumns prop types and typescript types

### DIFF
--- a/src/js/components/DataTableColumns/index.d.ts
+++ b/src/js/components/DataTableColumns/index.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 export interface DataTableColumnsProps {
   drop: boolean;
-  options: (string | { property: string; label: string })[];
+  options: (string | { property: string; label: string; disabled?: boolean })[];
 }
 
 declare const DataTableColumns: React.FC<DataTableColumnsProps>;

--- a/src/js/components/DataTableColumns/propTypes.js
+++ b/src/js/components/DataTableColumns/propTypes.js
@@ -8,6 +8,7 @@ if (process.env.NODE_ENV !== 'production') {
       PropTypes.arrayOf(PropTypes.string),
       PropTypes.arrayOf(
         PropTypes.shape({
+          disabled: PropTypes.bool,
           label: PropTypes.string,
           property: PropTypes.string,
         }),


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Update prop types and typescript types to support `disabled` on DataTableColumns options.

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
