### PR TITLE
DataSearch: Removed dependence on form

### DIFF
--- a/src/js/components/Data/DataForm.js
+++ b/src/js/components/Data/DataForm.js
@@ -13,7 +13,7 @@ import { Form } from '../Form';
 import { DataContext } from '../../contexts/DataContext';
 import { DataFormContext } from '../../contexts/DataFormContext';
 import { MessageContext } from '../../contexts/MessageContext';
-import { useDebounce } from '../../utils';
+import { useDebounce } from '../../utils/use-debounce';
 
 const MaxForm = styled(Form)`
   max-width: 100%;

--- a/src/js/components/Data/__tests__/__snapshots__/Data-test.tsx.snap
+++ b/src/js/components/Data/__tests__/__snapshots__/Data-test.tsx.snap
@@ -613,7 +613,7 @@ exports[`Data controlled search 2`] = `
               id="data--search"
               name="_search"
               type="search"
-              value=""
+              value="a"
             />
           </div>
         </div>
@@ -6074,7 +6074,7 @@ exports[`Data uncontrolled search 2`] = `
               id="data--search"
               name="_search"
               type="search"
-              value=""
+              value="a"
             />
           </div>
         </div>
@@ -6869,7 +6869,7 @@ exports[`Data view all 1`] = `
               id="data--search"
               name="_search"
               type="search"
-              value=""
+              value="a"
             />
           </div>
         </div>
@@ -8516,7 +8516,7 @@ exports[`Data view search 1`] = `
               id="data--search"
               name="_search"
               type="search"
-              value=""
+              value="a"
             />
           </div>
         </div>

--- a/src/js/components/Data/__tests__/__snapshots__/Data-test.tsx.snap
+++ b/src/js/components/Data/__tests__/__snapshots__/Data-test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Data controlled search 1`] = `
-.c6 {
+.c7 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -12,25 +12,25 @@ exports[`Data controlled search 1`] = `
   stroke: #666666;
 }
 
-.c6 g {
+.c7 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c6 *:not([stroke])[fill='none'] {
+.c7 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c6 *[stroke*='#'],
-.c6 *[STROKE*='#'] {
+.c7 *[stroke*='#'],
+.c7 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c6 *[fill-rule],
-.c6 *[FILL-RULE],
-.c6 *[fill*='#'],
-.c6 *[FILL*='#'] {
+.c7 *[fill-rule],
+.c7 *[FILL-RULE],
+.c7 *[fill*='#'],
+.c7 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -62,7 +62,21 @@ exports[`Data controlled search 1`] = `
   flex: 0 0 auto;
 }
 
-.c8 {
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -79,7 +93,7 @@ exports[`Data controlled search 1`] = `
   flex: 0 0 auto;
 }
 
-.c14 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -98,20 +112,6 @@ exports[`Data controlled search 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-}
-
-.c17 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
 }
 
 .c2 {
@@ -168,7 +168,7 @@ exports[`Data controlled search 1`] = `
   row-gap: 12px;
 }
 
-.c10 {
+.c11 {
   margin-top: 6px;
   margin-bottom: 6px;
   font-size: 18px;
@@ -181,7 +181,7 @@ exports[`Data controlled search 1`] = `
   font-weight: bold;
 }
 
-.c9 {
+.c10 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -201,47 +201,47 @@ exports[`Data controlled search 1`] = `
   padding: 12px;
 }
 
-.c9:focus {
+.c10:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c9:focus > circle,
-.c9:focus > ellipse,
-.c9:focus > line,
-.c9:focus > path,
-.c9:focus > polygon,
-.c9:focus > polyline,
-.c9:focus > rect {
+.c10:focus > circle,
+.c10:focus > ellipse,
+.c10:focus > line,
+.c10:focus > path,
+.c10:focus > polygon,
+.c10:focus > polyline,
+.c10:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c9:focus::-moz-focus-inner {
+.c10:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c9:focus:not(:focus-visible) {
+.c10:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c9:focus:not(:focus-visible) > circle,
-.c9:focus:not(:focus-visible) > ellipse,
-.c9:focus:not(:focus-visible) > line,
-.c9:focus:not(:focus-visible) > path,
-.c9:focus:not(:focus-visible) > polygon,
-.c9:focus:not(:focus-visible) > polyline,
-.c9:focus:not(:focus-visible) > rect {
+.c10:focus:not(:focus-visible) > circle,
+.c10:focus:not(:focus-visible) > ellipse,
+.c10:focus:not(:focus-visible) > line,
+.c10:focus:not(:focus-visible) > path,
+.c10:focus:not(:focus-visible) > polygon,
+.c10:focus:not(:focus-visible) > polyline,
+.c10:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c9:focus:not(:focus-visible)::-moz-focus-inner {
+.c10:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c7 {
+.c8 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -258,58 +258,58 @@ exports[`Data controlled search 1`] = `
   padding-left: 48px;
 }
 
-.c7:focus {
+.c8:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus > circle,
-.c7:focus > ellipse,
-.c7:focus > line,
-.c7:focus > path,
-.c7:focus > polygon,
-.c7:focus > polyline,
-.c7:focus > rect {
+.c8:focus > circle,
+.c8:focus > ellipse,
+.c8:focus > line,
+.c8:focus > path,
+.c8:focus > polygon,
+.c8:focus > polyline,
+.c8:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus::-moz-focus-inner {
+.c8:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c7::-webkit-input-placeholder {
+.c8::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-moz-placeholder {
+.c8::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c7:-ms-input-placeholder {
+.c8:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-webkit-search-decoration {
+.c8::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c7::-moz-focus-inner {
+.c8::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c7:-moz-placeholder,
-.c7::-moz-placeholder {
+.c8:-moz-placeholder,
+.c8::-moz-placeholder {
   opacity: 1;
 }
 
-.c4 {
+.c5 {
   position: relative;
   width: 100%;
 }
 
-.c5 {
+.c6 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -327,7 +327,7 @@ exports[`Data controlled search 1`] = `
   left: 12px;
 }
 
-.c13 {
+.c14 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -340,7 +340,7 @@ exports[`Data controlled search 1`] = `
   padding-bottom: 6px;
 }
 
-.c16 {
+.c17 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -352,23 +352,23 @@ exports[`Data controlled search 1`] = `
   padding-bottom: 6px;
 }
 
-.c11 {
+.c12 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
 }
 
-.c12 {
+.c13 {
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
 }
 
-.c15:focus {
+.c16:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c15:focus:not(:focus-visible) {
+.c16:focus:not(:focus-visible) {
   outline: none;
 }
 
@@ -413,41 +413,45 @@ exports[`Data controlled search 1`] = `
           <div
             class="c5"
           >
-            <svg
-              aria-label="Search"
+            <div
               class="c6"
-              viewBox="0 0 24 24"
             >
-              <path
-                d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
+              <svg
+                aria-label="Search"
+                class="c7"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
+            <input
+              aria-label="Search"
+              autocomplete="off"
+              class="c8"
+              id="data--search"
+              name="_search"
+              type="search"
+              value=""
+            />
           </div>
-          <input
-            aria-label="Search"
-            autocomplete="off"
-            class="c7"
-            id="data--search"
-            name="_search"
-            type="search"
-            value=""
-          />
         </div>
         <div
-          class="c8"
+          class="c9"
         >
           <button
             aria-label="Open filters"
-            class="c9"
+            class="c10"
             id="data--filters-control"
             type="button"
           >
             <svg
               aria-label="Filter"
-              class="c6"
+              class="c7"
               viewBox="0 0 24 24"
             >
               <path
@@ -462,12 +466,12 @@ exports[`Data controlled search 1`] = `
       </div>
     </div>
     <span
-      class="c10"
+      class="c11"
     >
       4 results of undefined items
     </span>
     <table
-      class="c11 c12"
+      class="c12 c13"
     >
       <thead
         class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -476,27 +480,27 @@ exports[`Data controlled search 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c13 "
+            class="c14 "
             scope="col"
           >
             <div
-              class="c14"
+              class="c15"
             />
           </th>
         </tr>
       </thead>
       <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c15"
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c16"
       >
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c16 "
+            class="c17 "
             scope="row"
           >
             <div
-              class="c17"
+              class="c4"
             >
               <span
                 class="c18"
@@ -510,11 +514,11 @@ exports[`Data controlled search 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c16 "
+            class="c17 "
             scope="row"
           >
             <div
-              class="c17"
+              class="c4"
             >
               <span
                 class="c18"
@@ -528,11 +532,11 @@ exports[`Data controlled search 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c16 "
+            class="c17 "
             scope="row"
           >
             <div
-              class="c17"
+              class="c4"
             >
               <span
                 class="c18"
@@ -546,11 +550,11 @@ exports[`Data controlled search 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c16 "
+            class="c17 "
             scope="row"
           >
             <div
-              class="c17"
+              class="c4"
             >
               <span
                 class="c18"
@@ -581,33 +585,37 @@ exports[`Data controlled search 2`] = `
         class="StyledBox-sc-13pk1d4-0 fnEswI"
       >
         <div
-          class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 dAhNeU"
+          class="StyledBox-sc-13pk1d4-0 kqmDKi"
         >
           <div
-            class="StyledTextInput__StyledIcon-sc-1x30a0s-3 iQFXNb"
+            class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 dAhNeU"
           >
-            <svg
-              aria-label="Search"
-              class="StyledIcon-sc-ofa7kd-0 bQiAMQ"
-              viewBox="0 0 24 24"
+            <div
+              class="StyledTextInput__StyledIcon-sc-1x30a0s-3 iQFXNb"
             >
-              <path
-                d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
+              <svg
+                aria-label="Search"
+                class="StyledIcon-sc-ofa7kd-0 bQiAMQ"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
+            <input
+              aria-label="Search"
+              autocomplete="off"
+              class="StyledTextInput-sc-1x30a0s-0 hLtcCB"
+              id="data--search"
+              name="_search"
+              type="search"
+              value=""
+            />
           </div>
-          <input
-            aria-label="Search"
-            autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 hLtcCB"
-            id="data--search"
-            name="_search"
-            type="search"
-            value=""
-          />
         </div>
         <div
           class="StyledBox-sc-13pk1d4-0 imzrdH"
@@ -740,7 +748,7 @@ exports[`Data controlled search 2`] = `
 `;
 
 exports[`Data messages 1`] = `
-.c6 {
+.c7 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -751,25 +759,25 @@ exports[`Data messages 1`] = `
   stroke: #666666;
 }
 
-.c6 g {
+.c7 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c6 *:not([stroke])[fill='none'] {
+.c7 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c6 *[stroke*='#'],
-.c6 *[STROKE*='#'] {
+.c7 *[stroke*='#'],
+.c7 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c6 *[fill-rule],
-.c6 *[FILL-RULE],
-.c6 *[fill*='#'],
-.c6 *[FILL*='#'] {
+.c7 *[fill-rule],
+.c7 *[FILL-RULE],
+.c7 *[fill*='#'],
+.c7 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -801,7 +809,21 @@ exports[`Data messages 1`] = `
   flex: 0 0 auto;
 }
 
-.c8 {
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -818,7 +840,7 @@ exports[`Data messages 1`] = `
   flex: 0 0 auto;
 }
 
-.c14 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -837,20 +859,6 @@ exports[`Data messages 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-}
-
-.c17 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
 }
 
 .c2 {
@@ -907,7 +915,7 @@ exports[`Data messages 1`] = `
   row-gap: 12px;
 }
 
-.c10 {
+.c11 {
   margin-top: 6px;
   margin-bottom: 6px;
   font-size: 18px;
@@ -925,7 +933,7 @@ exports[`Data messages 1`] = `
   line-height: 24px;
 }
 
-.c9 {
+.c10 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -945,47 +953,47 @@ exports[`Data messages 1`] = `
   padding: 12px;
 }
 
-.c9:focus {
+.c10:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c9:focus > circle,
-.c9:focus > ellipse,
-.c9:focus > line,
-.c9:focus > path,
-.c9:focus > polygon,
-.c9:focus > polyline,
-.c9:focus > rect {
+.c10:focus > circle,
+.c10:focus > ellipse,
+.c10:focus > line,
+.c10:focus > path,
+.c10:focus > polygon,
+.c10:focus > polyline,
+.c10:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c9:focus::-moz-focus-inner {
+.c10:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c9:focus:not(:focus-visible) {
+.c10:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c9:focus:not(:focus-visible) > circle,
-.c9:focus:not(:focus-visible) > ellipse,
-.c9:focus:not(:focus-visible) > line,
-.c9:focus:not(:focus-visible) > path,
-.c9:focus:not(:focus-visible) > polygon,
-.c9:focus:not(:focus-visible) > polyline,
-.c9:focus:not(:focus-visible) > rect {
+.c10:focus:not(:focus-visible) > circle,
+.c10:focus:not(:focus-visible) > ellipse,
+.c10:focus:not(:focus-visible) > line,
+.c10:focus:not(:focus-visible) > path,
+.c10:focus:not(:focus-visible) > polygon,
+.c10:focus:not(:focus-visible) > polyline,
+.c10:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c9:focus:not(:focus-visible)::-moz-focus-inner {
+.c10:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c7 {
+.c8 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -1002,58 +1010,58 @@ exports[`Data messages 1`] = `
   padding-left: 48px;
 }
 
-.c7:focus {
+.c8:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus > circle,
-.c7:focus > ellipse,
-.c7:focus > line,
-.c7:focus > path,
-.c7:focus > polygon,
-.c7:focus > polyline,
-.c7:focus > rect {
+.c8:focus > circle,
+.c8:focus > ellipse,
+.c8:focus > line,
+.c8:focus > path,
+.c8:focus > polygon,
+.c8:focus > polyline,
+.c8:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus::-moz-focus-inner {
+.c8:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c7::-webkit-input-placeholder {
+.c8::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-moz-placeholder {
+.c8::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c7:-ms-input-placeholder {
+.c8:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-webkit-search-decoration {
+.c8::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c7::-moz-focus-inner {
+.c8::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c7:-moz-placeholder,
-.c7::-moz-placeholder {
+.c8:-moz-placeholder,
+.c8::-moz-placeholder {
   opacity: 1;
 }
 
-.c4 {
+.c5 {
   position: relative;
   width: 100%;
 }
 
-.c5 {
+.c6 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1071,7 +1079,7 @@ exports[`Data messages 1`] = `
   left: 12px;
 }
 
-.c13 {
+.c14 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -1084,7 +1092,7 @@ exports[`Data messages 1`] = `
   padding-bottom: 6px;
 }
 
-.c16 {
+.c17 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -1096,23 +1104,23 @@ exports[`Data messages 1`] = `
   padding-bottom: 6px;
 }
 
-.c11 {
+.c12 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
 }
 
-.c12 {
+.c13 {
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
 }
 
-.c15:focus {
+.c16:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c15:focus:not(:focus-visible) {
+.c16:focus:not(:focus-visible) {
   outline: none;
 }
 
@@ -1157,41 +1165,45 @@ exports[`Data messages 1`] = `
           <div
             class="c5"
           >
-            <svg
-              aria-label="Search"
+            <div
               class="c6"
-              viewBox="0 0 24 24"
             >
-              <path
-                d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
+              <svg
+                aria-label="Search"
+                class="c7"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
+            <input
+              aria-label="Search"
+              autocomplete="off"
+              class="c8"
+              id="data--search"
+              name="_search"
+              type="search"
+              value=""
+            />
           </div>
-          <input
-            aria-label="Search"
-            autocomplete="off"
-            class="c7"
-            id="data--search"
-            name="_search"
-            type="search"
-            value=""
-          />
         </div>
         <div
-          class="c8"
+          class="c9"
         >
           <button
             aria-label="Open filters"
-            class="c9"
+            class="c10"
             id="data--filters-control"
             type="button"
           >
             <svg
               aria-label="Filter"
-              class="c6"
+              class="c7"
               viewBox="0 0 24 24"
             >
               <path
@@ -1206,12 +1218,12 @@ exports[`Data messages 1`] = `
       </div>
     </div>
     <span
-      class="c10"
+      class="c11"
     >
       4 things
     </span>
     <table
-      class="c11 c12"
+      class="c12 c13"
     >
       <thead
         class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -1220,35 +1232,35 @@ exports[`Data messages 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c13 "
+            class="c14 "
             scope="col"
           >
             <div
-              class="c14"
+              class="c15"
             />
           </th>
           <th
-            class="c13 "
+            class="c14 "
             scope="col"
           >
             <div
-              class="c14"
+              class="c15"
             />
           </th>
         </tr>
       </thead>
       <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c15"
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c16"
       >
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c16 "
+            class="c17 "
             scope="row"
           >
             <div
-              class="c17"
+              class="c4"
             >
               <span
                 class="c18"
@@ -1258,10 +1270,10 @@ exports[`Data messages 1`] = `
             </div>
           </th>
           <td
-            class="c16 "
+            class="c17 "
           >
             <div
-              class="c17"
+              class="c4"
             >
               <span
                 class="c19"
@@ -1275,11 +1287,11 @@ exports[`Data messages 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c16 "
+            class="c17 "
             scope="row"
           >
             <div
-              class="c17"
+              class="c4"
             >
               <span
                 class="c18"
@@ -1289,10 +1301,10 @@ exports[`Data messages 1`] = `
             </div>
           </th>
           <td
-            class="c16 "
+            class="c17 "
           >
             <div
-              class="c17"
+              class="c4"
             >
               <span
                 class="c19"
@@ -1306,11 +1318,11 @@ exports[`Data messages 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c16 "
+            class="c17 "
             scope="row"
           >
             <div
-              class="c17"
+              class="c4"
             >
               <span
                 class="c18"
@@ -1320,10 +1332,10 @@ exports[`Data messages 1`] = `
             </div>
           </th>
           <td
-            class="c16 "
+            class="c17 "
           >
             <div
-              class="c17"
+              class="c4"
             />
           </td>
         </tr>
@@ -1331,11 +1343,11 @@ exports[`Data messages 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c16 "
+            class="c17 "
             scope="row"
           >
             <div
-              class="c17"
+              class="c4"
             >
               <span
                 class="c18"
@@ -1345,10 +1357,10 @@ exports[`Data messages 1`] = `
             </div>
           </th>
           <td
-            class="c16 "
+            class="c17 "
           >
             <div
-              class="c17"
+              class="c4"
             />
           </td>
         </tr>
@@ -2970,7 +2982,7 @@ exports[`Data pagination step 1`] = `
 
 exports[`Data properties when property is an array 1`] = `
 <DocumentFragment>
-  .c6 {
+  .c7 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -2981,25 +2993,25 @@ exports[`Data properties when property is an array 1`] = `
   stroke: #666666;
 }
 
-.c6 g {
+.c7 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c6 *:not([stroke])[fill='none'] {
+.c7 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c6 *[stroke*='#'],
-.c6 *[STROKE*='#'] {
+.c7 *[stroke*='#'],
+.c7 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c6 *[fill-rule],
-.c6 *[FILL-RULE],
-.c6 *[fill*='#'],
-.c6 *[FILL*='#'] {
+.c7 *[fill-rule],
+.c7 *[FILL-RULE],
+.c7 *[fill*='#'],
+.c7 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -3031,7 +3043,21 @@ exports[`Data properties when property is an array 1`] = `
   flex: 0 0 auto;
 }
 
-.c8 {
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3048,7 +3074,7 @@ exports[`Data properties when property is an array 1`] = `
   flex: 0 0 auto;
 }
 
-.c14 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3067,20 +3093,6 @@ exports[`Data properties when property is an array 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-}
-
-.c18 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
 }
 
 .c2 {
@@ -3137,14 +3149,14 @@ exports[`Data properties when property is an array 1`] = `
   row-gap: 12px;
 }
 
-.c10 {
+.c11 {
   margin-top: 6px;
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
 }
 
-.c15 {
+.c16 {
   font-size: 18px;
   line-height: 24px;
 }
@@ -3155,7 +3167,7 @@ exports[`Data properties when property is an array 1`] = `
   font-weight: bold;
 }
 
-.c9 {
+.c10 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -3175,47 +3187,47 @@ exports[`Data properties when property is an array 1`] = `
   padding: 12px;
 }
 
-.c9:focus {
+.c10:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c9:focus > circle,
-.c9:focus > ellipse,
-.c9:focus > line,
-.c9:focus > path,
-.c9:focus > polygon,
-.c9:focus > polyline,
-.c9:focus > rect {
+.c10:focus > circle,
+.c10:focus > ellipse,
+.c10:focus > line,
+.c10:focus > path,
+.c10:focus > polygon,
+.c10:focus > polyline,
+.c10:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c9:focus::-moz-focus-inner {
+.c10:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c9:focus:not(:focus-visible) {
+.c10:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c9:focus:not(:focus-visible) > circle,
-.c9:focus:not(:focus-visible) > ellipse,
-.c9:focus:not(:focus-visible) > line,
-.c9:focus:not(:focus-visible) > path,
-.c9:focus:not(:focus-visible) > polygon,
-.c9:focus:not(:focus-visible) > polyline,
-.c9:focus:not(:focus-visible) > rect {
+.c10:focus:not(:focus-visible) > circle,
+.c10:focus:not(:focus-visible) > ellipse,
+.c10:focus:not(:focus-visible) > line,
+.c10:focus:not(:focus-visible) > path,
+.c10:focus:not(:focus-visible) > polygon,
+.c10:focus:not(:focus-visible) > polyline,
+.c10:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c9:focus:not(:focus-visible)::-moz-focus-inner {
+.c10:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c7 {
+.c8 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -3232,58 +3244,58 @@ exports[`Data properties when property is an array 1`] = `
   padding-left: 48px;
 }
 
-.c7:focus {
+.c8:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus > circle,
-.c7:focus > ellipse,
-.c7:focus > line,
-.c7:focus > path,
-.c7:focus > polygon,
-.c7:focus > polyline,
-.c7:focus > rect {
+.c8:focus > circle,
+.c8:focus > ellipse,
+.c8:focus > line,
+.c8:focus > path,
+.c8:focus > polygon,
+.c8:focus > polyline,
+.c8:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus::-moz-focus-inner {
+.c8:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c7::-webkit-input-placeholder {
+.c8::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-moz-placeholder {
+.c8::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c7:-ms-input-placeholder {
+.c8:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-webkit-search-decoration {
+.c8::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c7::-moz-focus-inner {
+.c8::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c7:-moz-placeholder,
-.c7::-moz-placeholder {
+.c8:-moz-placeholder,
+.c8::-moz-placeholder {
   opacity: 1;
 }
 
-.c4 {
+.c5 {
   position: relative;
   width: 100%;
 }
 
-.c5 {
+.c6 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -3301,7 +3313,7 @@ exports[`Data properties when property is an array 1`] = `
   left: 12px;
 }
 
-.c13 {
+.c14 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -3314,7 +3326,7 @@ exports[`Data properties when property is an array 1`] = `
   padding-bottom: 6px;
 }
 
-.c17 {
+.c18 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -3326,23 +3338,23 @@ exports[`Data properties when property is an array 1`] = `
   padding-bottom: 6px;
 }
 
-.c11 {
+.c12 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
 }
 
-.c12 {
+.c13 {
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
 }
 
-.c16:focus {
+.c17:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c16:focus:not(:focus-visible) {
+.c17:focus:not(:focus-visible) {
   outline: none;
 }
 
@@ -3387,41 +3399,45 @@ exports[`Data properties when property is an array 1`] = `
             <div
               class="c5"
             >
-              <svg
-                aria-label="Search"
+              <div
                 class="c6"
-                viewBox="0 0 24 24"
               >
-                <path
-                  d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                  fill="none"
-                  stroke="#000"
-                  stroke-width="2"
-                />
-              </svg>
+                <svg
+                  aria-label="Search"
+                  class="c7"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                    fill="none"
+                    stroke="#000"
+                    stroke-width="2"
+                  />
+                </svg>
+              </div>
+              <input
+                aria-label="Search"
+                autocomplete="off"
+                class="c8"
+                id="data--search"
+                name="_search"
+                type="search"
+                value=""
+              />
             </div>
-            <input
-              aria-label="Search"
-              autocomplete="off"
-              class="c7"
-              id="data--search"
-              name="_search"
-              type="search"
-              value=""
-            />
           </div>
           <div
-            class="c8"
+            class="c9"
           >
             <button
               aria-label="Open filters"
-              class="c9"
+              class="c10"
               id="data--filters-control"
               type="button"
             >
               <svg
                 aria-label="Filter"
-                class="c6"
+                class="c7"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -3436,12 +3452,12 @@ exports[`Data properties when property is an array 1`] = `
         </div>
       </div>
       <span
-        class="c10"
+        class="c11"
       >
         4 items
       </span>
       <table
-        class="c11 c12"
+        class="c12 c13"
       >
         <thead
           class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -3450,42 +3466,42 @@ exports[`Data properties when property is an array 1`] = `
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="c13 "
+              class="c14 "
               scope="col"
             >
               <div
-                class="c14"
+                class="c15"
               >
                 <span
-                  class="c15"
+                  class="c16"
                 >
                   Name
                 </span>
               </div>
             </th>
             <th
-              class="c13 "
+              class="c14 "
               scope="col"
             >
               <div
-                class="c14"
+                class="c15"
               >
                 <span
-                  class="c15"
+                  class="c16"
                 >
                   Note
                 </span>
               </div>
             </th>
             <th
-              class="c13 "
+              class="c14 "
               scope="col"
             >
               <div
-                class="c14"
+                class="c15"
               >
                 <span
-                  class="c15"
+                  class="c16"
                 >
                   Tags
                 </span>
@@ -3494,17 +3510,17 @@ exports[`Data properties when property is an array 1`] = `
           </tr>
         </thead>
         <tbody
-          class="StyledTable__StyledTableBody-sc-1m3u5g-3 c16"
+          class="StyledTable__StyledTableBody-sc-1m3u5g-3 c17"
         >
           <tr
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="c17 "
+              class="c18 "
               scope="row"
             >
               <div
-                class="c18"
+                class="c4"
               >
                 <span
                   class="c19"
@@ -3514,26 +3530,26 @@ exports[`Data properties when property is an array 1`] = `
               </div>
             </th>
             <td
-              class="c17 "
+              class="c18 "
             >
               <div
-                class="c18"
+                class="c4"
               >
                 <span
-                  class="c15"
+                  class="c16"
                 >
                   ZZ
                 </span>
               </div>
             </td>
             <td
-              class="c17 "
+              class="c18 "
             >
               <div
-                class="c18"
+                class="c4"
               >
                 <span
-                  class="c15"
+                  class="c16"
                 >
                   qa, staging, prod
                 </span>
@@ -3544,11 +3560,11 @@ exports[`Data properties when property is an array 1`] = `
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="c17 "
+              class="c18 "
               scope="row"
             >
               <div
-                class="c18"
+                class="c4"
               >
                 <span
                   class="c19"
@@ -3558,26 +3574,26 @@ exports[`Data properties when property is an array 1`] = `
               </div>
             </th>
             <td
-              class="c17 "
+              class="c18 "
             >
               <div
-                class="c18"
+                class="c4"
               >
                 <span
-                  class="c15"
+                  class="c16"
                 >
                   YY
                 </span>
               </div>
             </td>
             <td
-              class="c17 "
+              class="c18 "
             >
               <div
-                class="c18"
+                class="c4"
               >
                 <span
-                  class="c15"
+                  class="c16"
                 >
                   qa, staging
                 </span>
@@ -3588,11 +3604,11 @@ exports[`Data properties when property is an array 1`] = `
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="c17 "
+              class="c18 "
               scope="row"
             >
               <div
-                class="c18"
+                class="c4"
               >
                 <span
                   class="c19"
@@ -3602,20 +3618,20 @@ exports[`Data properties when property is an array 1`] = `
               </div>
             </th>
             <td
-              class="c17 "
+              class="c18 "
             >
               <div
-                class="c18"
+                class="c4"
               />
             </td>
             <td
-              class="c17 "
+              class="c18 "
             >
               <div
-                class="c18"
+                class="c4"
               >
                 <span
-                  class="c15"
+                  class="c16"
                 >
                   qa
                 </span>
@@ -3626,11 +3642,11 @@ exports[`Data properties when property is an array 1`] = `
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="c17 "
+              class="c18 "
               scope="row"
             >
               <div
-                class="c18"
+                class="c4"
               >
                 <span
                   class="c19"
@@ -3640,17 +3656,17 @@ exports[`Data properties when property is an array 1`] = `
               </div>
             </th>
             <td
-              class="c17 "
+              class="c18 "
             >
               <div
-                class="c18"
+                class="c4"
               />
             </td>
             <td
-              class="c17 "
+              class="c18 "
             >
               <div
-                class="c18"
+                class="c4"
               />
             </td>
           </tr>
@@ -3902,7 +3918,7 @@ exports[`Data renders 1`] = `
 `;
 
 exports[`Data toolbar 1`] = `
-.c6 {
+.c7 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -3913,25 +3929,25 @@ exports[`Data toolbar 1`] = `
   stroke: #666666;
 }
 
-.c6 g {
+.c7 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c6 *:not([stroke])[fill='none'] {
+.c7 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c6 *[stroke*='#'],
-.c6 *[STROKE*='#'] {
+.c7 *[stroke*='#'],
+.c7 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c6 *[fill-rule],
-.c6 *[FILL-RULE],
-.c6 *[fill*='#'],
-.c6 *[FILL*='#'] {
+.c7 *[fill-rule],
+.c7 *[FILL-RULE],
+.c7 *[fill*='#'],
+.c7 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -3963,7 +3979,21 @@ exports[`Data toolbar 1`] = `
   flex: 0 0 auto;
 }
 
-.c8 {
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3980,7 +4010,7 @@ exports[`Data toolbar 1`] = `
   flex: 0 0 auto;
 }
 
-.c14 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3999,20 +4029,6 @@ exports[`Data toolbar 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-}
-
-.c17 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
 }
 
 .c2 {
@@ -4069,7 +4085,7 @@ exports[`Data toolbar 1`] = `
   row-gap: 12px;
 }
 
-.c10 {
+.c11 {
   margin-top: 6px;
   margin-bottom: 6px;
   font-size: 18px;
@@ -4087,7 +4103,7 @@ exports[`Data toolbar 1`] = `
   line-height: 24px;
 }
 
-.c9 {
+.c10 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -4107,47 +4123,47 @@ exports[`Data toolbar 1`] = `
   padding: 12px;
 }
 
-.c9:focus {
+.c10:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c9:focus > circle,
-.c9:focus > ellipse,
-.c9:focus > line,
-.c9:focus > path,
-.c9:focus > polygon,
-.c9:focus > polyline,
-.c9:focus > rect {
+.c10:focus > circle,
+.c10:focus > ellipse,
+.c10:focus > line,
+.c10:focus > path,
+.c10:focus > polygon,
+.c10:focus > polyline,
+.c10:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c9:focus::-moz-focus-inner {
+.c10:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c9:focus:not(:focus-visible) {
+.c10:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c9:focus:not(:focus-visible) > circle,
-.c9:focus:not(:focus-visible) > ellipse,
-.c9:focus:not(:focus-visible) > line,
-.c9:focus:not(:focus-visible) > path,
-.c9:focus:not(:focus-visible) > polygon,
-.c9:focus:not(:focus-visible) > polyline,
-.c9:focus:not(:focus-visible) > rect {
+.c10:focus:not(:focus-visible) > circle,
+.c10:focus:not(:focus-visible) > ellipse,
+.c10:focus:not(:focus-visible) > line,
+.c10:focus:not(:focus-visible) > path,
+.c10:focus:not(:focus-visible) > polygon,
+.c10:focus:not(:focus-visible) > polyline,
+.c10:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c9:focus:not(:focus-visible)::-moz-focus-inner {
+.c10:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c7 {
+.c8 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -4164,58 +4180,58 @@ exports[`Data toolbar 1`] = `
   padding-left: 48px;
 }
 
-.c7:focus {
+.c8:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus > circle,
-.c7:focus > ellipse,
-.c7:focus > line,
-.c7:focus > path,
-.c7:focus > polygon,
-.c7:focus > polyline,
-.c7:focus > rect {
+.c8:focus > circle,
+.c8:focus > ellipse,
+.c8:focus > line,
+.c8:focus > path,
+.c8:focus > polygon,
+.c8:focus > polyline,
+.c8:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus::-moz-focus-inner {
+.c8:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c7::-webkit-input-placeholder {
+.c8::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-moz-placeholder {
+.c8::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c7:-ms-input-placeholder {
+.c8:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-webkit-search-decoration {
+.c8::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c7::-moz-focus-inner {
+.c8::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c7:-moz-placeholder,
-.c7::-moz-placeholder {
+.c8:-moz-placeholder,
+.c8::-moz-placeholder {
   opacity: 1;
 }
 
-.c4 {
+.c5 {
   position: relative;
   width: 100%;
 }
 
-.c5 {
+.c6 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -4233,7 +4249,7 @@ exports[`Data toolbar 1`] = `
   left: 12px;
 }
 
-.c13 {
+.c14 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -4246,7 +4262,7 @@ exports[`Data toolbar 1`] = `
   padding-bottom: 6px;
 }
 
-.c16 {
+.c17 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -4258,23 +4274,23 @@ exports[`Data toolbar 1`] = `
   padding-bottom: 6px;
 }
 
-.c11 {
+.c12 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
 }
 
-.c12 {
+.c13 {
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
 }
 
-.c15:focus {
+.c16:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c15:focus:not(:focus-visible) {
+.c16:focus:not(:focus-visible) {
   outline: none;
 }
 
@@ -4319,41 +4335,45 @@ exports[`Data toolbar 1`] = `
           <div
             class="c5"
           >
-            <svg
-              aria-label="Search"
+            <div
               class="c6"
-              viewBox="0 0 24 24"
             >
-              <path
-                d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
+              <svg
+                aria-label="Search"
+                class="c7"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
+            <input
+              aria-label="Search"
+              autocomplete="off"
+              class="c8"
+              id="data--search"
+              name="_search"
+              type="search"
+              value=""
+            />
           </div>
-          <input
-            aria-label="Search"
-            autocomplete="off"
-            class="c7"
-            id="data--search"
-            name="_search"
-            type="search"
-            value=""
-          />
         </div>
         <div
-          class="c8"
+          class="c9"
         >
           <button
             aria-label="Open filters"
-            class="c9"
+            class="c10"
             id="data--filters-control"
             type="button"
           >
             <svg
               aria-label="Filter"
-              class="c6"
+              class="c7"
               viewBox="0 0 24 24"
             >
               <path
@@ -4368,12 +4388,12 @@ exports[`Data toolbar 1`] = `
       </div>
     </div>
     <span
-      class="c10"
+      class="c11"
     >
       4 items
     </span>
     <table
-      class="c11 c12"
+      class="c12 c13"
     >
       <thead
         class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -4382,35 +4402,35 @@ exports[`Data toolbar 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c13 "
+            class="c14 "
             scope="col"
           >
             <div
-              class="c14"
+              class="c15"
             />
           </th>
           <th
-            class="c13 "
+            class="c14 "
             scope="col"
           >
             <div
-              class="c14"
+              class="c15"
             />
           </th>
         </tr>
       </thead>
       <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c15"
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c16"
       >
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c16 "
+            class="c17 "
             scope="row"
           >
             <div
-              class="c17"
+              class="c4"
             >
               <span
                 class="c18"
@@ -4420,10 +4440,10 @@ exports[`Data toolbar 1`] = `
             </div>
           </th>
           <td
-            class="c16 "
+            class="c17 "
           >
             <div
-              class="c17"
+              class="c4"
             >
               <span
                 class="c19"
@@ -4437,11 +4457,11 @@ exports[`Data toolbar 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c16 "
+            class="c17 "
             scope="row"
           >
             <div
-              class="c17"
+              class="c4"
             >
               <span
                 class="c18"
@@ -4451,10 +4471,10 @@ exports[`Data toolbar 1`] = `
             </div>
           </th>
           <td
-            class="c16 "
+            class="c17 "
           >
             <div
-              class="c17"
+              class="c4"
             >
               <span
                 class="c19"
@@ -4468,11 +4488,11 @@ exports[`Data toolbar 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c16 "
+            class="c17 "
             scope="row"
           >
             <div
-              class="c17"
+              class="c4"
             >
               <span
                 class="c18"
@@ -4482,10 +4502,10 @@ exports[`Data toolbar 1`] = `
             </div>
           </th>
           <td
-            class="c16 "
+            class="c17 "
           >
             <div
-              class="c17"
+              class="c4"
             />
           </td>
         </tr>
@@ -4493,11 +4513,11 @@ exports[`Data toolbar 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c16 "
+            class="c17 "
             scope="row"
           >
             <div
-              class="c17"
+              class="c4"
             >
               <span
                 class="c18"
@@ -4507,10 +4527,10 @@ exports[`Data toolbar 1`] = `
             </div>
           </th>
           <td
-            class="c16 "
+            class="c17 "
           >
             <div
-              class="c17"
+              class="c4"
             />
           </td>
         </tr>
@@ -4972,7 +4992,7 @@ exports[`Data toolbar filters 1`] = `
 `;
 
 exports[`Data toolbar search 1`] = `
-.c6 {
+.c7 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -4983,25 +5003,25 @@ exports[`Data toolbar search 1`] = `
   stroke: #666666;
 }
 
-.c6 g {
+.c7 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c6 *:not([stroke])[fill='none'] {
+.c7 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c6 *[stroke*='#'],
-.c6 *[STROKE*='#'] {
+.c7 *[stroke*='#'],
+.c7 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c6 *[fill-rule],
-.c6 *[FILL-RULE],
-.c6 *[fill*='#'],
-.c6 *[FILL*='#'] {
+.c7 *[fill-rule],
+.c7 *[FILL-RULE],
+.c7 *[fill*='#'],
+.c7 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -5033,7 +5053,21 @@ exports[`Data toolbar search 1`] = `
   flex: 0 0 auto;
 }
 
-.c12 {
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5052,20 +5086,6 @@ exports[`Data toolbar search 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-}
-
-.c15 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
 }
 
 .c2 {
@@ -5122,7 +5142,7 @@ exports[`Data toolbar search 1`] = `
   row-gap: 12px;
 }
 
-.c8 {
+.c9 {
   margin-top: 6px;
   margin-bottom: 6px;
   font-size: 18px;
@@ -5135,7 +5155,7 @@ exports[`Data toolbar search 1`] = `
   font-weight: bold;
 }
 
-.c7 {
+.c8 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -5152,58 +5172,58 @@ exports[`Data toolbar search 1`] = `
   padding-left: 48px;
 }
 
-.c7:focus {
+.c8:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus > circle,
-.c7:focus > ellipse,
-.c7:focus > line,
-.c7:focus > path,
-.c7:focus > polygon,
-.c7:focus > polyline,
-.c7:focus > rect {
+.c8:focus > circle,
+.c8:focus > ellipse,
+.c8:focus > line,
+.c8:focus > path,
+.c8:focus > polygon,
+.c8:focus > polyline,
+.c8:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus::-moz-focus-inner {
+.c8:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c7::-webkit-input-placeholder {
+.c8::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-moz-placeholder {
+.c8::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c7:-ms-input-placeholder {
+.c8:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-webkit-search-decoration {
+.c8::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c7::-moz-focus-inner {
+.c8::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c7:-moz-placeholder,
-.c7::-moz-placeholder {
+.c8:-moz-placeholder,
+.c8::-moz-placeholder {
   opacity: 1;
 }
 
-.c4 {
+.c5 {
   position: relative;
   width: 100%;
 }
 
-.c5 {
+.c6 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -5221,7 +5241,7 @@ exports[`Data toolbar search 1`] = `
   left: 12px;
 }
 
-.c11 {
+.c12 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -5234,7 +5254,7 @@ exports[`Data toolbar search 1`] = `
   padding-bottom: 6px;
 }
 
-.c14 {
+.c15 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -5246,23 +5266,23 @@ exports[`Data toolbar search 1`] = `
   padding-bottom: 6px;
 }
 
-.c9 {
+.c10 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
 }
 
-.c10 {
+.c11 {
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
 }
 
-.c13:focus {
+.c14:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c13:focus:not(:focus-visible) {
+.c14:focus:not(:focus-visible) {
   outline: none;
 }
 
@@ -5307,38 +5327,42 @@ exports[`Data toolbar search 1`] = `
           <div
             class="c5"
           >
-            <svg
-              aria-label="Search"
+            <div
               class="c6"
-              viewBox="0 0 24 24"
             >
-              <path
-                d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
+              <svg
+                aria-label="Search"
+                class="c7"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
+            <input
+              aria-label="Search"
+              autocomplete="off"
+              class="c8"
+              id="data--search"
+              name="_search"
+              type="search"
+              value=""
+            />
           </div>
-          <input
-            aria-label="Search"
-            autocomplete="off"
-            class="c7"
-            id="data--search"
-            name="_search"
-            type="search"
-            value=""
-          />
         </div>
       </div>
     </div>
     <span
-      class="c8"
+      class="c9"
     >
       4 items
     </span>
     <table
-      class="c9 c10"
+      class="c10 c11"
     >
       <thead
         class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -5347,27 +5371,27 @@ exports[`Data toolbar search 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c11 "
+            class="c12 "
             scope="col"
           >
             <div
-              class="c12"
+              class="c13"
             />
           </th>
         </tr>
       </thead>
       <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c13"
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c14"
       >
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c14 "
+            class="c15 "
             scope="row"
           >
             <div
-              class="c15"
+              class="c4"
             >
               <span
                 class="c16"
@@ -5381,11 +5405,11 @@ exports[`Data toolbar search 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c14 "
+            class="c15 "
             scope="row"
           >
             <div
-              class="c15"
+              class="c4"
             >
               <span
                 class="c16"
@@ -5399,11 +5423,11 @@ exports[`Data toolbar search 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c14 "
+            class="c15 "
             scope="row"
           >
             <div
-              class="c15"
+              class="c4"
             >
               <span
                 class="c16"
@@ -5417,11 +5441,11 @@ exports[`Data toolbar search 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c14 "
+            class="c15 "
             scope="row"
           >
             <div
-              class="c15"
+              class="c4"
             >
               <span
                 class="c16"
@@ -5438,7 +5462,7 @@ exports[`Data toolbar search 1`] = `
 `;
 
 exports[`Data uncontrolled search 1`] = `
-.c6 {
+.c7 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -5449,25 +5473,25 @@ exports[`Data uncontrolled search 1`] = `
   stroke: #666666;
 }
 
-.c6 g {
+.c7 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c6 *:not([stroke])[fill='none'] {
+.c7 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c6 *[stroke*='#'],
-.c6 *[STROKE*='#'] {
+.c7 *[stroke*='#'],
+.c7 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c6 *[fill-rule],
-.c6 *[FILL-RULE],
-.c6 *[fill*='#'],
-.c6 *[FILL*='#'] {
+.c7 *[fill-rule],
+.c7 *[FILL-RULE],
+.c7 *[fill*='#'],
+.c7 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -5499,7 +5523,21 @@ exports[`Data uncontrolled search 1`] = `
   flex: 0 0 auto;
 }
 
-.c8 {
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5516,7 +5554,7 @@ exports[`Data uncontrolled search 1`] = `
   flex: 0 0 auto;
 }
 
-.c14 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5535,20 +5573,6 @@ exports[`Data uncontrolled search 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-}
-
-.c17 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
 }
 
 .c2 {
@@ -5605,7 +5629,7 @@ exports[`Data uncontrolled search 1`] = `
   row-gap: 12px;
 }
 
-.c10 {
+.c11 {
   margin-top: 6px;
   margin-bottom: 6px;
   font-size: 18px;
@@ -5618,7 +5642,7 @@ exports[`Data uncontrolled search 1`] = `
   font-weight: bold;
 }
 
-.c9 {
+.c10 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -5638,47 +5662,47 @@ exports[`Data uncontrolled search 1`] = `
   padding: 12px;
 }
 
-.c9:focus {
+.c10:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c9:focus > circle,
-.c9:focus > ellipse,
-.c9:focus > line,
-.c9:focus > path,
-.c9:focus > polygon,
-.c9:focus > polyline,
-.c9:focus > rect {
+.c10:focus > circle,
+.c10:focus > ellipse,
+.c10:focus > line,
+.c10:focus > path,
+.c10:focus > polygon,
+.c10:focus > polyline,
+.c10:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c9:focus::-moz-focus-inner {
+.c10:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c9:focus:not(:focus-visible) {
+.c10:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c9:focus:not(:focus-visible) > circle,
-.c9:focus:not(:focus-visible) > ellipse,
-.c9:focus:not(:focus-visible) > line,
-.c9:focus:not(:focus-visible) > path,
-.c9:focus:not(:focus-visible) > polygon,
-.c9:focus:not(:focus-visible) > polyline,
-.c9:focus:not(:focus-visible) > rect {
+.c10:focus:not(:focus-visible) > circle,
+.c10:focus:not(:focus-visible) > ellipse,
+.c10:focus:not(:focus-visible) > line,
+.c10:focus:not(:focus-visible) > path,
+.c10:focus:not(:focus-visible) > polygon,
+.c10:focus:not(:focus-visible) > polyline,
+.c10:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c9:focus:not(:focus-visible)::-moz-focus-inner {
+.c10:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c7 {
+.c8 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -5695,58 +5719,58 @@ exports[`Data uncontrolled search 1`] = `
   padding-left: 48px;
 }
 
-.c7:focus {
+.c8:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus > circle,
-.c7:focus > ellipse,
-.c7:focus > line,
-.c7:focus > path,
-.c7:focus > polygon,
-.c7:focus > polyline,
-.c7:focus > rect {
+.c8:focus > circle,
+.c8:focus > ellipse,
+.c8:focus > line,
+.c8:focus > path,
+.c8:focus > polygon,
+.c8:focus > polyline,
+.c8:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus::-moz-focus-inner {
+.c8:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c7::-webkit-input-placeholder {
+.c8::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-moz-placeholder {
+.c8::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c7:-ms-input-placeholder {
+.c8:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-webkit-search-decoration {
+.c8::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c7::-moz-focus-inner {
+.c8::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c7:-moz-placeholder,
-.c7::-moz-placeholder {
+.c8:-moz-placeholder,
+.c8::-moz-placeholder {
   opacity: 1;
 }
 
-.c4 {
+.c5 {
   position: relative;
   width: 100%;
 }
 
-.c5 {
+.c6 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -5764,7 +5788,7 @@ exports[`Data uncontrolled search 1`] = `
   left: 12px;
 }
 
-.c13 {
+.c14 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -5777,7 +5801,7 @@ exports[`Data uncontrolled search 1`] = `
   padding-bottom: 6px;
 }
 
-.c16 {
+.c17 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -5789,23 +5813,23 @@ exports[`Data uncontrolled search 1`] = `
   padding-bottom: 6px;
 }
 
-.c11 {
+.c12 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
 }
 
-.c12 {
+.c13 {
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
 }
 
-.c15:focus {
+.c16:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c15:focus:not(:focus-visible) {
+.c16:focus:not(:focus-visible) {
   outline: none;
 }
 
@@ -5850,41 +5874,45 @@ exports[`Data uncontrolled search 1`] = `
           <div
             class="c5"
           >
-            <svg
-              aria-label="Search"
+            <div
               class="c6"
-              viewBox="0 0 24 24"
             >
-              <path
-                d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
+              <svg
+                aria-label="Search"
+                class="c7"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
+            <input
+              aria-label="Search"
+              autocomplete="off"
+              class="c8"
+              id="data--search"
+              name="_search"
+              type="search"
+              value=""
+            />
           </div>
-          <input
-            aria-label="Search"
-            autocomplete="off"
-            class="c7"
-            id="data--search"
-            name="_search"
-            type="search"
-            value=""
-          />
         </div>
         <div
-          class="c8"
+          class="c9"
         >
           <button
             aria-label="Open filters"
-            class="c9"
+            class="c10"
             id="data--filters-control"
             type="button"
           >
             <svg
               aria-label="Filter"
-              class="c6"
+              class="c7"
               viewBox="0 0 24 24"
             >
               <path
@@ -5899,12 +5927,12 @@ exports[`Data uncontrolled search 1`] = `
       </div>
     </div>
     <span
-      class="c10"
+      class="c11"
     >
       4 items
     </span>
     <table
-      class="c11 c12"
+      class="c12 c13"
     >
       <thead
         class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -5913,27 +5941,27 @@ exports[`Data uncontrolled search 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c13 "
+            class="c14 "
             scope="col"
           >
             <div
-              class="c14"
+              class="c15"
             />
           </th>
         </tr>
       </thead>
       <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c15"
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c16"
       >
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c16 "
+            class="c17 "
             scope="row"
           >
             <div
-              class="c17"
+              class="c4"
             >
               <span
                 class="c18"
@@ -5947,11 +5975,11 @@ exports[`Data uncontrolled search 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c16 "
+            class="c17 "
             scope="row"
           >
             <div
-              class="c17"
+              class="c4"
             >
               <span
                 class="c18"
@@ -5965,11 +5993,11 @@ exports[`Data uncontrolled search 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c16 "
+            class="c17 "
             scope="row"
           >
             <div
-              class="c17"
+              class="c4"
             >
               <span
                 class="c18"
@@ -5983,11 +6011,11 @@ exports[`Data uncontrolled search 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c16 "
+            class="c17 "
             scope="row"
           >
             <div
-              class="c17"
+              class="c4"
             >
               <span
                 class="c18"
@@ -6018,33 +6046,37 @@ exports[`Data uncontrolled search 2`] = `
         class="StyledBox-sc-13pk1d4-0 fnEswI"
       >
         <div
-          class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 dAhNeU"
+          class="StyledBox-sc-13pk1d4-0 kqmDKi"
         >
           <div
-            class="StyledTextInput__StyledIcon-sc-1x30a0s-3 iQFXNb"
+            class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 dAhNeU"
           >
-            <svg
-              aria-label="Search"
-              class="StyledIcon-sc-ofa7kd-0 bQiAMQ"
-              viewBox="0 0 24 24"
+            <div
+              class="StyledTextInput__StyledIcon-sc-1x30a0s-3 iQFXNb"
             >
-              <path
-                d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
+              <svg
+                aria-label="Search"
+                class="StyledIcon-sc-ofa7kd-0 bQiAMQ"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
+            <input
+              aria-label="Search"
+              autocomplete="off"
+              class="StyledTextInput-sc-1x30a0s-0 hLtcCB"
+              id="data--search"
+              name="_search"
+              type="search"
+              value=""
+            />
           </div>
-          <input
-            aria-label="Search"
-            autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 hLtcCB"
-            id="data--search"
-            name="_search"
-            type="search"
-            value=""
-          />
         </div>
         <div
           class="StyledBox-sc-13pk1d4-0 imzrdH"
@@ -6397,7 +6429,7 @@ exports[`Data view 1`] = `
 `;
 
 exports[`Data view all 1`] = `
-.c6 {
+.c7 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -6408,25 +6440,25 @@ exports[`Data view all 1`] = `
   stroke: #666666;
 }
 
-.c6 g {
+.c7 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c6 *:not([stroke])[fill='none'] {
+.c7 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c6 *[stroke*='#'],
-.c6 *[STROKE*='#'] {
+.c7 *[stroke*='#'],
+.c7 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c6 *[fill-rule],
-.c6 *[FILL-RULE],
-.c6 *[fill*='#'],
-.c6 *[FILL*='#'] {
+.c7 *[fill-rule],
+.c7 *[FILL-RULE],
+.c7 *[fill*='#'],
+.c7 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -6458,7 +6490,21 @@ exports[`Data view all 1`] = `
   flex: 0 0 auto;
 }
 
-.c8 {
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6475,7 +6521,7 @@ exports[`Data view all 1`] = `
   flex: 0 0 auto;
 }
 
-.c14 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6494,20 +6540,6 @@ exports[`Data view all 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-}
-
-.c17 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
 }
 
 .c2 {
@@ -6564,7 +6596,7 @@ exports[`Data view all 1`] = `
   row-gap: 12px;
 }
 
-.c10 {
+.c11 {
   margin-top: 6px;
   margin-bottom: 6px;
   font-size: 18px;
@@ -6582,7 +6614,7 @@ exports[`Data view all 1`] = `
   line-height: 24px;
 }
 
-.c9 {
+.c10 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -6602,47 +6634,47 @@ exports[`Data view all 1`] = `
   padding: 12px;
 }
 
-.c9:focus {
+.c10:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c9:focus > circle,
-.c9:focus > ellipse,
-.c9:focus > line,
-.c9:focus > path,
-.c9:focus > polygon,
-.c9:focus > polyline,
-.c9:focus > rect {
+.c10:focus > circle,
+.c10:focus > ellipse,
+.c10:focus > line,
+.c10:focus > path,
+.c10:focus > polygon,
+.c10:focus > polyline,
+.c10:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c9:focus::-moz-focus-inner {
+.c10:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c9:focus:not(:focus-visible) {
+.c10:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c9:focus:not(:focus-visible) > circle,
-.c9:focus:not(:focus-visible) > ellipse,
-.c9:focus:not(:focus-visible) > line,
-.c9:focus:not(:focus-visible) > path,
-.c9:focus:not(:focus-visible) > polygon,
-.c9:focus:not(:focus-visible) > polyline,
-.c9:focus:not(:focus-visible) > rect {
+.c10:focus:not(:focus-visible) > circle,
+.c10:focus:not(:focus-visible) > ellipse,
+.c10:focus:not(:focus-visible) > line,
+.c10:focus:not(:focus-visible) > path,
+.c10:focus:not(:focus-visible) > polygon,
+.c10:focus:not(:focus-visible) > polyline,
+.c10:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c9:focus:not(:focus-visible)::-moz-focus-inner {
+.c10:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c7 {
+.c8 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -6659,58 +6691,58 @@ exports[`Data view all 1`] = `
   padding-left: 48px;
 }
 
-.c7:focus {
+.c8:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus > circle,
-.c7:focus > ellipse,
-.c7:focus > line,
-.c7:focus > path,
-.c7:focus > polygon,
-.c7:focus > polyline,
-.c7:focus > rect {
+.c8:focus > circle,
+.c8:focus > ellipse,
+.c8:focus > line,
+.c8:focus > path,
+.c8:focus > polygon,
+.c8:focus > polyline,
+.c8:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus::-moz-focus-inner {
+.c8:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c7::-webkit-input-placeholder {
+.c8::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-moz-placeholder {
+.c8::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c7:-ms-input-placeholder {
+.c8:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-webkit-search-decoration {
+.c8::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c7::-moz-focus-inner {
+.c8::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c7:-moz-placeholder,
-.c7::-moz-placeholder {
+.c8:-moz-placeholder,
+.c8::-moz-placeholder {
   opacity: 1;
 }
 
-.c4 {
+.c5 {
   position: relative;
   width: 100%;
 }
 
-.c5 {
+.c6 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -6728,7 +6760,7 @@ exports[`Data view all 1`] = `
   left: 12px;
 }
 
-.c13 {
+.c14 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -6741,7 +6773,7 @@ exports[`Data view all 1`] = `
   padding-bottom: 6px;
 }
 
-.c16 {
+.c17 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -6753,23 +6785,23 @@ exports[`Data view all 1`] = `
   padding-bottom: 6px;
 }
 
-.c11 {
+.c12 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
 }
 
-.c12 {
+.c13 {
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
 }
 
-.c15:focus {
+.c16:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c15:focus:not(:focus-visible) {
+.c16:focus:not(:focus-visible) {
   outline: none;
 }
 
@@ -6814,41 +6846,45 @@ exports[`Data view all 1`] = `
           <div
             class="c5"
           >
-            <svg
-              aria-label="Search"
+            <div
               class="c6"
-              viewBox="0 0 24 24"
             >
-              <path
-                d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
+              <svg
+                aria-label="Search"
+                class="c7"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
+            <input
+              aria-label="Search"
+              autocomplete="off"
+              class="c8"
+              id="data--search"
+              name="_search"
+              type="search"
+              value=""
+            />
           </div>
-          <input
-            aria-label="Search"
-            autocomplete="off"
-            class="c7"
-            id="data--search"
-            name="_search"
-            type="search"
-            value=""
-          />
         </div>
         <div
-          class="c8"
+          class="c9"
         >
           <button
             aria-label="Open filters"
-            class="c9"
+            class="c10"
             id="data--filters-control"
             type="button"
           >
             <svg
               aria-label="Filter"
-              class="c6"
+              class="c7"
               viewBox="0 0 24 24"
             >
               <path
@@ -6863,12 +6899,12 @@ exports[`Data view all 1`] = `
       </div>
     </div>
     <span
-      class="c10"
+      class="c11"
     >
       1 result of 4 items
     </span>
     <table
-      class="c11 c12"
+      class="c12 c13"
     >
       <thead
         class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -6877,35 +6913,35 @@ exports[`Data view all 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c13 "
+            class="c14 "
             scope="col"
           >
             <div
-              class="c14"
+              class="c15"
             />
           </th>
           <th
-            class="c13 "
+            class="c14 "
             scope="col"
           >
             <div
-              class="c14"
+              class="c15"
             />
           </th>
         </tr>
       </thead>
       <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c15"
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c16"
       >
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c16 "
+            class="c17 "
             scope="row"
           >
             <div
-              class="c17"
+              class="c4"
             >
               <span
                 class="c18"
@@ -6915,10 +6951,10 @@ exports[`Data view all 1`] = `
             </div>
           </th>
           <td
-            class="c16 "
+            class="c17 "
           >
             <div
-              class="c17"
+              class="c4"
             >
               <span
                 class="c19"
@@ -6935,7 +6971,7 @@ exports[`Data view all 1`] = `
 `;
 
 exports[`Data view property option 1`] = `
-.c6 {
+.c7 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -6946,25 +6982,25 @@ exports[`Data view property option 1`] = `
   stroke: #666666;
 }
 
-.c6 g {
+.c7 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c6 *:not([stroke])[fill='none'] {
+.c7 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c6 *[stroke*='#'],
-.c6 *[STROKE*='#'] {
+.c7 *[stroke*='#'],
+.c7 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c6 *[fill-rule],
-.c6 *[FILL-RULE],
-.c6 *[fill*='#'],
-.c6 *[FILL*='#'] {
+.c7 *[fill-rule],
+.c7 *[FILL-RULE],
+.c7 *[fill*='#'],
+.c7 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -6996,7 +7032,21 @@ exports[`Data view property option 1`] = `
   flex: 0 0 auto;
 }
 
-.c8 {
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7013,7 +7063,7 @@ exports[`Data view property option 1`] = `
   flex: 0 0 auto;
 }
 
-.c14 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7032,20 +7082,6 @@ exports[`Data view property option 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-}
-
-.c17 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
 }
 
 .c2 {
@@ -7102,7 +7138,7 @@ exports[`Data view property option 1`] = `
   row-gap: 12px;
 }
 
-.c10 {
+.c11 {
   margin-top: 6px;
   margin-bottom: 6px;
   font-size: 18px;
@@ -7120,7 +7156,7 @@ exports[`Data view property option 1`] = `
   line-height: 24px;
 }
 
-.c9 {
+.c10 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -7140,47 +7176,47 @@ exports[`Data view property option 1`] = `
   padding: 12px;
 }
 
-.c9:focus {
+.c10:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c9:focus > circle,
-.c9:focus > ellipse,
-.c9:focus > line,
-.c9:focus > path,
-.c9:focus > polygon,
-.c9:focus > polyline,
-.c9:focus > rect {
+.c10:focus > circle,
+.c10:focus > ellipse,
+.c10:focus > line,
+.c10:focus > path,
+.c10:focus > polygon,
+.c10:focus > polyline,
+.c10:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c9:focus::-moz-focus-inner {
+.c10:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c9:focus:not(:focus-visible) {
+.c10:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c9:focus:not(:focus-visible) > circle,
-.c9:focus:not(:focus-visible) > ellipse,
-.c9:focus:not(:focus-visible) > line,
-.c9:focus:not(:focus-visible) > path,
-.c9:focus:not(:focus-visible) > polygon,
-.c9:focus:not(:focus-visible) > polyline,
-.c9:focus:not(:focus-visible) > rect {
+.c10:focus:not(:focus-visible) > circle,
+.c10:focus:not(:focus-visible) > ellipse,
+.c10:focus:not(:focus-visible) > line,
+.c10:focus:not(:focus-visible) > path,
+.c10:focus:not(:focus-visible) > polygon,
+.c10:focus:not(:focus-visible) > polyline,
+.c10:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c9:focus:not(:focus-visible)::-moz-focus-inner {
+.c10:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c7 {
+.c8 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -7197,58 +7233,58 @@ exports[`Data view property option 1`] = `
   padding-left: 48px;
 }
 
-.c7:focus {
+.c8:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus > circle,
-.c7:focus > ellipse,
-.c7:focus > line,
-.c7:focus > path,
-.c7:focus > polygon,
-.c7:focus > polyline,
-.c7:focus > rect {
+.c8:focus > circle,
+.c8:focus > ellipse,
+.c8:focus > line,
+.c8:focus > path,
+.c8:focus > polygon,
+.c8:focus > polyline,
+.c8:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus::-moz-focus-inner {
+.c8:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c7::-webkit-input-placeholder {
+.c8::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-moz-placeholder {
+.c8::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c7:-ms-input-placeholder {
+.c8:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-webkit-search-decoration {
+.c8::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c7::-moz-focus-inner {
+.c8::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c7:-moz-placeholder,
-.c7::-moz-placeholder {
+.c8:-moz-placeholder,
+.c8::-moz-placeholder {
   opacity: 1;
 }
 
-.c4 {
+.c5 {
   position: relative;
   width: 100%;
 }
 
-.c5 {
+.c6 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -7266,7 +7302,7 @@ exports[`Data view property option 1`] = `
   left: 12px;
 }
 
-.c13 {
+.c14 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -7279,7 +7315,7 @@ exports[`Data view property option 1`] = `
   padding-bottom: 6px;
 }
 
-.c16 {
+.c17 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -7291,23 +7327,23 @@ exports[`Data view property option 1`] = `
   padding-bottom: 6px;
 }
 
-.c11 {
+.c12 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
 }
 
-.c12 {
+.c13 {
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
 }
 
-.c15:focus {
+.c16:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c15:focus:not(:focus-visible) {
+.c16:focus:not(:focus-visible) {
   outline: none;
 }
 
@@ -7352,41 +7388,45 @@ exports[`Data view property option 1`] = `
           <div
             class="c5"
           >
-            <svg
-              aria-label="Search"
+            <div
               class="c6"
-              viewBox="0 0 24 24"
             >
-              <path
-                d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
+              <svg
+                aria-label="Search"
+                class="c7"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
+            <input
+              aria-label="Search"
+              autocomplete="off"
+              class="c8"
+              id="data--search"
+              name="_search"
+              type="search"
+              value=""
+            />
           </div>
-          <input
-            aria-label="Search"
-            autocomplete="off"
-            class="c7"
-            id="data--search"
-            name="_search"
-            type="search"
-            value=""
-          />
         </div>
         <div
-          class="c8"
+          class="c9"
         >
           <button
             aria-label="Open filters"
-            class="c9"
+            class="c10"
             id="data--filters-control"
             type="button"
           >
             <svg
               aria-label="Filter"
-              class="c6"
+              class="c7"
               viewBox="0 0 24 24"
             >
               <path
@@ -7401,12 +7441,12 @@ exports[`Data view property option 1`] = `
       </div>
     </div>
     <span
-      class="c10"
+      class="c11"
     >
       1 result of 4 items
     </span>
     <table
-      class="c11 c12"
+      class="c12 c13"
     >
       <thead
         class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -7415,35 +7455,35 @@ exports[`Data view property option 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c13 "
+            class="c14 "
             scope="col"
           >
             <div
-              class="c14"
+              class="c15"
             />
           </th>
           <th
-            class="c13 "
+            class="c14 "
             scope="col"
           >
             <div
-              class="c14"
+              class="c15"
             />
           </th>
         </tr>
       </thead>
       <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c15"
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c16"
       >
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c16 "
+            class="c17 "
             scope="row"
           >
             <div
-              class="c17"
+              class="c4"
             >
               <span
                 class="c18"
@@ -7453,10 +7493,10 @@ exports[`Data view property option 1`] = `
             </div>
           </th>
           <td
-            class="c16 "
+            class="c17 "
           >
             <div
-              class="c17"
+              class="c4"
             >
               <span
                 class="c19"
@@ -7473,7 +7513,7 @@ exports[`Data view property option 1`] = `
 `;
 
 exports[`Data view property range 1`] = `
-.c6 {
+.c7 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -7484,25 +7524,25 @@ exports[`Data view property range 1`] = `
   stroke: #666666;
 }
 
-.c6 g {
+.c7 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c6 *:not([stroke])[fill='none'] {
+.c7 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c6 *[stroke*='#'],
-.c6 *[STROKE*='#'] {
+.c7 *[stroke*='#'],
+.c7 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c6 *[fill-rule],
-.c6 *[FILL-RULE],
-.c6 *[fill*='#'],
-.c6 *[FILL*='#'] {
+.c7 *[fill-rule],
+.c7 *[FILL-RULE],
+.c7 *[fill*='#'],
+.c7 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -7534,7 +7574,21 @@ exports[`Data view property range 1`] = `
   flex: 0 0 auto;
 }
 
-.c8 {
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7551,7 +7605,7 @@ exports[`Data view property range 1`] = `
   flex: 0 0 auto;
 }
 
-.c14 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7570,20 +7624,6 @@ exports[`Data view property range 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-}
-
-.c17 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
 }
 
 .c2 {
@@ -7640,7 +7680,7 @@ exports[`Data view property range 1`] = `
   row-gap: 12px;
 }
 
-.c10 {
+.c11 {
   margin-top: 6px;
   margin-bottom: 6px;
   font-size: 18px;
@@ -7658,7 +7698,7 @@ exports[`Data view property range 1`] = `
   line-height: 24px;
 }
 
-.c9 {
+.c10 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -7678,47 +7718,47 @@ exports[`Data view property range 1`] = `
   padding: 12px;
 }
 
-.c9:focus {
+.c10:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c9:focus > circle,
-.c9:focus > ellipse,
-.c9:focus > line,
-.c9:focus > path,
-.c9:focus > polygon,
-.c9:focus > polyline,
-.c9:focus > rect {
+.c10:focus > circle,
+.c10:focus > ellipse,
+.c10:focus > line,
+.c10:focus > path,
+.c10:focus > polygon,
+.c10:focus > polyline,
+.c10:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c9:focus::-moz-focus-inner {
+.c10:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c9:focus:not(:focus-visible) {
+.c10:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c9:focus:not(:focus-visible) > circle,
-.c9:focus:not(:focus-visible) > ellipse,
-.c9:focus:not(:focus-visible) > line,
-.c9:focus:not(:focus-visible) > path,
-.c9:focus:not(:focus-visible) > polygon,
-.c9:focus:not(:focus-visible) > polyline,
-.c9:focus:not(:focus-visible) > rect {
+.c10:focus:not(:focus-visible) > circle,
+.c10:focus:not(:focus-visible) > ellipse,
+.c10:focus:not(:focus-visible) > line,
+.c10:focus:not(:focus-visible) > path,
+.c10:focus:not(:focus-visible) > polygon,
+.c10:focus:not(:focus-visible) > polyline,
+.c10:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c9:focus:not(:focus-visible)::-moz-focus-inner {
+.c10:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c7 {
+.c8 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -7735,58 +7775,58 @@ exports[`Data view property range 1`] = `
   padding-left: 48px;
 }
 
-.c7:focus {
+.c8:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus > circle,
-.c7:focus > ellipse,
-.c7:focus > line,
-.c7:focus > path,
-.c7:focus > polygon,
-.c7:focus > polyline,
-.c7:focus > rect {
+.c8:focus > circle,
+.c8:focus > ellipse,
+.c8:focus > line,
+.c8:focus > path,
+.c8:focus > polygon,
+.c8:focus > polyline,
+.c8:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus::-moz-focus-inner {
+.c8:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c7::-webkit-input-placeholder {
+.c8::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-moz-placeholder {
+.c8::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c7:-ms-input-placeholder {
+.c8:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-webkit-search-decoration {
+.c8::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c7::-moz-focus-inner {
+.c8::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c7:-moz-placeholder,
-.c7::-moz-placeholder {
+.c8:-moz-placeholder,
+.c8::-moz-placeholder {
   opacity: 1;
 }
 
-.c4 {
+.c5 {
   position: relative;
   width: 100%;
 }
 
-.c5 {
+.c6 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -7804,7 +7844,7 @@ exports[`Data view property range 1`] = `
   left: 12px;
 }
 
-.c13 {
+.c14 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -7817,7 +7857,7 @@ exports[`Data view property range 1`] = `
   padding-bottom: 6px;
 }
 
-.c16 {
+.c17 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -7829,23 +7869,23 @@ exports[`Data view property range 1`] = `
   padding-bottom: 6px;
 }
 
-.c11 {
+.c12 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
 }
 
-.c12 {
+.c13 {
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
 }
 
-.c15:focus {
+.c16:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c15:focus:not(:focus-visible) {
+.c16:focus:not(:focus-visible) {
   outline: none;
 }
 
@@ -7890,41 +7930,45 @@ exports[`Data view property range 1`] = `
           <div
             class="c5"
           >
-            <svg
-              aria-label="Search"
+            <div
               class="c6"
-              viewBox="0 0 24 24"
             >
-              <path
-                d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
+              <svg
+                aria-label="Search"
+                class="c7"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
+            <input
+              aria-label="Search"
+              autocomplete="off"
+              class="c8"
+              id="data--search"
+              name="_search"
+              type="search"
+              value=""
+            />
           </div>
-          <input
-            aria-label="Search"
-            autocomplete="off"
-            class="c7"
-            id="data--search"
-            name="_search"
-            type="search"
-            value=""
-          />
         </div>
         <div
-          class="c8"
+          class="c9"
         >
           <button
             aria-label="Open filters"
-            class="c9"
+            class="c10"
             id="data--filters-control"
             type="button"
           >
             <svg
               aria-label="Filter"
-              class="c6"
+              class="c7"
               viewBox="0 0 24 24"
             >
               <path
@@ -7939,12 +7983,12 @@ exports[`Data view property range 1`] = `
       </div>
     </div>
     <span
-      class="c10"
+      class="c11"
     >
       1 result of 4 items
     </span>
     <table
-      class="c11 c12"
+      class="c12 c13"
     >
       <thead
         class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -7953,43 +7997,43 @@ exports[`Data view property range 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c13 "
+            class="c14 "
             scope="col"
           >
             <div
-              class="c14"
+              class="c15"
             />
           </th>
           <th
-            class="c13 "
+            class="c14 "
             scope="col"
           >
             <div
-              class="c14"
+              class="c15"
             />
           </th>
           <th
-            class="c13 "
+            class="c14 "
             scope="col"
           >
             <div
-              class="c14"
+              class="c15"
             />
           </th>
         </tr>
       </thead>
       <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c15"
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c16"
       >
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c16 "
+            class="c17 "
             scope="row"
           >
             <div
-              class="c17"
+              class="c4"
             >
               <span
                 class="c18"
@@ -7999,10 +8043,10 @@ exports[`Data view property range 1`] = `
             </div>
           </th>
           <td
-            class="c16 "
+            class="c17 "
           >
             <div
-              class="c17"
+              class="c4"
             >
               <span
                 class="c19"
@@ -8012,10 +8056,10 @@ exports[`Data view property range 1`] = `
             </div>
           </td>
           <td
-            class="c16 "
+            class="c17 "
           >
             <div
-              class="c17"
+              class="c4"
             >
               <span
                 class="c19"
@@ -8032,7 +8076,7 @@ exports[`Data view property range 1`] = `
 `;
 
 exports[`Data view search 1`] = `
-.c6 {
+.c7 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -8043,25 +8087,25 @@ exports[`Data view search 1`] = `
   stroke: #666666;
 }
 
-.c6 g {
+.c7 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c6 *:not([stroke])[fill='none'] {
+.c7 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c6 *[stroke*='#'],
-.c6 *[STROKE*='#'] {
+.c7 *[stroke*='#'],
+.c7 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c6 *[fill-rule],
-.c6 *[FILL-RULE],
-.c6 *[fill*='#'],
-.c6 *[FILL*='#'] {
+.c7 *[fill-rule],
+.c7 *[FILL-RULE],
+.c7 *[fill*='#'],
+.c7 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -8093,7 +8137,21 @@ exports[`Data view search 1`] = `
   flex: 0 0 auto;
 }
 
-.c8 {
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8110,7 +8168,7 @@ exports[`Data view search 1`] = `
   flex: 0 0 auto;
 }
 
-.c14 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8129,20 +8187,6 @@ exports[`Data view search 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-}
-
-.c17 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
 }
 
 .c2 {
@@ -8199,7 +8243,7 @@ exports[`Data view search 1`] = `
   row-gap: 12px;
 }
 
-.c10 {
+.c11 {
   margin-top: 6px;
   margin-bottom: 6px;
   font-size: 18px;
@@ -8217,7 +8261,7 @@ exports[`Data view search 1`] = `
   line-height: 24px;
 }
 
-.c9 {
+.c10 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -8237,47 +8281,47 @@ exports[`Data view search 1`] = `
   padding: 12px;
 }
 
-.c9:focus {
+.c10:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c9:focus > circle,
-.c9:focus > ellipse,
-.c9:focus > line,
-.c9:focus > path,
-.c9:focus > polygon,
-.c9:focus > polyline,
-.c9:focus > rect {
+.c10:focus > circle,
+.c10:focus > ellipse,
+.c10:focus > line,
+.c10:focus > path,
+.c10:focus > polygon,
+.c10:focus > polyline,
+.c10:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c9:focus::-moz-focus-inner {
+.c10:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c9:focus:not(:focus-visible) {
+.c10:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c9:focus:not(:focus-visible) > circle,
-.c9:focus:not(:focus-visible) > ellipse,
-.c9:focus:not(:focus-visible) > line,
-.c9:focus:not(:focus-visible) > path,
-.c9:focus:not(:focus-visible) > polygon,
-.c9:focus:not(:focus-visible) > polyline,
-.c9:focus:not(:focus-visible) > rect {
+.c10:focus:not(:focus-visible) > circle,
+.c10:focus:not(:focus-visible) > ellipse,
+.c10:focus:not(:focus-visible) > line,
+.c10:focus:not(:focus-visible) > path,
+.c10:focus:not(:focus-visible) > polygon,
+.c10:focus:not(:focus-visible) > polyline,
+.c10:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c9:focus:not(:focus-visible)::-moz-focus-inner {
+.c10:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c7 {
+.c8 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -8294,58 +8338,58 @@ exports[`Data view search 1`] = `
   padding-left: 48px;
 }
 
-.c7:focus {
+.c8:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus > circle,
-.c7:focus > ellipse,
-.c7:focus > line,
-.c7:focus > path,
-.c7:focus > polygon,
-.c7:focus > polyline,
-.c7:focus > rect {
+.c8:focus > circle,
+.c8:focus > ellipse,
+.c8:focus > line,
+.c8:focus > path,
+.c8:focus > polygon,
+.c8:focus > polyline,
+.c8:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus::-moz-focus-inner {
+.c8:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c7::-webkit-input-placeholder {
+.c8::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-moz-placeholder {
+.c8::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c7:-ms-input-placeholder {
+.c8:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-webkit-search-decoration {
+.c8::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c7::-moz-focus-inner {
+.c8::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c7:-moz-placeholder,
-.c7::-moz-placeholder {
+.c8:-moz-placeholder,
+.c8::-moz-placeholder {
   opacity: 1;
 }
 
-.c4 {
+.c5 {
   position: relative;
   width: 100%;
 }
 
-.c5 {
+.c6 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -8363,7 +8407,7 @@ exports[`Data view search 1`] = `
   left: 12px;
 }
 
-.c13 {
+.c14 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -8376,7 +8420,7 @@ exports[`Data view search 1`] = `
   padding-bottom: 6px;
 }
 
-.c16 {
+.c17 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -8388,23 +8432,23 @@ exports[`Data view search 1`] = `
   padding-bottom: 6px;
 }
 
-.c11 {
+.c12 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
 }
 
-.c12 {
+.c13 {
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
 }
 
-.c15:focus {
+.c16:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c15:focus:not(:focus-visible) {
+.c16:focus:not(:focus-visible) {
   outline: none;
 }
 
@@ -8449,41 +8493,45 @@ exports[`Data view search 1`] = `
           <div
             class="c5"
           >
-            <svg
-              aria-label="Search"
+            <div
               class="c6"
-              viewBox="0 0 24 24"
             >
-              <path
-                d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
+              <svg
+                aria-label="Search"
+                class="c7"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
+            <input
+              aria-label="Search"
+              autocomplete="off"
+              class="c8"
+              id="data--search"
+              name="_search"
+              type="search"
+              value=""
+            />
           </div>
-          <input
-            aria-label="Search"
-            autocomplete="off"
-            class="c7"
-            id="data--search"
-            name="_search"
-            type="search"
-            value=""
-          />
         </div>
         <div
-          class="c8"
+          class="c9"
         >
           <button
             aria-label="Open filters"
-            class="c9"
+            class="c10"
             id="data--filters-control"
             type="button"
           >
             <svg
               aria-label="Filter"
-              class="c6"
+              class="c7"
               viewBox="0 0 24 24"
             >
               <path
@@ -8498,12 +8546,12 @@ exports[`Data view search 1`] = `
       </div>
     </div>
     <span
-      class="c10"
+      class="c11"
     >
       1 result of 4 items
     </span>
     <table
-      class="c11 c12"
+      class="c12 c13"
     >
       <thead
         class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -8512,35 +8560,35 @@ exports[`Data view search 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c13 "
+            class="c14 "
             scope="col"
           >
             <div
-              class="c14"
+              class="c15"
             />
           </th>
           <th
-            class="c13 "
+            class="c14 "
             scope="col"
           >
             <div
-              class="c14"
+              class="c15"
             />
           </th>
         </tr>
       </thead>
       <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c15"
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c16"
       >
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c16 "
+            class="c17 "
             scope="row"
           >
             <div
-              class="c17"
+              class="c4"
             >
               <span
                 class="c18"
@@ -8550,10 +8598,10 @@ exports[`Data view search 1`] = `
             </div>
           </th>
           <td
-            class="c16 "
+            class="c17 "
           >
             <div
-              class="c17"
+              class="c4"
             >
               <span
                 class="c19"
@@ -8570,7 +8618,7 @@ exports[`Data view search 1`] = `
 `;
 
 exports[`Data view sort 1`] = `
-.c6 {
+.c7 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -8581,25 +8629,25 @@ exports[`Data view sort 1`] = `
   stroke: #666666;
 }
 
-.c6 g {
+.c7 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c6 *:not([stroke])[fill='none'] {
+.c7 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c6 *[stroke*='#'],
-.c6 *[STROKE*='#'] {
+.c7 *[stroke*='#'],
+.c7 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c6 *[fill-rule],
-.c6 *[FILL-RULE],
-.c6 *[fill*='#'],
-.c6 *[FILL*='#'] {
+.c7 *[fill-rule],
+.c7 *[FILL-RULE],
+.c7 *[fill*='#'],
+.c7 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -8631,7 +8679,21 @@ exports[`Data view sort 1`] = `
   flex: 0 0 auto;
 }
 
-.c8 {
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8648,7 +8710,7 @@ exports[`Data view sort 1`] = `
   flex: 0 0 auto;
 }
 
-.c14 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8667,20 +8729,6 @@ exports[`Data view sort 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-}
-
-.c17 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
 }
 
 .c2 {
@@ -8737,7 +8785,7 @@ exports[`Data view sort 1`] = `
   row-gap: 12px;
 }
 
-.c10 {
+.c11 {
   margin-top: 6px;
   margin-bottom: 6px;
   font-size: 18px;
@@ -8755,7 +8803,7 @@ exports[`Data view sort 1`] = `
   line-height: 24px;
 }
 
-.c9 {
+.c10 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -8775,47 +8823,47 @@ exports[`Data view sort 1`] = `
   padding: 12px;
 }
 
-.c9:focus {
+.c10:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c9:focus > circle,
-.c9:focus > ellipse,
-.c9:focus > line,
-.c9:focus > path,
-.c9:focus > polygon,
-.c9:focus > polyline,
-.c9:focus > rect {
+.c10:focus > circle,
+.c10:focus > ellipse,
+.c10:focus > line,
+.c10:focus > path,
+.c10:focus > polygon,
+.c10:focus > polyline,
+.c10:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c9:focus::-moz-focus-inner {
+.c10:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c9:focus:not(:focus-visible) {
+.c10:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c9:focus:not(:focus-visible) > circle,
-.c9:focus:not(:focus-visible) > ellipse,
-.c9:focus:not(:focus-visible) > line,
-.c9:focus:not(:focus-visible) > path,
-.c9:focus:not(:focus-visible) > polygon,
-.c9:focus:not(:focus-visible) > polyline,
-.c9:focus:not(:focus-visible) > rect {
+.c10:focus:not(:focus-visible) > circle,
+.c10:focus:not(:focus-visible) > ellipse,
+.c10:focus:not(:focus-visible) > line,
+.c10:focus:not(:focus-visible) > path,
+.c10:focus:not(:focus-visible) > polygon,
+.c10:focus:not(:focus-visible) > polyline,
+.c10:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c9:focus:not(:focus-visible)::-moz-focus-inner {
+.c10:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c7 {
+.c8 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -8832,58 +8880,58 @@ exports[`Data view sort 1`] = `
   padding-left: 48px;
 }
 
-.c7:focus {
+.c8:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus > circle,
-.c7:focus > ellipse,
-.c7:focus > line,
-.c7:focus > path,
-.c7:focus > polygon,
-.c7:focus > polyline,
-.c7:focus > rect {
+.c8:focus > circle,
+.c8:focus > ellipse,
+.c8:focus > line,
+.c8:focus > path,
+.c8:focus > polygon,
+.c8:focus > polyline,
+.c8:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus::-moz-focus-inner {
+.c8:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c7::-webkit-input-placeholder {
+.c8::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-moz-placeholder {
+.c8::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c7:-ms-input-placeholder {
+.c8:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-webkit-search-decoration {
+.c8::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c7::-moz-focus-inner {
+.c8::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c7:-moz-placeholder,
-.c7::-moz-placeholder {
+.c8:-moz-placeholder,
+.c8::-moz-placeholder {
   opacity: 1;
 }
 
-.c4 {
+.c5 {
   position: relative;
   width: 100%;
 }
 
-.c5 {
+.c6 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -8901,7 +8949,7 @@ exports[`Data view sort 1`] = `
   left: 12px;
 }
 
-.c13 {
+.c14 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -8914,7 +8962,7 @@ exports[`Data view sort 1`] = `
   padding-bottom: 6px;
 }
 
-.c16 {
+.c17 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -8926,23 +8974,23 @@ exports[`Data view sort 1`] = `
   padding-bottom: 6px;
 }
 
-.c11 {
+.c12 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
 }
 
-.c12 {
+.c13 {
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
 }
 
-.c15:focus {
+.c16:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c15:focus:not(:focus-visible) {
+.c16:focus:not(:focus-visible) {
   outline: none;
 }
 
@@ -8987,41 +9035,45 @@ exports[`Data view sort 1`] = `
           <div
             class="c5"
           >
-            <svg
-              aria-label="Search"
+            <div
               class="c6"
-              viewBox="0 0 24 24"
             >
-              <path
-                d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
+              <svg
+                aria-label="Search"
+                class="c7"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
+            <input
+              aria-label="Search"
+              autocomplete="off"
+              class="c8"
+              id="data--search"
+              name="_search"
+              type="search"
+              value=""
+            />
           </div>
-          <input
-            aria-label="Search"
-            autocomplete="off"
-            class="c7"
-            id="data--search"
-            name="_search"
-            type="search"
-            value=""
-          />
         </div>
         <div
-          class="c8"
+          class="c9"
         >
           <button
             aria-label="Open filters"
-            class="c9"
+            class="c10"
             id="data--filters-control"
             type="button"
           >
             <svg
               aria-label="Filter"
-              class="c6"
+              class="c7"
               viewBox="0 0 24 24"
             >
               <path
@@ -9036,12 +9088,12 @@ exports[`Data view sort 1`] = `
       </div>
     </div>
     <span
-      class="c10"
+      class="c11"
     >
       4 items
     </span>
     <table
-      class="c11 c12"
+      class="c12 c13"
     >
       <thead
         class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -9050,35 +9102,35 @@ exports[`Data view sort 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c13 "
+            class="c14 "
             scope="col"
           >
             <div
-              class="c14"
+              class="c15"
             />
           </th>
           <th
-            class="c13 "
+            class="c14 "
             scope="col"
           >
             <div
-              class="c14"
+              class="c15"
             />
           </th>
         </tr>
       </thead>
       <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c15"
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c16"
       >
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c16 "
+            class="c17 "
             scope="row"
           >
             <div
-              class="c17"
+              class="c4"
             >
               <span
                 class="c18"
@@ -9088,10 +9140,10 @@ exports[`Data view sort 1`] = `
             </div>
           </th>
           <td
-            class="c16 "
+            class="c17 "
           >
             <div
-              class="c17"
+              class="c4"
             >
               <span
                 class="c19"
@@ -9105,11 +9157,11 @@ exports[`Data view sort 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c16 "
+            class="c17 "
             scope="row"
           >
             <div
-              class="c17"
+              class="c4"
             >
               <span
                 class="c18"
@@ -9119,10 +9171,10 @@ exports[`Data view sort 1`] = `
             </div>
           </th>
           <td
-            class="c16 "
+            class="c17 "
           >
             <div
-              class="c17"
+              class="c4"
             >
               <span
                 class="c19"
@@ -9136,11 +9188,11 @@ exports[`Data view sort 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c16 "
+            class="c17 "
             scope="row"
           >
             <div
-              class="c17"
+              class="c4"
             >
               <span
                 class="c18"
@@ -9150,10 +9202,10 @@ exports[`Data view sort 1`] = `
             </div>
           </th>
           <td
-            class="c16 "
+            class="c17 "
           >
             <div
-              class="c17"
+              class="c4"
             />
           </td>
         </tr>
@@ -9161,11 +9213,11 @@ exports[`Data view sort 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c16 "
+            class="c17 "
             scope="row"
           >
             <div
-              class="c17"
+              class="c4"
             >
               <span
                 class="c18"
@@ -9175,10 +9227,10 @@ exports[`Data view sort 1`] = `
             </div>
           </th>
           <td
-            class="c16 "
+            class="c17 "
           >
             <div
-              class="c17"
+              class="c4"
             />
           </td>
         </tr>

--- a/src/js/components/Data/__tests__/__snapshots__/Data-test.tsx.snap
+++ b/src/js/components/Data/__tests__/__snapshots__/Data-test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Data controlled search 1`] = `
-.c7 {
+.c6 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -12,25 +12,25 @@ exports[`Data controlled search 1`] = `
   stroke: #666666;
 }
 
-.c7 g {
+.c6 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c7 *:not([stroke])[fill='none'] {
+.c6 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c7 *[stroke*='#'],
-.c7 *[STROKE*='#'] {
+.c6 *[stroke*='#'],
+.c6 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c7 *[fill-rule],
-.c7 *[FILL-RULE],
-.c7 *[fill*='#'],
-.c7 *[FILL*='#'] {
+.c6 *[fill-rule],
+.c6 *[FILL-RULE],
+.c6 *[fill*='#'],
+.c6 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -62,7 +62,7 @@ exports[`Data controlled search 1`] = `
   flex: 0 0 auto;
 }
 
-.c9 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -79,7 +79,7 @@ exports[`Data controlled search 1`] = `
   flex: 0 0 auto;
 }
 
-.c15 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -100,7 +100,7 @@ exports[`Data controlled search 1`] = `
   justify-content: center;
 }
 
-.c18 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -168,20 +168,20 @@ exports[`Data controlled search 1`] = `
   row-gap: 12px;
 }
 
-.c11 {
+.c10 {
   margin-top: 6px;
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
 }
 
-.c19 {
+.c18 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
 }
 
-.c10 {
+.c9 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -201,51 +201,47 @@ exports[`Data controlled search 1`] = `
   padding: 12px;
 }
 
-.c10:focus {
+.c9:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c10:focus > circle,
-.c10:focus > ellipse,
-.c10:focus > line,
-.c10:focus > path,
-.c10:focus > polygon,
-.c10:focus > polyline,
-.c10:focus > rect {
+.c9:focus > circle,
+.c9:focus > ellipse,
+.c9:focus > line,
+.c9:focus > path,
+.c9:focus > polygon,
+.c9:focus > polyline,
+.c9:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c10:focus::-moz-focus-inner {
+.c9:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c10:focus:not(:focus-visible) {
+.c9:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c10:focus:not(:focus-visible) > circle,
-.c10:focus:not(:focus-visible) > ellipse,
-.c10:focus:not(:focus-visible) > line,
-.c10:focus:not(:focus-visible) > path,
-.c10:focus:not(:focus-visible) > polygon,
-.c10:focus:not(:focus-visible) > polyline,
-.c10:focus:not(:focus-visible) > rect {
+.c9:focus:not(:focus-visible) > circle,
+.c9:focus:not(:focus-visible) > ellipse,
+.c9:focus:not(:focus-visible) > line,
+.c9:focus:not(:focus-visible) > path,
+.c9:focus:not(:focus-visible) > polygon,
+.c9:focus:not(:focus-visible) > polyline,
+.c9:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c10:focus:not(:focus-visible)::-moz-focus-inner {
+.c9:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c4 {
-  max-width: 100%;
-}
-
-.c8 {
+.c7 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -262,58 +258,58 @@ exports[`Data controlled search 1`] = `
   padding-left: 48px;
 }
 
-.c8:focus {
+.c7:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c8:focus > circle,
-.c8:focus > ellipse,
-.c8:focus > line,
-.c8:focus > path,
-.c8:focus > polygon,
-.c8:focus > polyline,
-.c8:focus > rect {
+.c7:focus > circle,
+.c7:focus > ellipse,
+.c7:focus > line,
+.c7:focus > path,
+.c7:focus > polygon,
+.c7:focus > polyline,
+.c7:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c8:focus::-moz-focus-inner {
+.c7:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c8::-webkit-input-placeholder {
+.c7::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c8::-moz-placeholder {
+.c7::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c8:-ms-input-placeholder {
+.c7:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c8::-webkit-search-decoration {
+.c7::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c8::-moz-focus-inner {
+.c7::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c8:-moz-placeholder,
-.c8::-moz-placeholder {
+.c7:-moz-placeholder,
+.c7::-moz-placeholder {
   opacity: 1;
 }
 
-.c5 {
+.c4 {
   position: relative;
   width: 100%;
 }
 
-.c6 {
+.c5 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -331,7 +327,7 @@ exports[`Data controlled search 1`] = `
   left: 12px;
 }
 
-.c14 {
+.c13 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -344,7 +340,7 @@ exports[`Data controlled search 1`] = `
   padding-bottom: 6px;
 }
 
-.c17 {
+.c16 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -356,23 +352,23 @@ exports[`Data controlled search 1`] = `
   padding-bottom: 6px;
 }
 
-.c12 {
+.c11 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
 }
 
-.c13 {
+.c12 {
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
 }
 
-.c16:focus {
+.c15:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c16:focus:not(:focus-visible) {
+.c15:focus:not(:focus-visible) {
   outline: none;
 }
 
@@ -411,51 +407,47 @@ exports[`Data controlled search 1`] = `
       <div
         class="c3"
       >
-        <form
+        <div
           class="c4"
         >
           <div
             class="c5"
           >
-            <div
-              class="c6"
-            >
-              <svg
-                aria-label="Search"
-                class="c7"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                  fill="none"
-                  stroke="#000"
-                  stroke-width="2"
-                />
-              </svg>
-            </div>
-            <input
+            <svg
               aria-label="Search"
-              autocomplete="off"
-              class="c8"
-              id="data--search"
-              name="_search"
-              type="search"
-              value=""
-            />
+              class="c6"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
           </div>
-        </form>
+          <input
+            aria-label="Search"
+            autocomplete="off"
+            class="c7"
+            id="data--search"
+            name="_search"
+            type="search"
+            value=""
+          />
+        </div>
         <div
-          class="c9"
+          class="c8"
         >
           <button
             aria-label="Open filters"
-            class="c10"
+            class="c9"
             id="data--filters-control"
             type="button"
           >
             <svg
               aria-label="Filter"
-              class="c7"
+              class="c6"
               viewBox="0 0 24 24"
             >
               <path
@@ -470,12 +462,12 @@ exports[`Data controlled search 1`] = `
       </div>
     </div>
     <span
-      class="c11"
+      class="c10"
     >
       4 results of undefined items
     </span>
     <table
-      class="c12 c13"
+      class="c11 c12"
     >
       <thead
         class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -484,30 +476,30 @@ exports[`Data controlled search 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c14 "
+            class="c13 "
             scope="col"
           >
             <div
-              class="c15"
+              class="c14"
             />
           </th>
         </tr>
       </thead>
       <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c16"
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c15"
       >
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c17 "
+            class="c16 "
             scope="row"
           >
             <div
-              class="c18"
+              class="c17"
             >
               <span
-                class="c19"
+                class="c18"
               >
                 aa
               </span>
@@ -518,14 +510,14 @@ exports[`Data controlled search 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c17 "
+            class="c16 "
             scope="row"
           >
             <div
-              class="c18"
+              class="c17"
             >
               <span
-                class="c19"
+                class="c18"
               >
                 bb
               </span>
@@ -536,14 +528,14 @@ exports[`Data controlled search 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c17 "
+            class="c16 "
             scope="row"
           >
             <div
-              class="c18"
+              class="c17"
             >
               <span
-                class="c19"
+                class="c18"
               >
                 cc
               </span>
@@ -554,14 +546,14 @@ exports[`Data controlled search 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c17 "
+            class="c16 "
             scope="row"
           >
             <div
-              class="c18"
+              class="c17"
             >
               <span
-                class="c19"
+                class="c18"
               >
                 dd
               </span>
@@ -588,39 +580,35 @@ exports[`Data controlled search 2`] = `
       <div
         class="StyledBox-sc-13pk1d4-0 fnEswI"
       >
-        <form
-          class="DataForm__MaxForm-sc-v64e1r-0 iIonEc"
+        <div
+          class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 dAhNeU"
         >
           <div
-            class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 dAhNeU"
+            class="StyledTextInput__StyledIcon-sc-1x30a0s-3 iQFXNb"
           >
-            <div
-              class="StyledTextInput__StyledIcon-sc-1x30a0s-3 iQFXNb"
-            >
-              <svg
-                aria-label="Search"
-                class="StyledIcon-sc-ofa7kd-0 bQiAMQ"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                  fill="none"
-                  stroke="#000"
-                  stroke-width="2"
-                />
-              </svg>
-            </div>
-            <input
+            <svg
               aria-label="Search"
-              autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 hLtcCB"
-              id="data--search"
-              name="_search"
-              type="search"
-              value="a"
-            />
+              class="StyledIcon-sc-ofa7kd-0 bQiAMQ"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
           </div>
-        </form>
+          <input
+            aria-label="Search"
+            autocomplete="off"
+            class="StyledTextInput-sc-1x30a0s-0 hLtcCB"
+            id="data--search"
+            name="_search"
+            type="search"
+            value=""
+          />
+        </div>
         <div
           class="StyledBox-sc-13pk1d4-0 imzrdH"
         >
@@ -752,7 +740,7 @@ exports[`Data controlled search 2`] = `
 `;
 
 exports[`Data messages 1`] = `
-.c7 {
+.c6 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -763,25 +751,25 @@ exports[`Data messages 1`] = `
   stroke: #666666;
 }
 
-.c7 g {
+.c6 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c7 *:not([stroke])[fill='none'] {
+.c6 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c7 *[stroke*='#'],
-.c7 *[STROKE*='#'] {
+.c6 *[stroke*='#'],
+.c6 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c7 *[fill-rule],
-.c7 *[FILL-RULE],
-.c7 *[fill*='#'],
-.c7 *[FILL*='#'] {
+.c6 *[fill-rule],
+.c6 *[FILL-RULE],
+.c6 *[fill*='#'],
+.c6 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -813,7 +801,7 @@ exports[`Data messages 1`] = `
   flex: 0 0 auto;
 }
 
-.c9 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -830,7 +818,7 @@ exports[`Data messages 1`] = `
   flex: 0 0 auto;
 }
 
-.c15 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -851,7 +839,7 @@ exports[`Data messages 1`] = `
   justify-content: center;
 }
 
-.c18 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -919,25 +907,25 @@ exports[`Data messages 1`] = `
   row-gap: 12px;
 }
 
-.c11 {
+.c10 {
   margin-top: 6px;
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
 }
 
-.c19 {
+.c18 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
 }
 
-.c20 {
+.c19 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c10 {
+.c9 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -957,51 +945,47 @@ exports[`Data messages 1`] = `
   padding: 12px;
 }
 
-.c10:focus {
+.c9:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c10:focus > circle,
-.c10:focus > ellipse,
-.c10:focus > line,
-.c10:focus > path,
-.c10:focus > polygon,
-.c10:focus > polyline,
-.c10:focus > rect {
+.c9:focus > circle,
+.c9:focus > ellipse,
+.c9:focus > line,
+.c9:focus > path,
+.c9:focus > polygon,
+.c9:focus > polyline,
+.c9:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c10:focus::-moz-focus-inner {
+.c9:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c10:focus:not(:focus-visible) {
+.c9:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c10:focus:not(:focus-visible) > circle,
-.c10:focus:not(:focus-visible) > ellipse,
-.c10:focus:not(:focus-visible) > line,
-.c10:focus:not(:focus-visible) > path,
-.c10:focus:not(:focus-visible) > polygon,
-.c10:focus:not(:focus-visible) > polyline,
-.c10:focus:not(:focus-visible) > rect {
+.c9:focus:not(:focus-visible) > circle,
+.c9:focus:not(:focus-visible) > ellipse,
+.c9:focus:not(:focus-visible) > line,
+.c9:focus:not(:focus-visible) > path,
+.c9:focus:not(:focus-visible) > polygon,
+.c9:focus:not(:focus-visible) > polyline,
+.c9:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c10:focus:not(:focus-visible)::-moz-focus-inner {
+.c9:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c4 {
-  max-width: 100%;
-}
-
-.c8 {
+.c7 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -1018,58 +1002,58 @@ exports[`Data messages 1`] = `
   padding-left: 48px;
 }
 
-.c8:focus {
+.c7:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c8:focus > circle,
-.c8:focus > ellipse,
-.c8:focus > line,
-.c8:focus > path,
-.c8:focus > polygon,
-.c8:focus > polyline,
-.c8:focus > rect {
+.c7:focus > circle,
+.c7:focus > ellipse,
+.c7:focus > line,
+.c7:focus > path,
+.c7:focus > polygon,
+.c7:focus > polyline,
+.c7:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c8:focus::-moz-focus-inner {
+.c7:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c8::-webkit-input-placeholder {
+.c7::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c8::-moz-placeholder {
+.c7::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c8:-ms-input-placeholder {
+.c7:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c8::-webkit-search-decoration {
+.c7::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c8::-moz-focus-inner {
+.c7::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c8:-moz-placeholder,
-.c8::-moz-placeholder {
+.c7:-moz-placeholder,
+.c7::-moz-placeholder {
   opacity: 1;
 }
 
-.c5 {
+.c4 {
   position: relative;
   width: 100%;
 }
 
-.c6 {
+.c5 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1087,7 +1071,7 @@ exports[`Data messages 1`] = `
   left: 12px;
 }
 
-.c14 {
+.c13 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -1100,7 +1084,7 @@ exports[`Data messages 1`] = `
   padding-bottom: 6px;
 }
 
-.c17 {
+.c16 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -1112,23 +1096,23 @@ exports[`Data messages 1`] = `
   padding-bottom: 6px;
 }
 
-.c12 {
+.c11 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
 }
 
-.c13 {
+.c12 {
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
 }
 
-.c16:focus {
+.c15:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c16:focus:not(:focus-visible) {
+.c15:focus:not(:focus-visible) {
   outline: none;
 }
 
@@ -1167,51 +1151,47 @@ exports[`Data messages 1`] = `
       <div
         class="c3"
       >
-        <form
+        <div
           class="c4"
         >
           <div
             class="c5"
           >
-            <div
-              class="c6"
-            >
-              <svg
-                aria-label="Search"
-                class="c7"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                  fill="none"
-                  stroke="#000"
-                  stroke-width="2"
-                />
-              </svg>
-            </div>
-            <input
+            <svg
               aria-label="Search"
-              autocomplete="off"
-              class="c8"
-              id="data--search"
-              name="_search"
-              type="search"
-              value=""
-            />
+              class="c6"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
           </div>
-        </form>
+          <input
+            aria-label="Search"
+            autocomplete="off"
+            class="c7"
+            id="data--search"
+            name="_search"
+            type="search"
+            value=""
+          />
+        </div>
         <div
-          class="c9"
+          class="c8"
         >
           <button
             aria-label="Open filters"
-            class="c10"
+            class="c9"
             id="data--filters-control"
             type="button"
           >
             <svg
               aria-label="Filter"
-              class="c7"
+              class="c6"
               viewBox="0 0 24 24"
             >
               <path
@@ -1226,12 +1206,12 @@ exports[`Data messages 1`] = `
       </div>
     </div>
     <span
-      class="c11"
+      class="c10"
     >
       4 things
     </span>
     <table
-      class="c12 c13"
+      class="c11 c12"
     >
       <thead
         class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -1240,51 +1220,51 @@ exports[`Data messages 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c14 "
+            class="c13 "
             scope="col"
           >
             <div
-              class="c15"
+              class="c14"
             />
           </th>
           <th
-            class="c14 "
+            class="c13 "
             scope="col"
           >
             <div
-              class="c15"
+              class="c14"
             />
           </th>
         </tr>
       </thead>
       <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c16"
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c15"
       >
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c17 "
+            class="c16 "
             scope="row"
           >
             <div
-              class="c18"
+              class="c17"
             >
               <span
-                class="c19"
+                class="c18"
               >
                 aa
               </span>
             </div>
           </th>
           <td
-            class="c17 "
+            class="c16 "
           >
             <div
-              class="c18"
+              class="c17"
             >
               <span
-                class="c20"
+                class="c19"
               >
                 ZZ
               </span>
@@ -1295,27 +1275,27 @@ exports[`Data messages 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c17 "
+            class="c16 "
             scope="row"
           >
             <div
-              class="c18"
+              class="c17"
             >
               <span
-                class="c19"
+                class="c18"
               >
                 bb
               </span>
             </div>
           </th>
           <td
-            class="c17 "
+            class="c16 "
           >
             <div
-              class="c18"
+              class="c17"
             >
               <span
-                class="c20"
+                class="c19"
               >
                 YY
               </span>
@@ -1326,24 +1306,24 @@ exports[`Data messages 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c17 "
+            class="c16 "
             scope="row"
           >
             <div
-              class="c18"
+              class="c17"
             >
               <span
-                class="c19"
+                class="c18"
               >
                 cc
               </span>
             </div>
           </th>
           <td
-            class="c17 "
+            class="c16 "
           >
             <div
-              class="c18"
+              class="c17"
             />
           </td>
         </tr>
@@ -1351,24 +1331,24 @@ exports[`Data messages 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c17 "
+            class="c16 "
             scope="row"
           >
             <div
-              class="c18"
+              class="c17"
             >
               <span
-                class="c19"
+                class="c18"
               >
                 dd
               </span>
             </div>
           </th>
           <td
-            class="c17 "
+            class="c16 "
           >
             <div
-              class="c18"
+              class="c17"
             />
           </td>
         </tr>
@@ -2990,7 +2970,7 @@ exports[`Data pagination step 1`] = `
 
 exports[`Data properties when property is an array 1`] = `
 <DocumentFragment>
-  .c7 {
+  .c6 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -3001,25 +2981,25 @@ exports[`Data properties when property is an array 1`] = `
   stroke: #666666;
 }
 
-.c7 g {
+.c6 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c7 *:not([stroke])[fill='none'] {
+.c6 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c7 *[stroke*='#'],
-.c7 *[STROKE*='#'] {
+.c6 *[stroke*='#'],
+.c6 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c7 *[fill-rule],
-.c7 *[FILL-RULE],
-.c7 *[fill*='#'],
-.c7 *[FILL*='#'] {
+.c6 *[fill-rule],
+.c6 *[FILL-RULE],
+.c6 *[fill*='#'],
+.c6 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -3051,7 +3031,7 @@ exports[`Data properties when property is an array 1`] = `
   flex: 0 0 auto;
 }
 
-.c9 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3068,7 +3048,7 @@ exports[`Data properties when property is an array 1`] = `
   flex: 0 0 auto;
 }
 
-.c15 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3089,7 +3069,7 @@ exports[`Data properties when property is an array 1`] = `
   justify-content: center;
 }
 
-.c19 {
+.c18 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3157,25 +3137,25 @@ exports[`Data properties when property is an array 1`] = `
   row-gap: 12px;
 }
 
-.c11 {
+.c10 {
   margin-top: 6px;
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
 }
 
-.c16 {
+.c15 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c20 {
+.c19 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
 }
 
-.c10 {
+.c9 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -3195,51 +3175,47 @@ exports[`Data properties when property is an array 1`] = `
   padding: 12px;
 }
 
-.c10:focus {
+.c9:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c10:focus > circle,
-.c10:focus > ellipse,
-.c10:focus > line,
-.c10:focus > path,
-.c10:focus > polygon,
-.c10:focus > polyline,
-.c10:focus > rect {
+.c9:focus > circle,
+.c9:focus > ellipse,
+.c9:focus > line,
+.c9:focus > path,
+.c9:focus > polygon,
+.c9:focus > polyline,
+.c9:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c10:focus::-moz-focus-inner {
+.c9:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c10:focus:not(:focus-visible) {
+.c9:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c10:focus:not(:focus-visible) > circle,
-.c10:focus:not(:focus-visible) > ellipse,
-.c10:focus:not(:focus-visible) > line,
-.c10:focus:not(:focus-visible) > path,
-.c10:focus:not(:focus-visible) > polygon,
-.c10:focus:not(:focus-visible) > polyline,
-.c10:focus:not(:focus-visible) > rect {
+.c9:focus:not(:focus-visible) > circle,
+.c9:focus:not(:focus-visible) > ellipse,
+.c9:focus:not(:focus-visible) > line,
+.c9:focus:not(:focus-visible) > path,
+.c9:focus:not(:focus-visible) > polygon,
+.c9:focus:not(:focus-visible) > polyline,
+.c9:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c10:focus:not(:focus-visible)::-moz-focus-inner {
+.c9:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c4 {
-  max-width: 100%;
-}
-
-.c8 {
+.c7 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -3256,58 +3232,58 @@ exports[`Data properties when property is an array 1`] = `
   padding-left: 48px;
 }
 
-.c8:focus {
+.c7:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c8:focus > circle,
-.c8:focus > ellipse,
-.c8:focus > line,
-.c8:focus > path,
-.c8:focus > polygon,
-.c8:focus > polyline,
-.c8:focus > rect {
+.c7:focus > circle,
+.c7:focus > ellipse,
+.c7:focus > line,
+.c7:focus > path,
+.c7:focus > polygon,
+.c7:focus > polyline,
+.c7:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c8:focus::-moz-focus-inner {
+.c7:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c8::-webkit-input-placeholder {
+.c7::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c8::-moz-placeholder {
+.c7::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c8:-ms-input-placeholder {
+.c7:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c8::-webkit-search-decoration {
+.c7::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c8::-moz-focus-inner {
+.c7::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c8:-moz-placeholder,
-.c8::-moz-placeholder {
+.c7:-moz-placeholder,
+.c7::-moz-placeholder {
   opacity: 1;
 }
 
-.c5 {
+.c4 {
   position: relative;
   width: 100%;
 }
 
-.c6 {
+.c5 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -3325,7 +3301,7 @@ exports[`Data properties when property is an array 1`] = `
   left: 12px;
 }
 
-.c14 {
+.c13 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -3338,7 +3314,7 @@ exports[`Data properties when property is an array 1`] = `
   padding-bottom: 6px;
 }
 
-.c18 {
+.c17 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -3350,23 +3326,23 @@ exports[`Data properties when property is an array 1`] = `
   padding-bottom: 6px;
 }
 
-.c12 {
+.c11 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
 }
 
-.c13 {
+.c12 {
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
 }
 
-.c17:focus {
+.c16:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c17:focus:not(:focus-visible) {
+.c16:focus:not(:focus-visible) {
   outline: none;
 }
 
@@ -3405,51 +3381,47 @@ exports[`Data properties when property is an array 1`] = `
         <div
           class="c3"
         >
-          <form
+          <div
             class="c4"
           >
             <div
               class="c5"
             >
-              <div
-                class="c6"
-              >
-                <svg
-                  aria-label="Search"
-                  class="c7"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                    fill="none"
-                    stroke="#000"
-                    stroke-width="2"
-                  />
-                </svg>
-              </div>
-              <input
+              <svg
                 aria-label="Search"
-                autocomplete="off"
-                class="c8"
-                id="data--search"
-                name="_search"
-                type="search"
-                value=""
-              />
+                class="c6"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
             </div>
-          </form>
+            <input
+              aria-label="Search"
+              autocomplete="off"
+              class="c7"
+              id="data--search"
+              name="_search"
+              type="search"
+              value=""
+            />
+          </div>
           <div
-            class="c9"
+            class="c8"
           >
             <button
               aria-label="Open filters"
-              class="c10"
+              class="c9"
               id="data--filters-control"
               type="button"
             >
               <svg
                 aria-label="Filter"
-                class="c7"
+                class="c6"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -3464,12 +3436,12 @@ exports[`Data properties when property is an array 1`] = `
         </div>
       </div>
       <span
-        class="c11"
+        class="c10"
       >
         4 items
       </span>
       <table
-        class="c12 c13"
+        class="c11 c12"
       >
         <thead
           class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -3478,42 +3450,42 @@ exports[`Data properties when property is an array 1`] = `
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="c14 "
+              class="c13 "
               scope="col"
             >
               <div
-                class="c15"
+                class="c14"
               >
                 <span
-                  class="c16"
+                  class="c15"
                 >
                   Name
                 </span>
               </div>
             </th>
             <th
-              class="c14 "
+              class="c13 "
               scope="col"
             >
               <div
-                class="c15"
+                class="c14"
               >
                 <span
-                  class="c16"
+                  class="c15"
                 >
                   Note
                 </span>
               </div>
             </th>
             <th
-              class="c14 "
+              class="c13 "
               scope="col"
             >
               <div
-                class="c15"
+                class="c14"
               >
                 <span
-                  class="c16"
+                  class="c15"
                 >
                   Tags
                 </span>
@@ -3522,46 +3494,46 @@ exports[`Data properties when property is an array 1`] = `
           </tr>
         </thead>
         <tbody
-          class="StyledTable__StyledTableBody-sc-1m3u5g-3 c17"
+          class="StyledTable__StyledTableBody-sc-1m3u5g-3 c16"
         >
           <tr
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="c18 "
+              class="c17 "
               scope="row"
             >
               <div
-                class="c19"
+                class="c18"
               >
                 <span
-                  class="c20"
+                  class="c19"
                 >
                   aa
                 </span>
               </div>
             </th>
             <td
-              class="c18 "
+              class="c17 "
             >
               <div
-                class="c19"
+                class="c18"
               >
                 <span
-                  class="c16"
+                  class="c15"
                 >
                   ZZ
                 </span>
               </div>
             </td>
             <td
-              class="c18 "
+              class="c17 "
             >
               <div
-                class="c19"
+                class="c18"
               >
                 <span
-                  class="c16"
+                  class="c15"
                 >
                   qa, staging, prod
                 </span>
@@ -3572,40 +3544,40 @@ exports[`Data properties when property is an array 1`] = `
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="c18 "
+              class="c17 "
               scope="row"
             >
               <div
-                class="c19"
+                class="c18"
               >
                 <span
-                  class="c20"
+                  class="c19"
                 >
                   bb
                 </span>
               </div>
             </th>
             <td
-              class="c18 "
+              class="c17 "
             >
               <div
-                class="c19"
+                class="c18"
               >
                 <span
-                  class="c16"
+                  class="c15"
                 >
                   YY
                 </span>
               </div>
             </td>
             <td
-              class="c18 "
+              class="c17 "
             >
               <div
-                class="c19"
+                class="c18"
               >
                 <span
-                  class="c16"
+                  class="c15"
                 >
                   qa, staging
                 </span>
@@ -3616,34 +3588,34 @@ exports[`Data properties when property is an array 1`] = `
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="c18 "
+              class="c17 "
               scope="row"
             >
               <div
-                class="c19"
+                class="c18"
               >
                 <span
-                  class="c20"
+                  class="c19"
                 >
                   cc
                 </span>
               </div>
             </th>
             <td
-              class="c18 "
+              class="c17 "
             >
               <div
-                class="c19"
+                class="c18"
               />
             </td>
             <td
-              class="c18 "
+              class="c17 "
             >
               <div
-                class="c19"
+                class="c18"
               >
                 <span
-                  class="c16"
+                  class="c15"
                 >
                   qa
                 </span>
@@ -3654,31 +3626,31 @@ exports[`Data properties when property is an array 1`] = `
             class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
             <th
-              class="c18 "
+              class="c17 "
               scope="row"
             >
               <div
-                class="c19"
+                class="c18"
               >
                 <span
-                  class="c20"
+                  class="c19"
                 >
                   dd
                 </span>
               </div>
             </th>
             <td
-              class="c18 "
+              class="c17 "
             >
               <div
-                class="c19"
+                class="c18"
               />
             </td>
             <td
-              class="c18 "
+              class="c17 "
             >
               <div
-                class="c19"
+                class="c18"
               />
             </td>
           </tr>
@@ -3930,7 +3902,7 @@ exports[`Data renders 1`] = `
 `;
 
 exports[`Data toolbar 1`] = `
-.c7 {
+.c6 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -3941,25 +3913,25 @@ exports[`Data toolbar 1`] = `
   stroke: #666666;
 }
 
-.c7 g {
+.c6 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c7 *:not([stroke])[fill='none'] {
+.c6 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c7 *[stroke*='#'],
-.c7 *[STROKE*='#'] {
+.c6 *[stroke*='#'],
+.c6 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c7 *[fill-rule],
-.c7 *[FILL-RULE],
-.c7 *[fill*='#'],
-.c7 *[FILL*='#'] {
+.c6 *[fill-rule],
+.c6 *[FILL-RULE],
+.c6 *[fill*='#'],
+.c6 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -3991,7 +3963,7 @@ exports[`Data toolbar 1`] = `
   flex: 0 0 auto;
 }
 
-.c9 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4008,7 +3980,7 @@ exports[`Data toolbar 1`] = `
   flex: 0 0 auto;
 }
 
-.c15 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4029,7 +4001,7 @@ exports[`Data toolbar 1`] = `
   justify-content: center;
 }
 
-.c18 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4097,25 +4069,25 @@ exports[`Data toolbar 1`] = `
   row-gap: 12px;
 }
 
-.c11 {
+.c10 {
   margin-top: 6px;
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
 }
 
-.c19 {
+.c18 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
 }
 
-.c20 {
+.c19 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c10 {
+.c9 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -4135,51 +4107,47 @@ exports[`Data toolbar 1`] = `
   padding: 12px;
 }
 
-.c10:focus {
+.c9:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c10:focus > circle,
-.c10:focus > ellipse,
-.c10:focus > line,
-.c10:focus > path,
-.c10:focus > polygon,
-.c10:focus > polyline,
-.c10:focus > rect {
+.c9:focus > circle,
+.c9:focus > ellipse,
+.c9:focus > line,
+.c9:focus > path,
+.c9:focus > polygon,
+.c9:focus > polyline,
+.c9:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c10:focus::-moz-focus-inner {
+.c9:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c10:focus:not(:focus-visible) {
+.c9:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c10:focus:not(:focus-visible) > circle,
-.c10:focus:not(:focus-visible) > ellipse,
-.c10:focus:not(:focus-visible) > line,
-.c10:focus:not(:focus-visible) > path,
-.c10:focus:not(:focus-visible) > polygon,
-.c10:focus:not(:focus-visible) > polyline,
-.c10:focus:not(:focus-visible) > rect {
+.c9:focus:not(:focus-visible) > circle,
+.c9:focus:not(:focus-visible) > ellipse,
+.c9:focus:not(:focus-visible) > line,
+.c9:focus:not(:focus-visible) > path,
+.c9:focus:not(:focus-visible) > polygon,
+.c9:focus:not(:focus-visible) > polyline,
+.c9:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c10:focus:not(:focus-visible)::-moz-focus-inner {
+.c9:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c4 {
-  max-width: 100%;
-}
-
-.c8 {
+.c7 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -4196,58 +4164,58 @@ exports[`Data toolbar 1`] = `
   padding-left: 48px;
 }
 
-.c8:focus {
+.c7:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c8:focus > circle,
-.c8:focus > ellipse,
-.c8:focus > line,
-.c8:focus > path,
-.c8:focus > polygon,
-.c8:focus > polyline,
-.c8:focus > rect {
+.c7:focus > circle,
+.c7:focus > ellipse,
+.c7:focus > line,
+.c7:focus > path,
+.c7:focus > polygon,
+.c7:focus > polyline,
+.c7:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c8:focus::-moz-focus-inner {
+.c7:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c8::-webkit-input-placeholder {
+.c7::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c8::-moz-placeholder {
+.c7::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c8:-ms-input-placeholder {
+.c7:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c8::-webkit-search-decoration {
+.c7::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c8::-moz-focus-inner {
+.c7::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c8:-moz-placeholder,
-.c8::-moz-placeholder {
+.c7:-moz-placeholder,
+.c7::-moz-placeholder {
   opacity: 1;
 }
 
-.c5 {
+.c4 {
   position: relative;
   width: 100%;
 }
 
-.c6 {
+.c5 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -4265,7 +4233,7 @@ exports[`Data toolbar 1`] = `
   left: 12px;
 }
 
-.c14 {
+.c13 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -4278,7 +4246,7 @@ exports[`Data toolbar 1`] = `
   padding-bottom: 6px;
 }
 
-.c17 {
+.c16 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -4290,23 +4258,23 @@ exports[`Data toolbar 1`] = `
   padding-bottom: 6px;
 }
 
-.c12 {
+.c11 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
 }
 
-.c13 {
+.c12 {
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
 }
 
-.c16:focus {
+.c15:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c16:focus:not(:focus-visible) {
+.c15:focus:not(:focus-visible) {
   outline: none;
 }
 
@@ -4345,51 +4313,47 @@ exports[`Data toolbar 1`] = `
       <div
         class="c3"
       >
-        <form
+        <div
           class="c4"
         >
           <div
             class="c5"
           >
-            <div
-              class="c6"
-            >
-              <svg
-                aria-label="Search"
-                class="c7"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                  fill="none"
-                  stroke="#000"
-                  stroke-width="2"
-                />
-              </svg>
-            </div>
-            <input
+            <svg
               aria-label="Search"
-              autocomplete="off"
-              class="c8"
-              id="data--search"
-              name="_search"
-              type="search"
-              value=""
-            />
+              class="c6"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
           </div>
-        </form>
+          <input
+            aria-label="Search"
+            autocomplete="off"
+            class="c7"
+            id="data--search"
+            name="_search"
+            type="search"
+            value=""
+          />
+        </div>
         <div
-          class="c9"
+          class="c8"
         >
           <button
             aria-label="Open filters"
-            class="c10"
+            class="c9"
             id="data--filters-control"
             type="button"
           >
             <svg
               aria-label="Filter"
-              class="c7"
+              class="c6"
               viewBox="0 0 24 24"
             >
               <path
@@ -4404,12 +4368,12 @@ exports[`Data toolbar 1`] = `
       </div>
     </div>
     <span
-      class="c11"
+      class="c10"
     >
       4 items
     </span>
     <table
-      class="c12 c13"
+      class="c11 c12"
     >
       <thead
         class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -4418,51 +4382,51 @@ exports[`Data toolbar 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c14 "
+            class="c13 "
             scope="col"
           >
             <div
-              class="c15"
+              class="c14"
             />
           </th>
           <th
-            class="c14 "
+            class="c13 "
             scope="col"
           >
             <div
-              class="c15"
+              class="c14"
             />
           </th>
         </tr>
       </thead>
       <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c16"
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c15"
       >
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c17 "
+            class="c16 "
             scope="row"
           >
             <div
-              class="c18"
+              class="c17"
             >
               <span
-                class="c19"
+                class="c18"
               >
                 aa
               </span>
             </div>
           </th>
           <td
-            class="c17 "
+            class="c16 "
           >
             <div
-              class="c18"
+              class="c17"
             >
               <span
-                class="c20"
+                class="c19"
               >
                 ZZ
               </span>
@@ -4473,27 +4437,27 @@ exports[`Data toolbar 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c17 "
+            class="c16 "
             scope="row"
           >
             <div
-              class="c18"
+              class="c17"
             >
               <span
-                class="c19"
+                class="c18"
               >
                 bb
               </span>
             </div>
           </th>
           <td
-            class="c17 "
+            class="c16 "
           >
             <div
-              class="c18"
+              class="c17"
             >
               <span
-                class="c20"
+                class="c19"
               >
                 YY
               </span>
@@ -4504,24 +4468,24 @@ exports[`Data toolbar 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c17 "
+            class="c16 "
             scope="row"
           >
             <div
-              class="c18"
+              class="c17"
             >
               <span
-                class="c19"
+                class="c18"
               >
                 cc
               </span>
             </div>
           </th>
           <td
-            class="c17 "
+            class="c16 "
           >
             <div
-              class="c18"
+              class="c17"
             />
           </td>
         </tr>
@@ -4529,24 +4493,24 @@ exports[`Data toolbar 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c17 "
+            class="c16 "
             scope="row"
           >
             <div
-              class="c18"
+              class="c17"
             >
               <span
-                class="c19"
+                class="c18"
               >
                 dd
               </span>
             </div>
           </th>
           <td
-            class="c17 "
+            class="c16 "
           >
             <div
-              class="c18"
+              class="c17"
             />
           </td>
         </tr>
@@ -5008,7 +4972,7 @@ exports[`Data toolbar filters 1`] = `
 `;
 
 exports[`Data toolbar search 1`] = `
-.c7 {
+.c6 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -5019,25 +4983,25 @@ exports[`Data toolbar search 1`] = `
   stroke: #666666;
 }
 
-.c7 g {
+.c6 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c7 *:not([stroke])[fill='none'] {
+.c6 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c7 *[stroke*='#'],
-.c7 *[STROKE*='#'] {
+.c6 *[stroke*='#'],
+.c6 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c7 *[fill-rule],
-.c7 *[FILL-RULE],
-.c7 *[fill*='#'],
-.c7 *[FILL*='#'] {
+.c6 *[fill-rule],
+.c6 *[FILL-RULE],
+.c6 *[fill*='#'],
+.c6 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -5069,7 +5033,7 @@ exports[`Data toolbar search 1`] = `
   flex: 0 0 auto;
 }
 
-.c13 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5090,7 +5054,7 @@ exports[`Data toolbar search 1`] = `
   justify-content: center;
 }
 
-.c16 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5158,24 +5122,20 @@ exports[`Data toolbar search 1`] = `
   row-gap: 12px;
 }
 
-.c9 {
+.c8 {
   margin-top: 6px;
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
 }
 
-.c17 {
+.c16 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
 }
 
-.c4 {
-  max-width: 100%;
-}
-
-.c8 {
+.c7 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -5192,58 +5152,58 @@ exports[`Data toolbar search 1`] = `
   padding-left: 48px;
 }
 
-.c8:focus {
+.c7:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c8:focus > circle,
-.c8:focus > ellipse,
-.c8:focus > line,
-.c8:focus > path,
-.c8:focus > polygon,
-.c8:focus > polyline,
-.c8:focus > rect {
+.c7:focus > circle,
+.c7:focus > ellipse,
+.c7:focus > line,
+.c7:focus > path,
+.c7:focus > polygon,
+.c7:focus > polyline,
+.c7:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c8:focus::-moz-focus-inner {
+.c7:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c8::-webkit-input-placeholder {
+.c7::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c8::-moz-placeholder {
+.c7::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c8:-ms-input-placeholder {
+.c7:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c8::-webkit-search-decoration {
+.c7::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c8::-moz-focus-inner {
+.c7::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c8:-moz-placeholder,
-.c8::-moz-placeholder {
+.c7:-moz-placeholder,
+.c7::-moz-placeholder {
   opacity: 1;
 }
 
-.c5 {
+.c4 {
   position: relative;
   width: 100%;
 }
 
-.c6 {
+.c5 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -5261,7 +5221,7 @@ exports[`Data toolbar search 1`] = `
   left: 12px;
 }
 
-.c12 {
+.c11 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -5274,7 +5234,7 @@ exports[`Data toolbar search 1`] = `
   padding-bottom: 6px;
 }
 
-.c15 {
+.c14 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -5286,23 +5246,23 @@ exports[`Data toolbar search 1`] = `
   padding-bottom: 6px;
 }
 
-.c10 {
+.c9 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
 }
 
-.c11 {
+.c10 {
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
 }
 
-.c14:focus {
+.c13:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c14:focus:not(:focus-visible) {
+.c13:focus:not(:focus-visible) {
   outline: none;
 }
 
@@ -5341,48 +5301,44 @@ exports[`Data toolbar search 1`] = `
       <div
         class="c3"
       >
-        <form
+        <div
           class="c4"
         >
           <div
             class="c5"
           >
-            <div
-              class="c6"
-            >
-              <svg
-                aria-label="Search"
-                class="c7"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                  fill="none"
-                  stroke="#000"
-                  stroke-width="2"
-                />
-              </svg>
-            </div>
-            <input
+            <svg
               aria-label="Search"
-              autocomplete="off"
-              class="c8"
-              id="data--search"
-              name="_search"
-              type="search"
-              value=""
-            />
+              class="c6"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
           </div>
-        </form>
+          <input
+            aria-label="Search"
+            autocomplete="off"
+            class="c7"
+            id="data--search"
+            name="_search"
+            type="search"
+            value=""
+          />
+        </div>
       </div>
     </div>
     <span
-      class="c9"
+      class="c8"
     >
       4 items
     </span>
     <table
-      class="c10 c11"
+      class="c9 c10"
     >
       <thead
         class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -5391,30 +5347,30 @@ exports[`Data toolbar search 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c12 "
+            class="c11 "
             scope="col"
           >
             <div
-              class="c13"
+              class="c12"
             />
           </th>
         </tr>
       </thead>
       <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c14"
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c13"
       >
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c15 "
+            class="c14 "
             scope="row"
           >
             <div
-              class="c16"
+              class="c15"
             >
               <span
-                class="c17"
+                class="c16"
               >
                 aa
               </span>
@@ -5425,14 +5381,14 @@ exports[`Data toolbar search 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c15 "
+            class="c14 "
             scope="row"
           >
             <div
-              class="c16"
+              class="c15"
             >
               <span
-                class="c17"
+                class="c16"
               >
                 bb
               </span>
@@ -5443,14 +5399,14 @@ exports[`Data toolbar search 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c15 "
+            class="c14 "
             scope="row"
           >
             <div
-              class="c16"
+              class="c15"
             >
               <span
-                class="c17"
+                class="c16"
               >
                 cc
               </span>
@@ -5461,14 +5417,14 @@ exports[`Data toolbar search 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c15 "
+            class="c14 "
             scope="row"
           >
             <div
-              class="c16"
+              class="c15"
             >
               <span
-                class="c17"
+                class="c16"
               >
                 dd
               </span>
@@ -5482,7 +5438,7 @@ exports[`Data toolbar search 1`] = `
 `;
 
 exports[`Data uncontrolled search 1`] = `
-.c7 {
+.c6 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -5493,25 +5449,25 @@ exports[`Data uncontrolled search 1`] = `
   stroke: #666666;
 }
 
-.c7 g {
+.c6 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c7 *:not([stroke])[fill='none'] {
+.c6 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c7 *[stroke*='#'],
-.c7 *[STROKE*='#'] {
+.c6 *[stroke*='#'],
+.c6 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c7 *[fill-rule],
-.c7 *[FILL-RULE],
-.c7 *[fill*='#'],
-.c7 *[FILL*='#'] {
+.c6 *[fill-rule],
+.c6 *[FILL-RULE],
+.c6 *[fill*='#'],
+.c6 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -5543,7 +5499,7 @@ exports[`Data uncontrolled search 1`] = `
   flex: 0 0 auto;
 }
 
-.c9 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5560,7 +5516,7 @@ exports[`Data uncontrolled search 1`] = `
   flex: 0 0 auto;
 }
 
-.c15 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5581,7 +5537,7 @@ exports[`Data uncontrolled search 1`] = `
   justify-content: center;
 }
 
-.c18 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5649,20 +5605,20 @@ exports[`Data uncontrolled search 1`] = `
   row-gap: 12px;
 }
 
-.c11 {
+.c10 {
   margin-top: 6px;
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
 }
 
-.c19 {
+.c18 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
 }
 
-.c10 {
+.c9 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -5682,51 +5638,47 @@ exports[`Data uncontrolled search 1`] = `
   padding: 12px;
 }
 
-.c10:focus {
+.c9:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c10:focus > circle,
-.c10:focus > ellipse,
-.c10:focus > line,
-.c10:focus > path,
-.c10:focus > polygon,
-.c10:focus > polyline,
-.c10:focus > rect {
+.c9:focus > circle,
+.c9:focus > ellipse,
+.c9:focus > line,
+.c9:focus > path,
+.c9:focus > polygon,
+.c9:focus > polyline,
+.c9:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c10:focus::-moz-focus-inner {
+.c9:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c10:focus:not(:focus-visible) {
+.c9:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c10:focus:not(:focus-visible) > circle,
-.c10:focus:not(:focus-visible) > ellipse,
-.c10:focus:not(:focus-visible) > line,
-.c10:focus:not(:focus-visible) > path,
-.c10:focus:not(:focus-visible) > polygon,
-.c10:focus:not(:focus-visible) > polyline,
-.c10:focus:not(:focus-visible) > rect {
+.c9:focus:not(:focus-visible) > circle,
+.c9:focus:not(:focus-visible) > ellipse,
+.c9:focus:not(:focus-visible) > line,
+.c9:focus:not(:focus-visible) > path,
+.c9:focus:not(:focus-visible) > polygon,
+.c9:focus:not(:focus-visible) > polyline,
+.c9:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c10:focus:not(:focus-visible)::-moz-focus-inner {
+.c9:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c4 {
-  max-width: 100%;
-}
-
-.c8 {
+.c7 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -5743,58 +5695,58 @@ exports[`Data uncontrolled search 1`] = `
   padding-left: 48px;
 }
 
-.c8:focus {
+.c7:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c8:focus > circle,
-.c8:focus > ellipse,
-.c8:focus > line,
-.c8:focus > path,
-.c8:focus > polygon,
-.c8:focus > polyline,
-.c8:focus > rect {
+.c7:focus > circle,
+.c7:focus > ellipse,
+.c7:focus > line,
+.c7:focus > path,
+.c7:focus > polygon,
+.c7:focus > polyline,
+.c7:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c8:focus::-moz-focus-inner {
+.c7:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c8::-webkit-input-placeholder {
+.c7::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c8::-moz-placeholder {
+.c7::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c8:-ms-input-placeholder {
+.c7:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c8::-webkit-search-decoration {
+.c7::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c8::-moz-focus-inner {
+.c7::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c8:-moz-placeholder,
-.c8::-moz-placeholder {
+.c7:-moz-placeholder,
+.c7::-moz-placeholder {
   opacity: 1;
 }
 
-.c5 {
+.c4 {
   position: relative;
   width: 100%;
 }
 
-.c6 {
+.c5 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -5812,7 +5764,7 @@ exports[`Data uncontrolled search 1`] = `
   left: 12px;
 }
 
-.c14 {
+.c13 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -5825,7 +5777,7 @@ exports[`Data uncontrolled search 1`] = `
   padding-bottom: 6px;
 }
 
-.c17 {
+.c16 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -5837,23 +5789,23 @@ exports[`Data uncontrolled search 1`] = `
   padding-bottom: 6px;
 }
 
-.c12 {
+.c11 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
 }
 
-.c13 {
+.c12 {
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
 }
 
-.c16:focus {
+.c15:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c16:focus:not(:focus-visible) {
+.c15:focus:not(:focus-visible) {
   outline: none;
 }
 
@@ -5892,51 +5844,47 @@ exports[`Data uncontrolled search 1`] = `
       <div
         class="c3"
       >
-        <form
+        <div
           class="c4"
         >
           <div
             class="c5"
           >
-            <div
-              class="c6"
-            >
-              <svg
-                aria-label="Search"
-                class="c7"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                  fill="none"
-                  stroke="#000"
-                  stroke-width="2"
-                />
-              </svg>
-            </div>
-            <input
+            <svg
               aria-label="Search"
-              autocomplete="off"
-              class="c8"
-              id="data--search"
-              name="_search"
-              type="search"
-              value=""
-            />
+              class="c6"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
           </div>
-        </form>
+          <input
+            aria-label="Search"
+            autocomplete="off"
+            class="c7"
+            id="data--search"
+            name="_search"
+            type="search"
+            value=""
+          />
+        </div>
         <div
-          class="c9"
+          class="c8"
         >
           <button
             aria-label="Open filters"
-            class="c10"
+            class="c9"
             id="data--filters-control"
             type="button"
           >
             <svg
               aria-label="Filter"
-              class="c7"
+              class="c6"
               viewBox="0 0 24 24"
             >
               <path
@@ -5951,12 +5899,12 @@ exports[`Data uncontrolled search 1`] = `
       </div>
     </div>
     <span
-      class="c11"
+      class="c10"
     >
       4 items
     </span>
     <table
-      class="c12 c13"
+      class="c11 c12"
     >
       <thead
         class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -5965,30 +5913,30 @@ exports[`Data uncontrolled search 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c14 "
+            class="c13 "
             scope="col"
           >
             <div
-              class="c15"
+              class="c14"
             />
           </th>
         </tr>
       </thead>
       <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c16"
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c15"
       >
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c17 "
+            class="c16 "
             scope="row"
           >
             <div
-              class="c18"
+              class="c17"
             >
               <span
-                class="c19"
+                class="c18"
               >
                 aa
               </span>
@@ -5999,14 +5947,14 @@ exports[`Data uncontrolled search 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c17 "
+            class="c16 "
             scope="row"
           >
             <div
-              class="c18"
+              class="c17"
             >
               <span
-                class="c19"
+                class="c18"
               >
                 bb
               </span>
@@ -6017,14 +5965,14 @@ exports[`Data uncontrolled search 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c17 "
+            class="c16 "
             scope="row"
           >
             <div
-              class="c18"
+              class="c17"
             >
               <span
-                class="c19"
+                class="c18"
               >
                 cc
               </span>
@@ -6035,14 +5983,14 @@ exports[`Data uncontrolled search 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c17 "
+            class="c16 "
             scope="row"
           >
             <div
-              class="c18"
+              class="c17"
             >
               <span
-                class="c19"
+                class="c18"
               >
                 dd
               </span>
@@ -6069,39 +6017,35 @@ exports[`Data uncontrolled search 2`] = `
       <div
         class="StyledBox-sc-13pk1d4-0 fnEswI"
       >
-        <form
-          class="DataForm__MaxForm-sc-v64e1r-0 iIonEc"
+        <div
+          class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 dAhNeU"
         >
           <div
-            class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 dAhNeU"
+            class="StyledTextInput__StyledIcon-sc-1x30a0s-3 iQFXNb"
           >
-            <div
-              class="StyledTextInput__StyledIcon-sc-1x30a0s-3 iQFXNb"
-            >
-              <svg
-                aria-label="Search"
-                class="StyledIcon-sc-ofa7kd-0 bQiAMQ"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                  fill="none"
-                  stroke="#000"
-                  stroke-width="2"
-                />
-              </svg>
-            </div>
-            <input
+            <svg
               aria-label="Search"
-              autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 hLtcCB"
-              id="data--search"
-              name="_search"
-              type="search"
-              value="a"
-            />
+              class="StyledIcon-sc-ofa7kd-0 bQiAMQ"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
           </div>
-        </form>
+          <input
+            aria-label="Search"
+            autocomplete="off"
+            class="StyledTextInput-sc-1x30a0s-0 hLtcCB"
+            id="data--search"
+            name="_search"
+            type="search"
+            value=""
+          />
+        </div>
         <div
           class="StyledBox-sc-13pk1d4-0 imzrdH"
         >
@@ -6453,7 +6397,7 @@ exports[`Data view 1`] = `
 `;
 
 exports[`Data view all 1`] = `
-.c7 {
+.c6 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -6464,25 +6408,25 @@ exports[`Data view all 1`] = `
   stroke: #666666;
 }
 
-.c7 g {
+.c6 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c7 *:not([stroke])[fill='none'] {
+.c6 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c7 *[stroke*='#'],
-.c7 *[STROKE*='#'] {
+.c6 *[stroke*='#'],
+.c6 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c7 *[fill-rule],
-.c7 *[FILL-RULE],
-.c7 *[fill*='#'],
-.c7 *[FILL*='#'] {
+.c6 *[fill-rule],
+.c6 *[FILL-RULE],
+.c6 *[fill*='#'],
+.c6 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -6514,7 +6458,7 @@ exports[`Data view all 1`] = `
   flex: 0 0 auto;
 }
 
-.c9 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6531,7 +6475,7 @@ exports[`Data view all 1`] = `
   flex: 0 0 auto;
 }
 
-.c15 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6552,7 +6496,7 @@ exports[`Data view all 1`] = `
   justify-content: center;
 }
 
-.c18 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6620,25 +6564,25 @@ exports[`Data view all 1`] = `
   row-gap: 12px;
 }
 
-.c11 {
+.c10 {
   margin-top: 6px;
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
 }
 
-.c19 {
+.c18 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
 }
 
-.c20 {
+.c19 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c10 {
+.c9 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -6658,51 +6602,47 @@ exports[`Data view all 1`] = `
   padding: 12px;
 }
 
-.c10:focus {
+.c9:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c10:focus > circle,
-.c10:focus > ellipse,
-.c10:focus > line,
-.c10:focus > path,
-.c10:focus > polygon,
-.c10:focus > polyline,
-.c10:focus > rect {
+.c9:focus > circle,
+.c9:focus > ellipse,
+.c9:focus > line,
+.c9:focus > path,
+.c9:focus > polygon,
+.c9:focus > polyline,
+.c9:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c10:focus::-moz-focus-inner {
+.c9:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c10:focus:not(:focus-visible) {
+.c9:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c10:focus:not(:focus-visible) > circle,
-.c10:focus:not(:focus-visible) > ellipse,
-.c10:focus:not(:focus-visible) > line,
-.c10:focus:not(:focus-visible) > path,
-.c10:focus:not(:focus-visible) > polygon,
-.c10:focus:not(:focus-visible) > polyline,
-.c10:focus:not(:focus-visible) > rect {
+.c9:focus:not(:focus-visible) > circle,
+.c9:focus:not(:focus-visible) > ellipse,
+.c9:focus:not(:focus-visible) > line,
+.c9:focus:not(:focus-visible) > path,
+.c9:focus:not(:focus-visible) > polygon,
+.c9:focus:not(:focus-visible) > polyline,
+.c9:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c10:focus:not(:focus-visible)::-moz-focus-inner {
+.c9:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c4 {
-  max-width: 100%;
-}
-
-.c8 {
+.c7 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -6719,58 +6659,58 @@ exports[`Data view all 1`] = `
   padding-left: 48px;
 }
 
-.c8:focus {
+.c7:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c8:focus > circle,
-.c8:focus > ellipse,
-.c8:focus > line,
-.c8:focus > path,
-.c8:focus > polygon,
-.c8:focus > polyline,
-.c8:focus > rect {
+.c7:focus > circle,
+.c7:focus > ellipse,
+.c7:focus > line,
+.c7:focus > path,
+.c7:focus > polygon,
+.c7:focus > polyline,
+.c7:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c8:focus::-moz-focus-inner {
+.c7:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c8::-webkit-input-placeholder {
+.c7::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c8::-moz-placeholder {
+.c7::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c8:-ms-input-placeholder {
+.c7:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c8::-webkit-search-decoration {
+.c7::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c8::-moz-focus-inner {
+.c7::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c8:-moz-placeholder,
-.c8::-moz-placeholder {
+.c7:-moz-placeholder,
+.c7::-moz-placeholder {
   opacity: 1;
 }
 
-.c5 {
+.c4 {
   position: relative;
   width: 100%;
 }
 
-.c6 {
+.c5 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -6788,7 +6728,7 @@ exports[`Data view all 1`] = `
   left: 12px;
 }
 
-.c14 {
+.c13 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -6801,7 +6741,7 @@ exports[`Data view all 1`] = `
   padding-bottom: 6px;
 }
 
-.c17 {
+.c16 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -6813,23 +6753,23 @@ exports[`Data view all 1`] = `
   padding-bottom: 6px;
 }
 
-.c12 {
+.c11 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
 }
 
-.c13 {
+.c12 {
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
 }
 
-.c16:focus {
+.c15:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c16:focus:not(:focus-visible) {
+.c15:focus:not(:focus-visible) {
   outline: none;
 }
 
@@ -6868,51 +6808,47 @@ exports[`Data view all 1`] = `
       <div
         class="c3"
       >
-        <form
+        <div
           class="c4"
         >
           <div
             class="c5"
           >
-            <div
-              class="c6"
-            >
-              <svg
-                aria-label="Search"
-                class="c7"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                  fill="none"
-                  stroke="#000"
-                  stroke-width="2"
-                />
-              </svg>
-            </div>
-            <input
+            <svg
               aria-label="Search"
-              autocomplete="off"
-              class="c8"
-              id="data--search"
-              name="_search"
-              type="search"
-              value="a"
-            />
+              class="c6"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
           </div>
-        </form>
+          <input
+            aria-label="Search"
+            autocomplete="off"
+            class="c7"
+            id="data--search"
+            name="_search"
+            type="search"
+            value=""
+          />
+        </div>
         <div
-          class="c9"
+          class="c8"
         >
           <button
             aria-label="Open filters"
-            class="c10"
+            class="c9"
             id="data--filters-control"
             type="button"
           >
             <svg
               aria-label="Filter"
-              class="c7"
+              class="c6"
               viewBox="0 0 24 24"
             >
               <path
@@ -6927,12 +6863,12 @@ exports[`Data view all 1`] = `
       </div>
     </div>
     <span
-      class="c11"
+      class="c10"
     >
       1 result of 4 items
     </span>
     <table
-      class="c12 c13"
+      class="c11 c12"
     >
       <thead
         class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -6941,51 +6877,51 @@ exports[`Data view all 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c14 "
+            class="c13 "
             scope="col"
           >
             <div
-              class="c15"
+              class="c14"
             />
           </th>
           <th
-            class="c14 "
+            class="c13 "
             scope="col"
           >
             <div
-              class="c15"
+              class="c14"
             />
           </th>
         </tr>
       </thead>
       <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c16"
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c15"
       >
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c17 "
+            class="c16 "
             scope="row"
           >
             <div
-              class="c18"
+              class="c17"
             >
               <span
-                class="c19"
+                class="c18"
               >
                 aa
               </span>
             </div>
           </th>
           <td
-            class="c17 "
+            class="c16 "
           >
             <div
-              class="c18"
+              class="c17"
             >
               <span
-                class="c20"
+                class="c19"
               >
                 ZZ
               </span>
@@ -6999,7 +6935,7 @@ exports[`Data view all 1`] = `
 `;
 
 exports[`Data view property option 1`] = `
-.c7 {
+.c6 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -7010,25 +6946,25 @@ exports[`Data view property option 1`] = `
   stroke: #666666;
 }
 
-.c7 g {
+.c6 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c7 *:not([stroke])[fill='none'] {
+.c6 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c7 *[stroke*='#'],
-.c7 *[STROKE*='#'] {
+.c6 *[stroke*='#'],
+.c6 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c7 *[fill-rule],
-.c7 *[FILL-RULE],
-.c7 *[fill*='#'],
-.c7 *[FILL*='#'] {
+.c6 *[fill-rule],
+.c6 *[FILL-RULE],
+.c6 *[fill*='#'],
+.c6 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -7060,7 +6996,7 @@ exports[`Data view property option 1`] = `
   flex: 0 0 auto;
 }
 
-.c9 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7077,7 +7013,7 @@ exports[`Data view property option 1`] = `
   flex: 0 0 auto;
 }
 
-.c15 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7098,7 +7034,7 @@ exports[`Data view property option 1`] = `
   justify-content: center;
 }
 
-.c18 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7166,25 +7102,25 @@ exports[`Data view property option 1`] = `
   row-gap: 12px;
 }
 
-.c11 {
+.c10 {
   margin-top: 6px;
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
 }
 
-.c19 {
+.c18 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
 }
 
-.c20 {
+.c19 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c10 {
+.c9 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -7204,51 +7140,47 @@ exports[`Data view property option 1`] = `
   padding: 12px;
 }
 
-.c10:focus {
+.c9:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c10:focus > circle,
-.c10:focus > ellipse,
-.c10:focus > line,
-.c10:focus > path,
-.c10:focus > polygon,
-.c10:focus > polyline,
-.c10:focus > rect {
+.c9:focus > circle,
+.c9:focus > ellipse,
+.c9:focus > line,
+.c9:focus > path,
+.c9:focus > polygon,
+.c9:focus > polyline,
+.c9:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c10:focus::-moz-focus-inner {
+.c9:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c10:focus:not(:focus-visible) {
+.c9:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c10:focus:not(:focus-visible) > circle,
-.c10:focus:not(:focus-visible) > ellipse,
-.c10:focus:not(:focus-visible) > line,
-.c10:focus:not(:focus-visible) > path,
-.c10:focus:not(:focus-visible) > polygon,
-.c10:focus:not(:focus-visible) > polyline,
-.c10:focus:not(:focus-visible) > rect {
+.c9:focus:not(:focus-visible) > circle,
+.c9:focus:not(:focus-visible) > ellipse,
+.c9:focus:not(:focus-visible) > line,
+.c9:focus:not(:focus-visible) > path,
+.c9:focus:not(:focus-visible) > polygon,
+.c9:focus:not(:focus-visible) > polyline,
+.c9:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c10:focus:not(:focus-visible)::-moz-focus-inner {
+.c9:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c4 {
-  max-width: 100%;
-}
-
-.c8 {
+.c7 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -7265,58 +7197,58 @@ exports[`Data view property option 1`] = `
   padding-left: 48px;
 }
 
-.c8:focus {
+.c7:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c8:focus > circle,
-.c8:focus > ellipse,
-.c8:focus > line,
-.c8:focus > path,
-.c8:focus > polygon,
-.c8:focus > polyline,
-.c8:focus > rect {
+.c7:focus > circle,
+.c7:focus > ellipse,
+.c7:focus > line,
+.c7:focus > path,
+.c7:focus > polygon,
+.c7:focus > polyline,
+.c7:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c8:focus::-moz-focus-inner {
+.c7:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c8::-webkit-input-placeholder {
+.c7::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c8::-moz-placeholder {
+.c7::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c8:-ms-input-placeholder {
+.c7:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c8::-webkit-search-decoration {
+.c7::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c8::-moz-focus-inner {
+.c7::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c8:-moz-placeholder,
-.c8::-moz-placeholder {
+.c7:-moz-placeholder,
+.c7::-moz-placeholder {
   opacity: 1;
 }
 
-.c5 {
+.c4 {
   position: relative;
   width: 100%;
 }
 
-.c6 {
+.c5 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -7334,7 +7266,7 @@ exports[`Data view property option 1`] = `
   left: 12px;
 }
 
-.c14 {
+.c13 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -7347,7 +7279,7 @@ exports[`Data view property option 1`] = `
   padding-bottom: 6px;
 }
 
-.c17 {
+.c16 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -7359,23 +7291,23 @@ exports[`Data view property option 1`] = `
   padding-bottom: 6px;
 }
 
-.c12 {
+.c11 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
 }
 
-.c13 {
+.c12 {
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
 }
 
-.c16:focus {
+.c15:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c16:focus:not(:focus-visible) {
+.c15:focus:not(:focus-visible) {
   outline: none;
 }
 
@@ -7414,51 +7346,47 @@ exports[`Data view property option 1`] = `
       <div
         class="c3"
       >
-        <form
+        <div
           class="c4"
         >
           <div
             class="c5"
           >
-            <div
-              class="c6"
-            >
-              <svg
-                aria-label="Search"
-                class="c7"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                  fill="none"
-                  stroke="#000"
-                  stroke-width="2"
-                />
-              </svg>
-            </div>
-            <input
+            <svg
               aria-label="Search"
-              autocomplete="off"
-              class="c8"
-              id="data--search"
-              name="_search"
-              type="search"
-              value=""
-            />
+              class="c6"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
           </div>
-        </form>
+          <input
+            aria-label="Search"
+            autocomplete="off"
+            class="c7"
+            id="data--search"
+            name="_search"
+            type="search"
+            value=""
+          />
+        </div>
         <div
-          class="c9"
+          class="c8"
         >
           <button
             aria-label="Open filters"
-            class="c10"
+            class="c9"
             id="data--filters-control"
             type="button"
           >
             <svg
               aria-label="Filter"
-              class="c7"
+              class="c6"
               viewBox="0 0 24 24"
             >
               <path
@@ -7473,12 +7401,12 @@ exports[`Data view property option 1`] = `
       </div>
     </div>
     <span
-      class="c11"
+      class="c10"
     >
       1 result of 4 items
     </span>
     <table
-      class="c12 c13"
+      class="c11 c12"
     >
       <thead
         class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -7487,51 +7415,51 @@ exports[`Data view property option 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c14 "
+            class="c13 "
             scope="col"
           >
             <div
-              class="c15"
+              class="c14"
             />
           </th>
           <th
-            class="c14 "
+            class="c13 "
             scope="col"
           >
             <div
-              class="c15"
+              class="c14"
             />
           </th>
         </tr>
       </thead>
       <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c16"
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c15"
       >
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c17 "
+            class="c16 "
             scope="row"
           >
             <div
-              class="c18"
+              class="c17"
             >
               <span
-                class="c19"
+                class="c18"
               >
                 aa
               </span>
             </div>
           </th>
           <td
-            class="c17 "
+            class="c16 "
           >
             <div
-              class="c18"
+              class="c17"
             >
               <span
-                class="c20"
+                class="c19"
               >
                 ZZ
               </span>
@@ -7545,7 +7473,7 @@ exports[`Data view property option 1`] = `
 `;
 
 exports[`Data view property range 1`] = `
-.c7 {
+.c6 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -7556,25 +7484,25 @@ exports[`Data view property range 1`] = `
   stroke: #666666;
 }
 
-.c7 g {
+.c6 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c7 *:not([stroke])[fill='none'] {
+.c6 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c7 *[stroke*='#'],
-.c7 *[STROKE*='#'] {
+.c6 *[stroke*='#'],
+.c6 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c7 *[fill-rule],
-.c7 *[FILL-RULE],
-.c7 *[fill*='#'],
-.c7 *[FILL*='#'] {
+.c6 *[fill-rule],
+.c6 *[FILL-RULE],
+.c6 *[fill*='#'],
+.c6 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -7606,7 +7534,7 @@ exports[`Data view property range 1`] = `
   flex: 0 0 auto;
 }
 
-.c9 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7623,7 +7551,7 @@ exports[`Data view property range 1`] = `
   flex: 0 0 auto;
 }
 
-.c15 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7644,7 +7572,7 @@ exports[`Data view property range 1`] = `
   justify-content: center;
 }
 
-.c18 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7712,25 +7640,25 @@ exports[`Data view property range 1`] = `
   row-gap: 12px;
 }
 
-.c11 {
+.c10 {
   margin-top: 6px;
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
 }
 
-.c19 {
+.c18 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
 }
 
-.c20 {
+.c19 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c10 {
+.c9 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -7750,51 +7678,47 @@ exports[`Data view property range 1`] = `
   padding: 12px;
 }
 
-.c10:focus {
+.c9:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c10:focus > circle,
-.c10:focus > ellipse,
-.c10:focus > line,
-.c10:focus > path,
-.c10:focus > polygon,
-.c10:focus > polyline,
-.c10:focus > rect {
+.c9:focus > circle,
+.c9:focus > ellipse,
+.c9:focus > line,
+.c9:focus > path,
+.c9:focus > polygon,
+.c9:focus > polyline,
+.c9:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c10:focus::-moz-focus-inner {
+.c9:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c10:focus:not(:focus-visible) {
+.c9:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c10:focus:not(:focus-visible) > circle,
-.c10:focus:not(:focus-visible) > ellipse,
-.c10:focus:not(:focus-visible) > line,
-.c10:focus:not(:focus-visible) > path,
-.c10:focus:not(:focus-visible) > polygon,
-.c10:focus:not(:focus-visible) > polyline,
-.c10:focus:not(:focus-visible) > rect {
+.c9:focus:not(:focus-visible) > circle,
+.c9:focus:not(:focus-visible) > ellipse,
+.c9:focus:not(:focus-visible) > line,
+.c9:focus:not(:focus-visible) > path,
+.c9:focus:not(:focus-visible) > polygon,
+.c9:focus:not(:focus-visible) > polyline,
+.c9:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c10:focus:not(:focus-visible)::-moz-focus-inner {
+.c9:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c4 {
-  max-width: 100%;
-}
-
-.c8 {
+.c7 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -7811,58 +7735,58 @@ exports[`Data view property range 1`] = `
   padding-left: 48px;
 }
 
-.c8:focus {
+.c7:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c8:focus > circle,
-.c8:focus > ellipse,
-.c8:focus > line,
-.c8:focus > path,
-.c8:focus > polygon,
-.c8:focus > polyline,
-.c8:focus > rect {
+.c7:focus > circle,
+.c7:focus > ellipse,
+.c7:focus > line,
+.c7:focus > path,
+.c7:focus > polygon,
+.c7:focus > polyline,
+.c7:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c8:focus::-moz-focus-inner {
+.c7:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c8::-webkit-input-placeholder {
+.c7::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c8::-moz-placeholder {
+.c7::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c8:-ms-input-placeholder {
+.c7:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c8::-webkit-search-decoration {
+.c7::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c8::-moz-focus-inner {
+.c7::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c8:-moz-placeholder,
-.c8::-moz-placeholder {
+.c7:-moz-placeholder,
+.c7::-moz-placeholder {
   opacity: 1;
 }
 
-.c5 {
+.c4 {
   position: relative;
   width: 100%;
 }
 
-.c6 {
+.c5 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -7880,7 +7804,7 @@ exports[`Data view property range 1`] = `
   left: 12px;
 }
 
-.c14 {
+.c13 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -7893,7 +7817,7 @@ exports[`Data view property range 1`] = `
   padding-bottom: 6px;
 }
 
-.c17 {
+.c16 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -7905,23 +7829,23 @@ exports[`Data view property range 1`] = `
   padding-bottom: 6px;
 }
 
-.c12 {
+.c11 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
 }
 
-.c13 {
+.c12 {
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
 }
 
-.c16:focus {
+.c15:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c16:focus:not(:focus-visible) {
+.c15:focus:not(:focus-visible) {
   outline: none;
 }
 
@@ -7960,51 +7884,47 @@ exports[`Data view property range 1`] = `
       <div
         class="c3"
       >
-        <form
+        <div
           class="c4"
         >
           <div
             class="c5"
           >
-            <div
-              class="c6"
-            >
-              <svg
-                aria-label="Search"
-                class="c7"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                  fill="none"
-                  stroke="#000"
-                  stroke-width="2"
-                />
-              </svg>
-            </div>
-            <input
+            <svg
               aria-label="Search"
-              autocomplete="off"
-              class="c8"
-              id="data--search"
-              name="_search"
-              type="search"
-              value=""
-            />
+              class="c6"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
           </div>
-        </form>
+          <input
+            aria-label="Search"
+            autocomplete="off"
+            class="c7"
+            id="data--search"
+            name="_search"
+            type="search"
+            value=""
+          />
+        </div>
         <div
-          class="c9"
+          class="c8"
         >
           <button
             aria-label="Open filters"
-            class="c10"
+            class="c9"
             id="data--filters-control"
             type="button"
           >
             <svg
               aria-label="Filter"
-              class="c7"
+              class="c6"
               viewBox="0 0 24 24"
             >
               <path
@@ -8019,12 +7939,12 @@ exports[`Data view property range 1`] = `
       </div>
     </div>
     <span
-      class="c11"
+      class="c10"
     >
       1 result of 4 items
     </span>
     <table
-      class="c12 c13"
+      class="c11 c12"
     >
       <thead
         class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -8033,72 +7953,72 @@ exports[`Data view property range 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c14 "
+            class="c13 "
             scope="col"
           >
             <div
-              class="c15"
+              class="c14"
             />
           </th>
           <th
-            class="c14 "
+            class="c13 "
             scope="col"
           >
             <div
-              class="c15"
+              class="c14"
             />
           </th>
           <th
-            class="c14 "
+            class="c13 "
             scope="col"
           >
             <div
-              class="c15"
+              class="c14"
             />
           </th>
         </tr>
       </thead>
       <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c16"
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c15"
       >
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c17 "
+            class="c16 "
             scope="row"
           >
             <div
-              class="c18"
+              class="c17"
             >
               <span
-                class="c19"
+                class="c18"
               >
                 bb
               </span>
             </div>
           </th>
           <td
-            class="c17 "
+            class="c16 "
           >
             <div
-              class="c18"
+              class="c17"
             >
               <span
-                class="c20"
+                class="c19"
               >
                 YY
               </span>
             </div>
           </td>
           <td
-            class="c17 "
+            class="c16 "
           >
             <div
-              class="c18"
+              class="c17"
             >
               <span
-                class="c20"
+                class="c19"
               >
                 4.3
               </span>
@@ -8112,7 +8032,7 @@ exports[`Data view property range 1`] = `
 `;
 
 exports[`Data view search 1`] = `
-.c7 {
+.c6 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -8123,25 +8043,25 @@ exports[`Data view search 1`] = `
   stroke: #666666;
 }
 
-.c7 g {
+.c6 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c7 *:not([stroke])[fill='none'] {
+.c6 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c7 *[stroke*='#'],
-.c7 *[STROKE*='#'] {
+.c6 *[stroke*='#'],
+.c6 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c7 *[fill-rule],
-.c7 *[FILL-RULE],
-.c7 *[fill*='#'],
-.c7 *[FILL*='#'] {
+.c6 *[fill-rule],
+.c6 *[FILL-RULE],
+.c6 *[fill*='#'],
+.c6 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -8173,7 +8093,7 @@ exports[`Data view search 1`] = `
   flex: 0 0 auto;
 }
 
-.c9 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8190,7 +8110,7 @@ exports[`Data view search 1`] = `
   flex: 0 0 auto;
 }
 
-.c15 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8211,7 +8131,7 @@ exports[`Data view search 1`] = `
   justify-content: center;
 }
 
-.c18 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8279,25 +8199,25 @@ exports[`Data view search 1`] = `
   row-gap: 12px;
 }
 
-.c11 {
+.c10 {
   margin-top: 6px;
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
 }
 
-.c19 {
+.c18 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
 }
 
-.c20 {
+.c19 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c10 {
+.c9 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -8317,51 +8237,47 @@ exports[`Data view search 1`] = `
   padding: 12px;
 }
 
-.c10:focus {
+.c9:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c10:focus > circle,
-.c10:focus > ellipse,
-.c10:focus > line,
-.c10:focus > path,
-.c10:focus > polygon,
-.c10:focus > polyline,
-.c10:focus > rect {
+.c9:focus > circle,
+.c9:focus > ellipse,
+.c9:focus > line,
+.c9:focus > path,
+.c9:focus > polygon,
+.c9:focus > polyline,
+.c9:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c10:focus::-moz-focus-inner {
+.c9:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c10:focus:not(:focus-visible) {
+.c9:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c10:focus:not(:focus-visible) > circle,
-.c10:focus:not(:focus-visible) > ellipse,
-.c10:focus:not(:focus-visible) > line,
-.c10:focus:not(:focus-visible) > path,
-.c10:focus:not(:focus-visible) > polygon,
-.c10:focus:not(:focus-visible) > polyline,
-.c10:focus:not(:focus-visible) > rect {
+.c9:focus:not(:focus-visible) > circle,
+.c9:focus:not(:focus-visible) > ellipse,
+.c9:focus:not(:focus-visible) > line,
+.c9:focus:not(:focus-visible) > path,
+.c9:focus:not(:focus-visible) > polygon,
+.c9:focus:not(:focus-visible) > polyline,
+.c9:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c10:focus:not(:focus-visible)::-moz-focus-inner {
+.c9:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c4 {
-  max-width: 100%;
-}
-
-.c8 {
+.c7 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -8378,58 +8294,58 @@ exports[`Data view search 1`] = `
   padding-left: 48px;
 }
 
-.c8:focus {
+.c7:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c8:focus > circle,
-.c8:focus > ellipse,
-.c8:focus > line,
-.c8:focus > path,
-.c8:focus > polygon,
-.c8:focus > polyline,
-.c8:focus > rect {
+.c7:focus > circle,
+.c7:focus > ellipse,
+.c7:focus > line,
+.c7:focus > path,
+.c7:focus > polygon,
+.c7:focus > polyline,
+.c7:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c8:focus::-moz-focus-inner {
+.c7:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c8::-webkit-input-placeholder {
+.c7::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c8::-moz-placeholder {
+.c7::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c8:-ms-input-placeholder {
+.c7:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c8::-webkit-search-decoration {
+.c7::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c8::-moz-focus-inner {
+.c7::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c8:-moz-placeholder,
-.c8::-moz-placeholder {
+.c7:-moz-placeholder,
+.c7::-moz-placeholder {
   opacity: 1;
 }
 
-.c5 {
+.c4 {
   position: relative;
   width: 100%;
 }
 
-.c6 {
+.c5 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -8447,7 +8363,7 @@ exports[`Data view search 1`] = `
   left: 12px;
 }
 
-.c14 {
+.c13 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -8460,7 +8376,7 @@ exports[`Data view search 1`] = `
   padding-bottom: 6px;
 }
 
-.c17 {
+.c16 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -8472,23 +8388,23 @@ exports[`Data view search 1`] = `
   padding-bottom: 6px;
 }
 
-.c12 {
+.c11 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
 }
 
-.c13 {
+.c12 {
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
 }
 
-.c16:focus {
+.c15:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c16:focus:not(:focus-visible) {
+.c15:focus:not(:focus-visible) {
   outline: none;
 }
 
@@ -8527,51 +8443,47 @@ exports[`Data view search 1`] = `
       <div
         class="c3"
       >
-        <form
+        <div
           class="c4"
         >
           <div
             class="c5"
           >
-            <div
-              class="c6"
-            >
-              <svg
-                aria-label="Search"
-                class="c7"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                  fill="none"
-                  stroke="#000"
-                  stroke-width="2"
-                />
-              </svg>
-            </div>
-            <input
+            <svg
               aria-label="Search"
-              autocomplete="off"
-              class="c8"
-              id="data--search"
-              name="_search"
-              type="search"
-              value="a"
-            />
+              class="c6"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
           </div>
-        </form>
+          <input
+            aria-label="Search"
+            autocomplete="off"
+            class="c7"
+            id="data--search"
+            name="_search"
+            type="search"
+            value=""
+          />
+        </div>
         <div
-          class="c9"
+          class="c8"
         >
           <button
             aria-label="Open filters"
-            class="c10"
+            class="c9"
             id="data--filters-control"
             type="button"
           >
             <svg
               aria-label="Filter"
-              class="c7"
+              class="c6"
               viewBox="0 0 24 24"
             >
               <path
@@ -8586,12 +8498,12 @@ exports[`Data view search 1`] = `
       </div>
     </div>
     <span
-      class="c11"
+      class="c10"
     >
       1 result of 4 items
     </span>
     <table
-      class="c12 c13"
+      class="c11 c12"
     >
       <thead
         class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -8600,51 +8512,51 @@ exports[`Data view search 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c14 "
+            class="c13 "
             scope="col"
           >
             <div
-              class="c15"
+              class="c14"
             />
           </th>
           <th
-            class="c14 "
+            class="c13 "
             scope="col"
           >
             <div
-              class="c15"
+              class="c14"
             />
           </th>
         </tr>
       </thead>
       <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c16"
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c15"
       >
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c17 "
+            class="c16 "
             scope="row"
           >
             <div
-              class="c18"
+              class="c17"
             >
               <span
-                class="c19"
+                class="c18"
               >
                 aa
               </span>
             </div>
           </th>
           <td
-            class="c17 "
+            class="c16 "
           >
             <div
-              class="c18"
+              class="c17"
             >
               <span
-                class="c20"
+                class="c19"
               >
                 ZZ
               </span>
@@ -8658,7 +8570,7 @@ exports[`Data view search 1`] = `
 `;
 
 exports[`Data view sort 1`] = `
-.c7 {
+.c6 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -8669,25 +8581,25 @@ exports[`Data view sort 1`] = `
   stroke: #666666;
 }
 
-.c7 g {
+.c6 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c7 *:not([stroke])[fill='none'] {
+.c6 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c7 *[stroke*='#'],
-.c7 *[STROKE*='#'] {
+.c6 *[stroke*='#'],
+.c6 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c7 *[fill-rule],
-.c7 *[FILL-RULE],
-.c7 *[fill*='#'],
-.c7 *[FILL*='#'] {
+.c6 *[fill-rule],
+.c6 *[FILL-RULE],
+.c6 *[fill*='#'],
+.c6 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -8719,7 +8631,7 @@ exports[`Data view sort 1`] = `
   flex: 0 0 auto;
 }
 
-.c9 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8736,7 +8648,7 @@ exports[`Data view sort 1`] = `
   flex: 0 0 auto;
 }
 
-.c15 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8757,7 +8669,7 @@ exports[`Data view sort 1`] = `
   justify-content: center;
 }
 
-.c18 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8825,25 +8737,25 @@ exports[`Data view sort 1`] = `
   row-gap: 12px;
 }
 
-.c11 {
+.c10 {
   margin-top: 6px;
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
 }
 
-.c19 {
+.c18 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
 }
 
-.c20 {
+.c19 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c10 {
+.c9 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -8863,51 +8775,47 @@ exports[`Data view sort 1`] = `
   padding: 12px;
 }
 
-.c10:focus {
+.c9:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c10:focus > circle,
-.c10:focus > ellipse,
-.c10:focus > line,
-.c10:focus > path,
-.c10:focus > polygon,
-.c10:focus > polyline,
-.c10:focus > rect {
+.c9:focus > circle,
+.c9:focus > ellipse,
+.c9:focus > line,
+.c9:focus > path,
+.c9:focus > polygon,
+.c9:focus > polyline,
+.c9:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c10:focus::-moz-focus-inner {
+.c9:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c10:focus:not(:focus-visible) {
+.c9:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c10:focus:not(:focus-visible) > circle,
-.c10:focus:not(:focus-visible) > ellipse,
-.c10:focus:not(:focus-visible) > line,
-.c10:focus:not(:focus-visible) > path,
-.c10:focus:not(:focus-visible) > polygon,
-.c10:focus:not(:focus-visible) > polyline,
-.c10:focus:not(:focus-visible) > rect {
+.c9:focus:not(:focus-visible) > circle,
+.c9:focus:not(:focus-visible) > ellipse,
+.c9:focus:not(:focus-visible) > line,
+.c9:focus:not(:focus-visible) > path,
+.c9:focus:not(:focus-visible) > polygon,
+.c9:focus:not(:focus-visible) > polyline,
+.c9:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c10:focus:not(:focus-visible)::-moz-focus-inner {
+.c9:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c4 {
-  max-width: 100%;
-}
-
-.c8 {
+.c7 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -8924,58 +8832,58 @@ exports[`Data view sort 1`] = `
   padding-left: 48px;
 }
 
-.c8:focus {
+.c7:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c8:focus > circle,
-.c8:focus > ellipse,
-.c8:focus > line,
-.c8:focus > path,
-.c8:focus > polygon,
-.c8:focus > polyline,
-.c8:focus > rect {
+.c7:focus > circle,
+.c7:focus > ellipse,
+.c7:focus > line,
+.c7:focus > path,
+.c7:focus > polygon,
+.c7:focus > polyline,
+.c7:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c8:focus::-moz-focus-inner {
+.c7:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c8::-webkit-input-placeholder {
+.c7::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c8::-moz-placeholder {
+.c7::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c8:-ms-input-placeholder {
+.c7:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c8::-webkit-search-decoration {
+.c7::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c8::-moz-focus-inner {
+.c7::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c8:-moz-placeholder,
-.c8::-moz-placeholder {
+.c7:-moz-placeholder,
+.c7::-moz-placeholder {
   opacity: 1;
 }
 
-.c5 {
+.c4 {
   position: relative;
   width: 100%;
 }
 
-.c6 {
+.c5 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -8993,7 +8901,7 @@ exports[`Data view sort 1`] = `
   left: 12px;
 }
 
-.c14 {
+.c13 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -9006,7 +8914,7 @@ exports[`Data view sort 1`] = `
   padding-bottom: 6px;
 }
 
-.c17 {
+.c16 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -9018,23 +8926,23 @@ exports[`Data view sort 1`] = `
   padding-bottom: 6px;
 }
 
-.c12 {
+.c11 {
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
 }
 
-.c13 {
+.c12 {
   position: relative;
   border-spacing: 0;
   border-collapse: separate;
 }
 
-.c16:focus {
+.c15:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c16:focus:not(:focus-visible) {
+.c15:focus:not(:focus-visible) {
   outline: none;
 }
 
@@ -9073,51 +8981,47 @@ exports[`Data view sort 1`] = `
       <div
         class="c3"
       >
-        <form
+        <div
           class="c4"
         >
           <div
             class="c5"
           >
-            <div
-              class="c6"
-            >
-              <svg
-                aria-label="Search"
-                class="c7"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                  fill="none"
-                  stroke="#000"
-                  stroke-width="2"
-                />
-              </svg>
-            </div>
-            <input
+            <svg
               aria-label="Search"
-              autocomplete="off"
-              class="c8"
-              id="data--search"
-              name="_search"
-              type="search"
-              value=""
-            />
+              class="c6"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
           </div>
-        </form>
+          <input
+            aria-label="Search"
+            autocomplete="off"
+            class="c7"
+            id="data--search"
+            name="_search"
+            type="search"
+            value=""
+          />
+        </div>
         <div
-          class="c9"
+          class="c8"
         >
           <button
             aria-label="Open filters"
-            class="c10"
+            class="c9"
             id="data--filters-control"
             type="button"
           >
             <svg
               aria-label="Filter"
-              class="c7"
+              class="c6"
               viewBox="0 0 24 24"
             >
               <path
@@ -9132,12 +9036,12 @@ exports[`Data view sort 1`] = `
       </div>
     </div>
     <span
-      class="c11"
+      class="c10"
     >
       4 items
     </span>
     <table
-      class="c12 c13"
+      class="c11 c12"
     >
       <thead
         class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
@@ -9146,51 +9050,51 @@ exports[`Data view sort 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c14 "
+            class="c13 "
             scope="col"
           >
             <div
-              class="c15"
+              class="c14"
             />
           </th>
           <th
-            class="c14 "
+            class="c13 "
             scope="col"
           >
             <div
-              class="c15"
+              class="c14"
             />
           </th>
         </tr>
       </thead>
       <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c16"
+        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c15"
       >
         <tr
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c17 "
+            class="c16 "
             scope="row"
           >
             <div
-              class="c18"
+              class="c17"
             >
               <span
-                class="c19"
+                class="c18"
               >
                 aa
               </span>
             </div>
           </th>
           <td
-            class="c17 "
+            class="c16 "
           >
             <div
-              class="c18"
+              class="c17"
             >
               <span
-                class="c20"
+                class="c19"
               >
                 ZZ
               </span>
@@ -9201,27 +9105,27 @@ exports[`Data view sort 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c17 "
+            class="c16 "
             scope="row"
           >
             <div
-              class="c18"
+              class="c17"
             >
               <span
-                class="c19"
+                class="c18"
               >
                 bb
               </span>
             </div>
           </th>
           <td
-            class="c17 "
+            class="c16 "
           >
             <div
-              class="c18"
+              class="c17"
             >
               <span
-                class="c20"
+                class="c19"
               >
                 YY
               </span>
@@ -9232,24 +9136,24 @@ exports[`Data view sort 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c17 "
+            class="c16 "
             scope="row"
           >
             <div
-              class="c18"
+              class="c17"
             >
               <span
-                class="c19"
+                class="c18"
               >
                 cc
               </span>
             </div>
           </th>
           <td
-            class="c17 "
+            class="c16 "
           >
             <div
-              class="c18"
+              class="c17"
             />
           </td>
         </tr>
@@ -9257,24 +9161,24 @@ exports[`Data view sort 1`] = `
           class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
         >
           <th
-            class="c17 "
+            class="c16 "
             scope="row"
           >
             <div
-              class="c18"
+              class="c17"
             >
               <span
-                class="c19"
+                class="c18"
               >
                 dd
               </span>
             </div>
           </th>
           <td
-            class="c17 "
+            class="c16 "
           >
             <div
-              class="c18"
+              class="c17"
             />
           </td>
         </tr>

--- a/src/js/components/DataClearFilters/__tests__/__snapshots__/DataClearFilters-test.tsx.snap
+++ b/src/js/components/DataClearFilters/__tests__/__snapshots__/DataClearFilters-test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`DataClearFilters clears filters when clicked 1`] = `
 <DocumentFragment>
-  .c6 {
+  .c7 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -13,25 +13,25 @@ exports[`DataClearFilters clears filters when clicked 1`] = `
   stroke: #666666;
 }
 
-.c6 g {
+.c7 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c6 *:not([stroke])[fill='none'] {
+.c7 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c6 *[stroke*='#'],
-.c6 *[STROKE*='#'] {
+.c7 *[stroke*='#'],
+.c7 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c6 *[fill-rule],
-.c6 *[FILL-RULE],
-.c6 *[fill*='#'],
-.c6 *[FILL*='#'] {
+.c7 *[fill-rule],
+.c7 *[FILL-RULE],
+.c7 *[fill*='#'],
+.c7 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -53,7 +53,21 @@ exports[`DataClearFilters clears filters when clicked 1`] = `
   flex: 0 0 auto;
 }
 
-.c8 {
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -124,14 +138,14 @@ exports[`DataClearFilters clears filters when clicked 1`] = `
   row-gap: 12px;
 }
 
-.c10 {
+.c11 {
   margin-top: 6px;
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
 }
 
-.c9 {
+.c10 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -151,47 +165,47 @@ exports[`DataClearFilters clears filters when clicked 1`] = `
   padding: 12px;
 }
 
-.c9:focus {
+.c10:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c9:focus > circle,
-.c9:focus > ellipse,
-.c9:focus > line,
-.c9:focus > path,
-.c9:focus > polygon,
-.c9:focus > polyline,
-.c9:focus > rect {
+.c10:focus > circle,
+.c10:focus > ellipse,
+.c10:focus > line,
+.c10:focus > path,
+.c10:focus > polygon,
+.c10:focus > polyline,
+.c10:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c9:focus::-moz-focus-inner {
+.c10:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c9:focus:not(:focus-visible) {
+.c10:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c9:focus:not(:focus-visible) > circle,
-.c9:focus:not(:focus-visible) > ellipse,
-.c9:focus:not(:focus-visible) > line,
-.c9:focus:not(:focus-visible) > path,
-.c9:focus:not(:focus-visible) > polygon,
-.c9:focus:not(:focus-visible) > polyline,
-.c9:focus:not(:focus-visible) > rect {
+.c10:focus:not(:focus-visible) > circle,
+.c10:focus:not(:focus-visible) > ellipse,
+.c10:focus:not(:focus-visible) > line,
+.c10:focus:not(:focus-visible) > path,
+.c10:focus:not(:focus-visible) > polygon,
+.c10:focus:not(:focus-visible) > polyline,
+.c10:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c9:focus:not(:focus-visible)::-moz-focus-inner {
+.c10:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c11 {
+.c12 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -216,51 +230,51 @@ exports[`DataClearFilters clears filters when clicked 1`] = `
   transition-timing-function: ease-in-out;
 }
 
-.c11:hover {
+.c12:hover {
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c11:focus {
+.c12:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus > circle,
-.c11:focus > ellipse,
-.c11:focus > line,
-.c11:focus > path,
-.c11:focus > polygon,
-.c11:focus > polyline,
-.c11:focus > rect {
+.c12:focus > circle,
+.c12:focus > ellipse,
+.c12:focus > line,
+.c12:focus > path,
+.c12:focus > polygon,
+.c12:focus > polyline,
+.c12:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus::-moz-focus-inner {
+.c12:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c11:focus:not(:focus-visible) {
+.c12:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c11:focus:not(:focus-visible) > circle,
-.c11:focus:not(:focus-visible) > ellipse,
-.c11:focus:not(:focus-visible) > line,
-.c11:focus:not(:focus-visible) > path,
-.c11:focus:not(:focus-visible) > polygon,
-.c11:focus:not(:focus-visible) > polyline,
-.c11:focus:not(:focus-visible) > rect {
+.c12:focus:not(:focus-visible) > circle,
+.c12:focus:not(:focus-visible) > ellipse,
+.c12:focus:not(:focus-visible) > line,
+.c12:focus:not(:focus-visible) > path,
+.c12:focus:not(:focus-visible) > polygon,
+.c12:focus:not(:focus-visible) > polyline,
+.c12:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c11:focus:not(:focus-visible)::-moz-focus-inner {
+.c12:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c7 {
+.c8 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -277,58 +291,58 @@ exports[`DataClearFilters clears filters when clicked 1`] = `
   padding-left: 48px;
 }
 
-.c7:focus {
+.c8:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus > circle,
-.c7:focus > ellipse,
-.c7:focus > line,
-.c7:focus > path,
-.c7:focus > polygon,
-.c7:focus > polyline,
-.c7:focus > rect {
+.c8:focus > circle,
+.c8:focus > ellipse,
+.c8:focus > line,
+.c8:focus > path,
+.c8:focus > polygon,
+.c8:focus > polyline,
+.c8:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus::-moz-focus-inner {
+.c8:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c7::-webkit-input-placeholder {
+.c8::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-moz-placeholder {
+.c8::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c7:-ms-input-placeholder {
+.c8:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-webkit-search-decoration {
+.c8::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c7::-moz-focus-inner {
+.c8::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c7:-moz-placeholder,
-.c7::-moz-placeholder {
+.c8:-moz-placeholder,
+.c8::-moz-placeholder {
   opacity: 1;
 }
 
-.c4 {
+.c5 {
   position: relative;
   width: 100%;
 }
 
-.c5 {
+.c6 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -397,41 +411,45 @@ exports[`DataClearFilters clears filters when clicked 1`] = `
             <div
               class="c5"
             >
-              <svg
-                aria-label="Search"
+              <div
                 class="c6"
-                viewBox="0 0 24 24"
               >
-                <path
-                  d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                  fill="none"
-                  stroke="#000"
-                  stroke-width="2"
-                />
-              </svg>
+                <svg
+                  aria-label="Search"
+                  class="c7"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                    fill="none"
+                    stroke="#000"
+                    stroke-width="2"
+                  />
+                </svg>
+              </div>
+              <input
+                aria-label="Search"
+                autocomplete="off"
+                class="c8"
+                id="data--search"
+                name="_search"
+                type="search"
+                value=""
+              />
             </div>
-            <input
-              aria-label="Search"
-              autocomplete="off"
-              class="c7"
-              id="data--search"
-              name="_search"
-              type="search"
-              value=""
-            />
           </div>
           <div
-            class="c8"
+            class="c9"
           >
             <button
               aria-label="Open filters"
-              class="c9"
+              class="c10"
               id="data--filters-control"
               type="button"
             >
               <svg
                 aria-label="Filter"
-                class="c6"
+                class="c7"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -446,12 +464,12 @@ exports[`DataClearFilters clears filters when clicked 1`] = `
         </div>
       </div>
       <span
-        class="c10"
+        class="c11"
       >
         3 items
       </span>
       <button
-        class="c11"
+        class="c12"
         type="button"
       >
         Clear filters
@@ -579,7 +597,7 @@ exports[`DataClearFilters renders 1`] = `
 
 exports[`DataClearFilters renders custom message 1`] = `
 <DocumentFragment>
-  .c6 {
+  .c7 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -590,25 +608,25 @@ exports[`DataClearFilters renders custom message 1`] = `
   stroke: #666666;
 }
 
-.c6 g {
+.c7 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c6 *:not([stroke])[fill='none'] {
+.c7 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c6 *[stroke*='#'],
-.c6 *[STROKE*='#'] {
+.c7 *[stroke*='#'],
+.c7 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c6 *[fill-rule],
-.c6 *[FILL-RULE],
-.c6 *[fill*='#'],
-.c6 *[FILL*='#'] {
+.c7 *[fill-rule],
+.c7 *[FILL-RULE],
+.c7 *[fill*='#'],
+.c7 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -630,7 +648,21 @@ exports[`DataClearFilters renders custom message 1`] = `
   flex: 0 0 auto;
 }
 
-.c8 {
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -701,14 +733,14 @@ exports[`DataClearFilters renders custom message 1`] = `
   row-gap: 12px;
 }
 
-.c10 {
+.c11 {
   margin-top: 6px;
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
 }
 
-.c9 {
+.c10 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -728,47 +760,47 @@ exports[`DataClearFilters renders custom message 1`] = `
   padding: 12px;
 }
 
-.c9:focus {
+.c10:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c9:focus > circle,
-.c9:focus > ellipse,
-.c9:focus > line,
-.c9:focus > path,
-.c9:focus > polygon,
-.c9:focus > polyline,
-.c9:focus > rect {
+.c10:focus > circle,
+.c10:focus > ellipse,
+.c10:focus > line,
+.c10:focus > path,
+.c10:focus > polygon,
+.c10:focus > polyline,
+.c10:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c9:focus::-moz-focus-inner {
+.c10:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c9:focus:not(:focus-visible) {
+.c10:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c9:focus:not(:focus-visible) > circle,
-.c9:focus:not(:focus-visible) > ellipse,
-.c9:focus:not(:focus-visible) > line,
-.c9:focus:not(:focus-visible) > path,
-.c9:focus:not(:focus-visible) > polygon,
-.c9:focus:not(:focus-visible) > polyline,
-.c9:focus:not(:focus-visible) > rect {
+.c10:focus:not(:focus-visible) > circle,
+.c10:focus:not(:focus-visible) > ellipse,
+.c10:focus:not(:focus-visible) > line,
+.c10:focus:not(:focus-visible) > path,
+.c10:focus:not(:focus-visible) > polygon,
+.c10:focus:not(:focus-visible) > polyline,
+.c10:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c9:focus:not(:focus-visible)::-moz-focus-inner {
+.c10:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c11 {
+.c12 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -793,51 +825,51 @@ exports[`DataClearFilters renders custom message 1`] = `
   transition-timing-function: ease-in-out;
 }
 
-.c11:hover {
+.c12:hover {
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c11:focus {
+.c12:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus > circle,
-.c11:focus > ellipse,
-.c11:focus > line,
-.c11:focus > path,
-.c11:focus > polygon,
-.c11:focus > polyline,
-.c11:focus > rect {
+.c12:focus > circle,
+.c12:focus > ellipse,
+.c12:focus > line,
+.c12:focus > path,
+.c12:focus > polygon,
+.c12:focus > polyline,
+.c12:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus::-moz-focus-inner {
+.c12:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c11:focus:not(:focus-visible) {
+.c12:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c11:focus:not(:focus-visible) > circle,
-.c11:focus:not(:focus-visible) > ellipse,
-.c11:focus:not(:focus-visible) > line,
-.c11:focus:not(:focus-visible) > path,
-.c11:focus:not(:focus-visible) > polygon,
-.c11:focus:not(:focus-visible) > polyline,
-.c11:focus:not(:focus-visible) > rect {
+.c12:focus:not(:focus-visible) > circle,
+.c12:focus:not(:focus-visible) > ellipse,
+.c12:focus:not(:focus-visible) > line,
+.c12:focus:not(:focus-visible) > path,
+.c12:focus:not(:focus-visible) > polygon,
+.c12:focus:not(:focus-visible) > polyline,
+.c12:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c11:focus:not(:focus-visible)::-moz-focus-inner {
+.c12:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c7 {
+.c8 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -854,58 +886,58 @@ exports[`DataClearFilters renders custom message 1`] = `
   padding-left: 48px;
 }
 
-.c7:focus {
+.c8:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus > circle,
-.c7:focus > ellipse,
-.c7:focus > line,
-.c7:focus > path,
-.c7:focus > polygon,
-.c7:focus > polyline,
-.c7:focus > rect {
+.c8:focus > circle,
+.c8:focus > ellipse,
+.c8:focus > line,
+.c8:focus > path,
+.c8:focus > polygon,
+.c8:focus > polyline,
+.c8:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus::-moz-focus-inner {
+.c8:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c7::-webkit-input-placeholder {
+.c8::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-moz-placeholder {
+.c8::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c7:-ms-input-placeholder {
+.c8:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-webkit-search-decoration {
+.c8::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c7::-moz-focus-inner {
+.c8::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c7:-moz-placeholder,
-.c7::-moz-placeholder {
+.c8:-moz-placeholder,
+.c8::-moz-placeholder {
   opacity: 1;
 }
 
-.c4 {
+.c5 {
   position: relative;
   width: 100%;
 }
 
-.c5 {
+.c6 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -974,41 +1006,45 @@ exports[`DataClearFilters renders custom message 1`] = `
             <div
               class="c5"
             >
-              <svg
-                aria-label="Search"
+              <div
                 class="c6"
-                viewBox="0 0 24 24"
               >
-                <path
-                  d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                  fill="none"
-                  stroke="#000"
-                  stroke-width="2"
-                />
-              </svg>
+                <svg
+                  aria-label="Search"
+                  class="c7"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                    fill="none"
+                    stroke="#000"
+                    stroke-width="2"
+                  />
+                </svg>
+              </div>
+              <input
+                aria-label="Search"
+                autocomplete="off"
+                class="c8"
+                id="data--search"
+                name="_search"
+                type="search"
+                value=""
+              />
             </div>
-            <input
-              aria-label="Search"
-              autocomplete="off"
-              class="c7"
-              id="data--search"
-              name="_search"
-              type="search"
-              value=""
-            />
           </div>
           <div
-            class="c8"
+            class="c9"
           >
             <button
               aria-label="Open filters"
-              class="c9"
+              class="c10"
               id="data--filters-control"
               type="button"
             >
               <svg
                 aria-label="Filter"
-                class="c6"
+                class="c7"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -1023,12 +1059,12 @@ exports[`DataClearFilters renders custom message 1`] = `
         </div>
       </div>
       <span
-        class="c10"
+        class="c11"
       >
         3 items
       </span>
       <button
-        class="c11"
+        class="c12"
         type="button"
       >
         Remove all filters

--- a/src/js/components/DataClearFilters/__tests__/__snapshots__/DataClearFilters-test.tsx.snap
+++ b/src/js/components/DataClearFilters/__tests__/__snapshots__/DataClearFilters-test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`DataClearFilters clears filters when clicked 1`] = `
 <DocumentFragment>
-  .c7 {
+  .c6 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -13,25 +13,25 @@ exports[`DataClearFilters clears filters when clicked 1`] = `
   stroke: #666666;
 }
 
-.c7 g {
+.c6 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c7 *:not([stroke])[fill='none'] {
+.c6 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c7 *[stroke*='#'],
-.c7 *[STROKE*='#'] {
+.c6 *[stroke*='#'],
+.c6 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c7 *[fill-rule],
-.c7 *[FILL-RULE],
-.c7 *[fill*='#'],
-.c7 *[FILL*='#'] {
+.c6 *[fill-rule],
+.c6 *[FILL-RULE],
+.c6 *[fill*='#'],
+.c6 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -53,7 +53,7 @@ exports[`DataClearFilters clears filters when clicked 1`] = `
   flex: 0 0 auto;
 }
 
-.c9 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -124,14 +124,14 @@ exports[`DataClearFilters clears filters when clicked 1`] = `
   row-gap: 12px;
 }
 
-.c11 {
+.c10 {
   margin-top: 6px;
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
 }
 
-.c10 {
+.c9 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -151,47 +151,47 @@ exports[`DataClearFilters clears filters when clicked 1`] = `
   padding: 12px;
 }
 
-.c10:focus {
+.c9:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c10:focus > circle,
-.c10:focus > ellipse,
-.c10:focus > line,
-.c10:focus > path,
-.c10:focus > polygon,
-.c10:focus > polyline,
-.c10:focus > rect {
+.c9:focus > circle,
+.c9:focus > ellipse,
+.c9:focus > line,
+.c9:focus > path,
+.c9:focus > polygon,
+.c9:focus > polyline,
+.c9:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c10:focus::-moz-focus-inner {
+.c9:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c10:focus:not(:focus-visible) {
+.c9:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c10:focus:not(:focus-visible) > circle,
-.c10:focus:not(:focus-visible) > ellipse,
-.c10:focus:not(:focus-visible) > line,
-.c10:focus:not(:focus-visible) > path,
-.c10:focus:not(:focus-visible) > polygon,
-.c10:focus:not(:focus-visible) > polyline,
-.c10:focus:not(:focus-visible) > rect {
+.c9:focus:not(:focus-visible) > circle,
+.c9:focus:not(:focus-visible) > ellipse,
+.c9:focus:not(:focus-visible) > line,
+.c9:focus:not(:focus-visible) > path,
+.c9:focus:not(:focus-visible) > polygon,
+.c9:focus:not(:focus-visible) > polyline,
+.c9:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c10:focus:not(:focus-visible)::-moz-focus-inner {
+.c9:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c12 {
+.c11 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -216,55 +216,51 @@ exports[`DataClearFilters clears filters when clicked 1`] = `
   transition-timing-function: ease-in-out;
 }
 
-.c12:hover {
+.c11:hover {
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c12:focus {
+.c11:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus > circle,
-.c12:focus > ellipse,
-.c12:focus > line,
-.c12:focus > path,
-.c12:focus > polygon,
-.c12:focus > polyline,
-.c12:focus > rect {
+.c11:focus > circle,
+.c11:focus > ellipse,
+.c11:focus > line,
+.c11:focus > path,
+.c11:focus > polygon,
+.c11:focus > polyline,
+.c11:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus::-moz-focus-inner {
+.c11:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c12:focus:not(:focus-visible) {
+.c11:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible) > circle,
-.c12:focus:not(:focus-visible) > ellipse,
-.c12:focus:not(:focus-visible) > line,
-.c12:focus:not(:focus-visible) > path,
-.c12:focus:not(:focus-visible) > polygon,
-.c12:focus:not(:focus-visible) > polyline,
-.c12:focus:not(:focus-visible) > rect {
+.c11:focus:not(:focus-visible) > circle,
+.c11:focus:not(:focus-visible) > ellipse,
+.c11:focus:not(:focus-visible) > line,
+.c11:focus:not(:focus-visible) > path,
+.c11:focus:not(:focus-visible) > polygon,
+.c11:focus:not(:focus-visible) > polyline,
+.c11:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible)::-moz-focus-inner {
+.c11:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c4 {
-  max-width: 100%;
-}
-
-.c8 {
+.c7 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -281,58 +277,58 @@ exports[`DataClearFilters clears filters when clicked 1`] = `
   padding-left: 48px;
 }
 
-.c8:focus {
+.c7:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c8:focus > circle,
-.c8:focus > ellipse,
-.c8:focus > line,
-.c8:focus > path,
-.c8:focus > polygon,
-.c8:focus > polyline,
-.c8:focus > rect {
+.c7:focus > circle,
+.c7:focus > ellipse,
+.c7:focus > line,
+.c7:focus > path,
+.c7:focus > polygon,
+.c7:focus > polyline,
+.c7:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c8:focus::-moz-focus-inner {
+.c7:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c8::-webkit-input-placeholder {
+.c7::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c8::-moz-placeholder {
+.c7::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c8:-ms-input-placeholder {
+.c7:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c8::-webkit-search-decoration {
+.c7::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c8::-moz-focus-inner {
+.c7::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c8:-moz-placeholder,
-.c8::-moz-placeholder {
+.c7:-moz-placeholder,
+.c7::-moz-placeholder {
   opacity: 1;
 }
 
-.c5 {
+.c4 {
   position: relative;
   width: 100%;
 }
 
-.c6 {
+.c5 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -395,51 +391,47 @@ exports[`DataClearFilters clears filters when clicked 1`] = `
         <div
           class="c3"
         >
-          <form
+          <div
             class="c4"
           >
             <div
               class="c5"
             >
-              <div
-                class="c6"
-              >
-                <svg
-                  aria-label="Search"
-                  class="c7"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                    fill="none"
-                    stroke="#000"
-                    stroke-width="2"
-                  />
-                </svg>
-              </div>
-              <input
+              <svg
                 aria-label="Search"
-                autocomplete="off"
-                class="c8"
-                id="data--search"
-                name="_search"
-                type="search"
-                value=""
-              />
+                class="c6"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
             </div>
-          </form>
+            <input
+              aria-label="Search"
+              autocomplete="off"
+              class="c7"
+              id="data--search"
+              name="_search"
+              type="search"
+              value=""
+            />
+          </div>
           <div
-            class="c9"
+            class="c8"
           >
             <button
               aria-label="Open filters"
-              class="c10"
+              class="c9"
               id="data--filters-control"
               type="button"
             >
               <svg
                 aria-label="Filter"
-                class="c7"
+                class="c6"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -454,12 +446,12 @@ exports[`DataClearFilters clears filters when clicked 1`] = `
         </div>
       </div>
       <span
-        class="c11"
+        class="c10"
       >
         3 items
       </span>
       <button
-        class="c12"
+        class="c11"
         type="button"
       >
         Clear filters
@@ -587,7 +579,7 @@ exports[`DataClearFilters renders 1`] = `
 
 exports[`DataClearFilters renders custom message 1`] = `
 <DocumentFragment>
-  .c7 {
+  .c6 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -598,25 +590,25 @@ exports[`DataClearFilters renders custom message 1`] = `
   stroke: #666666;
 }
 
-.c7 g {
+.c6 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c7 *:not([stroke])[fill='none'] {
+.c6 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c7 *[stroke*='#'],
-.c7 *[STROKE*='#'] {
+.c6 *[stroke*='#'],
+.c6 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c7 *[fill-rule],
-.c7 *[FILL-RULE],
-.c7 *[fill*='#'],
-.c7 *[FILL*='#'] {
+.c6 *[fill-rule],
+.c6 *[FILL-RULE],
+.c6 *[fill*='#'],
+.c6 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -638,7 +630,7 @@ exports[`DataClearFilters renders custom message 1`] = `
   flex: 0 0 auto;
 }
 
-.c9 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -709,14 +701,14 @@ exports[`DataClearFilters renders custom message 1`] = `
   row-gap: 12px;
 }
 
-.c11 {
+.c10 {
   margin-top: 6px;
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
 }
 
-.c10 {
+.c9 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -736,47 +728,47 @@ exports[`DataClearFilters renders custom message 1`] = `
   padding: 12px;
 }
 
-.c10:focus {
+.c9:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c10:focus > circle,
-.c10:focus > ellipse,
-.c10:focus > line,
-.c10:focus > path,
-.c10:focus > polygon,
-.c10:focus > polyline,
-.c10:focus > rect {
+.c9:focus > circle,
+.c9:focus > ellipse,
+.c9:focus > line,
+.c9:focus > path,
+.c9:focus > polygon,
+.c9:focus > polyline,
+.c9:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c10:focus::-moz-focus-inner {
+.c9:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c10:focus:not(:focus-visible) {
+.c9:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c10:focus:not(:focus-visible) > circle,
-.c10:focus:not(:focus-visible) > ellipse,
-.c10:focus:not(:focus-visible) > line,
-.c10:focus:not(:focus-visible) > path,
-.c10:focus:not(:focus-visible) > polygon,
-.c10:focus:not(:focus-visible) > polyline,
-.c10:focus:not(:focus-visible) > rect {
+.c9:focus:not(:focus-visible) > circle,
+.c9:focus:not(:focus-visible) > ellipse,
+.c9:focus:not(:focus-visible) > line,
+.c9:focus:not(:focus-visible) > path,
+.c9:focus:not(:focus-visible) > polygon,
+.c9:focus:not(:focus-visible) > polyline,
+.c9:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c10:focus:not(:focus-visible)::-moz-focus-inner {
+.c9:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c12 {
+.c11 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -801,55 +793,51 @@ exports[`DataClearFilters renders custom message 1`] = `
   transition-timing-function: ease-in-out;
 }
 
-.c12:hover {
+.c11:hover {
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c12:focus {
+.c11:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus > circle,
-.c12:focus > ellipse,
-.c12:focus > line,
-.c12:focus > path,
-.c12:focus > polygon,
-.c12:focus > polyline,
-.c12:focus > rect {
+.c11:focus > circle,
+.c11:focus > ellipse,
+.c11:focus > line,
+.c11:focus > path,
+.c11:focus > polygon,
+.c11:focus > polyline,
+.c11:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus::-moz-focus-inner {
+.c11:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c12:focus:not(:focus-visible) {
+.c11:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible) > circle,
-.c12:focus:not(:focus-visible) > ellipse,
-.c12:focus:not(:focus-visible) > line,
-.c12:focus:not(:focus-visible) > path,
-.c12:focus:not(:focus-visible) > polygon,
-.c12:focus:not(:focus-visible) > polyline,
-.c12:focus:not(:focus-visible) > rect {
+.c11:focus:not(:focus-visible) > circle,
+.c11:focus:not(:focus-visible) > ellipse,
+.c11:focus:not(:focus-visible) > line,
+.c11:focus:not(:focus-visible) > path,
+.c11:focus:not(:focus-visible) > polygon,
+.c11:focus:not(:focus-visible) > polyline,
+.c11:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible)::-moz-focus-inner {
+.c11:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c4 {
-  max-width: 100%;
-}
-
-.c8 {
+.c7 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -866,58 +854,58 @@ exports[`DataClearFilters renders custom message 1`] = `
   padding-left: 48px;
 }
 
-.c8:focus {
+.c7:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c8:focus > circle,
-.c8:focus > ellipse,
-.c8:focus > line,
-.c8:focus > path,
-.c8:focus > polygon,
-.c8:focus > polyline,
-.c8:focus > rect {
+.c7:focus > circle,
+.c7:focus > ellipse,
+.c7:focus > line,
+.c7:focus > path,
+.c7:focus > polygon,
+.c7:focus > polyline,
+.c7:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c8:focus::-moz-focus-inner {
+.c7:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c8::-webkit-input-placeholder {
+.c7::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c8::-moz-placeholder {
+.c7::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c8:-ms-input-placeholder {
+.c7:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c8::-webkit-search-decoration {
+.c7::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c8::-moz-focus-inner {
+.c7::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c8:-moz-placeholder,
-.c8::-moz-placeholder {
+.c7:-moz-placeholder,
+.c7::-moz-placeholder {
   opacity: 1;
 }
 
-.c5 {
+.c4 {
   position: relative;
   width: 100%;
 }
 
-.c6 {
+.c5 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -980,51 +968,47 @@ exports[`DataClearFilters renders custom message 1`] = `
         <div
           class="c3"
         >
-          <form
+          <div
             class="c4"
           >
             <div
               class="c5"
             >
-              <div
-                class="c6"
-              >
-                <svg
-                  aria-label="Search"
-                  class="c7"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                    fill="none"
-                    stroke="#000"
-                    stroke-width="2"
-                  />
-                </svg>
-              </div>
-              <input
+              <svg
                 aria-label="Search"
-                autocomplete="off"
-                class="c8"
-                id="data--search"
-                name="_search"
-                type="search"
-                value=""
-              />
+                class="c6"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
             </div>
-          </form>
+            <input
+              aria-label="Search"
+              autocomplete="off"
+              class="c7"
+              id="data--search"
+              name="_search"
+              type="search"
+              value=""
+            />
+          </div>
           <div
-            class="c9"
+            class="c8"
           >
             <button
               aria-label="Open filters"
-              class="c10"
+              class="c9"
               id="data--filters-control"
               type="button"
             >
               <svg
                 aria-label="Filter"
-                class="c7"
+                class="c6"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -1039,12 +1023,12 @@ exports[`DataClearFilters renders custom message 1`] = `
         </div>
       </div>
       <span
-        class="c11"
+        class="c10"
       >
         3 items
       </span>
       <button
-        class="c12"
+        class="c11"
         type="button"
       >
         Remove all filters

--- a/src/js/components/DataSearch/DataSearch.js
+++ b/src/js/components/DataSearch/DataSearch.js
@@ -72,7 +72,10 @@ export const DataSearch = ({ drop, id: idProp, responsive, ...rest }) => {
     />
   );
 
-  if (inDataForm)
+  if (!inDataForm)
+    // likely in Toolbar
+    content = <Box>{content}</Box>;
+  else
     content = (
       <FormField
         htmlFor={id}

--- a/src/js/components/DataSearch/DataSearch.js
+++ b/src/js/components/DataSearch/DataSearch.js
@@ -28,6 +28,7 @@ export const DataSearch = ({ drop, id: idProp, responsive, ...rest }) => {
     addToolbarKey,
     onView,
     view,
+    views,
   } = useContext(DataContext);
   const { inDataForm } = useContext(DataFormContext);
   const { format } = useContext(MessageContext);
@@ -46,8 +47,18 @@ export const DataSearch = ({ drop, id: idProp, responsive, ...rest }) => {
   useEffect(() => setValue(view?.search), [view?.search]);
 
   const onChange = (e) => {
+    const nextValue = { ...view, search: e.target?.value };
+
+    // If there's a named view in effect that has a search term
+    // we'll clear the named view (but leave it's other filters)
+    const currentView =
+      nextValue.view && views?.find((v) => v.name === nextValue.view);
+    if (currentView?.search) {
+      delete nextValue.view;
+      delete nextValue.name;
+    }
     setValue(e.target?.value);
-    debounce(() => () => onView({ ...view, search: e.target?.value }));
+    debounce(() => () => onView(nextValue));
   };
 
   let content = skeleton ? null : (

--- a/src/js/components/DataSearch/DataSearch.js
+++ b/src/js/components/DataSearch/DataSearch.js
@@ -12,7 +12,7 @@ import { MessageContext } from '../../contexts/MessageContext';
 import { ResponsiveContext } from '../../contexts/ResponsiveContext';
 import { DataSearchPropTypes } from './propTypes';
 import { isSmall } from '../../utils/responsive';
-import { useDebounce } from '../../utils';
+import { useDebounce } from '../../utils/use-debounce';
 
 const dropProps = {
   align: { top: 'bottom', left: 'left' },
@@ -43,7 +43,7 @@ export const DataSearch = ({ drop, id: idProp, responsive, ...rest }) => {
     if (!inDataForm) addToolbarKey('_search');
   }, [addToolbarKey, inDataForm]);
 
-  useEffect(() => setValue(view?.search), [view.search]);
+  useEffect(() => setValue(view?.search), [view?.search]);
 
   const onChange = (e) => {
     setValue(e.target?.value);

--- a/src/js/components/DataSearch/DataSearch.js
+++ b/src/js/components/DataSearch/DataSearch.js
@@ -3,7 +3,6 @@ import { Search } from 'grommet-icons/icons/Search';
 import { ThemeContext } from 'styled-components';
 import { Box } from '../Box';
 import { DataContext } from '../../contexts/DataContext';
-// import { DataForm } from '../Data/DataForm';
 import { DropButton } from '../DropButton';
 import { DataFormContext } from '../../contexts/DataFormContext';
 import { FormField } from '../FormField';
@@ -13,6 +12,7 @@ import { MessageContext } from '../../contexts/MessageContext';
 import { ResponsiveContext } from '../../contexts/ResponsiveContext';
 import { DataSearchPropTypes } from './propTypes';
 import { isSmall } from '../../utils/responsive';
+import { useDebounce } from '../../utils';
 
 const dropProps = {
   align: { top: 'bottom', left: 'left' },
@@ -20,18 +20,6 @@ const dropProps = {
 
 // 300ms was chosen empirically as a reasonable default
 const DEBOUNCE_TIMEOUT = 300;
-
-const debounce = (func, timeout = DEBOUNCE_TIMEOUT) => {
-  let timer;
-  return (...args) => {
-    clearTimeout(timer);
-    timer = setTimeout(() => {
-      func(...args);
-    }, timeout);
-  };
-};
-
-const debounceSearch = debounce((onView, nextValue) => onView(nextValue));
 
 export const DataSearch = ({ drop, id: idProp, responsive, ...rest }) => {
   const {
@@ -46,15 +34,20 @@ export const DataSearch = ({ drop, id: idProp, responsive, ...rest }) => {
   const theme = useContext(ThemeContext);
   const size = useContext(ResponsiveContext);
   const skeleton = useSkeleton();
+  const debounce = useDebounce(DEBOUNCE_TIMEOUT);
   const [showContent, setShowContent] = useState();
+  const [value, setValue] = useState(view?.search);
   const id = idProp || `${dataId}--search`;
 
   useEffect(() => {
     if (!inDataForm) addToolbarKey('_search');
   }, [addToolbarKey, inDataForm]);
 
+  useEffect(() => setValue(view?.search), [view.search]);
+
   const onChange = (e) => {
-    debounceSearch(onView, { ...view, search: e.target?.value });
+    setValue(e.target?.value);
+    debounce(() => () => onView({ ...view, search: e.target?.value }));
   };
 
   let content = skeleton ? null : (
@@ -67,13 +60,15 @@ export const DataSearch = ({ drop, id: idProp, responsive, ...rest }) => {
       name="_search"
       icon={<Search />}
       type="search"
+      value={value}
       onChange={onChange}
       {...rest}
     />
   );
 
   if (!inDataForm)
-    // likely in Toolbar
+    // likely in Toolbar.
+    // Wrap in Box to give it a reasonable width
     content = <Box>{content}</Box>;
   else
     content = (

--- a/src/js/components/DataSearch/__tests__/__snapshots__/DataSearch-test.tsx.snap
+++ b/src/js/components/DataSearch/__tests__/__snapshots__/DataSearch-test.tsx.snap
@@ -195,7 +195,7 @@ exports[`DataSearch drop 3`] = `
 `;
 
 exports[`DataSearch no Data 1`] = `
-.c3 {
+.c4 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -206,30 +206,44 @@ exports[`DataSearch no Data 1`] = `
   stroke: #666666;
 }
 
-.c3 g {
+.c4 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c3 *:not([stroke])[fill='none'] {
+.c4 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c3 *[stroke*='#'],
-.c3 *[STROKE*='#'] {
+.c4 *[stroke*='#'],
+.c4 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c3 *[fill-rule],
-.c3 *[FILL-RULE],
-.c3 *[fill*='#'],
-.c3 *[FILL*='#'] {
+.c4 *[fill-rule],
+.c4 *[FILL-RULE],
+.c4 *[fill*='#'],
+.c4 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
 
-.c4 {
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c5 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -246,58 +260,58 @@ exports[`DataSearch no Data 1`] = `
   padding-left: 48px;
 }
 
-.c4:focus {
+.c5:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c4:focus > circle,
-.c4:focus > ellipse,
-.c4:focus > line,
-.c4:focus > path,
-.c4:focus > polygon,
-.c4:focus > polyline,
-.c4:focus > rect {
+.c5:focus > circle,
+.c5:focus > ellipse,
+.c5:focus > line,
+.c5:focus > path,
+.c5:focus > polygon,
+.c5:focus > polyline,
+.c5:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c4:focus::-moz-focus-inner {
+.c5:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c4::-webkit-input-placeholder {
+.c5::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c4::-moz-placeholder {
+.c5::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c4:-ms-input-placeholder {
+.c5:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c4::-webkit-search-decoration {
+.c5::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c4::-moz-focus-inner {
+.c5::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c4:-moz-placeholder,
-.c4::-moz-placeholder {
+.c5:-moz-placeholder,
+.c5::-moz-placeholder {
   opacity: 1;
 }
 
-.c1 {
+.c2 {
   position: relative;
   width: 100%;
 }
 
-.c2 {
+.c3 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -334,28 +348,32 @@ exports[`DataSearch no Data 1`] = `
     <div
       class="c2"
     >
-      <svg
-        aria-label="Search"
+      <div
         class="c3"
-        viewBox="0 0 24 24"
       >
-        <path
-          d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-          fill="none"
-          stroke="#000"
-          stroke-width="2"
-        />
-      </svg>
+        <svg
+          aria-label="Search"
+          class="c4"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+            fill="none"
+            stroke="#000"
+            stroke-width="2"
+          />
+        </svg>
+      </div>
+      <input
+        aria-label="Search"
+        autocomplete="off"
+        class="c5"
+        id="undefined--search"
+        name="_search"
+        type="search"
+        value=""
+      />
     </div>
-    <input
-      aria-label="Search"
-      autocomplete="off"
-      class="c4"
-      id="undefined--search"
-      name="_search"
-      type="search"
-      value=""
-    />
   </div>
 </div>
 `;

--- a/src/js/components/DataSearch/__tests__/__snapshots__/DataSearch-test.tsx.snap
+++ b/src/js/components/DataSearch/__tests__/__snapshots__/DataSearch-test.tsx.snap
@@ -195,7 +195,7 @@ exports[`DataSearch drop 3`] = `
 `;
 
 exports[`DataSearch no Data 1`] = `
-.c4 {
+.c3 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -206,34 +206,30 @@ exports[`DataSearch no Data 1`] = `
   stroke: #666666;
 }
 
-.c4 g {
+.c3 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c4 *:not([stroke])[fill='none'] {
+.c3 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c4 *[stroke*='#'],
-.c4 *[STROKE*='#'] {
+.c3 *[stroke*='#'],
+.c3 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c4 *[fill-rule],
-.c4 *[FILL-RULE],
-.c4 *[fill*='#'],
-.c4 *[FILL*='#'] {
+.c3 *[fill-rule],
+.c3 *[FILL-RULE],
+.c3 *[fill*='#'],
+.c3 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
 
-.c1 {
-  max-width: 100%;
-}
-
-.c5 {
+.c4 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -250,58 +246,58 @@ exports[`DataSearch no Data 1`] = `
   padding-left: 48px;
 }
 
-.c5:focus {
+.c4:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus > circle,
-.c5:focus > ellipse,
-.c5:focus > line,
-.c5:focus > path,
-.c5:focus > polygon,
-.c5:focus > polyline,
-.c5:focus > rect {
+.c4:focus > circle,
+.c4:focus > ellipse,
+.c4:focus > line,
+.c4:focus > path,
+.c4:focus > polygon,
+.c4:focus > polyline,
+.c4:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c5:focus::-moz-focus-inner {
+.c4:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c5::-webkit-input-placeholder {
+.c4::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c5::-moz-placeholder {
+.c4::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c5:-ms-input-placeholder {
+.c4:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c5::-webkit-search-decoration {
+.c4::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c5::-moz-focus-inner {
+.c4::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c5:-moz-placeholder,
-.c5::-moz-placeholder {
+.c4:-moz-placeholder,
+.c4::-moz-placeholder {
   opacity: 1;
 }
 
-.c2 {
+.c1 {
   position: relative;
   width: 100%;
 }
 
-.c3 {
+.c2 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -332,39 +328,35 @@ exports[`DataSearch no Data 1`] = `
 <div
   class="c0"
 >
-  <form
+  <div
     class="c1"
   >
     <div
       class="c2"
     >
-      <div
-        class="c3"
-      >
-        <svg
-          aria-label="Search"
-          class="c4"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-            fill="none"
-            stroke="#000"
-            stroke-width="2"
-          />
-        </svg>
-      </div>
-      <input
+      <svg
         aria-label="Search"
-        autocomplete="off"
-        class="c5"
-        id="undefined--search"
-        name="_search"
-        type="search"
-        value=""
-      />
+        class="c3"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+          fill="none"
+          stroke="#000"
+          stroke-width="2"
+        />
+      </svg>
     </div>
-  </form>
+    <input
+      aria-label="Search"
+      autocomplete="off"
+      class="c4"
+      id="undefined--search"
+      name="_search"
+      type="search"
+      value=""
+    />
+  </div>
 </div>
 `;
 

--- a/src/js/components/FormField/FormField.js
+++ b/src/js/components/FormField/FormField.js
@@ -13,8 +13,8 @@ import {
   shouldKeepFocus,
   withinDropPortal,
   PortalContext,
-  useDebounce,
 } from '../../utils';
+import { useDebounce } from '../../utils/use-debounce';
 import { focusStyle } from '../../utils/styles';
 import { parseMetricToNum } from '../../utils/mixins';
 import { useForwardedRef } from '../../utils/refs';

--- a/src/js/components/FormField/FormField.js
+++ b/src/js/components/FormField/FormField.js
@@ -4,7 +4,6 @@ import React, {
   forwardRef,
   useContext,
   useState,
-  useEffect,
 } from 'react';
 import styled, { ThemeContext } from 'styled-components';
 import { defaultProps } from '../../default-props';
@@ -14,6 +13,7 @@ import {
   shouldKeepFocus,
   withinDropPortal,
   PortalContext,
+  useDebounce,
 } from '../../utils';
 import { focusStyle } from '../../utils/styles';
 import { parseMetricToNum } from '../../utils/mixins';
@@ -154,19 +154,6 @@ const Input = ({ component, disabled, invalid, name, onChange, ...rest }) => {
       {...extraProps}
     />
   );
-};
-
-const useDebounce = () => {
-  const [func, setFunc] = useState();
-  const theme = useContext(ThemeContext) || defaultProps.theme;
-
-  useEffect(() => {
-    let timer;
-    if (func) timer = setTimeout(() => func(), theme.global.debounceDelay);
-    return () => clearTimeout(timer);
-  }, [func, theme.global.debounceDelay]);
-
-  return setFunc;
 };
 
 const FormField = forwardRef(

--- a/src/js/components/Toolbar/__tests__/__snapshots__/Toolbar-test.js.snap
+++ b/src/js/components/Toolbar/__tests__/__snapshots__/Toolbar-test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DataFilters renders 1`] = `
-.c6 {
+.c5 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -12,25 +12,25 @@ exports[`DataFilters renders 1`] = `
   stroke: #666666;
 }
 
-.c6 g {
+.c5 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c6 *:not([stroke])[fill='none'] {
+.c5 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c6 *[stroke*='#'],
-.c6 *[STROKE*='#'] {
+.c5 *[stroke*='#'],
+.c5 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c6 *[fill-rule],
-.c6 *[FILL-RULE],
-.c6 *[fill*='#'],
-.c6 *[FILL*='#'] {
+.c5 *[fill-rule],
+.c5 *[FILL-RULE],
+.c5 *[fill*='#'],
+.c5 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -323,7 +323,7 @@ exports[`DataFilters renders 1`] = `
   border: 0;
 }
 
-.c3 {
+.c7 {
   max-width: 100%;
 }
 
@@ -374,7 +374,7 @@ exports[`DataFilters renders 1`] = `
   flex-shrink: 0;
 }
 
-.c7 {
+.c6 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -391,58 +391,58 @@ exports[`DataFilters renders 1`] = `
   padding-left: 48px;
 }
 
-.c7:focus {
+.c6:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus > circle,
-.c7:focus > ellipse,
-.c7:focus > line,
-.c7:focus > path,
-.c7:focus > polygon,
-.c7:focus > polyline,
-.c7:focus > rect {
+.c6:focus > circle,
+.c6:focus > ellipse,
+.c6:focus > line,
+.c6:focus > path,
+.c6:focus > polygon,
+.c6:focus > polyline,
+.c6:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c7:focus::-moz-focus-inner {
+.c6:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c7::-webkit-input-placeholder {
+.c6::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-moz-placeholder {
+.c6::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c7:-ms-input-placeholder {
+.c6:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c7::-webkit-search-decoration {
+.c6::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c7::-moz-focus-inner {
+.c6::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c7:-moz-placeholder,
-.c7::-moz-placeholder {
+.c6:-moz-placeholder,
+.c6::-moz-placeholder {
   opacity: 1;
 }
 
-.c4 {
+.c3 {
   position: relative;
   width: 100%;
 }
 
-.c5 {
+.c4 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -533,41 +533,37 @@ exports[`DataFilters renders 1`] = `
     <div
       class="c2"
     >
-      <form
+      <div
         class="c3"
       >
         <div
           class="c4"
         >
-          <div
-            class="c5"
-          >
-            <svg
-              aria-label="Search"
-              class="c6"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </div>
-          <input
+          <svg
             aria-label="Search"
-            autocomplete="off"
-            class="c7"
-            id="data--search"
-            name="_search"
-            type="search"
-            value=""
-          />
+            class="c5"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+              fill="none"
+              stroke="#000"
+              stroke-width="2"
+            />
+          </svg>
         </div>
-      </form>
+        <input
+          aria-label="Search"
+          autocomplete="off"
+          class="c6"
+          id="data--search"
+          name="_search"
+          type="search"
+          value=""
+        />
+      </div>
       <form
-        class="c3"
+        class="c7"
       >
         <div
           class="c8"

--- a/src/js/components/Toolbar/__tests__/__snapshots__/Toolbar-test.js.snap
+++ b/src/js/components/Toolbar/__tests__/__snapshots__/Toolbar-test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DataFilters renders 1`] = `
-.c5 {
+.c6 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -12,25 +12,25 @@ exports[`DataFilters renders 1`] = `
   stroke: #666666;
 }
 
-.c5 g {
+.c6 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c5 *:not([stroke])[fill='none'] {
+.c6 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c5 *[stroke*='#'],
-.c5 *[STROKE*='#'] {
+.c6 *[stroke*='#'],
+.c6 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c5 *[fill-rule],
-.c5 *[FILL-RULE],
-.c5 *[fill*='#'],
-.c5 *[FILL*='#'] {
+.c6 *[fill-rule],
+.c6 *[FILL-RULE],
+.c6 *[fill*='#'],
+.c6 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -52,7 +52,21 @@ exports[`DataFilters renders 1`] = `
   flex: 0 0 auto;
 }
 
-.c8 {
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -67,7 +81,7 @@ exports[`DataFilters renders 1`] = `
   height: 100%;
 }
 
-.c9 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -85,7 +99,7 @@ exports[`DataFilters renders 1`] = `
   overflow: auto;
 }
 
-.c10 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -100,7 +114,7 @@ exports[`DataFilters renders 1`] = `
   flex-direction: column;
 }
 
-.c12 {
+.c13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -114,20 +128,6 @@ exports[`DataFilters renders 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   padding: 12px;
-}
-
-.c13 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
 }
 
 .c15 {
@@ -242,7 +242,7 @@ exports[`DataFilters renders 1`] = `
   height: 12px;
 }
 
-.c11 {
+.c12 {
   margin-left: 12px;
   margin-right: 12px;
   margin-top: 6px;
@@ -323,7 +323,7 @@ exports[`DataFilters renders 1`] = `
   border: 0;
 }
 
-.c7 {
+.c8 {
   max-width: 100%;
 }
 
@@ -374,7 +374,7 @@ exports[`DataFilters renders 1`] = `
   flex-shrink: 0;
 }
 
-.c6 {
+.c7 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -391,58 +391,58 @@ exports[`DataFilters renders 1`] = `
   padding-left: 48px;
 }
 
-.c6:focus {
+.c7:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c6:focus > circle,
-.c6:focus > ellipse,
-.c6:focus > line,
-.c6:focus > path,
-.c6:focus > polygon,
-.c6:focus > polyline,
-.c6:focus > rect {
+.c7:focus > circle,
+.c7:focus > ellipse,
+.c7:focus > line,
+.c7:focus > path,
+.c7:focus > polygon,
+.c7:focus > polyline,
+.c7:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c6:focus::-moz-focus-inner {
+.c7:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c6::-webkit-input-placeholder {
+.c7::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c6::-moz-placeholder {
+.c7::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c6:-ms-input-placeholder {
+.c7:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c6::-webkit-search-decoration {
+.c7::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c6::-moz-focus-inner {
+.c7::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c6:-moz-placeholder,
-.c6::-moz-placeholder {
+.c7:-moz-placeholder,
+.c7::-moz-placeholder {
   opacity: 1;
 }
 
-.c3 {
+.c4 {
   position: relative;
   width: 100%;
 }
 
-.c4 {
+.c5 {
   position: absolute;
   display: -webkit-box;
   display: -webkit-flex;
@@ -475,19 +475,19 @@ exports[`DataFilters renders 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c10 {
+  .c11 {
     margin-bottom: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c12 {
+  .c13 {
     border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c12 {
+  .c13 {
     padding: 6px;
   }
 }
@@ -539,55 +539,59 @@ exports[`DataFilters renders 1`] = `
         <div
           class="c4"
         >
-          <svg
-            aria-label="Search"
+          <div
             class="c5"
-            viewBox="0 0 24 24"
           >
-            <path
-              d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
+            <svg
+              aria-label="Search"
+              class="c6"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </div>
+          <input
+            aria-label="Search"
+            autocomplete="off"
+            class="c7"
+            id="data--search"
+            name="_search"
+            type="search"
+            value=""
+          />
         </div>
-        <input
-          aria-label="Search"
-          autocomplete="off"
-          class="c6"
-          id="data--search"
-          name="_search"
-          type="search"
-          value=""
-        />
       </div>
       <form
-        class="c7"
+        class="c8"
       >
         <div
-          class="c8"
+          class="c9"
         >
           <div
-            class="c9"
+            class="c10"
           >
             <div
               class="c1"
             >
               <div
-                class="c10 "
+                class="c11 "
               >
                 <label
-                  class="c11"
+                  class="c12"
                   for="data-name"
                 >
                   name
                 </label>
                 <div
-                  class="c12 FormField__FormFieldContentBox-sc-m9hood-1"
+                  class="c13 FormField__FormFieldContentBox-sc-m9hood-1"
                 >
                   <div
-                    class="c13 StyledCheckBoxGroup-sc-2nhc5d-0"
+                    class="c3 StyledCheckBoxGroup-sc-2nhc5d-0"
                     id="data-name"
                     role="group"
                   >

--- a/src/js/utils/index.js
+++ b/src/js/utils/index.js
@@ -13,4 +13,5 @@ export * from './pagination';
 export * from './PortalContext';
 export * from './refs';
 export * from './responsive';
+export * from './use-debounce';
 export * from './use-keyboard';

--- a/src/js/utils/index.js
+++ b/src/js/utils/index.js
@@ -13,5 +13,4 @@ export * from './pagination';
 export * from './PortalContext';
 export * from './refs';
 export * from './responsive';
-export * from './use-debounce';
 export * from './use-keyboard';

--- a/src/js/utils/use-debounce.js
+++ b/src/js/utils/use-debounce.js
@@ -1,5 +1,6 @@
 import { useContext, useEffect, useState } from 'react';
 import { ThemeContext } from 'styled-components';
+import { defaultProps } from '../default-props';
 
 export const useDebounce = (debounceDelay) => {
   const [func, setFunc] = useState();

--- a/src/js/utils/use-debounce.js
+++ b/src/js/utils/use-debounce.js
@@ -1,0 +1,17 @@
+import { useContext, useEffect, useState } from 'react';
+import { ThemeContext } from 'styled-components';
+
+export const useDebounce = (debounceDelay) => {
+  const [func, setFunc] = useState();
+  const theme = useContext(ThemeContext) || defaultProps.theme;
+  const delay = debounceDelay || theme.global.debounceDelay;
+  useEffect(() => {
+    let timer;
+    if (func) timer = setTimeout(() => func(), delay);
+    return () => clearTimeout(timer);
+  }, [func, delay]);
+
+  return setFunc;
+};
+
+export default useDebounce;


### PR DESCRIPTION
#### What does this PR do?
Remove use of DataForm from DataSearch and instead directly modify the `view`

#### Where should the reviewer start?
DataSearch.js

#### What testing has been done on this PR?
Each of the uses of Data in storybook that have the search ability

#### How should this be manually tested?
Storybook Data examples

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No need

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible
