### PR TITLE
Fix DataTableColumns undefined case

### DIFF
--- a/src/js/components/DataTableColumns/DataTableColumns.js
+++ b/src/js/components/DataTableColumns/DataTableColumns.js
@@ -28,7 +28,7 @@ const tabsProps = {
 // options can either be an array of property names or an array of objects.
 // The form value always uses an array of property names.
 const optionsToValue = (options) =>
-  options.map((o) => (typeof o === 'object' && o.property) || o) || [];
+  options?.map((o) => (typeof o === 'object' && o.property) || o) || [];
 
 const optionProperty = (option) =>
   typeof option === 'object' ? option.property : option;
@@ -47,7 +47,7 @@ const alignOrder = (value, prevValue, options) =>
 
 // Content is a separate component since it might be getting its form context
 // from the DataForm rendered inside DataTableColumns.
-const Content = ({ drop, options, ...rest }) => {
+const Content = ({ drop, options = [], ...rest }) => {
   const { id: dataId, messages } = useContext(DataContext);
   const { useFormInput } = useContext(FormContext);
   const { format } = useContext(MessageContext);


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Fixes error when DataTableColumns `options` is undefined. Even though `options` is a required prop, the app should not crash if it's not provided.

#### Where should the reviewer start?
src/js/components/DataTableColumns/DataTableColumns.js

#### What testing has been done on this PR?
Locally in storybook.

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

Discovered when reviewing https://github.com/grommet/grommet-designer/pull/137

#### Screenshots (if appropriate)

Fixes this where <DataTableColumns /> is used.

<img width="1654" alt="Screen Shot 2024-02-02 at 1 58 10 PM" src="https://github.com/grommet/grommet/assets/12522275/ed916b68-7c6d-4044-8318-f50629e08070">

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
No.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.