### PR TITLE
Upgrade chromatic version

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "babel-plugin-styled-components": "2.0.6",
     "babel-plugin-transform-imports": "^2.0.0",
     "bundlesize2": "^0.0.31",
-    "chromatic": "10.9.0",
+    "chromatic": "^11.3.0",
     "clean-webpack-plugin": "^4.0.0",
     "copy-webpack-plugin": "^12.0.2",
     "copyfiles": "^2.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5779,10 +5779,10 @@ chownr@^2.0.0:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
   integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
 
-chromatic@10.9.0:
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/chromatic/-/chromatic-10.9.0.tgz#8f8fa03d657e6d32be9291d0a22f30f556d13ab6"
-  integrity sha512-fA4RpmEwBe94na8+rxtsJFfzzfpkwAT2hvGT1udXiLC4v7y3xB+/2MHRRyAeIKU8EAUPHzuStc0bpxw5Tm9Biw==
+chromatic@^11.3.0:
+  version "11.3.0"
+  resolved "https://registry.yarnpkg.com/chromatic/-/chromatic-11.3.0.tgz#d46b7aac1a0eaed29a765645eaf93c484220174c"
+  integrity sha512-q1ZtJDJrjLGnz60ivpC16gmd7KFzcaA4eTb7gcytCqbaKqlHhCFr1xQmcUDsm14CK7JsqdkFU6S+JQdOd2ZNJg==
 
 chrome-remote-interface@^0.32.2:
   version "0.32.2"


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

The upgraded chromatic version was not the source of the snapshot changes. Instead, we believe it was the upgrade in Chromatic Cloud of which Chrome version is used.

Restoring our package.json to the latest chromatic version.

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
