### PR TITLE
List keyboard behavior test and fix lint issues

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -64,7 +64,7 @@
     "react/sort-comp": 0,
     "react/state-in-constructor": 0,
     "react/static-property-placement": 0,
-    "react-hooks/exhaustive-deps": 1,
+    "react-hooks/exhaustive-deps": 2,
     "react-hooks/rules-of-hooks": 2,
     "semi": [2, "always"]
   },

--- a/src/js/components/List/List.js
+++ b/src/js/components/List/List.js
@@ -1,11 +1,4 @@
-import React, {
-  Fragment,
-  useCallback,
-  useContext,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import React, { Fragment, useContext, useMemo, useRef, useState } from 'react';
 import styled, { ThemeContext } from 'styled-components';
 
 import { DataContext } from '../../contexts/DataContext';
@@ -252,54 +245,41 @@ const List = React.forwardRef(
       ariaProps['aria-activedescendant'] = activeId;
     }
 
-    const onSelectOption = useCallback(
-      (event) => {
-        if ((onClickItem || onOrder) && active >= 0) {
-          if (onOrder) {
-            const index = Math.trunc(active / 2);
-            // Call onOrder with the re-ordered data.
-            // Update the active control index so that the
-            // active control will stay on the same item
-            // even though it moved up or down.
-            const newIndex = active % 2 ? index + 1 : index - 1;
-            onOrder(reorder(orderableData, pinnedInfo, index, newIndex));
-            updateActive(
-              active % 2
-                ? Math.min(active + 2, orderableData.length * 2 - 2)
-                : Math.max(active - 2, 1),
-            );
-          } else if (
-            disabledItems?.includes(getValue(data[active], active, itemKey))
-          ) {
-            event.preventDefault();
-          } else if (onClickItem) {
-            event.persist();
-            const adjustedEvent = event;
-            adjustedEvent.item = data[active];
-            adjustedEvent.index = active;
-            onClickItem(adjustedEvent);
-            sendAnalytics({
-              type: 'listItemClick',
-              element: listRef.current,
-              event: adjustedEvent,
-              item: data[active],
-              index: active,
-            });
-          }
+    const onSelectOption = (event) => {
+      if ((onClickItem || onOrder) && active >= 0) {
+        if (onOrder) {
+          const index = Math.trunc(active / 2);
+          // Call onOrder with the re-ordered data.
+          // Update the active control index so that the
+          // active control will stay on the same item
+          // even though it moved up or down.
+          const newIndex = active % 2 ? index + 1 : index - 1;
+          onOrder(reorder(orderableData, pinnedInfo, index, newIndex));
+          updateActive(
+            active % 2
+              ? Math.min(active + 2, orderableData.length * 2 - 2)
+              : Math.max(active - 2, 1),
+          );
+        } else if (
+          disabledItems?.includes(getValue(data[active], active, itemKey))
+        ) {
+          event.preventDefault();
+        } else if (onClickItem) {
+          event.persist();
+          const adjustedEvent = event;
+          adjustedEvent.item = data[active];
+          adjustedEvent.index = active;
+          onClickItem(adjustedEvent);
+          sendAnalytics({
+            type: 'listItemClick',
+            element: listRef.current,
+            event: adjustedEvent,
+            item: data[active],
+            index: active,
+          });
         }
-      },
-      [
-        active,
-        onOrder,
-        orderableData,
-        pinnedInfo,
-        disabledItems,
-        data,
-        itemKey,
-        onClickItem,
-        updateActive,
-      ],
-    );
+      }
+    };
 
     return (
       <Container {...containterProps}>

--- a/src/js/components/List/__tests__/List-test.js
+++ b/src/js/components/List/__tests__/List-test.js
@@ -581,7 +581,7 @@ describe('List onOrder', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test.only('Keyboard move up', () => {
+  test('Keyboard move up', () => {
     const { container, getByText } = render(<App />);
 
     expect(container.firstChild).toMatchSnapshot();

--- a/src/js/components/List/__tests__/List-test.js
+++ b/src/js/components/List/__tests__/List-test.js
@@ -581,7 +581,7 @@ describe('List onOrder', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test('Keyboard move up', () => {
+  test.only('Keyboard move up', () => {
     const { container, getByText } = render(<App />);
 
     expect(container.firstChild).toMatchSnapshot();
@@ -600,11 +600,11 @@ describe('List onOrder', () => {
     // beta's up arrow control should be active
     expect(container.firstChild).toMatchSnapshot();
     fireEvent.keyDown(getByText('alpha'), {
-      key: 'Enter',
-      keyCode: 13,
-      which: 13,
+      key: 'Space',
+      keyCode: 32,
+      which: 32,
     });
-    expect(onOrder).toHaveBeenCalled();
+    expect(onOrder).toHaveBeenCalledWith([{ a: 'beta' }, { a: 'alpha' }]);
     expect(container.firstChild).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
#### What does this PR do?
Modifies one of the list tests to use the 'space' key on the onOrder buttons. The test covers behavior added in https://github.com/grommet/grommet/pull/7140.

https://github.com/grommet/grommet/pull/7140 introduced a lint error because the dependency array for onSelectOption didn't include everything. I ended up removing the `useCallback` for that function. I don't think we were getting much value from `useCallback` in this case.

I modified our lint rules to flag react-hooks/exhaustive-deps as an error instead of just a warning. I was not able to find a way to have lint fail on warnings (but I didn't spend a ton of time looking, so I could have missed something).

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
backwards compatible