### PR TITLE
add draft of summary

### DIFF
--- a/src/js/components/Pagination/Pagination.js
+++ b/src/js/components/Pagination/Pagination.js
@@ -5,6 +5,7 @@ import { DataContext } from '../../contexts/DataContext';
 import { Box } from '../Box';
 import { Nav } from '../Nav';
 import { PageControl } from './PageControl';
+import { PaginationSummary } from './PaginationSummary';
 import { PaginationPropTypes } from './propTypes';
 
 const StyledPaginationContainer = styled(Box)`
@@ -33,6 +34,7 @@ const Pagination = forwardRef(
       page: pageProp,
       size,
       step: stepProp,
+      summary,
       ...rest
     },
     ref,
@@ -199,7 +201,7 @@ const Pagination = forwardRef(
       ...navProps[control],
     }));
 
-    return (
+    let content = (
       <StyledPaginationContainer
         flex={false}
         {...theme.pagination.container}
@@ -222,6 +224,17 @@ const Pagination = forwardRef(
         </Nav>
       </StyledPaginationContainer>
     );
+
+    if (summary) {
+      content = (
+        <Box align="center" direction="row-responsive" gap="small" {...rest}>
+          <PaginationSummary page={page} step={step} numberItems={total} />
+          {content}
+        </Box>
+      );
+    }
+
+    return content;
   },
 );
 

--- a/src/js/components/Pagination/PaginationSummary.js
+++ b/src/js/components/Pagination/PaginationSummary.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Box } from '../Box';
+import { Text } from '../Text';
+
+export const PaginationSummary = ({ page, step, numberItems, ...rest }) => (
+  <Box flex="grow">
+    <Text {...rest}>
+      {`Showing ${(page - 1) * step + 1} - ${Math.min(
+        page * step,
+        numberItems,
+      )} of ${numberItems} items`}
+    </Text>
+  </Box>
+);

--- a/src/js/components/Pagination/stories/TestSummary.js
+++ b/src/js/components/Pagination/stories/TestSummary.js
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import { Box, Pagination, Data, DataTable } from 'grommet';
+import { data } from '../../DataTable/stories/data';
+
+export const Test = () => (
+  <Box align="center" pad="large">
+    <Data data={data} toolbar>
+      <DataTable size="large" />
+      <Pagination summary />
+    </Data>
+  </Box>
+);
+
+export default {
+  title: 'Controls/Pagination/Test',
+};


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
draft of pagination summary currently calling prop `summary` but we can discus better naming
#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
close #https://github.com/grommet/hpe-design-system/issues/3709
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
