### PR TITLE
Ensure ToggleGroup doesn't crash when options is undefined

### DIFF
--- a/src/js/components/ToggleGroup/ToggleGroup.js
+++ b/src/js/components/ToggleGroup/ToggleGroup.js
@@ -42,7 +42,7 @@ const ToggleGroup = ({
   const ref = useRef();
   const buttonRefs = useRef([]);
 
-  const values = options.map((option) =>
+  const values = options?.map((option) =>
     typeof option === 'object' ? option.value : option,
   );
 
@@ -117,7 +117,7 @@ const ToggleGroup = ({
         role={multiple ? 'group' : 'radiogroup'}
         {...rest}
       >
-        {options.map((option, index) => {
+        {options?.map((option, index) => {
           let label;
           let icon;
           let optionValue;

--- a/src/js/components/ToggleGroup/__tests__/ToggleGroup-test.tsx
+++ b/src/js/components/ToggleGroup/__tests__/ToggleGroup-test.tsx
@@ -24,6 +24,16 @@ describe('ToggleGroup', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
+  test('renders without props', () => {
+    const { asFragment } = render(
+      <Grommet>
+        <ToggleGroup />
+      </Grommet>,
+    );
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+
   test('string options', () => {
     const { asFragment } = render(
       <Grommet>

--- a/src/js/components/ToggleGroup/__tests__/__snapshots__/ToggleGroup-test.tsx.snap
+++ b/src/js/components/ToggleGroup/__tests__/__snapshots__/ToggleGroup-test.tsx.snap
@@ -2614,6 +2614,51 @@ exports[`ToggleGroup object options 1`] = `
 </DocumentFragment>
 `;
 
+exports[`ToggleGroup renders without props 1`] = `
+<DocumentFragment>
+  .c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: start;
+  align-self: flex-start;
+  border: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  border-radius: 6px;
+}
+
+<div
+    class="c0"
+  >
+    <div
+      class="c1"
+      role="radiogroup"
+    />
+  </div>
+</DocumentFragment>
+`;
+
 exports[`ToggleGroup should have no accessibility violations 1`] = `
 <DocumentFragment>
   .c0 {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Checks that options is defined before mapping. Error found when testing in Grommet Designer.

#### Where should the reviewer start?
ToggleGroup.

#### What testing has been done on this PR?
Grommet designer locally. Added jest test.

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [x] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)
Error from Grommet Designer.

<img width="1672" alt="Screen Shot 2024-04-22 at 11 44 00 AM" src="https://github.com/grommet/grommet/assets/12522275/04dbc087-f81f-488c-a290-27555907b17c">


#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.