### PR TITLE
Fix autoFocusingTags regex

### DIFF
--- a/src/js/utils/DOM.js
+++ b/src/js/utils/DOM.js
@@ -157,7 +157,8 @@ export const makeNodeFocusable = (node) => {
   }
 };
 
-const autoFocusingTags = /(a|area|input|select|textarea|button|iframe)$/;
+// Using ^ and $ to match the whole tagName, and not e.g. <meta> and <data>.
+const autoFocusingTags = /^(a|area|input|select|textarea|button|iframe)$/;
 
 export const makeNodeUnfocusable = (node) => {
   // do not touch aria live containers so that announcements work


### PR DESCRIPTION
Prevents unintentionally matching `data` and `meta` elements, and possibly custom web-components.

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [x] `screen` is used for querying.
- [x] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [x] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

- Issue https://github.com/grommet/grommet/issues/6981
- Comments on previous incorrect fix https://github.com/grommet/grommet/pull/6987

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?

Not certain, but I doubt it affects any real-world usecase