### PR TITLE
Update DataTableColumns snapshots to include drop

### DIFF
--- a/src/js/components/DataTableColumns/__tests__/DataTableColumns-test.tsx
+++ b/src/js/components/DataTableColumns/__tests__/DataTableColumns-test.tsx
@@ -16,6 +16,7 @@ const data = [
 ];
 
 describe('DataTableColumns', () => {
+  jest.useFakeTimers();
   window.scrollTo = jest.fn();
   beforeEach(createPortal);
 
@@ -38,6 +39,34 @@ describe('DataTableColumns', () => {
 
     expect(getByRole('button', { name: 'Open column selector' })).toBeTruthy();
     expect(container.firstChild).toMatchSnapshot();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Open column selector' }),
+    );
+
+    window.scrollTo = jest.fn();
+
+    // advance timers so drop can open
+    act(() => jest.advanceTimersByTime(200));
+    // Take a snapshot of the tab panel
+    const firstTabPanel = screen.getByRole('tabpanel', {
+      name: 'Select columns Tab Contents',
+    });
+    expect(firstTabPanel).toMatchSnapshot();
+
+    // Click on the "Order columns" tab
+    fireEvent.click(screen.getByRole('tab', { name: 'Order columns' }));
+
+    act(() => jest.advanceTimersByTime(200));
+
+    // Find the tab panel element using its role and aria-label
+    const secondTabPanel = screen.getByRole('tabpanel', {
+      name: 'Order columns Tab Contents',
+    });
+    // Take a snapshot of the tab panel
+    expect(secondTabPanel).toMatchSnapshot();
+
+    // click on button then snap shot
   });
 
   test('remove column', () => {
@@ -69,7 +98,10 @@ describe('DataTableColumns', () => {
     act(() => jest.advanceTimersByTime(200));
 
     // snapshot on drop
-    expectPortal('test-data--columns-control').toMatchSnapshot();
+    const tabPanel = screen.getByRole('tabpanel', {
+      name: 'Select columns Tab Contents',
+    });
+    expect(tabPanel).toMatchSnapshot();
 
     fireEvent.click(getByText('name'));
     expect(onView).toBeCalledWith(
@@ -110,7 +142,10 @@ describe('DataTableColumns', () => {
     act(() => jest.advanceTimersByTime(200));
 
     // snapshot on drop
-    expectPortal('test-data--columns-control').toMatchSnapshot();
+    const tabPanel = screen.getByRole('tabpanel', {
+      name: 'Select columns Tab Contents',
+    });
+    expect(tabPanel).toMatchSnapshot();
 
     // add content to search
     fireEvent.change(getByPlaceholderText('Search'), {
@@ -152,7 +187,7 @@ describe('DataTableColumns', () => {
       </Grommet>
     );
 
-    const { asFragment } = render(<App />);
+    render(<App />);
 
     fireEvent.click(
       screen.getByRole('button', { name: 'Open column selector' }),
@@ -163,8 +198,14 @@ describe('DataTableColumns', () => {
 
     fireEvent.click(screen.getByRole('tab', { name: 'Order columns' }));
 
+    act(() => jest.advanceTimersByTime(200));
+
     // snap order tab
-    expect(asFragment()).toMatchSnapshot();
+    const tabPanel = screen.getByRole('tabpanel', {
+      name: 'Order columns Tab Contents',
+    });
+    // Take a snapshot of the tab panel
+    expect(tabPanel).toMatchSnapshot();
 
     const bottomMoveUp = screen.getByRole('button', {
       name: '2 Percent move up',

--- a/src/js/components/DataTableColumns/__tests__/DataTableColumns-test.tsx
+++ b/src/js/components/DataTableColumns/__tests__/DataTableColumns-test.tsx
@@ -57,15 +57,12 @@ describe('DataTableColumns', () => {
     // Click on the "Order columns" tab
     fireEvent.click(screen.getByRole('tab', { name: 'Order columns' }));
 
-    act(() => jest.advanceTimersByTime(200));
-
     // Find the tab panel element using its role and aria-label
     const secondTabPanel = screen.getByRole('tabpanel', {
       name: 'Order columns Tab Contents',
     });
     // Take a snapshot of the tab panel
     expect(secondTabPanel).toMatchSnapshot();
-
   });
 
   test('remove column', () => {
@@ -196,8 +193,6 @@ describe('DataTableColumns', () => {
     act(() => jest.advanceTimersByTime(200));
 
     fireEvent.click(screen.getByRole('tab', { name: 'Order columns' }));
-
-    act(() => jest.advanceTimersByTime(200));
 
     // snap order tab
     const tabPanel = screen.getByRole('tabpanel', {

--- a/src/js/components/DataTableColumns/__tests__/DataTableColumns-test.tsx
+++ b/src/js/components/DataTableColumns/__tests__/DataTableColumns-test.tsx
@@ -21,7 +21,7 @@ describe('DataTableColumns', () => {
   beforeEach(createPortal);
 
   test('renders', () => {
-    const { container, getByRole } = render(
+    const { asFragment, getByRole } = render(
       <Grommet>
         <Data id="test-data" data={data}>
           <DataFilters>
@@ -38,7 +38,7 @@ describe('DataTableColumns', () => {
     );
 
     expect(getByRole('button', { name: 'Open column selector' })).toBeTruthy();
-    expect(container.firstChild).toMatchSnapshot();
+    expect(asFragment()).toMatchSnapshot();
 
     fireEvent.click(
       screen.getByRole('button', { name: 'Open column selector' }),
@@ -72,7 +72,7 @@ describe('DataTableColumns', () => {
   test('remove column', () => {
     jest.useFakeTimers();
     const onView = jest.fn();
-    const { container, getByRole, getByText } = render(
+    const { asFragment, getByRole, getByText } = render(
       <Grommet>
         <Data id="test-data" data={data} onView={onView}>
           <DataFilters updateOn="change">
@@ -90,7 +90,7 @@ describe('DataTableColumns', () => {
     );
     expect(getByRole('button', { name: 'Open column selector' })).toBeTruthy();
 
-    expect(container.firstChild).toMatchSnapshot();
+    expect(asFragment()).toMatchSnapshot();
 
     fireEvent.click(getByRole('button', { name: 'Open column selector' }));
 

--- a/src/js/components/DataTableColumns/__tests__/__snapshots__/DataTableColumns-test.tsx.snap
+++ b/src/js/components/DataTableColumns/__tests__/__snapshots__/DataTableColumns-test.tsx.snap
@@ -1,8 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DataTableColumns pinned 1`] = `
-<DocumentFragment>
-  .c4 {
+.c11 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -13,25 +12,25 @@ exports[`DataTableColumns pinned 1`] = `
   stroke: #666666;
 }
 
-.c4 g {
+.c11 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c4 *:not([stroke])[fill='none'] {
+.c11 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c4 *[stroke*='#'],
-.c4 *[STROKE*='#'] {
+.c11 *[stroke*='#'],
+.c11 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c4 *[fill-rule],
-.c4 *[FILL-RULE],
-.c4 *[fill*='#'],
-.c4 *[FILL*='#'] {
+.c11 *[fill-rule],
+.c11 *[FILL-RULE],
+.c11 *[fill*='#'],
+.c11 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -48,12 +47,34 @@ exports[`DataTableColumns pinned 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  padding-top: 12px;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-top: solid 1px rgba(0,0,0,0.33);
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
+  padding: 0px;
 }
 
-.c8 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -65,41 +86,168 @@ exports[`DataTableColumns pinned 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-}
-
-.c12 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
 }
 
 .c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.c13 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: #33333310;
+  color: #444444;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  padding: 0px;
+}
+
+.c15 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  padding: 12px;
+}
+
+.c16 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  padding: 0px;
+}
+
+.c6 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  width: 24px;
+}
+
+.c5 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c13 {
+.c8 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
 }
 
-.c3 {
+.c10 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  opacity: 0.3;
+  cursor: default;
+  line-height: 0;
+  padding: 12px;
+}
+
+.c10:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c10:focus:not(:focus-visible) > circle,
+.c10:focus:not(:focus-visible) > ellipse,
+.c10:focus:not(:focus-visible) > line,
+.c10:focus:not(:focus-visible) > path,
+.c10:focus:not(:focus-visible) > polygon,
+.c10:focus:not(:focus-visible) > polyline,
+.c10:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c10:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c12 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -119,103 +267,75 @@ exports[`DataTableColumns pinned 1`] = `
   padding: 12px;
 }
 
-.c3:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
+.c12:hover {
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
 }
 
-.c3:focus > circle,
-.c3:focus > ellipse,
-.c3:focus > line,
-.c3:focus > path,
-.c3:focus > polygon,
-.c3:focus > polyline,
-.c3:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c3:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.c3:focus:not(:focus-visible) {
+.c12:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible) > circle,
-.c3:focus:not(:focus-visible) > ellipse,
-.c3:focus:not(:focus-visible) > line,
-.c3:focus:not(:focus-visible) > path,
-.c3:focus:not(:focus-visible) > polygon,
-.c3:focus:not(:focus-visible) > polyline,
-.c3:focus:not(:focus-visible) > rect {
+.c12:focus:not(:focus-visible) > circle,
+.c12:focus:not(:focus-visible) > ellipse,
+.c12:focus:not(:focus-visible) > line,
+.c12:focus:not(:focus-visible) > path,
+.c12:focus:not(:focus-visible) > polygon,
+.c12:focus:not(:focus-visible) > polyline,
+.c12:focus:not(:focus-visible) > rect {
   outline: none;
   box-shadow: none;
 }
 
-.c3:focus:not(:focus-visible)::-moz-focus-inner {
+.c12:focus:not(:focus-visible)::-moz-focus-inner {
   border: 0;
 }
 
 .c2 {
-  max-width: 100%;
-}
-
-.c7 {
+  list-style: none;
   margin: 0;
   padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  border-bottom: solid 1px rgba(0,0,0,0.33);
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
 }
 
-.c11 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-.c5 {
-  border-spacing: 0;
-  border-collapse: collapse;
-  width: inherit;
-}
-
-.c6 {
-  position: relative;
-  border-spacing: 0;
-  border-collapse: separate;
-}
-
-.c10:focus {
+.c2:focus {
   outline: 2px solid #6FFFB0;
 }
 
-.c10:focus:not(:focus-visible) {
+.c2:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c2:focus:not(:focus-visible) > circle,
+.c2:focus:not(:focus-visible) > ellipse,
+.c2:focus:not(:focus-visible) > line,
+.c2:focus:not(:focus-visible) > path,
+.c2:focus:not(:focus-visible) > polygon,
+.c2:focus:not(:focus-visible) > polyline,
+.c2:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c2:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c4 {
+  cursor: move;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c14:focus {
   outline: none;
 }
 
 .c0 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
+  min-height: 0;
 }
 
 @media only screen and (max-width:768px) {
@@ -267,7 +387,52 @@ exports[`DataTableColumns pinned 1`] = `
 }
 
 @media only screen and (max-width:768px) {
+  .c1 {
+    padding-top: 6px;
+  }
+}
 
+@media only screen and (max-width:768px) {
+  .c3 {
+    border-top: solid 1px rgba(0,0,0,0.33);
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c3 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c13 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c13 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c15 {
+    padding: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c16 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c16 {
+    padding: 0px;
+  }
 }
 
 @media only screen and (max-width:768px) {
@@ -279,35 +444,9 @@ exports[`DataTableColumns pinned 1`] = `
 }
 
 @media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
-}
-
-@media only screen and (max-width:768px) {
-
+  .c6 {
+    width: 12px;
+  }
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
@@ -315,175 +454,203 @@ exports[`DataTableColumns pinned 1`] = `
 }
 
 <div
-    aria-hidden="true"
-    class="c0"
+  aria-label="Order columns Tab Contents"
+  class="c0"
+  role="tabpanel"
+>
+  <div
+    class="c1"
   >
-    <div
-      class="c1"
-      id="test-data"
+    <ul
+      aria-labelledby="test-data--order-columns-tab"
+      class="c2"
+      id="test-data--order-columns"
+      role="listbox"
+      tabindex="0"
     >
-      <form
-        class="c2"
+      <li
+        class="c3 c4"
+        draggable="true"
       >
-        <button
-          aria-label="Open column selector"
-          class="c3"
-          data-g-tabindex="none"
-          id="test-data--columns-control"
-          tabindex="-1"
-          type="button"
+        <span
+          class="c5"
+        >
+          1
+        </span>
+        <div
+          class="c6"
+        />
+        <div
+          class="c7"
+        >
+          <span
+            class="c8"
+          >
+            Name
+          </span>
+        </div>
+        <div
+          class="c6"
+        />
+        <div
+          class="c9"
+        >
+          <button
+            aria-label="1 Name move up"
+            class="c10"
+            disabled=""
+            id="NameMoveUp"
+            tabindex="-1"
+            type="button"
+          >
+            <svg
+              aria-label="FormUp"
+              class="c11"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 15-6-6-6 6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+          <button
+            aria-label="1 Name move down"
+            class="c12"
+            id="NameMoveDown"
+            tabindex="-1"
+            type="button"
+          >
+            <svg
+              aria-label="FormDown"
+              class="c11"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 9-6 6-6-6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </div>
+      </li>
+      <li
+        class="c13 c14"
+      >
+        <span
+          class="c5"
+        >
+          2
+        </span>
+        <div
+          class="c6"
+        />
+        <div
+          class="c7"
+        >
+          <span
+            class="c8"
+          >
+            Size
+          </span>
+        </div>
+        <div
+          class="c6"
+        />
+        <div
+          class="c15"
         >
           <svg
-            aria-label="Splits"
-            class="c4"
+            aria-label="FormPin"
+            class="c11"
             viewBox="0 0 24 24"
           >
             <path
-              d="M1 22h22V2H1v20zM8 2v20V2zm8 0v20V2z"
+              d="m4 19 4.455-4.454M12.273 5 18 10.727m-4.454-4.454L9.727 10.09s-2.545-.636-4.454 1.273l6.363 6.363c1.91-1.909 1.273-4.454 1.273-4.454l3.818-3.818-3.181-3.182Z"
               fill="none"
               stroke="#000"
               stroke-width="2"
             />
           </svg>
-        </button>
-      </form>
-      <table
-        class="c5 c6"
+        </div>
+      </li>
+      <li
+        class="c16 c4"
+        draggable="true"
       >
-        <thead
-          class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
+        <span
+          class="c5"
         >
-          <tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
-          >
-            <th
-              class="c7 "
-              scope="col"
-            >
-              <div
-                class="c8"
-              >
-                <span
-                  class="c9"
-                >
-                  Name
-                </span>
-              </div>
-            </th>
-            <th
-              class="c7 "
-              scope="col"
-            >
-              <div
-                class="c8"
-              >
-                <span
-                  class="c9"
-                >
-                  Size
-                </span>
-              </div>
-            </th>
-            <th
-              class="c7 "
-              scope="col"
-            >
-              <div
-                class="c8"
-              >
-                <span
-                  class="c9"
-                >
-                  Percent
-                </span>
-              </div>
-            </th>
-          </tr>
-        </thead>
-        <tbody
-          class="StyledTable__StyledTableBody-sc-1m3u5g-3 c10"
+          3
+        </span>
+        <div
+          class="c6"
+        />
+        <div
+          class="c7"
         >
-          <tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          <span
+            class="c8"
           >
-            <th
-              class="c11 "
-              scope="row"
-            >
-              <div
-                class="c12"
-              >
-                <span
-                  class="c13"
-                >
-                  a
-                </span>
-              </div>
-            </th>
-            <td
-              class="c11 "
-            >
-              <div
-                class="c12"
-              >
-                <span
-                  class="c9"
-                >
-                  s
-                </span>
-              </div>
-            </td>
-            <td
-              class="c11 "
-            >
-              <div
-                class="c12"
-              />
-            </td>
-          </tr>
-          <tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+            Percent
+          </span>
+        </div>
+        <div
+          class="c6"
+        />
+        <div
+          class="c9"
+        >
+          <button
+            aria-label="2 Percent move up"
+            class="c12"
+            id="PercentMoveUp"
+            tabindex="-1"
+            type="button"
           >
-            <th
-              class="c11 "
-              scope="row"
+            <svg
+              aria-label="FormUp"
+              class="c11"
+              viewBox="0 0 24 24"
             >
-              <div
-                class="c12"
-              >
-                <span
-                  class="c13"
-                >
-                  b
-                </span>
-              </div>
-            </th>
-            <td
-              class="c11 "
-            >
-              <div
-                class="c12"
-              >
-                <span
-                  class="c9"
-                >
-                  m
-                </span>
-              </div>
-            </td>
-            <td
-              class="c11 "
-            >
-              <div
-                class="c12"
+              <path
+                d="m18 15-6-6-6 6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
               />
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
+            </svg>
+          </button>
+          <button
+            aria-label="2 Percent move down"
+            class="c10"
+            disabled=""
+            id="PercentMoveDown"
+            tabindex="-1"
+            type="button"
+          >
+            <svg
+              aria-label="FormDown"
+              class="c11"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 9-6 6-6-6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </div>
+      </li>
+    </ul>
   </div>
-</DocumentFragment>
+</div>
 `;
 
 exports[`DataTableColumns remove column 1`] = `
@@ -872,88 +1039,498 @@ exports[`DataTableColumns remove column 1`] = `
 `;
 
 exports[`DataTableColumns remove column 2`] = `
-<button
-  aria-label="Open column selector"
-  class="StyledButton-sc-323bzc-0 hZNOgI"
-  data-g-tabindex="none"
-  id="test-data--columns-control"
-  tabindex="-1"
-  type="button"
->
-  <svg
-    aria-label="Splits"
-    class="StyledIcon-sc-ofa7kd-0 bQiAMQ"
-    viewBox="0 0 24 24"
-  >
-    <path
-      d="M1 22h22V2H1v20zM8 2v20V2zm8 0v20V2z"
-      fill="none"
-      stroke="#000"
-      stroke-width="2"
-    />
-  </svg>
-</button>
-`;
+.c4 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #666666;
+  stroke: #666666;
+}
 
-exports[`DataTableColumns remove column 3`] = `
-"@media only screen and (max-width: 768px) {
-  .kYOLuO {
-    margin-top: 12px;
+.c4 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c4 *:not([stroke])[fill='none'] {
+  stroke-width: 0;
+}
+
+.c4 *[stroke*='#'],
+.c4 *[STROKE*='#'] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c4 *[fill-rule],
+.c4 *[FILL-RULE],
+.c4 *[fill*='#'],
+.c4 *[FILL*='#'] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-right: 12px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c12 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: solid 2px #7D4CDB;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 24px;
+  width: 24px;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  border-radius: 4px;
+}
+
+.c6 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  height: 6px;
+}
+
+.c14 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  height: 12px;
+}
+
+.c13 {
+  box-sizing: border-box;
+  stroke-width: 4px;
+  stroke: #7D4CDB;
+  width: 24px;
+  height: 24px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  cursor: pointer;
+}
+
+.c8:hover input:not([disabled]) + div,
+.c8:hover input:not([disabled]) + span {
+  border-color: #000000;
+}
+
+.c11 {
+  opacity: 0;
+  -moz-appearance: none;
+  width: 0;
+  height: 0;
+  margin: 0;
+  cursor: pointer;
+}
+
+.c11:checked + span > span {
+  left: calc( 48px - 24px );
+  background: #7D4CDB;
+}
+
+.c10 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c5 {
+  box-sizing: border-box;
+  font-size: inherit;
+  font-family: inherit;
+  border: none;
+  -webkit-appearance: none;
+  background: transparent;
+  color: inherit;
+  width: 100%;
+  padding: 11px;
+  font-weight: 600;
+  margin: 0;
+  border: 1px solid rgba(0,0,0,0.33);
+  border-radius: 4px;
+  padding-left: 48px;
+}
+
+.c5:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c5:focus > circle,
+.c5:focus > ellipse,
+.c5:focus > line,
+.c5:focus > path,
+.c5:focus > polygon,
+.c5:focus > polyline,
+.c5:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c5:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c5::-webkit-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c5::-moz-placeholder {
+  color: #AAAAAA;
+}
+
+.c5:-ms-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c5::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+.c5::-moz-focus-inner {
+  border: none;
+  outline: none;
+}
+
+.c5:-moz-placeholder,
+.c5::-moz-placeholder {
+  opacity: 1;
+}
+
+.c2 {
+  position: relative;
+  width: 100%;
+}
+
+.c3 {
+  position: absolute;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-packjustify: center;
+  -webkit-justify: center;
+  -ms-flex-packjustify: center;
+  justify: center;
+  top: 50%;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  pointer-events: none;
+  left: 12px;
+}
+
+.c0 {
+  min-height: 0;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    padding-top: 6px;
+    padding-bottom: 6px;
   }
 }
-.hZNOgI {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  color: inherit;
-  outline: none;
-  border: none;
-  padding: 0;
-  text-align: inherit;
-  line-height: 0;
-  padding: 12px;
+
+@media only screen and (max-width:768px) {
+  .c9 {
+    margin-right: 6px;
+  }
 }
-.hZNOgI:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6fffb0;
+
+@media only screen and (max-width:768px) {
+  .c12 {
+    border: solid 2px #7D4CDB;
+  }
 }
-.hZNOgI:focus > circle,
-.hZNOgI:focus > ellipse,
-.hZNOgI:focus > line,
-.hZNOgI:focus > path,
-.hZNOgI:focus > polygon,
-.hZNOgI:focus > polyline,
-.hZNOgI:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6fffb0;
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    height: 3px;
+  }
 }
-.hZNOgI:focus::-moz-focus-inner {
-  border: 0;
+
+@media only screen and (max-width:768px) {
+  .c14 {
+    height: 6px;
+  }
 }
-.hZNOgI:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+
 }
-.hZNOgI:focus:not(:focus-visible) > circle,
-.hZNOgI:focus:not(:focus-visible) > ellipse,
-.hZNOgI:focus:not(:focus-visible) > line,
-.hZNOgI:focus:not(:focus-visible) > path,
-.hZNOgI:focus:not(:focus-visible) > polygon,
-.hZNOgI:focus:not(:focus-visible) > polyline,
-.hZNOgI:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
-}
-.hZNOgI:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}"
+
+<div
+  aria-label="Select columns Tab Contents"
+  class="c0"
+  role="tabpanel"
+>
+  <div
+    class="c1"
+  >
+    <div
+      class="c2"
+    >
+      <div
+        class="c3"
+      >
+        <svg
+          aria-label="Search"
+          class="c4"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+            fill="none"
+            stroke="#000"
+            stroke-width="2"
+          />
+        </svg>
+      </div>
+      <input
+        autocomplete="off"
+        class="c5"
+        placeholder="Search"
+        type="search"
+        value=""
+      />
+    </div>
+    <div
+      class="c6"
+    />
+    <div
+      aria-labelledby="test-data--select-columns-tab"
+      class="c7 StyledCheckBoxGroup-sc-2nhc5d-0"
+      id="test-data--select-columns"
+      role="group"
+    >
+      <label
+        class="c8"
+      >
+        <div
+          class="c9 c10"
+        >
+          <input
+            checked=""
+            class="c11"
+            type="checkbox"
+          />
+          <div
+            class="c12 "
+          >
+            <svg
+              class="c13"
+              preserveAspectRatio="xMidYMid meet"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M6,11.3 L10.3,16 L18,6.2"
+                fill="none"
+              />
+            </svg>
+          </div>
+        </div>
+        <span>
+          name
+        </span>
+      </label>
+      <div
+        class="c14"
+      />
+      <label
+        class="c8"
+      >
+        <div
+          class="c9 c10"
+        >
+          <input
+            checked=""
+            class="c11"
+            type="checkbox"
+          />
+          <div
+            class="c12 "
+          >
+            <svg
+              class="c13"
+              preserveAspectRatio="xMidYMid meet"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M6,11.3 L10.3,16 L18,6.2"
+                fill="none"
+              />
+            </svg>
+          </div>
+        </div>
+        <span>
+          size
+        </span>
+      </label>
+      <div
+        class="c14"
+      />
+      <label
+        class="c8"
+      >
+        <div
+          class="c9 c10"
+        >
+          <input
+            checked=""
+            class="c11"
+            type="checkbox"
+          />
+          <div
+            class="c12 "
+          >
+            <svg
+              class="c13"
+              preserveAspectRatio="xMidYMid meet"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M6,11.3 L10.3,16 L18,6.2"
+                fill="none"
+              />
+            </svg>
+          </div>
+        </div>
+        <span>
+          age
+        </span>
+      </label>
+    </div>
+  </div>
+</div>
 `;
 
 exports[`DataTableColumns renders 1`] = `
@@ -1472,6 +2049,984 @@ exports[`DataTableColumns renders 1`] = `
 </div>
 `;
 
+exports[`DataTableColumns renders 2`] = `
+.c4 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #666666;
+  stroke: #666666;
+}
+
+.c4 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c4 *:not([stroke])[fill='none'] {
+  stroke-width: 0;
+}
+
+.c4 *[stroke*='#'],
+.c4 *[STROKE*='#'] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c4 *[fill-rule],
+.c4 *[FILL-RULE],
+.c4 *[fill*='#'],
+.c4 *[FILL*='#'] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-right: 12px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c12 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: solid 2px #7D4CDB;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 24px;
+  width: 24px;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  border-radius: 4px;
+}
+
+.c6 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  height: 6px;
+}
+
+.c14 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  height: 12px;
+}
+
+.c13 {
+  box-sizing: border-box;
+  stroke-width: 4px;
+  stroke: #7D4CDB;
+  width: 24px;
+  height: 24px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  cursor: pointer;
+}
+
+.c8:hover input:not([disabled]) + div,
+.c8:hover input:not([disabled]) + span {
+  border-color: #000000;
+}
+
+.c11 {
+  opacity: 0;
+  -moz-appearance: none;
+  width: 0;
+  height: 0;
+  margin: 0;
+  cursor: pointer;
+}
+
+.c11:checked + span > span {
+  left: calc( 48px - 24px );
+  background: #7D4CDB;
+}
+
+.c10 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c5 {
+  box-sizing: border-box;
+  font-size: inherit;
+  font-family: inherit;
+  border: none;
+  -webkit-appearance: none;
+  background: transparent;
+  color: inherit;
+  width: 100%;
+  padding: 11px;
+  font-weight: 600;
+  margin: 0;
+  border: 1px solid rgba(0,0,0,0.33);
+  border-radius: 4px;
+  padding-left: 48px;
+}
+
+.c5:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c5:focus > circle,
+.c5:focus > ellipse,
+.c5:focus > line,
+.c5:focus > path,
+.c5:focus > polygon,
+.c5:focus > polyline,
+.c5:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c5:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c5::-webkit-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c5::-moz-placeholder {
+  color: #AAAAAA;
+}
+
+.c5:-ms-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c5::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+.c5::-moz-focus-inner {
+  border: none;
+  outline: none;
+}
+
+.c5:-moz-placeholder,
+.c5::-moz-placeholder {
+  opacity: 1;
+}
+
+.c2 {
+  position: relative;
+  width: 100%;
+}
+
+.c3 {
+  position: absolute;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-packjustify: center;
+  -webkit-justify: center;
+  -ms-flex-packjustify: center;
+  justify: center;
+  top: 50%;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  pointer-events: none;
+  left: 12px;
+}
+
+.c0 {
+  min-height: 0;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c9 {
+    margin-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c12 {
+    border: solid 2px #7D4CDB;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    height: 3px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c14 {
+    height: 6px;
+  }
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+
+}
+
+<div
+  aria-label="Select columns Tab Contents"
+  class="c0"
+  role="tabpanel"
+>
+  <div
+    class="c1"
+  >
+    <div
+      class="c2"
+    >
+      <div
+        class="c3"
+      >
+        <svg
+          aria-label="Search"
+          class="c4"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+            fill="none"
+            stroke="#000"
+            stroke-width="2"
+          />
+        </svg>
+      </div>
+      <input
+        autocomplete="off"
+        class="c5"
+        placeholder="Search"
+        type="search"
+        value=""
+      />
+    </div>
+    <div
+      class="c6"
+    />
+    <div
+      aria-labelledby="test-data--select-columns-tab"
+      class="c7 StyledCheckBoxGroup-sc-2nhc5d-0"
+      id="test-data--select-columns"
+      role="group"
+    >
+      <label
+        class="c8"
+      >
+        <div
+          class="c9 c10"
+        >
+          <input
+            checked=""
+            class="c11"
+            type="checkbox"
+          />
+          <div
+            class="c12 "
+          >
+            <svg
+              class="c13"
+              preserveAspectRatio="xMidYMid meet"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M6,11.3 L10.3,16 L18,6.2"
+                fill="none"
+              />
+            </svg>
+          </div>
+        </div>
+        <span>
+          name
+        </span>
+      </label>
+      <div
+        class="c14"
+      />
+      <label
+        class="c8"
+      >
+        <div
+          class="c9 c10"
+        >
+          <input
+            checked=""
+            class="c11"
+            type="checkbox"
+          />
+          <div
+            class="c12 "
+          >
+            <svg
+              class="c13"
+              preserveAspectRatio="xMidYMid meet"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M6,11.3 L10.3,16 L18,6.2"
+                fill="none"
+              />
+            </svg>
+          </div>
+        </div>
+        <span>
+          size
+        </span>
+      </label>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DataTableColumns renders 3`] = `
+<div
+  aria-label="Order columns Tab Contents"
+  class="StyledTabs__StyledTabPanel-sc-a4fwxl-1 llnZPb"
+  role="tabpanel"
+>
+  <div
+    class="StyledBox-sc-13pk1d4-0 btDoOz"
+  >
+    .c8 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #666666;
+  stroke: #666666;
+}
+
+.c8 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c8 *:not([stroke])[fill='none'] {
+  stroke-width: 0;
+}
+
+.c8 *[stroke*='#'],
+.c8 *[STROKE*='#'] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c8 *[fill-rule],
+.c8 *[FILL-RULE],
+.c8 *[fill*='#'],
+.c8 *[FILL*='#'] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-top: solid 1px rgba(0,0,0,0.33);
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  padding: 0px;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.c10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  padding: 0px;
+}
+
+.c4 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  width: 24px;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c7 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  opacity: 0.3;
+  cursor: default;
+  line-height: 0;
+  padding: 12px;
+}
+
+.c7:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c7:focus:not(:focus-visible) > circle,
+.c7:focus:not(:focus-visible) > ellipse,
+.c7:focus:not(:focus-visible) > line,
+.c7:focus:not(:focus-visible) > path,
+.c7:focus:not(:focus-visible) > polygon,
+.c7:focus:not(:focus-visible) > polyline,
+.c7:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c7:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c9 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  line-height: 0;
+  padding: 12px;
+}
+
+.c9:hover {
+  background-color: rgba(221,221,221,0.4);
+  color: #000000;
+}
+
+.c9:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c9:focus:not(:focus-visible) > circle,
+.c9:focus:not(:focus-visible) > ellipse,
+.c9:focus:not(:focus-visible) > line,
+.c9:focus:not(:focus-visible) > path,
+.c9:focus:not(:focus-visible) > polygon,
+.c9:focus:not(:focus-visible) > polyline,
+.c9:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c9:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c0 {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.c0:focus {
+  outline: 2px solid #6FFFB0;
+}
+
+.c0:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c0:focus:not(:focus-visible) > circle,
+.c0:focus:not(:focus-visible) > ellipse,
+.c0:focus:not(:focus-visible) > line,
+.c0:focus:not(:focus-visible) > path,
+.c0:focus:not(:focus-visible) > polygon,
+.c0:focus:not(:focus-visible) > polyline,
+.c0:focus:not(:focus-visible) > rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c0:focus:not(:focus-visible)::-moz-focus-inner {
+  border: 0;
+}
+
+.c2 {
+  cursor: move;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    border-top: solid 1px rgba(0,0,0,0.33);
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c10 {
+    border-bottom: solid 1px rgba(0,0,0,0.33);
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c10 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+  .c4 {
+    width: 12px;
+  }
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+
+}
+
+<ul
+      aria-labelledby="test-data--order-columns-tab"
+      class="c0"
+      id="test-data--order-columns"
+      role="listbox"
+      tabindex="0"
+    >
+      <li
+        class="c1 c2"
+        draggable="true"
+      >
+        <span
+          class="c3"
+        >
+          1
+        </span>
+        <div
+          class="c4"
+        />
+        <div
+          class="c5"
+        >
+          name
+        </div>
+        <div
+          class="c4"
+        />
+        <div
+          class="c6"
+        >
+          <button
+            aria-label="1 name move up"
+            class="c7"
+            disabled=""
+            id="nameMoveUp"
+            tabindex="-1"
+            type="button"
+          >
+            <svg
+              aria-label="FormUp"
+              class="c8"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 15-6-6-6 6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+          <button
+            aria-label="1 name move down"
+            class="c9"
+            id="nameMoveDown"
+            tabindex="-1"
+            type="button"
+          >
+            <svg
+              aria-label="FormDown"
+              class="c8"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 9-6 6-6-6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </div>
+      </li>
+      <li
+        class="c10 c2"
+        draggable="true"
+      >
+        <span
+          class="c3"
+        >
+          2
+        </span>
+        <div
+          class="c4"
+        />
+        <div
+          class="c5"
+        >
+          size
+        </div>
+        <div
+          class="c4"
+        />
+        <div
+          class="c6"
+        >
+          <button
+            aria-label="2 size move up"
+            class="c9"
+            id="sizeMoveUp"
+            tabindex="-1"
+            type="button"
+          >
+            <svg
+              aria-label="FormUp"
+              class="c8"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 15-6-6-6 6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+          <button
+            aria-label="2 size move down"
+            class="c7"
+            disabled=""
+            id="sizeMoveDown"
+            tabindex="-1"
+            type="button"
+          >
+            <svg
+              aria-label="FormDown"
+              class="c8"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 9-6 6-6-6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </div>
+      </li>
+    </ul>
+  </div>
+</div>
+`;
+
 exports[`DataTableColumns search 1`] = `
 .c4 {
   display: inline-block;
@@ -1830,6 +3385,468 @@ exports[`DataTableColumns search 1`] = `
 `;
 
 exports[`DataTableColumns search 2`] = `
+.c4 {
+  display: inline-block;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #666666;
+  stroke: #666666;
+}
+
+.c4 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c4 *:not([stroke])[fill='none'] {
+  stroke-width: 0;
+}
+
+.c4 *[stroke*='#'],
+.c4 *[STROKE*='#'] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c4 *[fill-rule],
+.c4 *[FILL-RULE],
+.c4 *[fill*='#'],
+.c4 *[FILL*='#'] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-right: 12px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c12 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: solid 2px #7D4CDB;
+  min-width: 0;
+  min-height: 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 24px;
+  width: 24px;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  border-radius: 4px;
+}
+
+.c6 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  height: 6px;
+}
+
+.c14 {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  height: 12px;
+}
+
+.c13 {
+  box-sizing: border-box;
+  stroke-width: 4px;
+  stroke: #7D4CDB;
+  width: 24px;
+  height: 24px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  cursor: pointer;
+}
+
+.c8:hover input:not([disabled]) + div,
+.c8:hover input:not([disabled]) + span {
+  border-color: #000000;
+}
+
+.c11 {
+  opacity: 0;
+  -moz-appearance: none;
+  width: 0;
+  height: 0;
+  margin: 0;
+  cursor: pointer;
+}
+
+.c11:checked + span > span {
+  left: calc( 48px - 24px );
+  background: #7D4CDB;
+}
+
+.c10 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c5 {
+  box-sizing: border-box;
+  font-size: inherit;
+  font-family: inherit;
+  border: none;
+  -webkit-appearance: none;
+  background: transparent;
+  color: inherit;
+  width: 100%;
+  padding: 11px;
+  font-weight: 600;
+  margin: 0;
+  border: 1px solid rgba(0,0,0,0.33);
+  border-radius: 4px;
+  padding-left: 48px;
+}
+
+.c5:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c5:focus > circle,
+.c5:focus > ellipse,
+.c5:focus > line,
+.c5:focus > path,
+.c5:focus > polygon,
+.c5:focus > polyline,
+.c5:focus > rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c5:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.c5::-webkit-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c5::-moz-placeholder {
+  color: #AAAAAA;
+}
+
+.c5:-ms-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c5::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+.c5::-moz-focus-inner {
+  border: none;
+  outline: none;
+}
+
+.c5:-moz-placeholder,
+.c5::-moz-placeholder {
+  opacity: 1;
+}
+
+.c2 {
+  position: relative;
+  width: 100%;
+}
+
+.c3 {
+  position: absolute;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-packjustify: center;
+  -webkit-justify: center;
+  -ms-flex-packjustify: center;
+  justify: center;
+  top: 50%;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  pointer-events: none;
+  left: 12px;
+}
+
+.c0 {
+  min-height: 0;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c9 {
+    margin-right: 6px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c12 {
+    border: solid 2px #7D4CDB;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c6 {
+    height: 3px;
+  }
+}
+
+@media only screen and (max-width:768px) {
+  .c14 {
+    height: 6px;
+  }
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+
+}
+
+<div
+  aria-label="Select columns Tab Contents"
+  class="c0"
+  role="tabpanel"
+>
+  <div
+    class="c1"
+  >
+    <div
+      class="c2"
+    >
+      <div
+        class="c3"
+      >
+        <svg
+          aria-label="Search"
+          class="c4"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="m15 15 7 7-7-7zm-5.5 2a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15z"
+            fill="none"
+            stroke="#000"
+            stroke-width="2"
+          />
+        </svg>
+      </div>
+      <input
+        autocomplete="off"
+        class="c5"
+        placeholder="Search"
+        type="search"
+        value=""
+      />
+    </div>
+    <div
+      class="c6"
+    />
+    <div
+      aria-labelledby="test-data--select-columns-tab"
+      class="c7 StyledCheckBoxGroup-sc-2nhc5d-0"
+      id="test-data--select-columns"
+      role="group"
+    >
+      <label
+        class="c8"
+      >
+        <div
+          class="c9 c10"
+        >
+          <input
+            checked=""
+            class="c11"
+            type="checkbox"
+          />
+          <div
+            class="c12 "
+          >
+            <svg
+              class="c13"
+              preserveAspectRatio="xMidYMid meet"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M6,11.3 L10.3,16 L18,6.2"
+                fill="none"
+              />
+            </svg>
+          </div>
+        </div>
+        <span>
+          name
+        </span>
+      </label>
+      <div
+        class="c14"
+      />
+      <label
+        class="c8"
+      >
+        <div
+          class="c9 c10"
+        >
+          <input
+            checked=""
+            class="c11"
+            type="checkbox"
+          />
+          <div
+            class="c12 "
+          >
+            <svg
+              class="c13"
+              preserveAspectRatio="xMidYMid meet"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M6,11.3 L10.3,16 L18,6.2"
+                fill="none"
+              />
+            </svg>
+          </div>
+        </div>
+        <span>
+          size
+        </span>
+      </label>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DataTableColumns search 3`] = `
 <button
   aria-label="Open column selector"
   class="StyledButton-sc-323bzc-0 hZNOgI"
@@ -1853,95 +3870,128 @@ exports[`DataTableColumns search 2`] = `
 </button>
 `;
 
-exports[`DataTableColumns search 3`] = `
+exports[`DataTableColumns search 4`] = `
 "@media only screen and (max-width: 768px) {
   .kYOLuO {
     margin-top: 12px;
   }
 }
-.hZNOgI {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  color: inherit;
-  outline: none;
-  border: none;
-  padding: 0;
-  text-align: inherit;
-  line-height: 0;
-  padding: 12px;
+@media only screen and (max-width: 768px) {
+  .iihVfL {
+    padding: 6px;
+  }
 }
-.hZNOgI:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6fffb0;
+@media only screen and (max-width: 768px) {
+  .zolhA {
+    margin-left: 6px;
+    margin-right: 6px;
+  }
 }
-.hZNOgI:focus > circle,
-.hZNOgI:focus > ellipse,
-.hZNOgI:focus > line,
-.hZNOgI:focus > path,
-.hZNOgI:focus > polygon,
-.hZNOgI:focus > polyline,
-.hZNOgI:focus > rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6fffb0;
+@media only screen and (max-width: 768px) {
+  .zolhA {
+    margin-top: 2px;
+    margin-bottom: 2px;
+  }
 }
-.hZNOgI:focus::-moz-focus-inner {
-  border: 0;
+@media only screen and (max-width: 768px) {
+  .zolhA {
+    border-bottom: solid 2px #000000;
+  }
 }
-.hZNOgI:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
+@media only screen and (max-width: 768px) {
+  .zolhA {
+    padding-bottom: 3px;
+  }
 }
-.hZNOgI:focus:not(:focus-visible) > circle,
-.hZNOgI:focus:not(:focus-visible) > ellipse,
-.hZNOgI:focus:not(:focus-visible) > line,
-.hZNOgI:focus:not(:focus-visible) > path,
-.hZNOgI:focus:not(:focus-visible) > polygon,
-.hZNOgI:focus:not(:focus-visible) > polyline,
-.hZNOgI:focus:not(:focus-visible) > rect {
-  outline: none;
-  box-shadow: none;
+@media only screen and (max-width: 768px) {
+  .cYmfUo {
+    margin-left: 6px;
+    margin-right: 6px;
+  }
 }
-.hZNOgI:focus:not(:focus-visible)::-moz-focus-inner {
-  border: 0;
-}"
-`;
-
-exports[`DataTableColumns search 4`] = `
-<button
-  aria-label="Open column selector"
-  class="StyledButton-sc-323bzc-0 hZNOgI"
-  data-g-tabindex="none"
-  id="test-data--columns-control"
-  tabindex="-1"
-  type="button"
->
-  <svg
-    aria-label="Splits"
-    class="StyledIcon-sc-ofa7kd-0 bQiAMQ"
-    viewBox="0 0 24 24"
-  >
-    <path
-      d="M1 22h22V2H1v20zM8 2v20V2zm8 0v20V2z"
-      fill="none"
-      stroke="#000"
-      stroke-width="2"
-    />
-  </svg>
-</button>
-`;
-
-exports[`DataTableColumns search 5`] = `
-"@media only screen and (max-width: 768px) {
-  .kYOLuO {
-    margin-top: 12px;
+@media only screen and (max-width: 768px) {
+  .cYmfUo {
+    margin-top: 2px;
+    margin-bottom: 2px;
+  }
+}
+@media only screen and (max-width: 768px) {
+  .cYmfUo {
+    border-bottom: solid 2px #7d4cdb;
+  }
+}
+@media only screen and (max-width: 768px) {
+  .cYmfUo {
+    padding-bottom: 3px;
+  }
+}
+@media only screen and (max-width: 768px) {
+  .kPFFvY {
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+}
+@media only screen and (max-width: 768px) {
+  .vOYHH {
+    margin-right: 6px;
+  }
+}
+@media only screen and (max-width: 768px) {
+  .fRMvyw {
+    border: solid 2px #7d4cdb;
+  }
+}
+@media only screen and (max-width: 768px) {
+  .btDoOz {
+    padding-top: 6px;
+  }
+}
+@media only screen and (max-width: 768px) {
+  .fdorKq {
+    border-top: solid 1px rgba(0, 0, 0, 0.33);
+    border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  }
+}
+@media only screen and (max-width: 768px) {
+  .fdorKq {
+    padding: 0px;
+  }
+}
+@media only screen and (max-width: 768px) {
+  .fPWQdE {
+    border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  }
+}
+@media only screen and (max-width: 768px) {
+  .fPWQdE {
+    padding: 0px;
+  }
+}
+@media only screen and (max-width: 768px) {
+  .jerLXD {
+    height: 3px;
+  }
+}
+@media only screen and (max-width: 768px) {
+  .biJsVL {
+    height: 6px;
+  }
+}
+@media only screen and (max-width: 768px) {
+  .ejkSNv {
+    width: 12px;
+  }
+}
+@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+  .jWOvQG {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
   }
 }
 .hZNOgI {

--- a/src/js/components/DataTableColumns/__tests__/__snapshots__/DataTableColumns-test.tsx.snap
+++ b/src/js/components/DataTableColumns/__tests__/__snapshots__/DataTableColumns-test.tsx.snap
@@ -654,7 +654,8 @@ exports[`DataTableColumns pinned 1`] = `
 `;
 
 exports[`DataTableColumns remove column 1`] = `
-.c4 {
+<DocumentFragment>
+  .c4 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -871,171 +872,172 @@ exports[`DataTableColumns remove column 1`] = `
 }
 
 <div
-  class="c0"
->
-  <div
-    class="c1"
-    id="test-data"
+    class="c0"
   >
-    <form
-      class="c2"
+    <div
+      class="c1"
+      id="test-data"
     >
-      <button
-        aria-label="Open column selector"
-        class="c3"
-        id="test-data--columns-control"
-        type="button"
+      <form
+        class="c2"
       >
-        <svg
-          aria-label="Splits"
-          class="c4"
-          viewBox="0 0 24 24"
+        <button
+          aria-label="Open column selector"
+          class="c3"
+          id="test-data--columns-control"
+          type="button"
         >
-          <path
-            d="M1 22h22V2H1v20zM8 2v20V2zm8 0v20V2z"
-            fill="none"
-            stroke="#000"
-            stroke-width="2"
-          />
-        </svg>
-      </button>
-    </form>
-    <table
-      class="c5 c6"
-    >
-      <thead
-        class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
-      >
-        <tr
-          class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
-        >
-          <th
-            class="c7 "
-            scope="col"
+          <svg
+            aria-label="Splits"
+            class="c4"
+            viewBox="0 0 24 24"
           >
-            <div
-              class="c8"
-            >
-              <span
-                class="c9"
-              >
-                Name
-              </span>
-            </div>
-          </th>
-          <th
-            class="c7 "
-            scope="col"
-          >
-            <div
-              class="c8"
-            >
-              <span
-                class="c9"
-              >
-                Age
-              </span>
-            </div>
-          </th>
-          <th
-            class="c7 "
-            scope="col"
-          >
-            <div
-              class="c8"
-            >
-              <span
-                class="c9"
-              >
-                Size
-              </span>
-            </div>
-          </th>
-        </tr>
-      </thead>
-      <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c10"
-      >
-        <tr
-          class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
-        >
-          <th
-            class="c11 "
-            scope="row"
-          >
-            <div
-              class="c12"
-            >
-              <span
-                class="c13"
-              >
-                a
-              </span>
-            </div>
-          </th>
-          <td
-            class="c11 "
-          >
-            <div
-              class="c12"
+            <path
+              d="M1 22h22V2H1v20zM8 2v20V2zm8 0v20V2z"
+              fill="none"
+              stroke="#000"
+              stroke-width="2"
             />
-          </td>
-          <td
-            class="c11 "
-          >
-            <div
-              class="c12"
-            >
-              <span
-                class="c9"
-              >
-                s
-              </span>
-            </div>
-          </td>
-        </tr>
-        <tr
-          class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          </svg>
+        </button>
+      </form>
+      <table
+        class="c5 c6"
+      >
+        <thead
+          class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
         >
-          <th
-            class="c11 "
-            scope="row"
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
-            <div
-              class="c12"
+            <th
+              class="c7 "
+              scope="col"
             >
-              <span
-                class="c13"
+              <div
+                class="c8"
               >
-                b
-              </span>
-            </div>
-          </th>
-          <td
-            class="c11 "
-          >
-            <div
-              class="c12"
-            />
-          </td>
-          <td
-            class="c11 "
-          >
-            <div
-              class="c12"
+                <span
+                  class="c9"
+                >
+                  Name
+                </span>
+              </div>
+            </th>
+            <th
+              class="c7 "
+              scope="col"
             >
-              <span
-                class="c9"
+              <div
+                class="c8"
               >
-                m
-              </span>
-            </div>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+                <span
+                  class="c9"
+                >
+                  Age
+                </span>
+              </div>
+            </th>
+            <th
+              class="c7 "
+              scope="col"
+            >
+              <div
+                class="c8"
+              >
+                <span
+                  class="c9"
+                >
+                  Size
+                </span>
+              </div>
+            </th>
+          </tr>
+        </thead>
+        <tbody
+          class="StyledTable__StyledTableBody-sc-1m3u5g-3 c10"
+        >
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c11 "
+              scope="row"
+            >
+              <div
+                class="c12"
+              >
+                <span
+                  class="c13"
+                >
+                  a
+                </span>
+              </div>
+            </th>
+            <td
+              class="c11 "
+            >
+              <div
+                class="c12"
+              />
+            </td>
+            <td
+              class="c11 "
+            >
+              <div
+                class="c12"
+              >
+                <span
+                  class="c9"
+                >
+                  s
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+          >
+            <th
+              class="c11 "
+              scope="row"
+            >
+              <div
+                class="c12"
+              >
+                <span
+                  class="c13"
+                >
+                  b
+                </span>
+              </div>
+            </th>
+            <td
+              class="c11 "
+            >
+              <div
+                class="c12"
+              />
+            </td>
+            <td
+              class="c11 "
+            >
+              <div
+                class="c12"
+              >
+                <span
+                  class="c9"
+                >
+                  m
+                </span>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
   </div>
-</div>
+</DocumentFragment>
 `;
 
 exports[`DataTableColumns remove column 2`] = `
@@ -1534,7 +1536,8 @@ exports[`DataTableColumns remove column 2`] = `
 `;
 
 exports[`DataTableColumns renders 1`] = `
-.c6 {
+<DocumentFragment>
+  .c6 {
   display: inline-block;
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -1888,165 +1891,166 @@ exports[`DataTableColumns renders 1`] = `
 }
 
 <div
-  class="c0"
->
-  <div
-    class="c1"
-    id="test-data"
+    class="c0"
   >
-    <form
-      class="c2"
+    <div
+      class="c1"
+      id="test-data"
     >
-      <div
-        class="c3"
+      <form
+        class="c2"
       >
         <div
-          class="c4"
+          class="c3"
         >
           <div
-            class="c1"
+            class="c4"
+          >
+            <div
+              class="c1"
+            >
+              <button
+                aria-label="Open column selector"
+                class="c5"
+                id="test-data--columns-control"
+                type="button"
+              >
+                <svg
+                  aria-label="Splits"
+                  class="c6"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M1 22h22V2H1v20zM8 2v20V2zm8 0v20V2z"
+                    fill="none"
+                    stroke="#000"
+                    stroke-width="2"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+          <footer
+            class="c7"
           >
             <button
-              aria-label="Open column selector"
-              class="c5"
-              id="test-data--columns-control"
-              type="button"
+              class="c8"
+              type="submit"
             >
-              <svg
-                aria-label="Splits"
-                class="c6"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M1 22h22V2H1v20zM8 2v20V2zm8 0v20V2z"
-                  fill="none"
-                  stroke="#000"
-                  stroke-width="2"
-                />
-              </svg>
+              Apply filters
             </button>
-          </div>
+          </footer>
         </div>
-        <footer
-          class="c7"
-        >
-          <button
-            class="c8"
-            type="submit"
-          >
-            Apply filters
-          </button>
-        </footer>
-      </div>
-    </form>
-    <table
-      class="c9 c10"
-    >
-      <thead
-        class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
+      </form>
+      <table
+        class="c9 c10"
       >
-        <tr
-          class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+        <thead
+          class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
         >
-          <th
-            class="c11 "
-            scope="col"
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
-            <div
-              class="c12"
+            <th
+              class="c11 "
+              scope="col"
             >
-              <span
-                class="c13"
+              <div
+                class="c12"
               >
-                Name
-              </span>
-            </div>
-          </th>
-          <th
-            class="c11 "
-            scope="col"
-          >
-            <div
-              class="c12"
+                <span
+                  class="c13"
+                >
+                  Name
+                </span>
+              </div>
+            </th>
+            <th
+              class="c11 "
+              scope="col"
             >
-              <span
-                class="c13"
+              <div
+                class="c12"
               >
-                Size
-              </span>
-            </div>
-          </th>
-        </tr>
-      </thead>
-      <tbody
-        class="StyledTable__StyledTableBody-sc-1m3u5g-3 c14"
-      >
-        <tr
-          class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+                <span
+                  class="c13"
+                >
+                  Size
+                </span>
+              </div>
+            </th>
+          </tr>
+        </thead>
+        <tbody
+          class="StyledTable__StyledTableBody-sc-1m3u5g-3 c14"
         >
-          <th
-            class="c15 "
-            scope="row"
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
-            <div
-              class="c16"
+            <th
+              class="c15 "
+              scope="row"
             >
-              <span
-                class="c17"
+              <div
+                class="c16"
               >
-                a
-              </span>
-            </div>
-          </th>
-          <td
-            class="c15 "
+                <span
+                  class="c17"
+                >
+                  a
+                </span>
+              </div>
+            </th>
+            <td
+              class="c15 "
+            >
+              <div
+                class="c16"
+              >
+                <span
+                  class="c13"
+                >
+                  s
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
           >
-            <div
-              class="c16"
+            <th
+              class="c15 "
+              scope="row"
             >
-              <span
-                class="c13"
+              <div
+                class="c16"
               >
-                s
-              </span>
-            </div>
-          </td>
-        </tr>
-        <tr
-          class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
-        >
-          <th
-            class="c15 "
-            scope="row"
-          >
-            <div
-              class="c16"
+                <span
+                  class="c17"
+                >
+                  b
+                </span>
+              </div>
+            </th>
+            <td
+              class="c15 "
             >
-              <span
-                class="c17"
+              <div
+                class="c16"
               >
-                b
-              </span>
-            </div>
-          </th>
-          <td
-            class="c15 "
-          >
-            <div
-              class="c16"
-            >
-              <span
-                class="c13"
-              >
-                m
-              </span>
-            </div>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+                <span
+                  class="c13"
+                >
+                  m
+                </span>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
   </div>
-</div>
+</DocumentFragment>
 `;
 
 exports[`DataTableColumns renders 2`] = `


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
updates the snap shots for dataTableColumns
#### Where should the reviewer start?
DataTableColumns.test
#### What testing has been done on this PR?
locally
#### How should this be manually tested?
snapshot
#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
there was snap shots being taken but these were not taken correctly of the correct tab panel 
#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
