### PR TITLE
Implement DataSearch updateOn property

### DIFF
--- a/src/js/components/DataSearch/__tests__/DataSearch-test.tsx
+++ b/src/js/components/DataSearch/__tests__/DataSearch-test.tsx
@@ -60,3 +60,29 @@ describe('DataSearch', () => {
     expectPortal('test-data--search-control').toMatchSnapshot();
   });
 });
+
+test('enter', async () => {
+  jest.useFakeTimers();
+  const onView = jest.fn();
+  const { getByRole } = render(
+    <Grommet>
+      <Data data={data} onView={onView}>
+        <DataSearch data-testid="input_submit" updateOn="submit" />
+      </Data>
+    </Grommet>,
+  );
+  const searchbox = getByRole('searchbox');
+  expect(searchbox).toBeTruthy();
+
+  fireEvent.change(searchbox, { target: { value: 'one' } });
+  act(() => jest.advanceTimersByTime(300));
+
+  fireEvent.keyDown(searchbox, { key: 'enter', keyCode: 13 });
+
+  expect(onView).toHaveBeenNthCalledWith(
+    1,
+    expect.objectContaining({
+      search: 'one',
+    }),
+  );
+}, 20000);

--- a/src/js/components/DataSearch/index.d.ts
+++ b/src/js/components/DataSearch/index.d.ts
@@ -4,6 +4,7 @@ import { TextInputProps } from '../TextInput/index';
 export interface DataSearchProps {
   drop?: boolean;
   responsive?: boolean;
+  updateOn?: string;
 }
 
 export interface DataSearchExtendedProps

--- a/src/js/components/DataSearch/index.d.ts
+++ b/src/js/components/DataSearch/index.d.ts
@@ -4,7 +4,7 @@ import { TextInputProps } from '../TextInput/index';
 export interface DataSearchProps {
   drop?: boolean;
   responsive?: boolean;
-  updateOn?: string;
+  updateOn?: 'change' | 'submit';
 }
 
 export interface DataSearchExtendedProps

--- a/src/js/components/DataSearch/propTypes.js
+++ b/src/js/components/DataSearch/propTypes.js
@@ -5,6 +5,7 @@ if (process.env.NODE_ENV !== 'production') {
   PropType = {
     drop: PropTypes.bool,
     responsive: PropTypes.bool,
+    updateOn: PropTypes.oneOf(['change', 'submit']),
   };
 }
 export const DataSearchPropTypes = PropType;

--- a/src/js/components/DataSearch/stories/ChangeonEnter.js
+++ b/src/js/components/DataSearch/stories/ChangeonEnter.js
@@ -1,0 +1,30 @@
+import React from 'react';
+
+import { Data, DataSummary, DataTable, Grid, Paragraph } from 'grommet';
+
+import { DataSearch } from '../DataSearch';
+import { columns, DATA } from '../../DataTable/stories/data';
+
+export const ChangeOnEnter = () => (
+  // Uncomment <Grommet> lines when using outside of storybook
+  // <Grommet theme={...}>
+  <Grid pad="large" columns={[['medium', 'large']]} justifyContent="center">
+    <Paragraph color="text-weak">
+      Note: Results are filtered once you hit enter.
+    </Paragraph>
+    <Data data={DATA}>
+      <DataSearch updateOn="submit" />
+      <DataSummary />
+      <DataTable columns={columns} />
+    </Data>
+  </Grid>
+  // </Grommet>
+);
+
+ChangeOnEnter.args = {
+  full: true,
+};
+
+export default {
+  title: 'Data/DataSearch/ChangeOnEnter',
+};

--- a/src/js/components/DataSearch/stories/UpdateOnSubmit.js
+++ b/src/js/components/DataSearch/stories/UpdateOnSubmit.js
@@ -25,6 +25,10 @@ UpdateOnSubmit.args = {
   full: true,
 };
 
+UpdateOnSubmit.parameters = {
+  chromatic: { disable: true },
+};
+
 UpdateOnSubmit.storyName = 'Update on submit';
 
 export default {

--- a/src/js/components/DataSearch/stories/UpdateOnSubmit.js
+++ b/src/js/components/DataSearch/stories/UpdateOnSubmit.js
@@ -25,6 +25,8 @@ UpdateOnSubmit.args = {
   full: true,
 };
 
+UpdateOnSubmit.storyName = 'Update on submit';
+
 export default {
-  title: 'Data/DataSearch/UpdateOnSubmit',
+  title: 'Data/DataSearch/Update on submit',
 };

--- a/src/js/components/DataSearch/stories/UpdateOnSubmit.js
+++ b/src/js/components/DataSearch/stories/UpdateOnSubmit.js
@@ -5,7 +5,7 @@ import { Data, DataSummary, DataTable, Grid, Paragraph } from 'grommet';
 import { DataSearch } from '../DataSearch';
 import { columns, DATA } from '../../DataTable/stories/data';
 
-export const ChangeOnEnter = () => (
+export const UpdateOnSubmit = () => (
   // Uncomment <Grommet> lines when using outside of storybook
   // <Grommet theme={...}>
   <Grid pad="large" columns={[['medium', 'large']]} justifyContent="center">
@@ -21,10 +21,10 @@ export const ChangeOnEnter = () => (
   // </Grommet>
 );
 
-ChangeOnEnter.args = {
+UpdateOnSubmit.args = {
   full: true,
 };
 
 export default {
-  title: 'Data/DataSearch/ChangeOnEnter',
+  title: 'Data/DataSearch/UpdateOnSubmit',
 };


### PR DESCRIPTION
This is an updated version of PR #7029 originally raised by @anoopadvaitha.

Currently DataSearch filters data as soon as we start typing (onchange). This becomes challenge in scenarios where the data is fetched from API. 


#### What does this PR do?
The PR provides updateOn parameter which is passed to DataForm so that developer can leverage to either use change or submit. 

#### Where should the reviewer start?
\src\js\components\DataSearch\DataSearch.js

#### What testing has been done on this PR?
Tested when no value is provided for DataSearch and when submit is provided and works in both scenarios. 

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
#7024 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Yes, will be raising the PR on that

#### Should this PR be mentioned in the release notes?
No.

#### Is this change backwards compatible or is it a breaking change?
Yes