### PR TITLE
Run form submit validation when submit is fired directly on input

### DIFF
--- a/src/js/components/Form/Form.js
+++ b/src/js/components/Form/Form.js
@@ -714,7 +714,11 @@ const Form = forwardRef(
           // bubbles up to the "outer" form even though in the DOM the portal
           // doesn't render as child of the "outer" form.
           // https://legacy.reactjs.org/docs/portals.html#event-bubbling-through-portals
-          if (formRef.current && event.target === formRef.current) {
+          if (
+            formRef.current &&
+            (event.target === formRef.current ||
+              event.target.form === formRef.current)
+          ) {
             setPendingValidation(undefined);
             // adding validateOn: "submit" prop to the undefined validateOn
             // fields as we want to trigger "submit" validation once form

--- a/src/js/components/Form/__tests__/Form-test-uncontrolled.js
+++ b/src/js/components/Form/__tests__/Form-test-uncontrolled.js
@@ -1596,7 +1596,7 @@ describe('Form uncontrolled', () => {
     );
   });
 
-  test.only('should validate when submit is fired directly on input', () => {
+  test('should validate when submit is fired directly on input', () => {
     render(
       <Grommet>
         <Form>

--- a/src/js/components/Form/__tests__/Form-test-uncontrolled.js
+++ b/src/js/components/Form/__tests__/Form-test-uncontrolled.js
@@ -1595,4 +1595,34 @@ describe('Form uncontrolled', () => {
       }),
     );
   });
+
+  test.only('should validate when submit is fired directly on input', () => {
+    render(
+      <Grommet>
+        <Form>
+          <FormField
+            label="My field"
+            name="my-field"
+            htmlFor="my-field"
+            validate={{
+              regexp: /^some-value/,
+              message: 'Invalid email address',
+              status: 'error',
+            }}
+          >
+            <TextInput
+              name="my-field"
+              id="my-field"
+              placeholder="placeholder text"
+            />
+          </FormField>
+          <Button label="Submit" type="submit" />
+        </Form>
+      </Grommet>,
+    );
+
+    const element = screen.getByPlaceholderText('placeholder text');
+    fireEvent.submit(element);
+    expect(screen.getByText('Invalid email address')).toBeTruthy();
+  });
 });


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Fixing bug introduced by https://github.com/grommet/grommet/pull/7005, where if a submit event is fired directly on an input element, the form validations won't run.

This ensures that the event is either being trigged by the form or an input within the form, but still keeps the initial fix to avoid the React portals issue noted in the original issue.

#### Where should the reviewer start?
src/js/components/Form/Form.js

#### What testing has been done on this PR?
Locally created test and added jest test:

```
test('should validate when submit is fired directly on input', () => {
    render(
      <Grommet>
        <Form>
          <FormField
            label="My field"
            name="my-field"
            htmlFor="my-field"
            validate={{
              regexp: /^some-value/,
              message: 'Invalid email address',
              status: 'error',
            }}
          >
            <TextInput
              name="my-field"
              id="my-field"
              placeholder="placeholder text"
            />
          </FormField>
          <Button label="Submit" type="submit" />
        </Form>
      </Grommet>,
    );

    const element = screen.getByPlaceholderText('placeholder text');
    fireEvent.submit(element);
    expect(screen.getByText('Invalid email address')).toBeTruthy();
  });
```

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.