### PR TITLE
Refine DataFilters badge behavior for RangeSelector reset to min/max

### DIFF
--- a/src/js/components/DataFilters/DataFilters.js
+++ b/src/js/components/DataFilters/DataFilters.js
@@ -80,10 +80,9 @@ export const DataFilters = ({
       }
     };
 
-    window.addEventListener('rangeselectorreset', updatePendingReset);
+    window.addEventListener('valuereset', updatePendingReset);
 
-    return () =>
-      window.removeEventListener('rangeselectorreset', updatePendingReset);
+    return () => window.removeEventListener('valuereset', updatePendingReset);
   }, [touched, view]);
 
   // if filters have been cleared via clearFilters in DataContext,

--- a/src/js/components/DataFilters/DataFiltersContext.js
+++ b/src/js/components/DataFilters/DataFiltersContext.js
@@ -1,0 +1,3 @@
+import React from 'react';
+
+export const DataFiltersContext = React.createContext({});

--- a/src/js/components/RangeSelector/RangeSelector.js
+++ b/src/js/components/RangeSelector/RangeSelector.js
@@ -16,6 +16,7 @@ import { Text } from '../Text';
 import { parseMetricToNum } from '../../utils';
 import { MessageContext } from '../../contexts/MessageContext';
 import { RangeSelectorPropTypes } from './propTypes';
+import { DataFiltersContext } from '../DataFilters/DataFiltersContext';
 
 const Container = styled(Box)`
   user-select: none;
@@ -86,20 +87,18 @@ const RangeSelector = forwardRef(
       initialValue: defaultValues,
     });
 
-    // for DataFilters, notify when RangeSelector has returned to its min/max
-    useEffect(() => {
-      // eslint-disable-next-line no-undef
-      const resetEvent = new CustomEvent('valuereset', {
-        // https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/detail
-        detail: {
-          name,
-        },
-      });
-
-      if (values[0] === min && values[1] === max) {
-        window.dispatchEvent(resetEvent);
-      }
-    }, [min, max, values, name]);
+    // for DataFilters to know when RangeSelector is set to its min/max
+    const { pendingReset } = useContext(DataFiltersContext);
+    const updatePendingReset = useCallback(
+      (nextMin, nextMax) => {
+        if (nextMin === min && nextMax === max) {
+          pendingReset?.current.add(name);
+        } else if (pendingReset?.current?.has(name)) {
+          pendingReset?.current.delete(name);
+        }
+      },
+      [max, min, name, pendingReset],
+    );
 
     const change = useCallback(
       (nextValues) => {
@@ -117,11 +116,12 @@ const RangeSelector = forwardRef(
         // make sure this is only called if both of the values
         // are actually distinct from the previous values
         if (nextMin !== values[0] || nextMax !== values[1]) {
+          updatePendingReset(nextMin, nextMax);
           setValues([nextMin, nextMax]);
           if (onChange) onChange([nextMin, nextMax]);
         }
       },
-      [onChange, setValues, step, max, min, values],
+      [onChange, setValues, step, max, min, values, updatePendingReset],
     );
 
     const valueForMouseCoord = useCallback(

--- a/src/js/components/RangeSelector/RangeSelector.js
+++ b/src/js/components/RangeSelector/RangeSelector.js
@@ -86,6 +86,21 @@ const RangeSelector = forwardRef(
       initialValue: defaultValues,
     });
 
+    // for DataFilters, notify when RangeSelector has returned to its min/max
+    useEffect(() => {
+      // eslint-disable-next-line no-undef
+      const resetEvent = new CustomEvent('rangeselectorreset', {
+        // https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/detail
+        detail: {
+          name,
+        },
+      });
+
+      if (values[0] === min && values[1] === max) {
+        window.dispatchEvent(resetEvent);
+      }
+    }, [min, max, values, name]);
+
     const change = useCallback(
       (nextValues) => {
         let [nextMin, nextMax] = nextValues;

--- a/src/js/components/RangeSelector/RangeSelector.js
+++ b/src/js/components/RangeSelector/RangeSelector.js
@@ -89,7 +89,7 @@ const RangeSelector = forwardRef(
     // for DataFilters, notify when RangeSelector has returned to its min/max
     useEffect(() => {
       // eslint-disable-next-line no-undef
-      const resetEvent = new CustomEvent('rangeselectorreset', {
+      const resetEvent = new CustomEvent('valuereset', {
         // https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/detail
         detail: {
           name,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

When RangeSelector is reset to its min/max, DataFilters should not "badge" that a filter has been applied. Putting this as a draft to get reactions to the approach.

Prior to this, a badge would apply even if RangeSelector is at its min/max. This is because technically RangeSelector always has a value, so once it was view as "touched" by DataFilters, there was no way to get it to be removed from the "touched" object without clearing all filters.

This is done by:
1. Creating a DataFiltersContext that has a value of a `pendingReset` ref in DataFilters.
2. `pendingReset` ref in DataFilters whose value is a Javascript Set, to track which range selectors should not be included in the "touched" object.
3. on change of its value, RangeSelector will add/remove itself from pendingReset depending on if its value is at its min/max.

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #7082 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
