### PR TITLE
Change datafilters default presentation within toolbar to `layer`

### DIFF
--- a/src/js/components/Data/Data.js
+++ b/src/js/components/Data/Data.js
@@ -145,7 +145,7 @@ export const Data = ({
       <Toolbar key="toolbar">
         {(toolbar === true || toolbar === 'search') && <DataSearch />}
         {(toolbar === true || toolbar === 'view') && <DataView />}
-        {(toolbar === true || toolbar === 'filters') && <DataFilters drop />}
+        {(toolbar === true || toolbar === 'filters') && <DataFilters layer />}
       </Toolbar>,
       <DataSummary key="summary" />,
     ];

--- a/src/js/components/Data/__tests__/__snapshots__/Data-test.tsx.snap
+++ b/src/js/components/Data/__tests__/__snapshots__/Data-test.tsx.snap
@@ -3829,7 +3829,27 @@ exports[`Data properties when property is an array 2`] = `
 
 }
 
-@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
 
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

In 80% of use cases where filters are hidden behind a filter button, they should open into a side drawer. More often than not, there are many attributes to be filtered on (especially in the default case before any `properties` have been specified. This ensures that we don't provide a default experience where there are tons of filters displayed in a drop which breaks our design recommendations.

This does not alter the default behavior for use cases not leveraging the `toolbar` prop. In those scenarios, the default behavior remains as inline and can be opted into via `layer`.

#### Where should the reviewer start?
src/js/components/Data/Data.js

#### What testing has been done on this PR?
Local in storybook Data Simple.js

#### How should this be manually tested?

Any storybook that's using `toolbar` on Data.

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

Closes #7056 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
Breaking change, but this is fine because Data + friends are still in beta.