### PR TITLE
Add skeleton.extend to theme

### DIFF
--- a/src/js/components/Skeleton/StyledSkeleton.js
+++ b/src/js/components/Skeleton/StyledSkeleton.js
@@ -38,4 +38,5 @@ export const StyledSkeleton = styled.div`
     )}
   ${(props) =>
     props.round && roundStyle(props.round, props.responsive, props.theme)}
+  ${(props) => props.theme?.skeleton?.extend}
 `;

--- a/src/js/components/Skeleton/__tests__/Skeleton-test.tsx
+++ b/src/js/components/Skeleton/__tests__/Skeleton-test.tsx
@@ -111,6 +111,7 @@ describe('Skeleton', () => {
               light: ['#a2a8a8', '#adb9ba'],
             },
             round: 'xsmall',
+            extend: 'border: 1px solid blue;',
           },
         }}
       >

--- a/src/js/components/Skeleton/__tests__/__snapshots__/Skeleton-test.tsx.snap
+++ b/src/js/components/Skeleton/__tests__/__snapshots__/Skeleton-test.tsx.snap
@@ -597,6 +597,7 @@ exports[`Skeleton Skeleton with theme 1`] = `
   height: 18px;
   min-width: 100px;
   width: 100px;
+  border: 1px solid blue;
 }
 
 .c0 {

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -1470,7 +1470,7 @@ export interface ThemeType {
   selectMultiple?: {
     maxInline?: number;
   };
-  skeleton?: BoxProps & { colors?: SkeletonColorsType };
+  skeleton?: BoxProps & { colors?: SkeletonColorsType; extend?: ExtendType };
   skipLinks?: {
     position?: LayerPositionType;
     container?: BoxProps;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1725,6 +1725,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         dark: ['background', 'background-front'],
         light: ['background', 'background-back'],
       },
+      // extend: undefined,
     },
     skipLinks: {
       position: 'top',


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Adds `skeleton.extend` to theme to support custom animations or styling.

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.