### PR TITLE
Remove engine-strict: true from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "type": "git",
     "url": "https://github.com/grommet/grommet.git"
   },
-  "engine-strict": true,
   "engines": {
     "node": ">= 18"
   },


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Removes `engine-strict` true from package.json so that projects running node versions less than what is defined in `engines.node` of package.json don't fail with an error on install. This aligns back with the [default package.json behavior](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#engines).

We recently changed our package.json to increase our supported node version from >=16 to >=18 since node 16 has already reached its end of life date. That being said, we don't want to cause errors on dependency install for projects that still use node 16.

#### Where should the reviewer start?
package.json

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
