### PR TITLE
Adjust logic in DataClearFilters story

### DIFF
--- a/src/js/components/DataClearFilters/stories/Simple.js
+++ b/src/js/components/DataClearFilters/stories/Simple.js
@@ -49,7 +49,7 @@ export const Simple = () => (
 );
 
 const DataToolbar = () => {
-  const { filteredTotal, total } = useContext(DataContext);
+  const { view } = useContext(DataContext);
 
   return (
     <Toolbar gap="medium" align="end">
@@ -75,7 +75,7 @@ const DataToolbar = () => {
           <DataFilter property="percent" />
           <DataFilter property="paid" />
         </DataFilters>
-        {filteredTotal !== total ? <DataClearFilters /> : null}
+        {view?.properties !== undefined ? <DataClearFilters /> : null}
       </Toolbar>
       <DataView />
     </Toolbar>


### PR DESCRIPTION
#### What does this PR do?
When you type into the search field on the DataClearFilters/Simple story the clear filters button is displayed. When the clear filters button is clicked it doesn't clear out the search field. This PR adjusts the logic so the clear filters button is only displayed when DataFilters are applied.

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
backwards compatible