### PR TITLE
Fix vertical pad on readOnlyCopy button

### DIFF
--- a/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.tsx.snap
+++ b/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.tsx.snap
@@ -14883,6 +14883,8 @@ exports[`DateInput read only copy 1`] = `
   border-radius: 4px;
   padding-left: 11px;
   padding-right: 11px;
+  padding-top: 0;
+  padding-bottom: 0;
 }
 
 @media only screen and (max-width:768px) {

--- a/src/js/components/TextInput/CopyButton.js
+++ b/src/js/components/TextInput/CopyButton.js
@@ -29,12 +29,14 @@ export const CopyButton = ({
       <StyledButton
         onClick={onClickCopy}
         icon={<Copy />}
-        // only apply horizontal padding since button will
-        // fill height of input
         pad={{
           horizontal: theme.global.input.padding?.horizontal,
           left: theme.global.input.padding?.left,
           right: theme.global.input.padding?.right,
+          // only apply horizontal padding since button will
+          // fill height of input
+          top: '0',
+          bottom: '0',
         }}
         onBlur={onBlurCopy}
         onMouseOut={onBlurCopy}

--- a/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.tsx.snap
+++ b/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.tsx.snap
@@ -3156,6 +3156,8 @@ exports[`TextInput read only copy 1`] = `
   border-radius: 4px;
   padding-left: 11px;
   padding-right: 11px;
+  padding-top: 0;
+  padding-bottom: 0;
 }
 
 @media only screen and (max-width:768px) {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

`readOnlyCopy` button should not apply vertical pad, and should instead just fill the height of input. This was the originally intended behavior that seemed to not be implemented as expected.

#### Where should the reviewer start?
TextInput or DateInput

#### What testing has been done on this PR?
Local in storybook

<img width="575" alt="Captura de Pantalla 2024-03-19 a la(s) 2 03 46 p m" src="https://github.com/grommet/grommet/assets/12522275/d1581b5a-818f-424a-9176-508397943e06">

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.