### PR TITLE
fix: add an alternative to trap the focus in RadioButtonGroup

### DIFF
--- a/src/js/components/RadioButtonGroup/RadioButtonGroup.js
+++ b/src/js/components/RadioButtonGroup/RadioButtonGroup.js
@@ -15,11 +15,12 @@ const RadioButtonGroup = forwardRef(
       defaultValue,
       disabled,
       focusIndicator = true,
+      gap,
       name,
       onChange,
       options: optionsProp,
+      trapFocus = false,
       value: valueProp,
-      gap,
       ...rest
     },
     ref,
@@ -83,7 +84,12 @@ const RadioButtonGroup = forwardRef(
       // Chrome behaves differently in that focus is given to radio buttons
       // when the user selects one, unlike Safari and Firefox.
       setTimeout(() => {
-        setFocus(true);
+        // In case the focus needs to be trapped inside the input instead of the
+        // Box wrapper
+        if (trapFocus) {
+          // console.log('optionRefs.current[0]', optionRefs.current[0]);
+          setFocus(optionRefs.current[0]);
+        } else setFocus(true);
       }, 1);
     };
 
@@ -92,7 +98,7 @@ const RadioButtonGroup = forwardRef(
       if (onChange) {
         event.persist(); // extract from React synthetic event pool
         // event.target.value gives value as a string which needs to be
-        // manually typecasted according to the type of original option value.
+        // manually typecasting according to the type of original option value.
         // return the original option value attached with the event.
         const adjustedEvent = event;
         adjustedEvent.value = optionValue;
@@ -140,7 +146,7 @@ const RadioButtonGroup = forwardRef(
                 optionValue === value ||
                 (value === undefined && !index) ||
                 // when nothing has been selected, show focus
-                // on the first radiobutton
+                // on the first radio-button
                 (value === '' && index === 0);
 
               if (optionRest.checked) {
@@ -165,7 +171,7 @@ const RadioButtonGroup = forwardRef(
                   // so that the FormField has focus style. However, we still
                   // need to visually indicate when a RadioButton is active.
                   // In RadioButton, if focus = true but focusIndicator = false,
-                  // we will apply the hover treament.
+                  // we will apply the hover treatment.
                   focusIndicator={focusIndicator}
                   id={id}
                   value={optionValue}

--- a/src/js/components/RadioButtonGroup/index.d.ts
+++ b/src/js/components/RadioButtonGroup/index.d.ts
@@ -17,6 +17,7 @@ export interface RadioButtonGroupProps {
         value: string | number | boolean;
       }
   )[];
+  trapFocus?: boolean;
   value?: string | number | boolean | object;
 }
 

--- a/src/js/components/RadioButtonGroup/propTypes.js
+++ b/src/js/components/RadioButtonGroup/propTypes.js
@@ -24,6 +24,7 @@ if (process.env.NODE_ENV !== 'production') {
         }),
       ),
     ]).isRequired,
+    trapFocus: PropTypes.bool,
     value: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.number,

--- a/src/js/components/RadioButtonGroup/stories/TrapFocus.js
+++ b/src/js/components/RadioButtonGroup/stories/TrapFocus.js
@@ -1,0 +1,46 @@
+import React, { useEffect, useState } from 'react';
+
+import { Box, RadioButtonGroup } from 'grommet';
+
+export const TrapFocus = () => {
+  const [value, setValue] = useState({ value: '' });
+
+  const input = React.useRef();
+
+  useEffect(() => {
+    setTimeout(() => {
+      input.current?.focus();
+      console.log('here', input.current);
+    }, 500);
+  }, []);
+
+  const postMethods = [
+    { label: 'FTP', value: 'FTP' },
+    {
+      label: 'File System',
+      value: 'FileSystem',
+    },
+    {
+      label: 'FTP & File System',
+      value: 'FTPCopy',
+    },
+  ];
+
+  // In this example there is no keyboard access to the RBG component
+  // The trapFocus should fix the initial focus
+  return (
+    <Box align="center" pad="large">
+      <RadioButtonGroup
+        ref={input}
+        name="radio"
+        options={postMethods}
+        value={value}
+        onChange={(event) => setValue(event.value)}
+        // trapFocus
+      />
+    </Box>
+  );
+};
+export default {
+  title: 'Input/RadioButtonGroup/Trap Focus',
+};


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR is enhancing RadioButtonGroup with a new prop `trapFocus`.
The `trapFocus` prop allows the user to set focus inside the RadioButtonGroup and on the first element. 
The current behavior, w/o `trapFocus`, is that the component assigns a given `ref` to RadioButtonGroup which is a Box; the Box doesn't process the focus and the focus is lost. The keyboard focus works as expected, the ref focus doesn't.

The use case this fix will solve for our team is when the RadioButtonGroup is inside of a form, and we apply a logic that focuses on an input field that has an error upon submission, the RBG doesn't accept the focus. We send the `ref` of the RadioButtonGroup via form hook; this mostly works well for Grommet components that we use, aside of RGB which doesn't capture the focus.

The goal is to be able to focus on RGB, but since RGB is a Box, and the Box shouldn't be focusable, we expect to be focusing on the first RB element; a similar behavior to how the keyboard navigation works when tabbing between form elements and the first RB within a RBG gets the focus upon entering the component with Tab.

I am not locked on this solution, and I'm very much open to other proposals or workarounds that will help my team solve the problem and move forward. I used the `trapFocus` approach to somewhat be consistent with the Drop component that uses this prop as well. Please let me know what other type of info you might be needing to understand and agree on a solution for this issue.

#### Where should the reviewer start?
RBG
#### What testing has been done on this PR?
Storybook - but it is not completed yet, I'd like to get feedback on the approach if possible
#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Yes, new prop
#### Should this PR be mentioned in the release notes?
Yes
#### Is this change backwards compatible or is it a breaking change?
b/c