### PR TITLE
Set min-width of DataFilters layer

### DIFF
--- a/src/js/components/DataFilters/DataFilters.js
+++ b/src/js/components/DataFilters/DataFilters.js
@@ -218,7 +218,7 @@ export const DataFilters = ({
           onClickOutside={() => setShowContent(undefined)}
           onEsc={() => setShowContent(undefined)}
         >
-          {content}
+          <Box width={{ min: 'medium' }}>{content}</Box>
         </Layer>
       )}
     </Box>

--- a/src/js/components/DataFilters/__tests__/__snapshots__/DataFilters-test.tsx.snap
+++ b/src/js/components/DataFilters/__tests__/__snapshots__/DataFilters-test.tsx.snap
@@ -1097,7 +1097,7 @@ exports[`DataFilters layer 1`] = `
 `;
 
 exports[`DataFilters layer 2`] = `
-.c12 {
+.c13 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -1108,30 +1108,30 @@ exports[`DataFilters layer 2`] = `
   stroke: #666666;
 }
 
-.c12 g {
+.c13 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c12 *:not([stroke])[fill='none'] {
+.c13 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c12 *[stroke*='#'],
-.c12 *[STROKE*='#'] {
+.c13 *[stroke*='#'],
+.c13 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c12 *[fill-rule],
-.c12 *[FILL-RULE],
-.c12 *[fill*='#'],
-.c12 *[FILL*='#'] {
+.c13 *[fill-rule],
+.c13 *[FILL-RULE],
+.c13 *[fill*='#'],
+.c13 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
 
-.c7 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1148,7 +1148,22 @@ exports[`DataFilters layer 2`] = `
   flex: 0 0 auto;
 }
 
-.c5 {
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  min-width: 384px;
+}
+
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1163,7 +1178,7 @@ exports[`DataFilters layer 2`] = `
   height: 100%;
 }
 
-.c6 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1184,7 +1199,7 @@ exports[`DataFilters layer 2`] = `
   overflow: auto;
 }
 
-.c8 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1209,7 +1224,7 @@ exports[`DataFilters layer 2`] = `
   justify-content: space-between;
 }
 
-.c13 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1224,7 +1239,7 @@ exports[`DataFilters layer 2`] = `
   flex-direction: column;
 }
 
-.c15 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1240,7 +1255,7 @@ exports[`DataFilters layer 2`] = `
   padding: 12px;
 }
 
-.c16 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1254,7 +1269,7 @@ exports[`DataFilters layer 2`] = `
   flex-direction: column;
 }
 
-.c18 {
+.c19 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1277,7 +1292,7 @@ exports[`DataFilters layer 2`] = `
   justify-content: center;
 }
 
-.c21 {
+.c22 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1303,7 +1318,7 @@ exports[`DataFilters layer 2`] = `
   border-radius: 4px;
 }
 
-.c23 {
+.c24 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1332,7 +1347,7 @@ exports[`DataFilters layer 2`] = `
   padding-bottom: 24px;
 }
 
-.c10 {
+.c11 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -1342,7 +1357,7 @@ exports[`DataFilters layer 2`] = `
   width: 24px;
 }
 
-.c22 {
+.c23 {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -1352,7 +1367,7 @@ exports[`DataFilters layer 2`] = `
   height: 12px;
 }
 
-.c14 {
+.c15 {
   margin-left: 12px;
   margin-right: 12px;
   margin-top: 6px;
@@ -1361,7 +1376,7 @@ exports[`DataFilters layer 2`] = `
   line-height: 24px;
 }
 
-.c11 {
+.c12 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -1381,47 +1396,47 @@ exports[`DataFilters layer 2`] = `
   padding: 12px;
 }
 
-.c11:focus {
+.c12:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus > circle,
-.c11:focus > ellipse,
-.c11:focus > line,
-.c11:focus > path,
-.c11:focus > polygon,
-.c11:focus > polyline,
-.c11:focus > rect {
+.c12:focus > circle,
+.c12:focus > ellipse,
+.c12:focus > line,
+.c12:focus > path,
+.c12:focus > polygon,
+.c12:focus > polyline,
+.c12:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus::-moz-focus-inner {
+.c12:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c11:focus:not(:focus-visible) {
+.c12:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c11:focus:not(:focus-visible) > circle,
-.c11:focus:not(:focus-visible) > ellipse,
-.c11:focus:not(:focus-visible) > line,
-.c11:focus:not(:focus-visible) > path,
-.c11:focus:not(:focus-visible) > polygon,
-.c11:focus:not(:focus-visible) > polyline,
-.c11:focus:not(:focus-visible) > rect {
+.c12:focus:not(:focus-visible) > circle,
+.c12:focus:not(:focus-visible) > ellipse,
+.c12:focus:not(:focus-visible) > line,
+.c12:focus:not(:focus-visible) > path,
+.c12:focus:not(:focus-visible) > polygon,
+.c12:focus:not(:focus-visible) > polyline,
+.c12:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c11:focus:not(:focus-visible)::-moz-focus-inner {
+.c12:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c24 {
+.c25 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -1449,56 +1464,56 @@ exports[`DataFilters layer 2`] = `
   transition-timing-function: ease-in-out;
 }
 
-.c24:hover {
+.c25:hover {
   box-shadow: 0px 0px 0px 2px #7D4CDB;
 }
 
-.c24:focus {
+.c25:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c24:focus > circle,
-.c24:focus > ellipse,
-.c24:focus > line,
-.c24:focus > path,
-.c24:focus > polygon,
-.c24:focus > polyline,
-.c24:focus > rect {
+.c25:focus > circle,
+.c25:focus > ellipse,
+.c25:focus > line,
+.c25:focus > path,
+.c25:focus > polygon,
+.c25:focus > polyline,
+.c25:focus > rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c24:focus::-moz-focus-inner {
+.c25:focus::-moz-focus-inner {
   border: 0;
 }
 
-.c24:focus:not(:focus-visible) {
+.c25:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c24:focus:not(:focus-visible) > circle,
-.c24:focus:not(:focus-visible) > ellipse,
-.c24:focus:not(:focus-visible) > line,
-.c24:focus:not(:focus-visible) > path,
-.c24:focus:not(:focus-visible) > polygon,
-.c24:focus:not(:focus-visible) > polyline,
-.c24:focus:not(:focus-visible) > rect {
+.c25:focus:not(:focus-visible) > circle,
+.c25:focus:not(:focus-visible) > ellipse,
+.c25:focus:not(:focus-visible) > line,
+.c25:focus:not(:focus-visible) > path,
+.c25:focus:not(:focus-visible) > polygon,
+.c25:focus:not(:focus-visible) > polyline,
+.c25:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c24:focus:not(:focus-visible)::-moz-focus-inner {
+.c25:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
-.c4 {
+.c5 {
   max-width: 100%;
   max-height: 100%;
 }
 
-.c17 {
+.c18 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1520,12 +1535,12 @@ exports[`DataFilters layer 2`] = `
   cursor: pointer;
 }
 
-.c17:hover input:not([disabled]) + div,
-.c17:hover input:not([disabled]) + span {
+.c18:hover input:not([disabled]) + div,
+.c18:hover input:not([disabled]) + span {
   border-color: #000000;
 }
 
-.c20 {
+.c21 {
   opacity: 0;
   -moz-appearance: none;
   width: 0;
@@ -1534,18 +1549,18 @@ exports[`DataFilters layer 2`] = `
   cursor: pointer;
 }
 
-.c20:checked + span > span {
+.c21:checked + span > span {
   left: calc( 48px - 24px );
   background: #7D4CDB;
 }
 
-.c19 {
+.c20 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c9 {
+.c10 {
   margin: 0px;
   font-size: 34px;
   line-height: 40px;
@@ -1642,75 +1657,75 @@ exports[`DataFilters layer 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c6 {
+  .c7 {
     padding-left: 12px;
     padding-right: 12px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c6 {
+  .c7 {
     padding-top: 12px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c13 {
+  .c14 {
     margin-bottom: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c15 {
+  .c16 {
     border-bottom: solid 1px rgba(0,0,0,0.33);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c15 {
+  .c16 {
     padding: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c18 {
+  .c19 {
     margin-right: 6px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c21 {
+  .c22 {
     border: solid 2px rgba(0,0,0,0.15);
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c23 {
+  .c24 {
     margin-top: 12px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c23 {
+  .c24 {
     padding-left: 12px;
     padding-right: 12px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c23 {
+  .c24 {
     padding-bottom: 12px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c10 {
+  .c11 {
     width: 12px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c22 {
+  .c23 {
     height: 6px;
   }
 }
@@ -1720,13 +1735,13 @@ exports[`DataFilters layer 2`] = `
 }
 
 @media only screen and (max-width:768px) {
-  .c9 {
+  .c10 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width:768px) {
-  .c9 {
+  .c10 {
     font-size: 26px;
     line-height: 32px;
     max-width: 624px;
@@ -1777,12 +1792,12 @@ exports[`DataFilters layer 2`] = `
       class="c3"
       tabindex="-1"
     />
-    <form
+    <div
       class="c4"
-      fill="vertical"
     >
-      <div
+      <form
         class="c5"
+        fill="vertical"
       >
         <div
           class="c6"
@@ -1790,110 +1805,114 @@ exports[`DataFilters layer 2`] = `
           <div
             class="c7"
           >
-            <header
+            <div
               class="c8"
             >
-              <h2
+              <header
                 class="c9"
               >
-                Filters
-              </h2>
-              <div
-                class="c10"
-              />
-              <button
-                class="c11"
-                type="button"
-              >
-                <svg
-                  aria-label="Close"
-                  class="c12"
-                  viewBox="0 0 24 24"
+                <h2
+                  class="c10"
                 >
-                  <path
-                    d="m3 3 18 18M3 21 21 3"
-                    fill="none"
-                    stroke="#000"
-                    stroke-width="2"
-                  />
-                </svg>
-              </button>
-            </header>
-            <div
-              class="c13 "
-            >
-              <label
-                class="c14"
-                for="test-data-name"
-              >
-                name
-              </label>
-              <div
-                class="c15 FormField__FormFieldContentBox-sc-m9hood-1"
-              >
+                  Filters
+                </h2>
                 <div
-                  class="c16 StyledCheckBoxGroup-sc-2nhc5d-0"
-                  id="test-data-name"
-                  role="group"
+                  class="c11"
+                />
+                <button
+                  class="c12"
+                  type="button"
                 >
-                  <label
-                    class="c17"
-                    label="a"
+                  <svg
+                    aria-label="Close"
+                    class="c13"
+                    viewBox="0 0 24 24"
                   >
-                    <div
-                      class="c18 c19"
-                    >
-                      <input
-                        class="c20"
-                        type="checkbox"
-                      />
-                      <div
-                        class="c21 "
-                      />
-                    </div>
-                    <span>
-                      a
-                    </span>
-                  </label>
+                    <path
+                      d="m3 3 18 18M3 21 21 3"
+                      fill="none"
+                      stroke="#000"
+                      stroke-width="2"
+                    />
+                  </svg>
+                </button>
+              </header>
+              <div
+                class="c14 "
+              >
+                <label
+                  class="c15"
+                  for="test-data-name"
+                >
+                  name
+                </label>
+                <div
+                  class="c16 FormField__FormFieldContentBox-sc-m9hood-1"
+                >
                   <div
-                    class="c22"
-                  />
-                  <label
-                    class="c17"
-                    label="b"
+                    class="c17 StyledCheckBoxGroup-sc-2nhc5d-0"
+                    id="test-data-name"
+                    role="group"
                   >
-                    <div
-                      class="c18 c19"
+                    <label
+                      class="c18"
+                      label="a"
                     >
-                      <input
-                        class="c20"
-                        type="checkbox"
-                      />
                       <div
-                        class="c21 "
-                      />
-                    </div>
-                    <span>
-                      b
-                    </span>
-                  </label>
+                        class="c19 c20"
+                      >
+                        <input
+                          class="c21"
+                          type="checkbox"
+                        />
+                        <div
+                          class="c22 "
+                        />
+                      </div>
+                      <span>
+                        a
+                      </span>
+                    </label>
+                    <div
+                      class="c23"
+                    />
+                    <label
+                      class="c18"
+                      label="b"
+                    >
+                      <div
+                        class="c19 c20"
+                      >
+                        <input
+                          class="c21"
+                          type="checkbox"
+                        />
+                        <div
+                          class="c22 "
+                        />
+                      </div>
+                      <span>
+                        b
+                      </span>
+                    </label>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
-        </div>
-        <footer
-          class="c23"
-        >
-          <button
+          <footer
             class="c24"
-            type="submit"
           >
-            Apply filters
-          </button>
-        </footer>
-      </div>
-    </form>
+            <button
+              class="c25"
+              type="submit"
+            >
+              Apply filters
+            </button>
+          </footer>
+        </div>
+      </form>
+    </div>
   </div>
 </div>
 `;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Sets min-width of medium on DataFilters layer for more reasonable default width. With removal of "undo changes" which previously was holding some space to make the layer wider, the DataFilter layer was rendering quite narrow if the data labels were short. This sets a reasonable default for consistency.

#### Where should the reviewer start?
src/js/components/DataFilters/DataFilters.js

#### What testing has been done on this PR?

BEFORE
<img width="1417" alt="Screen Shot 2024-01-23 at 5 23 50 PM" src="https://github.com/grommet/grommet/assets/12522275/207915d0-0c03-4c06-beb4-fdab275fdf9f">

AFTER
<img width="1419" alt="Screen Shot 2024-01-23 at 5 19 40 PM" src="https://github.com/grommet/grommet/assets/12522275/e2f96336-b97a-4be8-a089-18e7c11ebc51">

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
