### PR TITLE
added a new prop for simple calendar selection #7055

### DIFF
--- a/src/js/components/Calendar/Calendar.js
+++ b/src/js/components/Calendar/Calendar.js
@@ -268,6 +268,7 @@ const Calendar = forwardRef(
       showAdjacentDays = true,
       size = 'medium',
       timestamp: timestampProp,
+      simpleSelection = false,
       ...rest
     },
     ref,
@@ -497,6 +498,7 @@ const Calendar = forwardRef(
 
     const handleRange = useCallback(
       (selectedDate) => {
+        console.log(simpleSelection);
         let result;
         const priorRange = normalizeRange(value, activeDate);
         // deselect when date clicked was the start/end of the range
@@ -507,9 +509,12 @@ const Calendar = forwardRef(
           result = [[priorRange[0][0], undefined]];
           setActiveDate('end');
         }
+
         // selecting start date
         else if (activeDate === 'start') {
-          if (!priorRange) {
+          if (simpleSelection) {
+            result = [[selectedDate, undefined]];
+          } else if (!priorRange) {
             result = [[selectedDate, undefined]];
           } else if (!priorRange[0][1]) {
             result = [[selectedDate, priorRange[0][1]]];
@@ -519,16 +524,25 @@ const Calendar = forwardRef(
             result = [[selectedDate, undefined]];
           }
           setActiveDate('end');
-        }
-        // selecting end date
-        else if (!priorRange) {
-          result = [[undefined, selectedDate]];
-          setActiveDate('start');
-        } else if (selectedDate.getTime() < priorRange[0][0].getTime()) {
-          result = [[selectedDate, undefined]];
-          setActiveDate('end');
-        } else if (selectedDate.getTime() > priorRange[0][0].getTime()) {
-          result = [[priorRange[0][0], selectedDate]];
+        } else {
+          // selecting end date
+          // swap if start date is after end date
+          if (
+            simpleSelection &&
+            selectedDate.getTime() < priorRange?.[0]?.[0]?.getTime()
+          ) {
+            result = [[selectedDate, priorRange[0][0]]];
+          } else if (simpleSelection) {
+            result = [[priorRange[0][0], selectedDate]];
+          } else if (!priorRange) {
+            result = [[undefined, selectedDate]];
+            setActiveDate('start');
+          } else if (selectedDate.getTime() < priorRange[0][0].getTime()) {
+            result = [[selectedDate, undefined]];
+            setActiveDate('end');
+          } else if (selectedDate.getTime() > priorRange[0][0].getTime()) {
+            result = [[priorRange[0][0], selectedDate]];
+          }
           setActiveDate('start');
         }
 

--- a/src/js/components/Calendar/index.d.ts
+++ b/src/js/components/Calendar/index.d.ts
@@ -50,6 +50,7 @@ export interface CalendarProps {
   reference?: string;
   showAdjacentDays?: boolean | 'trim';
   size?: 'small' | 'medium' | 'large' | string;
+  simpleSelection?: boolean;
 }
 
 export interface CalendarExtendedProps

--- a/src/js/components/Calendar/stories/RangeSimple.js
+++ b/src/js/components/Calendar/stories/RangeSimple.js
@@ -1,0 +1,16 @@
+import React from 'react';
+
+import { Box, Calendar } from 'grommet';
+
+export const RangeSimple = () => (
+  // Uncomment <Grommet> lines when using outside of storybook
+  // <Grommet theme={...}>
+  <Box align="center" pad="large">
+    <Calendar date={[['2020-04-03', '2020-04-08']]} range simpleSelection />
+  </Box>
+  // </Grommet>
+);
+
+export default {
+  title: 'Visualizations/Calendar/RangeSimple',
+};


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Current calendar range selection is ambiguous without the start date and end date inputs. Added a prop simpleSelection which is more predictive selection of date.

#### Where should the reviewer start?



#### What testing has been done on this PR?
test cases are pending

#### How should this be manually tested?
Visualizations/Calendar/RangeSimple
this storybook has the working example

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
#7055
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
yes
#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
yes