### PR TITLE
DataClearFilters story - Check properties length before displaying data clear filters button

### DIFF
--- a/src/js/components/DataClearFilters/stories/Simple.js
+++ b/src/js/components/DataClearFilters/stories/Simple.js
@@ -75,7 +75,10 @@ const DataToolbar = () => {
           <DataFilter property="percent" />
           <DataFilter property="paid" />
         </DataFilters>
-        {view?.properties !== undefined ? <DataClearFilters /> : null}
+        {view?.properties !== undefined &&
+        Object.keys(view?.properties).length !== 0 ? (
+          <DataClearFilters />
+        ) : null}
       </Toolbar>
       <DataView />
     </Toolbar>


### PR DESCRIPTION
#### What does this PR do?
Changes the DataClearFilters story example to check that `view.properties` length before displaying the DataClearFilters button.

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
backwards compatible