### PR TITLE
Fix pagination step state synchronisation issue

### DIFF
--- a/src/js/components/Pagination/Pagination.js
+++ b/src/js/components/Pagination/Pagination.js
@@ -222,6 +222,11 @@ const Pagination = forwardRef(
       </Nav>
     );
 
+    // Synchronise internal step state with prop
+    useEffect(() => {
+      if (stepProp) setStep(stepProp);
+    }, [stepProp]);
+
     // for backwards compatibility
     if (!summary && !stepOptions)
       return (


### PR DESCRIPTION
#### What does this PR do?

This PR addresses an issue whereby the `step` state is managed by the parent component of the `Pagination` component.

Currently, after the `Pagination` is initially mounted, if the `step` prop is changes within the parent component, this isn't reflected within the internal `step` state of the `Pagination` component. This leads to an incorrect calculation of the internal `totalPages` value, therefore rendering the incorrect number of pages.

#### Where should the reviewer start?

N/A

#### What testing has been done on this PR?

Local developer testing.

#### How should this be manually tested?

Create a minimal application with a component which renders the `Pagination` component with the `step` prop specified which is managed within local state. Any changes to this local state will now be reflected within the total number of rendered pages within the `Pagination` component.

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

N/A

#### What are the relevant issues?

N/A

#### Screenshots (if appropriate)

N/A

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

Sure.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible (bug fix).
