### PR TITLE
Enhance DataTableColumns ordering options

### DIFF
--- a/src/js/components/DataTableColumns/DataTableColumns.js
+++ b/src/js/components/DataTableColumns/DataTableColumns.js
@@ -64,6 +64,18 @@ const Content = ({ drop, options = [], ...rest }) => {
     [options],
   );
 
+  const pinned = useMemo(() => {
+    const pinOrderList = [];
+    if (objectOptions) {
+      options.forEach((option) => {
+        if (option.pinOrder && option.label) {
+          pinOrderList.push(option.label);
+        }
+      });
+    }
+    return pinOrderList;
+  }, [options, objectOptions]);
+
   // 'value' is an array of property names
   const [value, setValue] = useFormInput({
     name: formColumnsKey,
@@ -139,6 +151,7 @@ const Content = ({ drop, options = [], ...rest }) => {
               onOrder={(nextData) => setValue(optionsToValue(nextData))}
               pad="none"
               primaryKey={(objectOptions && 'label') || undefined}
+              pinned={pinned}
             />
           </Box>
         </Tab>

--- a/src/js/components/DataTableColumns/index.d.ts
+++ b/src/js/components/DataTableColumns/index.d.ts
@@ -2,7 +2,15 @@ import * as React from 'react';
 
 export interface DataTableColumnsProps {
   drop: boolean;
-  options: (string | { property: string; label: string; disabled?: boolean })[];
+  options: (
+    | string
+    | {
+        property: string;
+        label: string;
+        disabled?: boolean;
+        pinOrder?: boolean;
+      }
+  )[];
 }
 
 declare const DataTableColumns: React.FC<DataTableColumnsProps>;

--- a/src/js/components/DataTableColumns/propTypes.js
+++ b/src/js/components/DataTableColumns/propTypes.js
@@ -10,6 +10,7 @@ if (process.env.NODE_ENV !== 'production') {
         PropTypes.shape({
           disabled: PropTypes.bool,
           label: PropTypes.string,
+          pinOrder: PropTypes.bool,
           property: PropTypes.string,
         }),
       ),

--- a/src/js/components/DataTableColumns/stories/Simple.js
+++ b/src/js/components/DataTableColumns/stories/Simple.js
@@ -11,10 +11,19 @@ import {
 import { columns, DATA } from '../../DataTable/stories/data';
 
 // simplify option label for name property
-const options = columns.map(({ header, property }) => ({
-  property,
-  label: property === 'name' ? 'Name' : header,
-}));
+// const options = columns.map() => ({
+//   property,
+//   label: property === 'name' ? 'Name' : header,
+//   property: 'id'
+// }));
+
+const OPTIONS = [
+  { label: 'Name', property: 'name', pinOrder: true },
+  { label: 'Location', property: 'location' },
+  { label: 'Date', property: 'date', pinOrder: true },
+  { label: 'Percent', property: 'percent' },
+  { label: 'Paid', property: 'paid' },
+];
 
 export const Simple = () => (
   // Uncomment <Grommet> lines when using outside of storybook
@@ -23,7 +32,7 @@ export const Simple = () => (
     <Data data={DATA}>
       <Toolbar>
         <DataSearch />
-        <DataTableColumns drop options={options} />
+        <DataTableColumns drop options={OPTIONS} />
       </Toolbar>
       <DataSummary />
       <DataTable columns={columns} primaryKey="name" />


### PR DESCRIPTION
This is a partial, draft, PR to enhance DataTableColumns to disallow changing the order of selected columns.

This PR addresses this issue: https://github.com/grommet/grommet/issues/7170

A new attribute, pinOrder, can be specified in an object in the options property.  This attribute pins the order of this column in DataTableColumns.

This is implemented using the existing pinned property of the List component.

Here is a description of requirements provided by Taylor Seamans:
1. Whichever item is effectively the “first” reorderable item should have the up arrow button disabled
2. If an item that isn’t the leftmost is not reorderable, then the items around it should shift while keeping its order fixed
3. This behavior should work for both drag + drop as well as using the arrow keys

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

![image](https://github.com/grommet/grommet/assets/91684949/17efdeae-4549-4858-86b5-07c605f85b38)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
