### PR TITLE
Adjust NameValueList to account for xsmall screen size

### DIFF
--- a/src/js/components/DataSearch/DataSearch.js
+++ b/src/js/components/DataSearch/DataSearch.js
@@ -11,6 +11,7 @@ import { TextInput } from '../TextInput';
 import { MessageContext } from '../../contexts/MessageContext';
 import { ResponsiveContext } from '../../contexts/ResponsiveContext';
 import { DataSearchPropTypes } from './propTypes';
+import { isSmall } from '../../utils/responsive';
 
 const dropProps = {
   align: { top: 'bottom', left: 'left' },
@@ -63,8 +64,7 @@ export const DataSearch = ({ drop, id: idProp, responsive, ...rest }) => {
       </FormField>
     );
 
-  if (!drop && (!responsive || (size !== 'small' && size !== 'xsmall')))
-    return content;
+  if (!drop && (!responsive || !isSmall(size))) return content;
 
   const control = (
     <DropButton

--- a/src/js/components/NameValueList/NameValueList.js
+++ b/src/js/components/NameValueList/NameValueList.js
@@ -25,7 +25,7 @@ const NameValueList = forwardRef(
     let columns;
     const valueWidth = valueProps?.width || theme.nameValueList.value.width;
     const nameWidth = nameProps?.width || theme.nameValueList.name.width;
-    if (size === 'small' || layout === 'grid')
+    if (size === 'small' || size === 'xsmall' || layout === 'grid')
       columns = {
         count: 'fit',
         size: !Array.isArray(valueWidth) ? ['auto', valueWidth] : valueWidth,
@@ -39,7 +39,9 @@ const NameValueList = forwardRef(
 
     let { gap } = theme.nameValueList;
     if (
-      (pairProps.direction === 'column' || size === 'small') &&
+      (pairProps.direction === 'column' ||
+        size === 'small' ||
+        size === 'xsmall') &&
       theme.nameValueList.pair?.column?.gap
     ) {
       gap = theme.nameValueList.pair.column.gap;

--- a/src/js/components/NameValueList/NameValueList.js
+++ b/src/js/components/NameValueList/NameValueList.js
@@ -3,6 +3,7 @@ import { ThemeContext } from 'styled-components';
 import { Grid } from '../Grid';
 import { ResponsiveContext } from '../../contexts/ResponsiveContext';
 import { NameValueListContext } from './NameValueListContext';
+import { isSmall } from '../../utils/responsive';
 
 const NameValueList = forwardRef(
   (
@@ -25,7 +26,7 @@ const NameValueList = forwardRef(
     let columns;
     const valueWidth = valueProps?.width || theme.nameValueList.value.width;
     const nameWidth = nameProps?.width || theme.nameValueList.name.width;
-    if (size === 'small' || size === 'xsmall' || layout === 'grid')
+    if (isSmall(size) || layout === 'grid')
       columns = {
         count: 'fit',
         size: !Array.isArray(valueWidth) ? ['auto', valueWidth] : valueWidth,
@@ -39,9 +40,7 @@ const NameValueList = forwardRef(
 
     let { gap } = theme.nameValueList;
     if (
-      (pairProps.direction === 'column' ||
-        size === 'small' ||
-        size === 'xsmall') &&
+      (pairProps.direction === 'column' || isSmall(size)) &&
       theme.nameValueList.pair?.column?.gap
     ) {
       gap = theme.nameValueList.pair.column.gap;

--- a/src/js/components/NameValuePair/NameValuePair.js
+++ b/src/js/components/NameValuePair/NameValuePair.js
@@ -4,6 +4,7 @@ import { Box } from '../Box';
 import { Text } from '../Text';
 import { ResponsiveContext } from '../../contexts/ResponsiveContext';
 import { NameValueListContext } from '../NameValueList/NameValueListContext';
+import { isSmall } from '../../utils/responsive';
 
 const NameValuePair = ({ children, name: nameProp }) => {
   const { nameProps, pairProps, valueProps } = useContext(NameValueListContext);
@@ -12,17 +13,12 @@ const NameValuePair = ({ children, name: nameProp }) => {
   const direction = pairProps?.direction;
 
   const column =
-    direction === 'column' ||
-    direction === 'column-reverse' ||
-    size === 'small' ||
-    size === 'xsmall';
+    direction === 'column' || direction === 'column-reverse' || isSmall(size);
 
   const Container = column ? Box : Fragment;
 
-  const nameAlign =
-    size !== 'small' && size !== 'xsmall' ? nameProps?.align : undefined;
-  const valueAlign =
-    size !== 'small' && size !== 'xsmall' ? valueProps?.align : undefined;
+  const nameAlign = !isSmall(size) ? nameProps?.align : undefined;
+  const valueAlign = !isSmall(size) ? valueProps?.align : undefined;
   // using margin to act as gap
   // <dl> elements must only directly contain
   // properly-ordered <dt> and <dd> groups

--- a/src/js/components/NameValuePair/NameValuePair.js
+++ b/src/js/components/NameValuePair/NameValuePair.js
@@ -14,12 +14,15 @@ const NameValuePair = ({ children, name: nameProp }) => {
   const column =
     direction === 'column' ||
     direction === 'column-reverse' ||
-    size === 'small';
+    size === 'small' ||
+    size === 'xsmall';
 
   const Container = column ? Box : Fragment;
 
-  const nameAlign = size !== 'small' ? nameProps?.align : undefined;
-  const valueAlign = size !== 'small' ? valueProps?.align : undefined;
+  const nameAlign =
+    size !== 'small' && size !== 'xsmall' ? nameProps?.align : undefined;
+  const valueAlign =
+    size !== 'small' && size !== 'xsmall' ? valueProps?.align : undefined;
   // using margin to act as gap
   // <dl> elements must only directly contain
   // properly-ordered <dt> and <dd> groups

--- a/src/js/components/Toolbar/Toolbar.js
+++ b/src/js/components/Toolbar/Toolbar.js
@@ -2,6 +2,7 @@ import React, { useContext } from 'react';
 import { Box } from '../Box';
 import { ResponsiveContext } from '../../contexts/ResponsiveContext';
 import { ToolbarPropTypes } from './propTypes';
+import { isSmall } from '../../utils/responsive';
 
 const defaultLayoutProps = {
   direction: 'row',
@@ -18,10 +19,7 @@ const smallLayoutProps = {
 
 export const Toolbar = ({ children, ...rest }) => {
   const size = useContext(ResponsiveContext);
-  const layoutProps =
-    size === 'small' || size === 'xsmall'
-      ? smallLayoutProps
-      : defaultLayoutProps;
+  const layoutProps = isSmall(size) ? smallLayoutProps : defaultLayoutProps;
   return (
     <Box flex={false} cssGap {...layoutProps} {...rest}>
       {children}

--- a/src/js/utils/responsive.js
+++ b/src/js/utils/responsive.js
@@ -14,7 +14,7 @@ export const getBreakpoint = (viewportWidth, theme) => {
   // the last breakpoint on the sorted array should have
   // no windowWidth boundaries
   const lastBreakpoint = sortedBreakpoints[sortedBreakpoints.length - 1];
-  const result = sortedBreakpoints.find(name => {
+  const result = sortedBreakpoints.find((name) => {
     const breakpoint = theme.global.breakpoints[name];
     return !breakpoint.value || breakpoint.value >= viewportWidth
       ? name
@@ -35,3 +35,7 @@ export const getBreakpointStyle = (theme, breakpointSize) => {
   if (!breakpoint.size) breakpoint.size = theme.global.size;
   return breakpoint;
 };
+
+// for checks that look for a small screen size, flag for xsmall
+// as well since we use xsmall in the hpe theme
+export const isSmall = (size) => ['xsmall', 'small'].includes(size);


### PR DESCRIPTION
#### What does this PR do?
Adjusts the code in NameValueList and NameValuePair to account for both 'xsmall' and 'small' screen sizes instead of just 'small'.

#### Where should the reviewer start?

#### What testing has been done on this PR?
Tested with existing NameValueList/Simple story with the hpe theme

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes https://github.com/grommet/grommet/issues/6944
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
no (only relevant to hpe theme users)
#### Is this change backwards compatible or is it a breaking change?
backwards compatible