### PR TITLE
Fix pagination step and stepOptions behaviors when step is controlled

### DIFF
--- a/src/js/components/Pagination/Pagination.js
+++ b/src/js/components/Pagination/Pagination.js
@@ -8,7 +8,6 @@ import { PageControl } from './PageControl';
 import { PaginationStep } from './PaginationStep';
 import { PaginationSummary } from './PaginationSummary';
 import { PaginationPropTypes } from './propTypes';
-import { useControlled } from '../../utils/useControlled';
 
 const StyledPaginationContainer = styled(Box)`
   ${(props) =>
@@ -45,11 +44,7 @@ const Pagination = forwardRef(
   ) => {
     const theme = useContext(ThemeContext) || defaultProps.theme;
     const { onView, filteredTotal, view } = useContext(DataContext);
-    const [step, setStep] = useControlled({
-      prop: stepProp,
-      defaultProp: view?.step || 10,
-      onChange,
-    });
+    const [step, setStep] = useState(stepProp || view?.step || 10);
     const total = numberItems ?? filteredTotal ?? 0;
     const page = pageProp || view?.page || 1;
 
@@ -58,6 +53,10 @@ const Pagination = forwardRef(
     const [activePage, setActivePage] = useState(
       Math.min(page, totalPages) || 1,
     );
+
+    useEffect(() => {
+      if (stepProp) setStep(stepProp);
+    }, [stepProp]);
 
     useEffect(() => {
       setActivePage(page);

--- a/src/js/components/Pagination/__tests__/Pagination-test.tsx
+++ b/src/js/components/Pagination/__tests__/Pagination-test.tsx
@@ -444,6 +444,46 @@ describe('Pagination', () => {
     expect(updatedSelectButton).toBeTruthy();
   });
 
+  test('should respect stepOptions and controlled step', async () => {
+    window.scrollTo = jest.fn();
+    const user = userEvent.setup();
+    const App = () => {
+      const [step, setStep] = useState(10);
+      return (
+        <Grommet>
+          <Select
+            a11yTitle="Controlled select"
+            options={[10, 25, 50, 100]}
+            onChange={({ option }) => setStep(option)}
+          />
+          <Pagination numberItems={NUM_ITEMS} step={step} stepOptions />
+        </Grommet>
+      );
+    };
+    render(<App />);
+    await user.click(
+      screen.getByRole('button', { name: /Controlled select/i }),
+    );
+    await user.click(screen.getByRole('option', { name: '50' }));
+    // stepOptions should have updated
+    const updatedSelectButton = screen.getByRole('button', {
+      name: 'Open Drop; Selected: 50',
+    });
+    expect(updatedSelectButton).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Go to page 5' })).toBeTruthy();
+    // there should only be 5 pages based on step = 50 and NUM_ITEMS
+    expect(
+      screen.queryByRole('button', { name: 'Go to page 6' }),
+    ).not.toBeInTheDocument();
+    await user.click(updatedSelectButton);
+    await user.click(screen.getByRole('option', { name: '25' }));
+    expect(screen.getByRole('button', { name: 'Go to page 10' })).toBeTruthy();
+    // there should only be 10 pages based on step = 25 and NUM_ITEMS
+    expect(
+      screen.queryByRole('button', { name: 'Go to page 11' }),
+    ).not.toBeInTheDocument();
+  });
+
   test('should apply a text component with summary', () => {
     const { asFragment } = render(
       <Grommet>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR fixes handling on `step` to ensure that in a controlled scenario, the internal state value is updated. It also ensures that `step` + `stepOptions` works.

Previously, https://github.com/grommet/grommet/pull/7188 caused the internal management of `stepOptions` to break.

For context, we had explored introducing a `useControlled` hook to reduce 1 extra re-render caused by the `useEffect` pattern. That said, this assumes that the `prop` being controlled (in this case `step`) has an equivalent change handler (which doesn't currently exist). Therefore, by passing `onChange` to the `useControlled` hook, we were incorrectly calling a change event more frequently than previously as well as not allowing `stepOptions` to update the internal step in cases where `step` was also used.

Given we follow the `useEffect` pattern elsewhere in Grommet, we will still with that for the time being as opposed to extending Pagination's API surface to include a step handler like `onStep`.

#### Where should the reviewer start?
src/js/components/Pagination/Pagination.js

#### What testing has been done on this PR?

Locally in storybook.

```
import React from 'react';

import { Box, Pagination, Text, Select } from 'grommet';

export const Simple = () => {
  const [page, setPage] = React.useState(1);
  const [step, setStep] = React.useState(10);

  return (
    // Uncomment <Grommet> lines when using outside of storybook
    // <Grommet theme={...}>
    <Box align="start" pad="small" gap="medium">
      <Box>
        <Select
          options={[10, 25, 50, 100]}
          onChange={({ option }) => setStep(option)}
          value={step}
        />
        <Text>Default</Text>
        <Pagination
          numberItems={237}
          page={page}
          onChange={({ page: nextPage }) => {
            console.log(nextPage);
            setPage(nextPage);
          }}
          step={step}
          stepOptions
        />
      </Box>
    </Box>
    // </Grommet>
  );
};

export default {
  title: 'Controls/Pagination/Simple',
};
```

Added jest tests.

#### How should this be manually tested?

In storybook locally as mentioned above.

#### Do Jest tests follow these best practices?

- [x] `screen` is used for querying.
- [x] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [x] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes https://github.com/grommet/grommet/issues/7201

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
Yes.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.