### PR TITLE
Add primaryKey to List theme

### DIFF
--- a/src/js/components/List/List.js
+++ b/src/js/components/List/List.js
@@ -366,7 +366,7 @@ const List = React.forwardRef(
                   content =
                     typeof primary === 'string' ||
                     typeof primary === 'number' ? (
-                      <Text key="p" weight="bold">
+                      <Text key="p" {...theme.list.primaryKey}>
                         {primary}
                       </Text>
                     ) : (

--- a/src/js/components/List/__tests__/List-test.js
+++ b/src/js/components/List/__tests__/List-test.js
@@ -296,6 +296,34 @@ describe('List', () => {
     expect(onOrder).toHaveBeenCalled();
     expect(asFragment()).toMatchSnapshot();
   });
+
+  test('renders custom theme for primaryKey', () => {
+    const theme = {
+      list: {
+        primaryKey: {
+          color: 'brand',
+          weight: 500,
+        },
+      },
+    };
+
+    const { asFragment } = render(
+      <Grommet theme={theme}>
+        <List
+          data={[
+            { a: 'one', b: 1 },
+            { a: 'two', b: 2 },
+          ]}
+          primaryKey="a"
+        />
+      </Grommet>,
+    );
+
+    const primaryKey = screen.getByText('one');
+    const styles = window.getComputedStyle(primaryKey);
+    expect(styles.fontWeight).toBe('500');
+    expect(asFragment()).toMatchSnapshot();
+  });
 });
 
 describe('List events', () => {

--- a/src/js/components/List/__tests__/__snapshots__/List-test.js.snap
+++ b/src/js/components/List/__tests__/__snapshots__/List-test.js.snap
@@ -20731,6 +20731,151 @@ exports[`List renders a11yTitle and aria-label 1`] = `
 </div>
 `;
 
+exports[`List renders custom theme for primaryKey 1`] = `
+<DocumentFragment>
+  .c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border-top: solid 1px rgba(0,0,0,0.33);
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  padding-left: 24px;
+  padding-right: 24px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  padding-left: 24px;
+  padding-right: 24px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+
+.c4 {
+  font-size: 18px;
+  line-height: 24px;
+  color: #7D4CDB;
+  font-weight: 500;
+}
+
+.c1 {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    border-top: solid 1px rgba(0,0,0,0.33);
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c2 {
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c5 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c5 {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c5 {
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+}
+
+<div
+    class="c0"
+  >
+    <ul
+      class="c1"
+      role="list"
+    >
+      <li
+        class="c2 c3"
+      >
+        <span
+          class="c4"
+        >
+          one
+        </span>
+      </li>
+      <li
+        class="c5 c3"
+      >
+        <span
+          class="c4"
+        >
+          two
+        </span>
+      </li>
+    </ul>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`List secondaryKey 1`] = `
 .c0 {
   font-size: 18px;

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -1804,6 +1804,9 @@ exports[`Components loads 1`] = `
               },
             },
           },
+          "primaryKey": {
+            "weight": "bold",
+          },
         },
         "maskedInput": {},
         "menu": {
@@ -3792,6 +3795,9 @@ exports[`Components loads 1`] = `
                 "size": "medium",
               },
             },
+          },
+          "primaryKey": {
+            "weight": "bold",
           },
         },
         "maskedInput": {},

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -1076,6 +1076,7 @@ export interface ThemeType {
       pad?: PadType;
       extend?: ExtendType;
     };
+    primaryKey?: TextProps;
     icons?: {
       down?: React.ReactNode | Icon;
       up?: React.ReactNode | Icon;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1111,6 +1111,10 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         pad: { horizontal: 'medium', vertical: 'small' },
         // extend: undefined,
       },
+      primaryKey: {
+        // any text props
+        weight: 'bold',
+      },
       icons: {
         down: FormDown,
         up: FormUp,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Added `theme.list.primaryKey` to theme support in order to allow customization of List primaryKey styling. Accepts all Text props.

#### Where should the reviewer start?
src/js/components/List/List.js

#### What testing has been done on this PR?
Tested locally in storybook and added jest test.

#### How should this be manually tested?
In storybook List "Custom Theme" story, add `list.primaryKey` to custom theme.

```
import React from 'react';

import { Grommet, Box, List } from 'grommet';
import { grommet, ThemeType } from 'grommet/themes';
import { deepMerge } from 'grommet/utils';

const locations = [
  'Boise',
  'Fort Collins',
  'Los Gatos',
  'Palo Alto',
  'San Francisco',
];

const data = [];

for (let i = 0; i < 40; i += 1) {
  data.push({
    entry: `entry-${i + 1}`,
    location: locations[i % locations.length],
  });
}

// Type annotations can only be used in TypeScript files.
// Remove ': ThemeType' if you are not using Typescript.
const theme: ThemeType = deepMerge(grommet, {
  list: {
    item: {
      pad: { horizontal: 'large', vertical: 'xsmall' },
      background: ['white', 'light-2'],
      border: true,
    },
    primaryKey: {
      weight: 500,
    },
  },
});

export const ThemedList = () => (
  <Grommet theme={theme}>
    <Box align="center" pad="large">
      <List
        data={data.slice(0, 10)}
        primaryKey="entry"
        secondaryKey="location"
      />
    </Box>
  </Grommet>
);

ThemedList.storyName = 'Themed List';

export default {
  title: 'Visualizations/List/Custom Themed/Themed List',
};
```

#### Do Jest tests follow these best practices?

- [x] `screen` is used for querying.
- [x] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [x] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

Previously, list primaryKey weight was hard coded, we should support customization in the theme.

#### What are the relevant issues?

Closes #7102 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Yes.

#### Should this PR be mentioned in the release notes?
Yes. Added `theme.list.primaryKey` to List theme.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.