### PR TITLE
Fix dropHeight of DataFilter SelectMultiple

### DIFF
--- a/src/js/components/DataFilter/DataFilter.js
+++ b/src/js/components/DataFilter/DataFilter.js
@@ -217,6 +217,7 @@ export const DataFilter = ({
           <SelectMultiple
             aria-label={ariaLabel}
             id={id}
+            dropHeight="medium"
             name={property}
             showSelectedInline
             options={searchedOptions}

--- a/src/js/components/DataFilter/__tests__/__snapshots__/DataFilter-test.tsx.snap
+++ b/src/js/components/DataFilter/__tests__/__snapshots__/DataFilter-test.tsx.snap
@@ -4599,7 +4599,7 @@ exports[`DataFilter select multiple options search 2`] = `
 }
 
 .c3 {
-  max-height: inherit;
+  max-height: 384px;
 }
 
 .c15 {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

DataFilter SelectMultiple should have a reasonable dropHeight so it doesn't just fill all the available space. Setting to `medium`.

#### Where should the reviewer start?
src/js/components/DataFilter/DataFilter.js

#### What testing has been done on this PR?

BEFORE
<img width="1393" alt="Screen Shot 2024-03-06 at 10 12 43 AM" src="https://github.com/grommet/grommet/assets/12522275/540d9bf5-3088-4237-88ee-684ef062daa9">

AFTER
<img width="1382" alt="Screen Shot 2024-03-06 at 10 12 30 AM" src="https://github.com/grommet/grommet/assets/12522275/ad4dd6f4-d908-42b9-93d0-cee8945669a2">

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
