### PR TITLE
Ensure PaginationSummary reflects active page

### DIFF
--- a/src/js/components/Data/stories/SpaceX.js
+++ b/src/js/components/Data/stories/SpaceX.js
@@ -1,15 +1,6 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
-import {
-  Box,
-  DataTable,
-  Data,
-  Footer,
-  Grid,
-  Pagination,
-  Text,
-  Tip,
-} from 'grommet';
+import { Box, DataTable, Data, Grid, Pagination, Text, Tip } from 'grommet';
 
 import { StatusCritical } from 'grommet-icons';
 
@@ -165,15 +156,6 @@ export const SpaceX = () => {
     });
   }, [view]);
 
-  const pageBounds = useMemo(() => {
-    if (result?.page)
-      return [
-        (result.page - 1) * view.step + 1,
-        Math.min(result.page * view.step, result.filteredTotal),
-      ];
-    return [];
-  }, [result, view]);
-
   return (
     // Uncomment <Grommet> lines when using outside of storybook
     // <Grommet theme={...}>
@@ -198,12 +180,7 @@ export const SpaceX = () => {
       >
         <DataTable columns={columns} sortable />
         {result.filteredTotal > view.step && (
-          <Footer border="top" pad={{ vertical: 'xsmall' }}>
-            <Text>
-              Showing {pageBounds[0]}-{pageBounds[1]} of {result.filteredTotal}
-            </Text>
-            <Pagination />
-          </Footer>
+          <Pagination summary border="top" pad={{ vertical: 'xsmall' }} />
         )}
       </Data>
     </Grid>

--- a/src/js/components/Pagination/Pagination.js
+++ b/src/js/components/Pagination/Pagination.js
@@ -248,7 +248,7 @@ const Pagination = forwardRef(
           {summary && (
             <PaginationSummary
               messages={messages}
-              page={page}
+              page={activePage}
               step={step}
               numberItems={total}
             />

--- a/src/js/components/Pagination/PaginationStep.js
+++ b/src/js/components/Pagination/PaginationStep.js
@@ -16,7 +16,7 @@ export const PaginationStep = ({
   const theme = useContext(ThemeContext);
   return (
     <Box direction="row" align="center" gap="xsmall" {...rest}>
-      <Text> {formatMessage({ id: 'pagination.stepLabel', messages })}</Text>
+      <Text>{formatMessage({ id: 'pagination.stepLabel', messages })}</Text>
       <Select
         options={options}
         value={step}


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

PaginationSummary should always reflect active page. When used outside of Data, the summary wasn't updating.

Also removed extra space in PaginationStep and updated SpaceX story to demo latest `summary` support.

#### Where should the reviewer start?
src/js/components/Pagination/Pagination.js

#### What testing has been done on this PR?
Local.

#### How should this be manually tested?
On "Steps" story, change page and PaginationSummary should update.

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.