### PR TITLE
remove stable notification from storybook for data components

### DIFF
--- a/src/js/components/Cards/stories/Simple.js
+++ b/src/js/components/Cards/stories/Simple.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Grid, Notification } from 'grommet';
+import { Grid } from 'grommet';
 import { Cards } from '../Cards';
 
 const locations = [
@@ -17,10 +17,6 @@ export const Simple = () => (
     justifyContent="center"
     gap="large"
   >
-    <Notification
-      status="info"
-      message="Cards is in 'beta'. The API surface is subject to change."
-    />
     <Cards a11yTitle="Locations" data={locations} />
   </Grid>
 );

--- a/src/js/components/Data/stories/Cards.js
+++ b/src/js/components/Data/stories/Cards.js
@@ -11,7 +11,6 @@ import {
   DataSummary,
   Grid,
   Heading,
-  Notification,
   Toolbar,
 } from 'grommet';
 
@@ -28,10 +27,6 @@ export const Example = () => (
     justifyContent="center"
     gap="large"
   >
-    <Notification
-      status="info"
-      message="Data is in 'beta'. The API surface is subject to change."
-    />
     <Data data={DATA}>
       <Toolbar>
         <DataSearch />

--- a/src/js/components/Data/stories/Complex.js
+++ b/src/js/components/Data/stories/Complex.js
@@ -6,7 +6,6 @@ import {
   DataFilters,
   DataSearch,
   DataSummary,
-  Notification,
   Text,
   Toolbar,
 } from 'grommet';
@@ -90,10 +89,6 @@ export const Complex = () => (
     justifyContent="center"
     gap="large"
   >
-    <Notification
-      status="info"
-      message="Data is in 'beta'. The API surface is subject to change."
-    />
     <Data data={data} properties={properties}>
       <Toolbar>
         <DataSearch />

--- a/src/js/components/Data/stories/Controlled.js
+++ b/src/js/components/Data/stories/Controlled.js
@@ -7,7 +7,6 @@ import {
   DataSummary,
   DataTable,
   Grid,
-  Notification,
   Toolbar,
 } from 'grommet';
 
@@ -67,10 +66,6 @@ export const Controlled = () => {
       justifyContent="center"
       gap="large"
     >
-      <Notification
-        status="info"
-        message="Data is in 'beta'. The API surface is subject to change."
-      />
       <Data
         data={data}
         total={DATA.length}

--- a/src/js/components/Data/stories/DataTable.js
+++ b/src/js/components/Data/stories/DataTable.js
@@ -9,7 +9,6 @@ import {
   DataSummary,
   DataTable,
   Grid,
-  Notification,
   Toolbar,
 } from 'grommet';
 
@@ -27,10 +26,6 @@ export const Table = () => (
     alignContent="start"
     gap="large"
   >
-    <Notification
-      status="info"
-      message="Data is in 'beta'. The API surface is subject to change."
-    />
     <Data data={DATA}>
       <Toolbar>
         <DataSearch />

--- a/src/js/components/Data/stories/Infinite.js
+++ b/src/js/components/Data/stories/Infinite.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
-import { Box, DataTable, Data, Grid, Notification, Text, Tip } from 'grommet';
+import { Box, DataTable, Data, Grid, Text, Tip } from 'grommet';
 
 import { StatusCritical } from 'grommet-icons';
 
@@ -162,10 +162,6 @@ export const Table = () => {
       justifyContent="center"
       gap="large"
     >
-      <Notification
-        status="info"
-        message="Data is in 'beta'. The API surface is subject to change."
-      />
       <Box>
         <Data
           properties={{

--- a/src/js/components/Data/stories/Inline.js
+++ b/src/js/components/Data/stories/Inline.js
@@ -9,7 +9,6 @@ import {
   DataTableGroupBy,
   Grid,
   Heading,
-  Notification,
   ResponsiveContext,
   Toolbar,
 } from 'grommet';
@@ -72,12 +71,6 @@ export const Inline = () => {
       }}
       data={DATA}
     >
-      <Box pad={{ top: 'medium' }} align="center">
-        <Notification
-          status="info"
-          message="Data is in 'beta'. The API surface is subject to change."
-        />
-      </Box>
       <Grid
         columns={sidebar ? ['auto', ['small', 'large']] : 'auto'}
         gap="large"

--- a/src/js/components/Data/stories/List.js
+++ b/src/js/components/Data/stories/List.js
@@ -7,7 +7,6 @@ import {
   DataSummary,
   Grid,
   List,
-  Notification,
   Toolbar,
 } from 'grommet';
 
@@ -24,10 +23,6 @@ export const Example = () => (
     justifyContent="center"
     gap="large"
   >
-    <Notification
-      status="info"
-      message="Data is in 'beta'. The API surface is subject to change."
-    />
     <Data data={DATA}>
       <Toolbar>
         <DataSearch />

--- a/src/js/components/Data/stories/Properties.js
+++ b/src/js/components/Data/stories/Properties.js
@@ -11,7 +11,6 @@ import {
   DataSort,
   DataSearch,
   DataFilters,
-  Notification,
   Text,
   Toolbar,
 } from 'grommet';
@@ -34,11 +33,6 @@ export const Properties = () => (
     pad="xlarge"
     gap="medium"
   >
-    <Notification
-      fill="horizontal"
-      status="info"
-      message="Data is in 'beta'. The API surface is subject to change."
-    />
     <Data
       data={DATA}
       updateOn="change"

--- a/src/js/components/Data/stories/Simple.js
+++ b/src/js/components/Data/stories/Simple.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Grid, DataTable, Notification } from 'grommet';
+import { Grid, DataTable } from 'grommet';
 
 import { Data } from '../Data';
 import { columns, DATA } from '../../DataTable/stories/data';
@@ -15,10 +15,6 @@ export const Simple = () => (
     justifyContent="center"
     gap="large"
   >
-    <Notification
-      status="info"
-      message="Data is in 'beta'. The API surface is subject to change."
-    />
     <Data data={DATA} toolbar>
       <DataTable columns={columns} />
     </Data>

--- a/src/js/components/Data/stories/SpaceX.js
+++ b/src/js/components/Data/stories/SpaceX.js
@@ -6,7 +6,6 @@ import {
   Data,
   Footer,
   Grid,
-  Notification,
   Pagination,
   Text,
   Tip,
@@ -185,10 +184,6 @@ export const SpaceX = () => {
       justifyContent="center"
       gap="large"
     >
-      <Notification
-        status="info"
-        message="Data is in 'beta'. The API surface is subject to change."
-      />
       <Box>
         <Data
           properties={{

--- a/src/js/components/Data/stories/StarWars.js
+++ b/src/js/components/Data/stories/StarWars.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { Box, Data, Grid, List, Notification, Pagination } from 'grommet';
+import { Box, Data, Grid, List, Pagination } from 'grommet';
 
 // Uses the StarWars API for starships, see https://swapi.dev
 
@@ -57,10 +57,6 @@ export const StarWars = () => {
       justifyContent="center"
       gap="large"
     >
-      <Notification
-        status="info"
-        message="Data is in 'beta'. The API surface is subject to change."
-      />
       <Box skeleton={!result.data}>
         <Data
           data={result.data}

--- a/src/js/components/Data/stories/Views.js
+++ b/src/js/components/Data/stories/Views.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Grid, DataTable, Notification } from 'grommet';
+import { Grid, DataTable } from 'grommet';
 
 import { Data } from '../Data';
 import { columns, DATA } from '../../DataTable/stories/data';
@@ -15,10 +15,6 @@ export const Views = () => (
     justifyContent="center"
     gap="large"
   >
-    <Notification
-      status="info"
-      message="Data is in 'beta'. The API surface is subject to change."
-    />
     <Data
       data={DATA}
       views={[

--- a/src/js/components/DataFilter/stories/Simple.js
+++ b/src/js/components/DataFilter/stories/Simple.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Box, Data, Notification } from 'grommet';
+import { Box, Data } from 'grommet';
 
 import { DataFilter } from '../DataFilter';
 import { DATA } from '../../DataTable/stories/data';
@@ -9,10 +9,6 @@ export const Simple = () => (
   // Uncomment <Grommet> lines when using outside of storybook
   // <Grommet theme={...}>
   <Box align="center" justify="start" pad="large" gap="medium">
-    <Notification
-      status="info"
-      message="Data is in 'beta'. The API surface is subject to change."
-    />
     <Data data={DATA}>
       <DataFilter property="location" />
     </Data>

--- a/src/js/components/DataFilters/stories/Drop.js
+++ b/src/js/components/DataFilters/stories/Drop.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Box, Data, DataFilter, Notification } from 'grommet';
+import { Box, Data, DataFilter } from 'grommet';
 
 import { DataFilters } from '../DataFilters';
 import { DATA } from '../../DataTable/stories/data';
@@ -9,10 +9,6 @@ export const Drop = () => (
   // Uncomment <Grommet> lines when using outside of storybook
   // <Grommet theme={...}>
   <Box align="center" justify="start" pad="large" gap="medium">
-    <Notification
-      status="info"
-      message="Data is in 'beta'. The API surface is subject to change."
-    />
     <Data data={DATA}>
       <DataFilters drop>
         <DataFilter property="location" />

--- a/src/js/components/DataFilters/stories/Inline.js
+++ b/src/js/components/DataFilters/stories/Inline.js
@@ -1,14 +1,6 @@
 import React from 'react';
 
-import {
-  Box,
-  Data,
-  DataFilter,
-  DataSearch,
-  DataSort,
-  DataView,
-  Notification,
-} from 'grommet';
+import { Box, Data, DataFilter, DataSearch, DataSort, DataView } from 'grommet';
 
 import { DataFilters } from '../DataFilters';
 import { DATA } from '../../DataTable/stories/data';
@@ -17,10 +9,6 @@ export const Inline = () => (
   // Uncomment <Grommet> lines when using outside of storybook
   // <Grommet theme={...}>
   <Box align="center" justify="start" pad="large" gap="medium">
-    <Notification
-      status="info"
-      message="Data is in 'beta'. The API surface is subject to change."
-    />
     <Data
       data={DATA}
       views={[

--- a/src/js/components/DataFilters/stories/Layer.js
+++ b/src/js/components/DataFilters/stories/Layer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Box, Data, DataFilter, Notification } from 'grommet';
+import { Box, Data, DataFilter } from 'grommet';
 
 import { DataFilters } from '../DataFilters';
 import { DATA } from '../../DataTable/stories/data';
@@ -9,10 +9,6 @@ export const Layer = () => (
   // Uncomment <Grommet> lines when using outside of storybook
   // <Grommet theme={...}>
   <Box align="center" justify="start" pad="large" gap="medium">
-    <Notification
-      status="info"
-      message="Data is in 'beta'. The API surface is subject to change."
-    />
     <Data data={DATA}>
       <DataFilters layer>
         <DataFilter property="name" />

--- a/src/js/components/DataFilters/stories/Simple.js
+++ b/src/js/components/DataFilters/stories/Simple.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Box, Data, Notification } from 'grommet';
+import { Box, Data } from 'grommet';
 
 import { DataFilters } from '../DataFilters';
 import { DATA } from '../../DataTable/stories/data';
@@ -9,10 +9,6 @@ export const Simple = () => (
   // Uncomment <Grommet> lines when using outside of storybook
   // <Grommet theme={...}>
   <Box align="center" justify="start" pad="large" gap="medium">
-    <Notification
-      status="info"
-      message="Data is in 'beta'. The API surface is subject to change."
-    />
     <Data data={DATA}>
       <DataFilters />
     </Data>

--- a/src/js/components/DataSearch/stories/Drop.js
+++ b/src/js/components/DataSearch/stories/Drop.js
@@ -1,13 +1,6 @@
 import React from 'react';
 
-import {
-  Data,
-  DataSummary,
-  DataTable,
-  Grid,
-  Notification,
-  Paragraph,
-} from 'grommet';
+import { Data, DataSummary, DataTable, Grid, Paragraph } from 'grommet';
 
 import { DataSearch } from '../DataSearch';
 import { columns, DATA } from '../../DataTable/stories/data';
@@ -16,10 +9,6 @@ export const Drop = () => (
   // Uncomment <Grommet> lines when using outside of storybook
   // <Grommet theme={...}>
   <Grid pad="large" columns={['large']} justifyContent="center">
-    <Notification
-      status="info"
-      message="Data is in 'beta'. The API surface is subject to change."
-    />
     <Paragraph color="text-weak">
       Note: Results are filtered as you type, checking all fields.
     </Paragraph>

--- a/src/js/components/DataSearch/stories/Responsive.js
+++ b/src/js/components/DataSearch/stories/Responsive.js
@@ -1,13 +1,6 @@
 import React from 'react';
 
-import {
-  Data,
-  DataSummary,
-  DataTable,
-  Grid,
-  Notification,
-  Paragraph,
-} from 'grommet';
+import { Data, DataSummary, DataTable, Grid, Paragraph } from 'grommet';
 
 import { DataSearch } from '../DataSearch';
 import { columns, DATA } from '../../DataTable/stories/data';
@@ -16,10 +9,6 @@ export const Responsive = () => (
   // Uncomment <Grommet> lines when using outside of storybook
   // <Grommet theme={...}>
   <Grid pad="large" columns={[['medium', 'large']]} justifyContent="center">
-    <Notification
-      status="info"
-      message="Data is in 'beta'. The API surface is subject to change."
-    />
     <Paragraph color="text-weak">
       Note: Results are filtered as you type, checking all fields.
     </Paragraph>

--- a/src/js/components/DataSearch/stories/Simple.js
+++ b/src/js/components/DataSearch/stories/Simple.js
@@ -1,13 +1,6 @@
 import React from 'react';
 
-import {
-  Data,
-  DataSummary,
-  DataTable,
-  Grid,
-  Notification,
-  Paragraph,
-} from 'grommet';
+import { Data, DataSummary, DataTable, Grid, Paragraph } from 'grommet';
 
 import { DataSearch } from '../DataSearch';
 import { columns, DATA } from '../../DataTable/stories/data';
@@ -16,10 +9,6 @@ export const Simple = () => (
   // Uncomment <Grommet> lines when using outside of storybook
   // <Grommet theme={...}>
   <Grid pad="large" columns={['large']} justifyContent="center">
-    <Notification
-      status="info"
-      message="Data is in 'beta'. The API surface is subject to change."
-    />
     <Paragraph color="text-weak">
       Note: Results are filtered as you type, checking all fields.
     </Paragraph>

--- a/src/js/components/DataSort/stories/Drop.js
+++ b/src/js/components/DataSort/stories/Drop.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Box, Data, DataTable, Notification, Toolbar } from 'grommet';
+import { Box, Data, DataTable, Toolbar } from 'grommet';
 
 import { DataSort } from '../DataSort';
 import { columns, DATA } from '../../DataTable/stories/data';
@@ -9,10 +9,6 @@ export const Drop = () => (
   // Uncomment <Grommet> lines when using outside of storybook
   // <Grommet theme={...}>
   <Box align="center" justify="start" pad="large" gap="medium">
-    <Notification
-      status="info"
-      message="Data is in 'beta'. The API surface is subject to change."
-    />
     <Data data={DATA}>
       <Toolbar>
         <DataSort drop />

--- a/src/js/components/DataSort/stories/Simple.js
+++ b/src/js/components/DataSort/stories/Simple.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Box, Data, DataTable, Notification } from 'grommet';
+import { Box, Data, DataTable } from 'grommet';
 
 import { DataSort } from '../DataSort';
 import { columns, DATA } from '../../DataTable/stories/data';
@@ -9,10 +9,6 @@ export const Simple = () => (
   // Uncomment <Grommet> lines when using outside of storybook
   // <Grommet theme={...}>
   <Box align="center" justify="start" pad="large" gap="medium">
-    <Notification
-      status="info"
-      message="Data is in 'beta'. The API surface is subject to change."
-    />
     <Data data={DATA}>
       <DataSort />
       <DataTable columns={columns} />

--- a/src/js/components/DataSummary/stories/Simple.js
+++ b/src/js/components/DataSummary/stories/Simple.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Box, Data, DataTable, Notification } from 'grommet';
+import { Box, Data, DataTable } from 'grommet';
 
 import { DataSummary } from '../DataSummary';
 import { columns, DATA } from '../../DataTable/stories/data';
@@ -9,10 +9,6 @@ export const Simple = () => (
   // Uncomment <Grommet> lines when using outside of storybook
   // <Grommet theme={...}>
   <Box align="center" justify="start" pad="large" gap="medium">
-    <Notification
-      status="info"
-      message="Data is in 'beta'. The API surface is subject to change."
-    />
     <Data data={DATA}>
       <DataSummary />
       <DataTable columns={columns} />

--- a/src/js/components/DataTableColumns/stories/Simple.js
+++ b/src/js/components/DataTableColumns/stories/Simple.js
@@ -6,7 +6,6 @@ import {
   DataSearch,
   DataSummary,
   DataTable,
-  Notification,
   Toolbar,
 } from 'grommet';
 
@@ -23,10 +22,6 @@ export const Simple = () => (
   // Uncomment <Grommet> lines when using outside of storybook
   // <Grommet theme={...}>
   <Box align="center" justify="start" pad="large" gap="medium">
-    <Notification
-      status="info"
-      message="Data is in 'beta'. The API surface is subject to change."
-    />
     <Data data={DATA}>
       <Toolbar>
         <DataSearch />

--- a/src/js/components/DataTableGroupBy/stories/Simple.js
+++ b/src/js/components/DataTableGroupBy/stories/Simple.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Box, Data, DataTable, Notification, Toolbar } from 'grommet';
+import { Box, Data, DataTable, Toolbar } from 'grommet';
 
 import { DataTableGroupBy } from '../DataTableGroupBy';
 import { columns, DATA } from '../../DataTable/stories/data';
@@ -14,10 +14,6 @@ export const Simple = () => (
   // Uncomment <Grommet> lines when using outside of storybook
   // <Grommet theme={...}>
   <Box align="center" justify="start" pad="large" gap="medium">
-    <Notification
-      status="info"
-      message="Data is in 'beta'. The API surface is subject to change."
-    />
     <Data data={DATA}>
       <Toolbar>
         <DataTableGroupBy options={options} />

--- a/src/js/components/DataView/stories/Simple.js
+++ b/src/js/components/DataView/stories/Simple.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Box, Data, DataTable, Notification } from 'grommet';
+import { Box, Data, DataTable } from 'grommet';
 
 import { DataView } from '../DataView';
 import { DATA } from '../../DataTable/stories/data';
@@ -9,10 +9,7 @@ export const Simple = () => (
   // Uncomment <Grommet> lines when using outside of storybook
   // <Grommet theme={...}>
   <Box align="center" justify="start" pad="large" gap="medium">
-    <Notification
-      status="info"
-      message="Data is in 'beta'. The API surface is subject to change."
-    />
+    s
     <Data
       data={DATA}
       views={[

--- a/src/js/components/DataView/stories/Simple.js
+++ b/src/js/components/DataView/stories/Simple.js
@@ -9,7 +9,6 @@ export const Simple = () => (
   // Uncomment <Grommet> lines when using outside of storybook
   // <Grommet theme={...}>
   <Box align="center" justify="start" pad="large" gap="medium">
-    s
     <Data
       data={DATA}
       views={[

--- a/src/js/components/Toolbar/stories/Simple.js
+++ b/src/js/components/Toolbar/stories/Simple.js
@@ -1,13 +1,6 @@
 import React from 'react';
 
-import {
-  Box,
-  Button,
-  Data,
-  DataFilters,
-  DataSearch,
-  Notification,
-} from 'grommet';
+import { Box, Button, Data, DataFilters, DataSearch } from 'grommet';
 
 import { Toolbar } from '../Toolbar';
 import { DATA } from '../../DataTable/stories/data';
@@ -16,10 +9,6 @@ export const Simple = () => (
   // Uncomment <Grommet> lines when using outside of storybook
   // <Grommet theme={...}>
   <Box fill align="center" justify="start" pad="large" gap="large">
-    <Notification
-      status="info"
-      message="Toolbar is in 'beta'. The API surface is subject to change."
-    />
     <Box width="large">
       <Data data={DATA}>
         <Toolbar>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
removes stable flag from data and friends components 
#### Where should the reviewer start?
stories
#### What testing has been done on this PR?
locally 
#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
when we are ready for release we can merge and update our storybook
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
