### PR TITLE
update step prop

### DIFF
--- a/src/js/components/Pagination/Pagination.js
+++ b/src/js/components/Pagination/Pagination.js
@@ -48,6 +48,11 @@ const Pagination = forwardRef(
     const total = numberItems ?? filteredTotal ?? 0;
     const page = pageProp || view?.page || 1;
 
+    // watch for changes to stepProp
+    useEffect(() => {
+      if (stepProp) setStep(stepProp);
+    }, [stepProp]);
+
     /* Calculate total number pages */
     const totalPages = Math.ceil(total / step);
     const [activePage, setActivePage] = useState(

--- a/src/js/components/Pagination/__tests__/Pagination-test.tsx
+++ b/src/js/components/Pagination/__tests__/Pagination-test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import 'jest-styled-components';
 import 'jest-axe/extend-expect';
 import 'regenerator-runtime/runtime';
@@ -9,6 +9,7 @@ import userEvent from '@testing-library/user-event';
 import { render, fireEvent, screen } from '@testing-library/react';
 
 import { Grommet } from '../../Grommet';
+import { Select } from '../../Select';
 import { Pagination } from '..';
 
 const NUM_ITEMS = 237;
@@ -469,5 +470,65 @@ describe('Pagination', () => {
       </Grommet>,
     );
     expect(asFragment()).toMatchSnapshot();
+  });
+
+  const TestComponent = () => {
+    const NUM_ITEMS = 100;
+    const [itemPerPage, setItemPerPage] = useState(20); // Initialize itemPerPage state
+
+    return (
+      <Grommet>
+        <Select
+          options={[10, 20, 50, 100]}
+          value={itemPerPage} // Set value of Select to itemPerPage
+          onChange={({ option }) => {
+            // Update itemPerPage state when Select value changes
+            setItemPerPage(option);
+          }}
+        />
+        <Pagination step={itemPerPage} numberItems={NUM_ITEMS} summary />
+      </Grommet>
+    );
+  };
+
+  test('should update page range based on step prop dynamically changing', async () => {
+    render(<TestComponent />);
+    // Open select
+    await userEvent.click(screen.getByRole('button', { name: /Open Drop/i }));
+    // Click on the option '10'
+    await userEvent.click(screen.getByRole('option', { name: '10' }));
+
+    // Expect input value to be 10
+    const updatedSelectButton = screen.getByRole('button', {
+      name: 'Open Drop; Selected: 10',
+    });
+    expect(updatedSelectButton).toBeTruthy();
+    expect(screen.getByText(`Showing 1-10 of 100`)).toBeTruthy();
+
+    // Open select again
+    await userEvent.click(screen.getByRole('button', { name: /Open Drop/i }));
+
+    // Click on the option '50'
+    await userEvent.click(screen.getByRole('option', { name: /50/i }));
+
+    // Expect input value to be 50
+    const updatedSelectButton1 = screen.getByRole('button', {
+      name: 'Open Drop; Selected: 50',
+    });
+    expect(updatedSelectButton1).toBeTruthy();
+    expect(screen.getByText(`Showing 1-50 of 100`)).toBeTruthy();
+
+    // Open select again
+    await userEvent.click(screen.getByRole('button', { name: /Open Drop/i }));
+
+    // Click on the option '100'
+    await userEvent.click(screen.getByRole('option', { name: /100/i }));
+
+    // Expect input value to be 100
+    const updatedSelectButton2 = screen.getByRole('button', {
+      name: 'Open Drop; Selected: 100',
+    });
+    expect(updatedSelectButton2).toBeTruthy();
+    expect(screen.getByText(`Showing 1-100 of 100`)).toBeTruthy();
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fixes a bug where step was not being updated based on `stepProp` 
#### Where should the reviewer start?
pagination.js
#### What testing has been done on this PR?
added a jest test 
#### How should this be manually tested?
```
  const [itemsPerPage, setItemsPerPage] = useState(20);
  const [totalItems, setTotalItems] = useState(itemsPerPage);

  useEffect(() => {
    setTotalItems(250);
  }, []);

  return (
    <Grommet theme={theme}>
      <Select
        testId="rows-per-page-dropdown"
        defaultVal={20}
        value={itemsPerPage}
        options={[10, 20, 50, 100]}
        onChange={({ option }) => {
          console.log(option);
          setItemsPerPage(option);
        }}
      />
      <Pagination numberItems={totalItems} step={itemsPerPage} />
    </Grommet>
  );
```
#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
We added a step state then set that value within the PaginationStep so since I changed step from being directly assigned to stepProp to using useState it was only getting the initial value of stepProp during the initial render and was not updating
#### What are the relevant issues?
team need
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible