### PR TITLE
Align Data+friends propTypes/index.d.ts to latest behavior

### DIFF
--- a/src/js/components/Data/index.d.ts
+++ b/src/js/components/Data/index.d.ts
@@ -16,7 +16,7 @@ export interface View {
   search?: string;
   sort?: {
     property: string;
-    direction: 'asc' | 'desc';
+    direction: string;
   };
   step?: number; // page size
 
@@ -73,18 +73,24 @@ export interface DataProps {
       clear?: string;
       heading?: string;
       open?: string;
+      openSet?: {
+        singular?: string;
+        plural?: string;
+      };
     };
     dataForm?: {
       submit?: string;
     };
     dataSearch?: {
       label?: string;
+      open?: string;
     };
     dataSort?: {
       ascending?: string;
       by?: string;
       descending?: string;
       direction?: string;
+      open?: string;
     };
     dataSummary?: {
       filtered?: string;
@@ -93,6 +99,19 @@ export interface DataProps {
       itemsSingle?: string;
       total?: string;
       totalSingle?: string;
+    };
+    dataTableColumns?: {
+      open?: string;
+      order?: string;
+      select?: string;
+      tip?: string;
+    };
+    dataTableGroupBy?: {
+      clear?: string;
+      label?: string;
+    };
+    dataView?: {
+      label?: string;
     };
   };
 

--- a/src/js/components/Data/index.d.ts
+++ b/src/js/components/Data/index.d.ts
@@ -37,7 +37,7 @@ export interface DataProps {
   onView?: (view: View) => void;
 
   // whether to render a Toolbar
-  toolbar?: boolean | 'search' | 'filters';
+  toolbar?: boolean | 'search' | 'filters' | 'view';
 
   properties?:
     | string[]
@@ -75,7 +75,6 @@ export interface DataProps {
       open?: string;
     };
     dataForm?: {
-      reset?: string;
       submit?: string;
     };
     dataSearch?: {
@@ -88,8 +87,12 @@ export interface DataProps {
       direction?: string;
     };
     dataSummary?: {
-      filteredTotal?: string;
+      filtered?: string;
+      filteredSingle?: string;
+      items?: string;
+      itemsSingle?: string;
       total?: string;
+      totalSingle?: string;
     };
   };
 

--- a/src/js/components/Data/propTypes.js
+++ b/src/js/components/Data/propTypes.js
@@ -24,18 +24,24 @@ if (process.env.NODE_ENV !== 'production') {
         clear: PropTypes.string,
         heading: PropTypes.string,
         open: PropTypes.string,
+        openSet: PropTypes.shape({
+          singular: PropTypes.string,
+          plural: PropTypes.string,
+        }),
       }),
       dataForm: PropTypes.shape({
         submit: PropTypes.string,
       }),
       dataSearch: PropTypes.shape({
         label: PropTypes.string,
+        open: PropTypes.string,
       }),
       dataSort: PropTypes.shape({
         ascending: PropTypes.string,
         by: PropTypes.string,
         descending: PropTypes.string,
         direction: PropTypes.string,
+        open: PropTypes.string,
       }),
       dataSummary: PropTypes.shape({
         filtered: PropTypes.string,
@@ -45,6 +51,19 @@ if (process.env.NODE_ENV !== 'production') {
         total: PropTypes.string,
         totalSingle: PropTypes.string,
       }),
+      dataTableColumns: {
+        open: PropTypes.string,
+        order: PropTypes.string,
+        select: PropTypes.string,
+        tip: PropTypes.string,
+      },
+      dataTableGroupBy: {
+        clear: PropTypes.string,
+        label: PropTypes.string,
+      },
+      dataView: {
+        label: PropTypes.string,
+      },
     }),
     onView: PropTypes.func,
     properties: PropTypes.oneOfType([

--- a/src/js/components/Data/propTypes.js
+++ b/src/js/components/Data/propTypes.js
@@ -51,19 +51,19 @@ if (process.env.NODE_ENV !== 'production') {
         total: PropTypes.string,
         totalSingle: PropTypes.string,
       }),
-      dataTableColumns: {
+      dataTableColumns: PropTypes.shape({
         open: PropTypes.string,
         order: PropTypes.string,
         select: PropTypes.string,
         tip: PropTypes.string,
-      },
-      dataTableGroupBy: {
+      }),
+      dataTableGroupBy: PropTypes.shape({
         clear: PropTypes.string,
         label: PropTypes.string,
-      },
-      dataView: {
+      }),
+      dataView: PropTypes.shape({
         label: PropTypes.string,
-      },
+      }),
     }),
     onView: PropTypes.func,
     properties: PropTypes.oneOfType([

--- a/src/js/components/Data/propTypes.js
+++ b/src/js/components/Data/propTypes.js
@@ -17,6 +17,35 @@ if (process.env.NODE_ENV !== 'production') {
   PropType = {
     data: PropTypes.arrayOf(PropTypes.shape({})),
     defaultView: viewType,
+    filteredTotal: PropTypes.number,
+    id: PropTypes.string,
+    messages: PropTypes.shape({
+      dataFilters: PropTypes.shape({
+        clear: PropTypes.string,
+        heading: PropTypes.string,
+        open: PropTypes.string,
+      }),
+      dataForm: PropTypes.shape({
+        submit: PropTypes.string,
+      }),
+      dataSearch: PropTypes.shape({
+        label: PropTypes.string,
+      }),
+      dataSort: PropTypes.shape({
+        ascending: PropTypes.string,
+        by: PropTypes.string,
+        descending: PropTypes.string,
+        direction: PropTypes.string,
+      }),
+      dataSummary: PropTypes.shape({
+        filtered: PropTypes.string,
+        filteredSingle: PropTypes.string,
+        items: PropTypes.string,
+        itemsSingle: PropTypes.string,
+        total: PropTypes.string,
+        totalSingle: PropTypes.string,
+      }),
+    }),
     onView: PropTypes.func,
     properties: PropTypes.oneOfType([
       PropTypes.arrayOf(PropTypes.string),
@@ -40,10 +69,11 @@ if (process.env.NODE_ENV !== 'production') {
     ]),
     toolbar: PropTypes.oneOfType([
       PropTypes.bool,
-      PropTypes.oneOf(['search', 'filters']),
+      PropTypes.oneOf(['search', 'filters', 'view']),
     ]),
     total: PropTypes.number,
     view: PropTypes.oneOfType([PropTypes.string, viewType]),
+    views: PropTypes.arrayOf(PropTypes.viewType),
   };
 }
 

--- a/src/js/components/Data/propTypes.js
+++ b/src/js/components/Data/propTypes.js
@@ -73,7 +73,7 @@ if (process.env.NODE_ENV !== 'production') {
     ]),
     total: PropTypes.number,
     view: PropTypes.oneOfType([PropTypes.string, viewType]),
-    views: PropTypes.arrayOf(PropTypes.viewType),
+    views: PropTypes.arrayOf(viewType),
   };
 }
 

--- a/src/js/components/DataFilters/index.d.ts
+++ b/src/js/components/DataFilters/index.d.ts
@@ -2,10 +2,10 @@ import * as React from 'react';
 import { BoxProps } from '../Box/index';
 
 export interface DataFiltersProps {
+  clearFilters?: boolean;
   drop?: boolean;
   heading?: string | React.ReactNode;
   layer?: boolean;
-  clearFilters?: boolean;
   // when view changes should be delivered
   updateOn?: 'change' | 'submit';
 }

--- a/src/js/components/DataFilters/propTypes.js
+++ b/src/js/components/DataFilters/propTypes.js
@@ -3,10 +3,10 @@ import PropTypes from 'prop-types';
 let PropType = {};
 if (process.env.NODE_ENV !== 'production') {
   PropType = {
+    clearFilters: PropTypes.bool,
     drop: PropTypes.bool,
     heading: PropTypes.string,
     layer: PropTypes.bool,
-    clearFilters: PropTypes.bool,
     updateOn: PropTypes.oneOf(['change', 'submit']),
   };
 }

--- a/src/js/components/Grommet/index.d.ts
+++ b/src/js/components/Grommet/index.d.ts
@@ -51,7 +51,6 @@ export interface GrommetProps {
         };
       };
       dataForm?: {
-        reset?: string;
         submit?: string;
       };
       dataSearch?: {

--- a/src/js/components/Grommet/propTypes.js
+++ b/src/js/components/Grommet/propTypes.js
@@ -50,7 +50,6 @@ if (process.env.NODE_ENV !== 'production') {
           }),
         }),
         dataForm: PropTypes.shape({
-          reset: PropTypes.string,
           submit: PropTypes.string,
         }),
         dataSearch: PropTypes.shape({


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

`dataForm.reset` was removed by #7088. This removes the index.d.ts/propTypes support of it.

Additionally, making sure all propTypes/index.d.ts are up to date with latest functionality.

#### Where should the reviewer start?
src/js/components/Grommet/index.d.ts

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.