### PR TITLE
ehancement: add MaskedInput icon click-ability

### DIFF
--- a/src/js/components/MaskedInput/MaskedInput.js
+++ b/src/js/components/MaskedInput/MaskedInput.js
@@ -163,6 +163,7 @@ const MaskedInput = forwardRef(
       focus: focusProp,
       focusIndicator = true,
       icon,
+      maskIconClickable = false,
       id,
       mask = defaultMask,
       name,
@@ -372,7 +373,20 @@ const MaskedInput = forwardRef(
     return (
       <StyledMaskedInputContainer plain={plain}>
         {maskedInputIcon && (
-          <StyledIcon reverse={reverse} theme={theme}>
+          <StyledIcon
+            reverse={reverse}
+            theme={theme}
+            maskIconClickable={maskIconClickable}
+            onClick={
+              maskIconClickable
+                ? (event) => {
+                    setFocus(true);
+                    setShowDrop(true);
+                    if (onFocus) onFocus(event);
+                  }
+                : undefined
+            }
+          >
             {maskedInputIcon}
           </StyledIcon>
         )}

--- a/src/js/components/MaskedInput/StyledMaskedInput.js
+++ b/src/js/components/MaskedInput/StyledMaskedInput.js
@@ -39,7 +39,8 @@ export const StyledIcon = styled.div`
   justify: center;
   top: 50%;
   transform: translateY(-50%);
-  pointer-events: none;
+  pointer-events: ${(props) => (props.maskIconClickable ? 'auto' : 'none')};
+  ${(props) => (props.maskIconClickable ? 'cursor: pointer;' : '')};
   ${(props) =>
     props.reverse
       ? `right: ${getInputPadBySide(props, 'right')};`

--- a/src/js/components/MaskedInput/index.d.ts
+++ b/src/js/components/MaskedInput/index.d.ts
@@ -8,6 +8,7 @@ export interface MaskedInputProps {
   dropProps?: DropType;
   focusIndicator?: boolean;
   icon?: JSX.Element;
+  maskIconClickable?: boolean;
   id?: string;
   mask?: Array<{
     length?: number | number[];


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Introduces the ability to make the MaskedInput icon clickable, triggering the display of suggestion options.

#### Where should the reviewer start?
Review changes in the MaskedInput component related to icon click-ability(components/MaskedInput/MaskedInput.js).

#### What testing has been done on this PR?
- Manually clicking the icon to ensure the expected behavior.
- Local Jest tests.

#### How should this be manually tested?
Manually test by clicking the icon in a MaskedInput field with the `maskIconClickable` prop set to `true` and verify the suggestion options appear. Then, test with `maskIconClickable` set to `false` and ensure the icon does not trigger the suggestions.

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
This enhancement improves user interaction with MaskedInput by allowing suggestions to be triggered by clicking the icon.

#### What are the relevant issues?
fixes: #7042

#### Screen-record (if appropriate)

https://github.com/grommet/grommet/assets/134603758/33ef4c65-339d-41ea-aadd-ff0bca396c4a

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Not sure.

#### Is this change backwards compatible or is it a breaking change?
No.
