### PR TITLE
Fix undefined case for DataFilter

### DIFF
--- a/src/js/components/DataFilter/DataFilter.js
+++ b/src/js/components/DataFilter/DataFilter.js
@@ -15,8 +15,7 @@ const minSelectSearchOptions = 10;
 const defaultRangeSteps = 20;
 
 const getValueAt = (valueObject, pathArg) => {
-  if (!pathArg) return undefined;
-  if (valueObject === undefined) return undefined;
+  if (!pathArg || valueObject === undefined) return undefined;
   const path = Array.isArray(pathArg) ? pathArg : pathArg.split('.');
   if (path.length === 1) return valueObject[path];
   return getValueAt(valueObject[path.shift()], path);

--- a/src/js/components/DataFilter/DataFilter.js
+++ b/src/js/components/DataFilter/DataFilter.js
@@ -15,6 +15,7 @@ const minSelectSearchOptions = 10;
 const defaultRangeSteps = 20;
 
 const getValueAt = (valueObject, pathArg) => {
+  if (!pathArg) return undefined;
   if (valueObject === undefined) return undefined;
   const path = Array.isArray(pathArg) ? pathArg : pathArg.split('.');
   if (path.length === 1) return valueObject[path];


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

When testing Grommet designer, if DataFilter was added and no `property` had been defined yet, the app would crash.

In a Typescript project, the typings would already flag that `property` is required, so this is a fix for non-Typescript projects.

#### Where should the reviewer start?

#### What testing has been done on this PR?
Tested locally in storybook.

#### How should this be manually tested?

```
<DataFilter />
```
#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

Got this error in Grommet designer:

<img width="841" alt="Screen Shot 2024-01-29 at 4 18 27 PM" src="https://github.com/grommet/grommet/assets/12522275/77e512d8-b325-4b31-97dc-7d914c90e3d4">

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.