### PR TITLE
fix(list): updates typescript types for `children` prop

### DIFF
--- a/src/js/components/List/index.d.ts
+++ b/src/js/components/List/index.d.ts
@@ -43,7 +43,7 @@ export interface ListProps<ListItemType> {
     | string[]
     | { light: string | string[]; dark: string | string[] };
   border?: BorderType;
-  children?: (...args: ListItemType[]) => any;
+  children?: (...args: ListItemType[], index: number, state: Record<string, any>) => any;
   data?: ListItemType[];
   disabled?: string[];
   gridArea?: GridAreaType;

--- a/src/js/components/List/index.d.ts
+++ b/src/js/components/List/index.d.ts
@@ -43,7 +43,7 @@ export interface ListProps<ListItemType> {
     | string[]
     | { light: string | string[]; dark: string | string[] };
   border?: BorderType;
-  children?: (...args: any[]) => any;
+  children?: (...args: ListItemType[]) => any;
   data?: ListItemType[];
   disabled?: string[];
   gridArea?: GridAreaType;
@@ -76,7 +76,7 @@ export interface ListExtendedProps<ListItemType>
     ulProps {}
 
 declare const List: <ListItemType = string | {}>(
-  p: React.PropsWithChildren<ListExtendedProps<ListItemType>>,
+  p: ListExtendedProps<ListItemType>,
 ) => React.ReactElement<ListExtendedProps<ListItemType>>;
 
 export { List };


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

This PR fixes the TypeScript types for `ListExtendedProps` to align with the documentation.

#### Where should the reviewer start?

There isn't much to this PR.  I would start with reading through https://github.com/grommet/grommet/issues/7160 and then pulling the code down to test in a development environment.

#### What testing has been done on this PR?

Manual only (is DTSLint or something similar in use for validating types?)

#### How should this be manually tested?

Use it in a development environment.

#### What are the relevant issues?

Closes #7160

#### Screenshots (if appropriate)

<figure>
<img alt="Screenshot of intellisense in VSCode" src="https://github.com/grommet/grommet/assets/28069638/d80e12e2-5605-406c-a0ce-12da3a41c375" />
<figcaption>Type inference works properly with this change in the types</figcaption>
</figure>

#### Do the grommet docs need to be updated?

No, although I'm not sure what the type for the third argument should be based on the docs, so I left it a vague `Record<string, any>`

#### Should this PR be mentioned in the release notes?

No

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible unless people leveraged module augmentation or similar to get around the issue.