### PR TITLE
add toggleButtonGroup

### DIFF
--- a/src/js/components/Button/stories/CustomThemed/Typescript.tsx
+++ b/src/js/components/Button/stories/CustomThemed/Typescript.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { ThemeType } from 'grommet/themes';
-import { Box, Button, Grommet } from 'grommet';
+import { Box, Button, Tag, Grommet } from 'grommet';
 
 // Type annotations can only be used in TypeScript files.
 // Remove ': ThemeType' if you are not using Typescript.
@@ -51,27 +51,16 @@ const customTheme: ThemeType = {
 
 export const TSCustom = () => (
   <>
-    <Grommet theme={customTheme}>
-      <Box align="center" pad="large">
-        <Button label="custom theme" onClick={() => {}} primary />
+    <Grommet>
+      <Box pad="large" gap="medium" align="start">
+        <Tag name="name" value="value" />
+        <Tag value="value" />
+        <Tag
+          name="name that is much longer and may need to wrap"
+          value="value"
+        />
       </Box>
     </Grommet>
-    <Grommet theme={customTheme}>
-      <Box align="center" pad="large">
-        <Button label="custom theme disabled" disabled primary />
-      </Box>
-    </Grommet>
-    <Box align="center" pad="large">
-      <Button as="span" label="Custom as=span" />
-    </Box>
-    <Box align="center" pad="large">
-      <Button
-        rel="noopener"
-        target="_blank"
-        href="https://v2.grommet.io/button"
-        label="Link to Button docs"
-      />
-    </Box>
   </>
 );
 TSCustom.storyName = 'TS-Custom';

--- a/src/js/components/CheckBox/CheckBox.js
+++ b/src/js/components/CheckBox/CheckBox.js
@@ -5,6 +5,8 @@ import { removeUndefined } from '../../utils/object';
 import { defaultProps } from '../../default-props';
 import { Box } from '../Box';
 import { FormContext } from '../Form/FormContext';
+// eslint-disable-next-line max-len
+import { ToggleButtonGroupContext } from '../ToggleButtonGroup/ToggleButtonGroupContext';
 import { CheckBoxPropTypes } from './propTypes';
 
 import {
@@ -59,6 +61,7 @@ const CheckBox = forwardRef(
   ) => {
     const theme = useContext(ThemeContext) || defaultProps.theme;
     const formContext = useContext(FormContext);
+    const { inToggleButtonGroup } = useContext(ToggleButtonGroupContext);
 
     const [checked, setChecked] = formContext.useFormInput({
       name,
@@ -170,7 +173,11 @@ const CheckBox = forwardRef(
         as={Box}
         align="center"
         justify="center"
-        margin={label && { [side]: theme.checkBox.gap || 'small' }}
+        margin={
+          !inToggleButtonGroup
+            ? label && { [side]: theme.checkBox.gap || 'small' }
+            : undefined
+        }
         {...themeableProps}
       >
         <StyledCheckBoxInput
@@ -209,6 +216,8 @@ const CheckBox = forwardRef(
     const first = reverse ? normalizedLabel : checkBoxNode;
     const second = reverse ? checkBoxNode : normalizedLabel;
 
+    // we dont want normalizedLabel
+
     return (
       <StyledCheckBoxContainer
         fillProp={fill}
@@ -225,7 +234,7 @@ const CheckBox = forwardRef(
         {...themeableProps}
       >
         {first}
-        {second}
+        {!inToggleButtonGroup ? second : undefined}
       </StyledCheckBoxContainer>
     );
   },

--- a/src/js/components/CheckBox/CheckBox.js
+++ b/src/js/components/CheckBox/CheckBox.js
@@ -18,6 +18,8 @@ import {
   StyledCheckBoxToggle,
   StyledCheckBoxKnob,
 } from './StyledCheckBox';
+// eslint-disable-next-line max-len
+import { StyledToggleButtonGroupContainer } from '../ToggleButtonGroup/StyledToggleButtonGroup';
 
 import { normalizeColor } from '../../utils';
 
@@ -168,47 +170,60 @@ const CheckBox = forwardRef(
     );
 
     const side = !reverse !== !theme.dir ? 'left' : 'right';
-    const checkBoxNode = (
-      <StyledCheckBox
-        as={Box}
-        align="center"
-        justify="center"
-        margin={
-          !inToggleButtonGroup
-            ? label && { [side]: theme.checkBox.gap || 'small' }
-            : undefined
-        }
+    const checkBoxInput = (
+      <StyledCheckBoxInput
+        aria-label={ariaLabel || a11yTitle}
+        {...rest}
+        ref={ref}
+        type="checkbox"
+        {...removeUndefined({
+          id,
+          name,
+          checked,
+          disabled,
+        })}
         {...themeableProps}
-      >
-        <StyledCheckBoxInput
-          aria-label={ariaLabel || a11yTitle}
-          {...rest}
-          ref={ref}
-          type="checkbox"
-          {...removeUndefined({
-            id,
-            name,
-            checked,
-            disabled,
-          })}
-          {...themeableProps}
-          onFocus={(event) => {
-            setFocus(true);
-            if (onFocus) onFocus(event);
-          }}
-          onBlur={(event) => {
-            setFocus(false);
-            if (onBlur) onBlur(event);
-          }}
-          onChange={(event) => {
-            setChecked(event.target.checked);
-            if (onChange) onChange(event);
-          }}
-        />
-        {children ? children({ checked, indeterminate }) : visual}
-        {hidden}
-      </StyledCheckBox>
+        onFocus={(event) => {
+          setFocus(true);
+          if (onFocus) onFocus(event);
+        }}
+        onBlur={(event) => {
+          setFocus(false);
+          if (onBlur) onBlur(event);
+        }}
+        onChange={(event) => {
+          setChecked(event.target.checked);
+          if (onChange) onChange(event);
+        }}
+      />
     );
+    let checkBoxNode;
+    if (inToggleButtonGroup) {
+      checkBoxNode = (
+        <Box as={Box} align="center" justify="center">
+          {checkBoxInput}
+          {children({ checked, indeterminate })}
+          {hidden}
+        </Box>
+      );
+    } else
+      checkBoxNode = (
+        <StyledCheckBox
+          as={Box}
+          align="center"
+          justify="center"
+          margin={
+            !inToggleButtonGroup
+              ? label && { [side]: theme.checkBox.gap || 'small' }
+              : undefined
+          }
+          {...themeableProps}
+        >
+          {checkBoxInput}
+          {children ? children({ checked, indeterminate }) : visual}
+          {hidden}
+        </StyledCheckBox>
+      );
 
     const normalizedLabel =
       typeof label === 'string' ? <span>{label}</span> : label;
@@ -216,27 +231,48 @@ const CheckBox = forwardRef(
     const first = reverse ? normalizedLabel : checkBoxNode;
     const second = reverse ? checkBoxNode : normalizedLabel;
 
-    // we dont want normalizedLabel
+    let content;
+    if (inToggleButtonGroup) {
+      content = (
+        <StyledToggleButtonGroupContainer
+          fillProp={fill}
+          reverse={reverse}
+          {...removeUndefined({ htmlFor: id, disabled })}
+          checked={checked}
+          labelProp={label}
+          onClick={stopLabelClick}
+          pad={pad}
+          onMouseEnter={(event) => onMouseEnter?.(event)}
+          onMouseOver={(event) => onMouseOver?.(event)}
+          onMouseLeave={(event) => onMouseLeave?.(event)}
+          onMouseOut={(event) => onMouseOut?.(event)}
+          {...themeableProps}
+        >
+          {first}
+        </StyledToggleButtonGroupContainer>
+      );
+    } else
+      content = (
+        <StyledCheckBoxContainer
+          fillProp={fill}
+          reverse={reverse}
+          {...removeUndefined({ htmlFor: id, disabled })}
+          checked={checked}
+          labelProp={label}
+          onClick={stopLabelClick}
+          pad={pad}
+          onMouseEnter={(event) => onMouseEnter?.(event)}
+          onMouseOver={(event) => onMouseOver?.(event)}
+          onMouseLeave={(event) => onMouseLeave?.(event)}
+          onMouseOut={(event) => onMouseOut?.(event)}
+          {...themeableProps}
+        >
+          {first}
+          {second}
+        </StyledCheckBoxContainer>
+      );
 
-    return (
-      <StyledCheckBoxContainer
-        fillProp={fill}
-        reverse={reverse}
-        {...removeUndefined({ htmlFor: id, disabled })}
-        checked={checked}
-        labelProp={label}
-        onClick={stopLabelClick}
-        pad={pad}
-        onMouseEnter={(event) => onMouseEnter?.(event)}
-        onMouseOver={(event) => onMouseOver?.(event)}
-        onMouseLeave={(event) => onMouseLeave?.(event)}
-        onMouseOut={(event) => onMouseOut?.(event)}
-        {...themeableProps}
-      >
-        {first}
-        {!inToggleButtonGroup ? second : undefined}
-      </StyledCheckBoxContainer>
-    );
+    return content;
   },
 );
 

--- a/src/js/components/CheckBoxGroup/stories/Children.js
+++ b/src/js/components/CheckBoxGroup/stories/Children.js
@@ -5,12 +5,9 @@ import { Ascend, Descend } from 'grommet-icons';
 
 const optionsObjects = [
   {
-    label: 'asc',
-    disabled: true,
     value: 'asc',
   },
   {
-    label: 'desc',
     value: 'desc',
   },
 ];

--- a/src/js/components/RadioButton/RadioButton.js
+++ b/src/js/components/RadioButton/RadioButton.js
@@ -4,6 +4,8 @@ import { ThemeContext } from 'styled-components';
 import { Box } from '../Box';
 import { defaultProps } from '../../default-props';
 import { normalizeColor, removeUndefined } from '../../utils';
+// eslint-disable-next-line max-len
+import { ToggleButtonGroupContext } from '../ToggleButtonGroup/ToggleButtonGroupContext';
 
 import {
   StyledRadioButton,
@@ -13,6 +15,8 @@ import {
   StyledRadioButtonLabel,
   StyledRadioButtonBox,
 } from './StyledRadioButton';
+// eslint-disable-next-line max-len
+import { StyledToggleButtonGroupContainer } from '../ToggleButtonGroup/StyledToggleButtonGroup';
 import { RadioButtonPropTypes } from './propTypes';
 
 const RadioButton = forwardRef(
@@ -33,6 +37,7 @@ const RadioButton = forwardRef(
     ref,
   ) => {
     const theme = useContext(ThemeContext) || defaultProps.theme;
+    const { inToggleButtonGroup } = useContext(ToggleButtonGroupContext);
     const [hover, setHover] = useState();
     const normalizedLabel =
       typeof label === 'string' ? (
@@ -59,6 +64,61 @@ const RadioButton = forwardRef(
       }
     }
 
+    const RadioButtonInput = (
+      <>
+        <StyledRadioButtonInput
+          aria-label={a11yTitle}
+          {...rest}
+          ref={ref}
+          type="radio"
+          {...removeUndefined({
+            id,
+            name,
+            checked,
+            disabled,
+            onChange,
+          })}
+        />
+        {children ? (
+          children({ checked, focus: focus && focusIndicator, hover })
+        ) : (
+          <StyledRadioButtonBox
+            focus={focus && focusIndicator}
+            as={Box}
+            align="center"
+            justify="center"
+            width={theme.radioButton.size}
+            height={theme.radioButton.size}
+            border={{
+              size: theme.radioButton.border.width,
+              color: borderColor,
+            }}
+            backgroundColor={backgroundColor}
+            round={theme.radioButton.check.radius}
+          >
+            {checked &&
+              (Icon ? (
+                <Icon theme={theme} as={StyledRadioButtonIcon} />
+              ) : (
+                <StyledRadioButtonIcon
+                  viewBox="0 0 24 24"
+                  preserveAspectRatio="xMidYMid meet"
+                >
+                  <circle cx={12} cy={12} r={6} />
+                </StyledRadioButtonIcon>
+              ))}
+          </StyledRadioButtonBox>
+        )}
+      </>
+    );
+
+    if (inToggleButtonGroup) {
+      return (
+        <StyledToggleButtonGroupContainer>
+          <Box flex={false}>{RadioButtonInput}</Box>
+        </StyledToggleButtonGroupContainer>
+      );
+    }
     return (
       <StyledRadioButtonContainer
         {...removeUndefined({ htmlFor: id, disabled })}
@@ -81,49 +141,7 @@ const RadioButton = forwardRef(
             label ? { right: theme.radioButton.gap || 'small' } : undefined
           }
         >
-          <StyledRadioButtonInput
-            aria-label={a11yTitle}
-            {...rest}
-            ref={ref}
-            type="radio"
-            {...removeUndefined({
-              id,
-              name,
-              checked,
-              disabled,
-              onChange,
-            })}
-          />
-          {children ? (
-            children({ checked, focus: focus && focusIndicator, hover })
-          ) : (
-            <StyledRadioButtonBox
-              focus={focus && focusIndicator}
-              as={Box}
-              align="center"
-              justify="center"
-              width={theme.radioButton.size}
-              height={theme.radioButton.size}
-              border={{
-                size: theme.radioButton.border.width,
-                color: borderColor,
-              }}
-              backgroundColor={backgroundColor}
-              round={theme.radioButton.check.radius}
-            >
-              {checked &&
-                (Icon ? (
-                  <Icon theme={theme} as={StyledRadioButtonIcon} />
-                ) : (
-                  <StyledRadioButtonIcon
-                    viewBox="0 0 24 24"
-                    preserveAspectRatio="xMidYMid meet"
-                  >
-                    <circle cx={12} cy={12} r={6} />
-                  </StyledRadioButtonIcon>
-                ))}
-            </StyledRadioButtonBox>
-          )}
+          {RadioButtonInput}
         </StyledRadioButton>
         {normalizedLabel}
       </StyledRadioButtonContainer>

--- a/src/js/components/ToggleButtonGroup/README.MD
+++ b/src/js/components/ToggleButtonGroup/README.MD
@@ -1,0 +1,2 @@
+## ToggleButtonGroup
+Documentation for this component: https://v2.grommet.io/ToggleButtonGroup

--- a/src/js/components/ToggleButtonGroup/StyledToggleButtonGroup.js
+++ b/src/js/components/ToggleButtonGroup/StyledToggleButtonGroup.js
@@ -1,0 +1,59 @@
+import styled from 'styled-components';
+
+import { normalizeColor } from '../../utils';
+import { defaultProps } from '../../default-props';
+
+const disabledStyle = `
+  opacity: 0.5;
+  cursor: default;
+`;
+
+const StyledToggleButtonGroupContainer = styled.label`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  user-select: none;
+  width: fit-content;
+  ${(props) => props.disabled && disabledStyle} ${(props) =>
+    !props.disabled && 'cursor: pointer;'}
+
+  :hover input:not([disabled]) + div,
+  :hover input:not([disabled]) + span {
+    border-color: ${(props) =>
+      // eslint-disable-next-line max-len
+      normalizeColor(
+        props.theme.toggleButtonGroup.hover.border.color,
+        props.theme,
+      )};
+  }
+  :hover {
+    background-color: ${(props) =>
+      normalizeColor(
+        !props.disabled &&
+          props.theme.toggleButtonGroup.hover &&
+          props.theme.toggleButtonGroup.hover.background &&
+          props.theme.toggleButtonGroup.hover.background.color,
+        props.theme,
+      )};
+  }
+  ${(props) =>
+    props.focus &&
+    !props.focusIndicator &&
+    `
+      input:not([disabled]) + div,
+      input:not([disabled]) + span {
+      border-color: ${normalizeColor(
+        props.theme.toggleButtonGroup.hover.border.color,
+        props.theme,
+      )};
+    }
+    `}
+`;
+
+StyledToggleButtonGroupContainer.defaultProps = {};
+Object.setPrototypeOf(
+  StyledToggleButtonGroupContainer.defaultProps,
+  defaultProps,
+);
+
+export { StyledToggleButtonGroupContainer };

--- a/src/js/components/ToggleButtonGroup/ToggleButtonGroup.js
+++ b/src/js/components/ToggleButtonGroup/ToggleButtonGroup.js
@@ -4,8 +4,14 @@ import { Box } from '../Box';
 import { RadioButtonGroup } from '../RadioButtonGroup';
 import { CheckBoxGroup } from '../CheckBoxGroup';
 
-const ToggleButtonGroup = ({ options, value, onChange, type, ...rest }) => {
-  // this sshould be in theme eventtuually which should we expose in base theme?
+const ToggleButtonGroup = ({
+  options,
+  value,
+  onChange,
+  exclusive,
+  ...rest
+}) => {
+  // this sshould be in theme eventually which should we expose in base theme?
   const toggleButtonGroupProps = {
     direction: 'row',
     margin: 'none',
@@ -14,30 +20,39 @@ const ToggleButtonGroup = ({ options, value, onChange, type, ...rest }) => {
     round: 'xsmall',
   };
   const contextValue = useMemo(() => ({ inToggleButtonGroup: true }), []);
+  const flatOptions = options.map((option) =>
+    typeof option === 'object' ? option.label : option,
+  );
 
   let content;
 
-  if (type === 'single') {
+  if (exclusive) {
     content = (
-      <RadioButtonGroup
-        name="radio"
-        options={options}
-        value={value}
-        onChange={onChange}
-        {...toggleButtonGroupProps}
-        {...rest}
-      >
-        {(option, { checked }) => (
-          <Box
-            background={checked ? 'active-background' : undefined}
-            // take off border on last option
-            border={{ side: 'right' }}
-            pad="xsmall"
-          >
-            {option.label || option}
-          </Box>
-        )}
-      </RadioButtonGroup>
+      <ToggleButtonGroupContext.Provider value={contextValue}>
+        <RadioButtonGroup
+          name="radio"
+          options={options}
+          value={value}
+          onChange={onChange}
+          {...toggleButtonGroupProps}
+          {...rest}
+        >
+          {(option, { checked }) => (
+            <Box
+              background={checked ? 'active-background' : undefined}
+              border={
+                flatOptions.indexOf(option.label || option) <
+                flatOptions.length - 1
+                  ? { side: 'right', color: 'border' }
+                  : undefined
+              }
+              pad="xsmall"
+            >
+              {option.label || option}
+            </Box>
+          )}
+        </RadioButtonGroup>
+      </ToggleButtonGroupContext.Provider>
     );
   } else {
     content = (
@@ -55,8 +70,12 @@ const ToggleButtonGroup = ({ options, value, onChange, type, ...rest }) => {
             <Box
               // move this to theme?
               background={checked ? 'active-background' : undefined}
-              // take off border on last option
-              border={{ side: 'right' }}
+              border={
+                flatOptions.indexOf(option.label || option) <
+                flatOptions.length - 1
+                  ? { side: 'right', color: 'border' }
+                  : undefined
+              }
               pad="xsmall"
             >
               {option.label || option.value}

--- a/src/js/components/ToggleButtonGroup/ToggleButtonGroup.js
+++ b/src/js/components/ToggleButtonGroup/ToggleButtonGroup.js
@@ -5,14 +5,13 @@ import { RadioButtonGroup } from '../RadioButtonGroup';
 import { CheckBoxGroup } from '../CheckBoxGroup';
 
 const ToggleButtonGroup = ({ options, value, onChange, type, ...rest }) => {
+  // this sshould be in theme eventtuually which should we expose in base theme?
   const toggleButtonGroupProps = {
     direction: 'row',
     margin: 'none',
     gap: 'none',
     border: true,
     round: 'xsmall',
-    // why is it growing past content
-    style: { width: 'fit-content' },
   };
   const contextValue = useMemo(() => ({ inToggleButtonGroup: true }), []);
 

--- a/src/js/components/ToggleButtonGroup/ToggleButtonGroup.js
+++ b/src/js/components/ToggleButtonGroup/ToggleButtonGroup.js
@@ -1,0 +1,75 @@
+import React, { useMemo } from 'react';
+import { ToggleButtonGroupContext } from './ToggleButtonGroupContext';
+import { Box } from '../Box';
+import { RadioButtonGroup } from '../RadioButtonGroup';
+import { CheckBoxGroup } from '../CheckBoxGroup';
+
+const ToggleButtonGroup = ({ options, value, onChange, type, ...rest }) => {
+  const toggleButtonGroupProps = {
+    direction: 'row',
+    margin: 'none',
+    gap: 'none',
+    border: true,
+    round: 'xsmall',
+    // why is it growing past content
+    style: { width: 'fit-content' },
+  };
+  const contextValue = useMemo(() => ({ inToggleButtonGroup: true }), []);
+
+  let content;
+
+  if (type === 'single') {
+    content = (
+      <RadioButtonGroup
+        name="radio"
+        options={options}
+        value={value}
+        onChange={onChange}
+        {...toggleButtonGroupProps}
+        {...rest}
+      >
+        {(option, { checked }) => (
+          <Box
+            background={checked ? 'active-background' : undefined}
+            // take off border on last option
+            border={{ side: 'right' }}
+            pad="xsmall"
+          >
+            {option.label || option}
+          </Box>
+        )}
+      </RadioButtonGroup>
+    );
+  } else {
+    content = (
+      <ToggleButtonGroupContext.Provider value={contextValue}>
+        <CheckBoxGroup
+          name="checkBox"
+          options={options}
+          value={value}
+          onChange={onChange}
+          labelKey="label"
+          {...toggleButtonGroupProps}
+          {...rest}
+        >
+          {(option, { checked }) => (
+            <Box
+              // move this to theme?
+              background={checked ? 'active-background' : undefined}
+              // take off border on last option
+              border={{ side: 'right' }}
+              pad="xsmall"
+            >
+              {option.label || option.value}
+            </Box>
+          )}
+        </CheckBoxGroup>
+      </ToggleButtonGroupContext.Provider>
+    );
+  }
+
+  return content;
+};
+
+ToggleButtonGroup.displayName = 'ToggleButtonGroup';
+export { ToggleButtonGroup };

--- a/src/js/components/ToggleButtonGroup/ToggleButtonGroupContext.js
+++ b/src/js/components/ToggleButtonGroup/ToggleButtonGroupContext.js
@@ -1,0 +1,3 @@
+import React from 'react';
+
+export const ToggleButtonGroupContext = React.createContext({});

--- a/src/js/components/ToggleButtonGroup/index.d.ts
+++ b/src/js/components/ToggleButtonGroup/index.d.ts
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import { RadioButtonGroupProps } from '../RadioButtonGroup/index';
+import { CheckBoxProps } from '../CheckBox/index';
+import { CheckBoxGroupProps } from '../CheckBoxGroup/index';
+
+interface OnChangeEvent {
+  value: string;
+  option: string | CheckBoxProps;
+}
+
+export interface CheckBoxType
+  extends Omit<CheckBoxProps & JSX.IntrinsicElements['input'], 'checked'> {
+  [key: string]: any;
+}
+
+export interface ToggleButtonGroupProps {
+  exclusive?: boolean;
+  onChange?: (event?: OnChangeEvent) => void;
+  options: (
+    | string
+    | number
+    | boolean
+    | CheckBoxType
+    | {
+        disabled?: boolean;
+        id?: string;
+        label?: string | React.ReactNode;
+        value: string | number | boolean;
+      }
+  )[];
+  value?: string | number | boolean | object | (number | string)[];
+}
+
+export interface ToggleButtonGoupExtendedProps
+  extends Omit<
+      RadioButtonGroupProps,
+      'name' | 'value' | 'options' | 'onChange'
+    >,
+    Omit<CheckBoxGroupProps, 'value' | 'options' | 'onChange'>,
+    ToggleButtonGroupProps {}
+
+declare const ToggleButtonGroup: React.FC<ToggleButtonGoupExtendedProps>;
+
+export { ToggleButtonGroup };

--- a/src/js/components/ToggleButtonGroup/index.js
+++ b/src/js/components/ToggleButtonGroup/index.js
@@ -1,0 +1,1 @@
+export { ToggleButtonGroup } from './ToggleButtonGroup';

--- a/src/js/components/ToggleButtonGroup/stories/custom.js
+++ b/src/js/components/ToggleButtonGroup/stories/custom.js
@@ -1,0 +1,47 @@
+import React from 'react';
+
+import { Grommet, Box, ToggleButtonGroup } from 'grommet';
+import { hpe } from 'grommet-theme-hpe';
+import { deepMerge } from 'grommet/utils';
+
+const theme = deepMerge(hpe, {
+  radioButton: {
+    container: {
+      extend: () => `
+          padding: none;
+        `,
+    },
+    extend: () => `
+          padding: none;
+        `,
+  },
+  radioButtonGroup: {
+    container: {
+      gap: 'none',
+      margin: {
+        vertical: 'none',
+      },
+    },
+  },
+});
+
+export const ThemedToggleButtonGroup = () => (
+  <Grommet theme={theme}>
+    <Box align="center" pad="large" gap="large">
+      <ToggleButtonGroup
+        exclusive
+        options={['button1', 'button2', 'button3']}
+      />
+      <ToggleButtonGroup
+        pad="none"
+        options={['button1', 'button2', 'button3']}
+      />
+    </Box>
+  </Grommet>
+);
+
+ThemedToggleButtonGroup.storyName = 'Theme';
+
+export default {
+  title: 'Input/ToggleButtonGroup/Theme',
+};

--- a/src/js/components/ToggleButtonGroup/stories/simple.js
+++ b/src/js/components/ToggleButtonGroup/stories/simple.js
@@ -14,7 +14,7 @@ const optionsObjects = [
   {
     label: (
       <Box direction="row">
-        Bold <Bold />
+        <Bold /> Bold
       </Box>
     ),
     value: 'bold',
@@ -22,7 +22,7 @@ const optionsObjects = [
   {
     label: (
       <Box direction="row">
-        Italic <Italic />
+        <Italic /> Italic
       </Box>
     ),
     value: 'italic',
@@ -30,7 +30,7 @@ const optionsObjects = [
   {
     label: (
       <Box direction="row">
-        Underline <Underline />
+        <Underline /> Underline
       </Box>
     ),
     value: 'underline',

--- a/src/js/components/ToggleButtonGroup/stories/simple.js
+++ b/src/js/components/ToggleButtonGroup/stories/simple.js
@@ -1,6 +1,6 @@
-import React, { useState } from 'react';
+import React from 'react';
 
-import { Box, ToggleButtonGroup, Select, Heading } from 'grommet';
+import { Box, ToggleButtonGroup, Heading } from 'grommet';
 import {
   List,
   MapLocation,
@@ -13,7 +13,7 @@ import {
 const optionsObjects = [
   {
     label: (
-      <Box direction="row">
+      <Box align="center" direction="row">
         <Bold /> Bold
       </Box>
     ),
@@ -21,7 +21,7 @@ const optionsObjects = [
   },
   {
     label: (
-      <Box direction="row">
+      <Box align="center" direction="row">
         <Italic /> Italic
       </Box>
     ),
@@ -29,7 +29,7 @@ const optionsObjects = [
   },
   {
     label: (
-      <Box direction="row">
+      <Box align="center" direction="row">
         <Underline /> Underline
       </Box>
     ),
@@ -52,34 +52,26 @@ const optionsIcons = [
   },
 ];
 
-export const Simple = () => {
-  const [value, setValue] = useState('single');
-  return (
-    <Box gap="large" pad="large">
-      <Heading margin="none" level={3}>
-        Default type is single which is RadioButtonGroup under the hood
-      </Heading>
-      <Box width="small">
-        <Select
-          id="select"
-          name="select"
-          placeholder="Select"
-          value={value}
-          options={['single', 'multiple']}
-          onChange={({ option }) => setValue(option)}
-        />
-      </Box>
-      <Box direction="row" gap="medium">
-        <ToggleButtonGroup
-          type={value}
-          options={['button1', 'button2', 'button3']}
-        />
-        <ToggleButtonGroup type={value} options={optionsIcons} />
-        <ToggleButtonGroup type={value} options={optionsObjects} />
-      </Box>
+export const Simple = () => (
+  <Box gap="large" pad="large">
+    <Heading margin="none" level={3}>
+      Default type is Multiple
+    </Heading>
+    <Box direction="row" gap="medium">
+      <ToggleButtonGroup options={['button1', 'button2', 'button3']} />
+      <ToggleButtonGroup options={optionsIcons} />
+      <ToggleButtonGroup options={optionsObjects} />
     </Box>
-  );
-};
+    <Box direction="row" gap="medium">
+      <ToggleButtonGroup
+        exclusive
+        options={['button1', 'button2', 'button3']}
+      />
+      <ToggleButtonGroup exclusive options={optionsIcons} />
+      <ToggleButtonGroup exclusive options={optionsObjects} />
+    </Box>
+  </Box>
+);
 
 export default {
   title: 'Input/ToggleButtonGroup/Simple',

--- a/src/js/components/ToggleButtonGroup/stories/simple.js
+++ b/src/js/components/ToggleButtonGroup/stories/simple.js
@@ -1,0 +1,86 @@
+import React, { useState } from 'react';
+
+import { Box, ToggleButtonGroup, Select, Heading } from 'grommet';
+import {
+  List,
+  MapLocation,
+  Table,
+  Bold,
+  Italic,
+  Underline,
+} from 'grommet-icons';
+
+const optionsObjects = [
+  {
+    label: (
+      <Box direction="row">
+        Bold <Bold />
+      </Box>
+    ),
+    value: 'bold',
+  },
+  {
+    label: (
+      <Box direction="row">
+        Italic <Italic />
+      </Box>
+    ),
+    value: 'italic',
+  },
+  {
+    label: (
+      <Box direction="row">
+        Underline <Underline />
+      </Box>
+    ),
+    value: 'underline',
+  },
+];
+
+const optionsIcons = [
+  {
+    label: <List />,
+    value: 'list',
+  },
+  {
+    label: <Table />,
+    value: 'table',
+  },
+  {
+    label: <MapLocation />,
+    value: 'map',
+  },
+];
+
+export const Simple = () => {
+  const [value, setValue] = useState('single');
+  return (
+    <Box gap="large" pad="large">
+      <Heading margin="none" level={3}>
+        Default type is single which is RadioButtonGroup under the hood
+      </Heading>
+      <Box width="small">
+        <Select
+          id="select"
+          name="select"
+          placeholder="Select"
+          value={value}
+          options={['single', 'multiple']}
+          onChange={({ option }) => setValue(option)}
+        />
+      </Box>
+      <Box direction="row" gap="medium">
+        <ToggleButtonGroup
+          type={value}
+          options={['button1', 'button2', 'button3']}
+        />
+        <ToggleButtonGroup type={value} options={optionsIcons} />
+        <ToggleButtonGroup type={value} options={optionsObjects} />
+      </Box>
+    </Box>
+  );
+};
+
+export default {
+  title: 'Input/ToggleButtonGroup/Simple',
+};

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -5034,6 +5034,7 @@ exports[`Components loads 1`] = `
     },
     "render": [Function],
   },
+  "ToggleButtonGroup": [Function],
   "Toolbar": [Function],
   "Video": {
     "$$typeof": Symbol(react.forward_ref),

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -2716,6 +2716,13 @@ exports[`Components loads 1`] = `
             "margin": "none",
           },
         },
+        "toggleButtonGroup": {
+          "hover": {
+            "border": {
+              "color": "border",
+            },
+          },
+        },
         "video": {
           "captions": {
             "background": "rgba(0, 0, 0, 0.7)",
@@ -4707,6 +4714,13 @@ exports[`Components loads 1`] = `
             "background": "none",
             "elevation": "none",
             "margin": "none",
+          },
+        },
+        "toggleButtonGroup": {
+          "hover": {
+            "border": {
+              "color": "border",
+            },
           },
         },
         "video": {

--- a/src/js/components/index.d.ts
+++ b/src/js/components/index.d.ts
@@ -88,6 +88,7 @@ export * from './TextArea';
 export * from './TextInput';
 export * from './ThumbsRating';
 export * from './Tip';
+export * from './ToggleButtonGroup';
 export * from './Toolbar';
 export * from './Video';
 export * from './WorldMap';

--- a/src/js/components/index.js
+++ b/src/js/components/index.js
@@ -89,6 +89,7 @@ export * from './Text';
 export * from './TextArea';
 export * from './TextInput';
 export * from './Tip';
+export * from './ToggleButtonGroup';
 export * from './Toolbar';
 export * from './ThumbsRating';
 export * from './Video';

--- a/src/js/index.d.ts
+++ b/src/js/index.d.ts
@@ -89,6 +89,7 @@ export * from './components/TextArea';
 export * from './components/TextInput';
 export * from './components/ThumbsRating';
 export * from './components/Tip';
+export * from './components/ToggleButtonGroup';
 export * from './components/Toolbar';
 export * from './components/Video';
 export * from './components/WorldMap';

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1934,6 +1934,13 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         margin: 'none',
       },
     },
+    toggleButtonGroup: {
+      hover: {
+        border: {
+          color: 'border',
+        },
+      },
+    },
     video: {
       captions: {
         background: 'rgba(0, 0, 0, 0.7)',


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This is a proposal for a ToggleButtonGroup component to follow on which design work that has been done.

The ToggleButtonGroup is a RadioButtonGroup if `type=single` and a CheckboxGroup if `type=multiple'. This component provides the layout of the container which has rounded edges, direction='row', and a right border that is served as a separator since `gap='none`. 

```
// API
  options: (
    | string
    | number
    | boolean
    | {
        disabled?: boolean;
        id?: string;
        label?: string | React.ReactNode;
        value: string | number | boolean;
      }
  )[];
value?: string | number | boolean | object;
onChange?:  (event: React.ChangeEvent<HTMLInputElement>) => void;
type?: single | multiple
```

// default Props 
```
  const toggleButtonGroupProps = {
    direction: 'row',
    margin: 'none',
    gap: 'none',
    border: true,
    round: 'xsmall',
  };
```

We can move default props into theme for users to change how the styling will be. We can also discuss what we want in base.js


To-do:

- [ ] add testing
- [ ] add stories

## Questions

1. should the size of the box stay the same what if one label is larger than others? 
2. As of now I had to have a toggleButtonGroup Context because checkbox always shows value and label. (is this correct?)
4. Do we like the prop `type` for changing between `checkboxGroup` and `RadioButtonGroup` 
5. Need to have an option of selecting just one but you can also select none. So one or none.
6. what hover behavior do we want?

#### Where should the reviewer start?
[ToggleButtonGroup.js](https://github.com/grommet/grommet/compare/master...britt6612:Add-toggleButtonGroup?expand=1#diff-8002567d9fcaff5455a46ebc6975147afce9ac0de841e8f7140021f9b39d613a)
#### What testing has been done on this PR?
storybook
#### How should this be manually tested?
storybook
#### Do Jest tests follow these best practices?

- [ ] - Need to add tests

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
NEW toggleButtonGroup component was needed 
#### What are the relevant issues?
https://github.com/grommet/hpe-design-system/issues/3739
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
yes
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
 backwards compatible