### PR TITLE
Enhance Box `gap` to accept object with `row` and `column`

### DIFF
--- a/src/js/components/Box/Box.js
+++ b/src/js/components/Box/Box.js
@@ -221,7 +221,7 @@ const Box = forwardRef(
         fillProp={fill}
         focus={focus}
         gap={
-          (boxOptions?.cssGap || cssGap) &&
+          (boxOptions?.cssGap || cssGap || typeof gap === 'object') &&
           gap &&
           gap !== 'none' &&
           border !== 'between' &&

--- a/src/js/components/Box/Box.js
+++ b/src/js/components/Box/Box.js
@@ -113,7 +113,7 @@ const Box = forwardRef(
     if (
       gap &&
       gap !== 'none' &&
-      (!(boxOptions?.cssGap || cssGap) ||
+      (!(boxOptions?.cssGap || cssGap || typeof gap === 'object') ||
         // need this approach to show border between
         border === 'between' ||
         border?.side === 'between' ||

--- a/src/js/components/Box/StyledBox.js
+++ b/src/js/components/Box/StyledBox.js
@@ -213,12 +213,25 @@ const gapStyle = (directionProp, gap, responsive, wrap, theme) => {
           theme.global.edgeSize[gap.column] || gap.column
         };`,
       );
+      if (responsiveMetric) {
+        styles.push(breakpointStyle(breakpoint, `gap: ${responsiveMetric};`));
+      }
     } else if (gap.row !== undefined) {
       styles.push(`row-gap: ${theme.global.edgeSize[gap.row] || gap.row};`);
+      if (responsiveMetric) {
+        styles.push(
+          breakpointStyle(breakpoint, `row-gap: ${responsiveMetric};`),
+        );
+      }
     } else if (gap.column !== undefined) {
       styles.push(
         `column-gap: ${theme.global.edgeSize[gap.column] || gap.column};`,
       );
+      if (responsiveMetric) {
+        styles.push(
+          breakpointStyle(breakpoint, `column-gap: ${responsiveMetric};`),
+        );
+      }
     }
   }
   if (directionProp === 'column' || directionProp === 'column-reverse') {

--- a/src/js/components/Box/StyledBox.js
+++ b/src/js/components/Box/StyledBox.js
@@ -213,11 +213,9 @@ const gapStyle = (directionProp, gap, responsive, wrap, theme) => {
           theme.global.edgeSize[gap.column] || gap.column
         };`,
       );
-    }
-    if (gap.row !== undefined && gap.column === undefined) {
+    } else if (gap.row !== undefined) {
       styles.push(`row-gap: ${theme.global.edgeSize[gap.row] || gap.row};`);
-    }
-    if (gap.row === undefined && gap.column !== undefined) {
+    } else if (gap.column !== undefined) {
       styles.push(
         `column-gap: ${theme.global.edgeSize[gap.column] || gap.column};`,
       );

--- a/src/js/components/Box/StyledBox.js
+++ b/src/js/components/Box/StyledBox.js
@@ -206,6 +206,12 @@ const gapStyle = (directionProp, gap, responsive, wrap, theme) => {
   const responsiveMetric = responsive && breakpoint && breakpoint.edgeSize[gap];
 
   const styles = [];
+  if (directionProp === 'column' || directionProp === 'column-reverse') {
+    styles.push(`row-gap: ${metric};`);
+    if (responsiveMetric) {
+      styles.push(breakpointStyle(breakpoint, `row-gap: ${responsiveMetric};`));
+    }
+  }
   if (typeof gap === 'object') {
     if (gap.row !== undefined && gap.column !== undefined) {
       styles.push(
@@ -232,12 +238,6 @@ const gapStyle = (directionProp, gap, responsive, wrap, theme) => {
           breakpointStyle(breakpoint, `column-gap: ${responsiveMetric};`),
         );
       }
-    }
-  }
-  if (directionProp === 'column' || directionProp === 'column-reverse') {
-    styles.push(`row-gap: ${metric};`);
-    if (responsiveMetric) {
-      styles.push(breakpointStyle(breakpoint, `row-gap: ${responsiveMetric};`));
     }
   } else {
     styles.push(`column-gap: ${metric};`);

--- a/src/js/components/Box/StyledBox.js
+++ b/src/js/components/Box/StyledBox.js
@@ -206,12 +206,6 @@ const gapStyle = (directionProp, gap, responsive, wrap, theme) => {
   const responsiveMetric = responsive && breakpoint && breakpoint.edgeSize[gap];
 
   const styles = [];
-  if (directionProp === 'column' || directionProp === 'column-reverse') {
-    styles.push(`row-gap: ${metric};`);
-    if (responsiveMetric) {
-      styles.push(breakpointStyle(breakpoint, `row-gap: ${responsiveMetric};`));
-    }
-  }
   if (typeof gap === 'object') {
     if (gap.row !== undefined && gap.column !== undefined) {
       styles.push(
@@ -238,6 +232,11 @@ const gapStyle = (directionProp, gap, responsive, wrap, theme) => {
           breakpointStyle(breakpoint, `column-gap: ${responsiveMetric};`),
         );
       }
+    }
+  } else if (directionProp === 'column' || directionProp === 'column-reverse') {
+    styles.push(`row-gap: ${metric};`);
+    if (responsiveMetric) {
+      styles.push(breakpointStyle(breakpoint, `row-gap: ${responsiveMetric};`));
     }
   } else {
     styles.push(`column-gap: ${metric};`);

--- a/src/js/components/Box/StyledBox.js
+++ b/src/js/components/Box/StyledBox.js
@@ -206,6 +206,23 @@ const gapStyle = (directionProp, gap, responsive, wrap, theme) => {
   const responsiveMetric = responsive && breakpoint && breakpoint.edgeSize[gap];
 
   const styles = [];
+  if (typeof gap === 'object') {
+    if (gap.row !== undefined && gap.column !== undefined) {
+      styles.push(
+        `gap: ${theme.global.edgeSize[gap.row] || gap.row} ${
+          theme.global.edgeSize[gap.column] || gap.column
+        };`,
+      );
+    }
+    if (gap.row !== undefined && gap.column === undefined) {
+      styles.push(`row-gap: ${theme.global.edgeSize[gap.row] || gap.row};`);
+    }
+    if (gap.row === undefined && gap.column !== undefined) {
+      styles.push(
+        `column-gap: ${theme.global.edgeSize[gap.column] || gap.column};`,
+      );
+    }
+  }
   if (directionProp === 'column' || directionProp === 'column-reverse') {
     styles.push(`row-gap: ${metric};`);
     if (responsiveMetric) {

--- a/src/js/components/Box/__tests__/Box-layout-test.tsx
+++ b/src/js/components/Box/__tests__/Box-layout-test.tsx
@@ -230,7 +230,7 @@ describe('Box', () => {
   });
 
   test('row and column gap', () => {
-    const { container } = render(
+    const { asFragment } = render(
       <Grommet>
         <Box gap={{ row: 'xlarge', column: '30px' }} direction="row">
           <Box />

--- a/src/js/components/Box/__tests__/Box-layout-test.tsx
+++ b/src/js/components/Box/__tests__/Box-layout-test.tsx
@@ -243,7 +243,7 @@ describe('Box', () => {
       </Grommet>,
     );
 
-    expect(container.firstChild).toMatchSnapshot();
+    expect(asFragment()).toMatchSnapshot();
   });
 
   test('margin', () => {

--- a/src/js/components/Box/__tests__/Box-layout-test.tsx
+++ b/src/js/components/Box/__tests__/Box-layout-test.tsx
@@ -229,6 +229,23 @@ describe('Box', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  test('row and column gap', () => {
+    const { container } = render(
+      <Grommet>
+        <Box gap={{ row: 'xlarge', column: '30px' }} direction="row">
+          <Box />
+          <Box />
+        </Box>
+        <Box as="span" gap="small">
+          <span>first</span>
+          <span>second</span>
+        </Box>
+      </Grommet>,
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
   test('margin', () => {
     const { container } = render(
       <Grommet>

--- a/src/js/components/Box/__tests__/__snapshots__/Box-layout-test.tsx.snap
+++ b/src/js/components/Box/__tests__/__snapshots__/Box-layout-test.tsx.snap
@@ -3236,7 +3236,8 @@ exports[`Box responsive 1`] = `
 `;
 
 exports[`Box row and column gap 1`] = `
-.c0 {
+<DocumentFragment>
+  .c0 {
   font-size: 18px;
   line-height: 24px;
   box-sizing: border-box;
@@ -3304,35 +3305,36 @@ exports[`Box row and column gap 1`] = `
 }
 
 <div
-  class="c0"
->
-  <div
-    class="c1"
+    class="c0"
   >
     <div
-      class="c2"
-    />
-    <div
-      class="c3"
-    />
-    <div
-      class="c2"
-    />
-  </div>
-  <span
-    class="c2"
-  >
-    <span>
-      first
-    </span>
+      class="c1"
+    >
+      <div
+        class="c2"
+      />
+      <div
+        class="c3"
+      />
+      <div
+        class="c2"
+      />
+    </div>
     <span
-      class="c4"
-    />
-    <span>
-      second
+      class="c2"
+    >
+      <span>
+        first
+      </span>
+      <span
+        class="c4"
+      />
+      <span>
+        second
+      </span>
     </span>
-  </span>
-</div>
+  </div>
+</DocumentFragment>
 `;
 
 exports[`Box width 1`] = `

--- a/src/js/components/Box/__tests__/__snapshots__/Box-layout-test.tsx.snap
+++ b/src/js/components/Box/__tests__/__snapshots__/Box-layout-test.tsx.snap
@@ -1162,6 +1162,8 @@ exports[`Box css gap 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   row-gap: 12px;
+  -webkit-column-gap: 12px;
+  column-gap: 12px;
 }
 
 @media only screen and (max-width:768px) {
@@ -3260,8 +3262,6 @@ exports[`Box row and column gap 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   gap: 96px 30px;
-  -webkit-column-gap: [object Object];
-  column-gap: [object Object];
 }
 
 .c2 {

--- a/src/js/components/Box/__tests__/__snapshots__/Box-layout-test.tsx.snap
+++ b/src/js/components/Box/__tests__/__snapshots__/Box-layout-test.tsx.snap
@@ -3285,21 +3285,11 @@ exports[`Box row and column gap 1`] = `
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
   align-self: stretch;
-  width: [object Object];
-}
-
-.c4 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  -webkit-align-self: stretch;
-  -ms-flex-item-align: stretch;
-  align-self: stretch;
   height: 12px;
 }
 
 @media only screen and (max-width:768px) {
-  .c4 {
+  .c3 {
     height: 6px;
   }
 }
@@ -3314,9 +3304,6 @@ exports[`Box row and column gap 1`] = `
         class="c2"
       />
       <div
-        class="c3"
-      />
-      <div
         class="c2"
       />
     </div>
@@ -3327,7 +3314,7 @@ exports[`Box row and column gap 1`] = `
         first
       </span>
       <span
-        class="c4"
+        class="c3"
       />
       <span>
         second

--- a/src/js/components/Box/__tests__/__snapshots__/Box-layout-test.tsx.snap
+++ b/src/js/components/Box/__tests__/__snapshots__/Box-layout-test.tsx.snap
@@ -3235,6 +3235,106 @@ exports[`Box responsive 1`] = `
 </div>
 `;
 
+exports[`Box row and column gap 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 96px 30px;
+  -webkit-column-gap: [object Object];
+  column-gap: [object Object];
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  width: [object Object];
+}
+
+.c4 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  height: 12px;
+}
+
+@media only screen and (max-width:768px) {
+  .c4 {
+    height: 6px;
+  }
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+  >
+    <div
+      class="c2"
+    />
+    <div
+      class="c3"
+    />
+    <div
+      class="c2"
+    />
+  </div>
+  <span
+    class="c2"
+  >
+    <span>
+      first
+    </span>
+    <span
+      class="c4"
+    />
+    <span>
+      second
+    </span>
+  </span>
+</div>
+`;
+
 exports[`Box width 1`] = `
 .c0 {
   font-size: 18px;

--- a/src/js/components/Box/__tests__/__snapshots__/Box-layout-test.tsx.snap
+++ b/src/js/components/Box/__tests__/__snapshots__/Box-layout-test.tsx.snap
@@ -1162,8 +1162,6 @@ exports[`Box css gap 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   row-gap: 12px;
-  -webkit-column-gap: 12px;
-  column-gap: 12px;
 }
 
 @media only screen and (max-width:768px) {

--- a/src/js/components/Box/index.d.ts
+++ b/src/js/components/Box/index.d.ts
@@ -38,7 +38,7 @@ export interface BoxProps {
   flex?: 'grow' | 'shrink' | boolean | { grow?: number; shrink?: number };
   fill?: FillType;
   focusIndicator?: boolean;
-  gap?: GapType;
+  gap?: GapType | object;
   height?: HeightType;
   hoverIndicator?:
     | { background?: BackgroundType; elevation?: ElevationType }

--- a/src/js/components/Box/index.d.ts
+++ b/src/js/components/Box/index.d.ts
@@ -38,7 +38,7 @@ export interface BoxProps {
   flex?: 'grow' | 'shrink' | boolean | { grow?: number; shrink?: number };
   fill?: FillType;
   focusIndicator?: boolean;
-  gap?: GapType | { row?: string; column?: string };
+  gap?: GapType | { row?: GapType; column?: GapType };
   height?: HeightType;
   hoverIndicator?:
     | { background?: BackgroundType; elevation?: ElevationType }

--- a/src/js/components/Box/index.d.ts
+++ b/src/js/components/Box/index.d.ts
@@ -38,7 +38,7 @@ export interface BoxProps {
   flex?: 'grow' | 'shrink' | boolean | { grow?: number; shrink?: number };
   fill?: FillType;
   focusIndicator?: boolean;
-  gap?: GapType | object;
+  gap?: GapType | { row?: string; gap?: string };
   height?: HeightType;
   hoverIndicator?:
     | { background?: BackgroundType; elevation?: ElevationType }

--- a/src/js/components/Box/index.d.ts
+++ b/src/js/components/Box/index.d.ts
@@ -38,7 +38,7 @@ export interface BoxProps {
   flex?: 'grow' | 'shrink' | boolean | { grow?: number; shrink?: number };
   fill?: FillType;
   focusIndicator?: boolean;
-  gap?: GapType | { row?: string; gap?: string };
+  gap?: GapType | { row?: string; column?: string };
   height?: HeightType;
   hoverIndicator?:
     | { background?: BackgroundType; elevation?: ElevationType }

--- a/src/js/components/Box/propTypes.js
+++ b/src/js/components/Box/propTypes.js
@@ -153,6 +153,7 @@ if (process.env.NODE_ENV !== 'production') {
         'xlarge',
       ]),
       PropTypes.string,
+      PropTypes.object,
     ]),
     height: heightPropType,
     hoverIndicator: hoverIndicatorPropType,

--- a/src/js/components/Box/propTypes.js
+++ b/src/js/components/Box/propTypes.js
@@ -153,7 +153,7 @@ if (process.env.NODE_ENV !== 'production') {
         'xlarge',
       ]),
       PropTypes.string,
-      PropTypes.object,
+      PropTypes.shape({ row: PropTypes.string, column: PropTypes.string }),
     ]),
     height: heightPropType,
     hoverIndicator: hoverIndicatorPropType,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR enhances `gap` on Box so a user can pass in {{ row: small, column: 'large' }}
#### Where should the reviewer start?
styledBox.js
#### What testing has been done on this PR?
local storybook also wrote snapshot
#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
yes
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible