### PR TITLE
change filters test to improve run time

### DIFF
--- a/src/js/components/DataFilters/__tests__/DataFilters-test.tsx
+++ b/src/js/components/DataFilters/__tests__/DataFilters-test.tsx
@@ -106,7 +106,6 @@ describe('DataFilters', () => {
   });
 
   test('should display all filter options regardless of result set', async () => {
-    const user = userEvent.setup();
     const filters = ['a', 'blue', 'b', 'red'];
     const { asFragment } = render(
       <Grommet>
@@ -137,14 +136,14 @@ describe('DataFilters', () => {
     // expect all results to be present
     expect(results).toHaveTextContent('a');
     expect(results).toHaveTextContent('b');
-    await user.click(screen.getByRole('checkbox', { name: 'a' }));
-    await user.click(applyFiltersButton);
+    fireEvent.click(screen.getByRole('checkbox', { name: 'a' }));
+    fireEvent.click(applyFiltersButton);
 
     // expect only 'a' to be present
     expect(results).toHaveTextContent('a');
     expect(results).not.toHaveTextContent('b');
-    await user.click(screen.getByRole('checkbox', { name: 'red' }));
-    await user.click(applyFiltersButton);
+    fireEvent.click(screen.getByRole('checkbox', { name: 'red' }));
+    fireEvent.click(applyFiltersButton);
 
     // expect no results to be present
     expect(results).not.toHaveTextContent('a');

--- a/src/js/components/DataFilters/__tests__/DataFilters-test.tsx
+++ b/src/js/components/DataFilters/__tests__/DataFilters-test.tsx
@@ -105,7 +105,7 @@ describe('DataFilters', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test('should display all filter options regardless of result set', async () => {
+  test('should display all filter options regardless of result set', () => {
     const filters = ['a', 'blue', 'b', 'red'];
     const { asFragment } = render(
       <Grommet>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
changes filters test to use `fireEvent`
#### Where should the reviewer start?
DataFilters.tsx
#### What testing has been done on this PR?
locally run jest test
#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
changed to use `fireEvent` instead of `user.click` so doesn't time out
#### What are the relevant issues?
https://github.com/orgs/grommet/projects/22/views/1?pane=issue&itemId=52570269
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
 backwards compatible