### PR TITLE
fix List component children  React 18 and typescript

### DIFF
--- a/src/js/components/List/index.d.ts
+++ b/src/js/components/List/index.d.ts
@@ -43,7 +43,11 @@ export interface ListProps<ListItemType> {
     | string[]
     | { light: string | string[]; dark: string | string[] };
   border?: BorderType;
-  children?: (...args: any[]) => any;
+  children?: (
+    item: ListItemType,
+    index?: number,
+    options?: { active?: boolean },
+  ) => React.ReactNode;
   data?: ListItemType[];
   disabled?: string[];
   gridArea?: GridAreaType;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR fixes List component children  React 18 and typescript error

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #6836 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Yes

#### Should this PR be mentioned in the release notes?
Yes

#### Is this change backwards compatible or is it a breaking change?
Backward compatible
