### PR TITLE
When RangeSelector is reset to min/max set value to undefined 

### DIFF
--- a/src/js/components/Data/DataForm.js
+++ b/src/js/components/Data/DataForm.js
@@ -183,10 +183,7 @@ const resetPage = (nextFormValue, prevFormValue) => {
 const transformTouched = (touched, value) => {
   const result = {};
   Object.keys(touched).forEach((key) => {
-    // special case _range fields
-    const parts = key.split('.');
-    if (parts[1] === formRangeKey) result[key] = value[parts[0]];
-    else result[key] = flatten(value, { full: true })[key];
+    result[key] = flatten(value, { full: true })[key];
   });
   return result;
 };

--- a/src/js/components/RangeSelector/RangeSelector.js
+++ b/src/js/components/RangeSelector/RangeSelector.js
@@ -63,10 +63,12 @@ const RangeSelector = forwardRef(
 
     const change = useCallback(
       (nextValues) => {
-        setValues(nextValues);
+        if (nextValues[0] === min && nextValues[1] === max)
+          setValues(undefined);
+        else setValues(nextValues);
         if (onChange) onChange(nextValues);
       },
-      [onChange, setValues],
+      [onChange, setValues, min, max],
     );
 
     const valueForMouseCoord = useCallback(


### PR DESCRIPTION
#### What does this PR do?
When RangeSelector is reset so that the value is equal to the min and max set the value to undefined. In a DataFilters context this ensures that the DataFilter doesn't show a filter being applied when the range is set to the min/max

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
https://github.com/grommet/grommet/issues/6730

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
