### PR TITLE
Fixed Grommet ThemeMode "auto" to ensure window is available for server side render

### DIFF
--- a/src/js/components/Grommet/Grommet.js
+++ b/src/js/components/Grommet/Grommet.js
@@ -89,6 +89,7 @@ const Grommet = forwardRef((props, ref) => {
 
     if (
       themeMode === 'auto' &&
+      typeof window !== 'undefined' &&
       window.matchMedia &&
       window.matchMedia('(prefers-color-scheme: dark)').matches
     ) {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Adds check to ensure `window` is available when checking for color scheme preference.

#### Where should the reviewer start?

Grommet.js

#### What testing has been done on this PR?

Applied fix to local project's `node_modules/grommet/es6/components/Grommet/Grommet,js`

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

N/A

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

NextJS app throws error :
```
node_modules/.pnpm/grommet@2.35.0_react-dom@18.2.0_react@18.2.0_styled-components@5.3.11/node_modules/grommet/es6/components/Grommet/Grommet.js (71:32) @ window
 ⨯ Internal error: ReferenceError: window is not defined
    at eval (./node_modules/.pnpm/grommet@2.35.0_react-dom@18.2.0_react@18.2.0_styled-components@5.3.11/node_modules/grommet/es6/components/Grommet/Grommet.js:110:37)
 ```

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

Yes.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.
