### PR TITLE
fix: DataClearFilters type export missing

### DIFF
--- a/src/js/components/index.d.ts
+++ b/src/js/components/index.d.ts
@@ -21,6 +21,7 @@ export * from './Data';
 export * from './DataChart';
 export * from './DataFilter';
 export * from './DataFilters';
+export * from './DataClearFilters';
 export * from './DataSearch';
 export * from './DataSort';
 export * from './DataSummary';


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
fix: DataClearFilters type export missing

#### Where should the reviewer start?
[src/js/components/index.d.ts](https://github.com/qburst/grommet-1/compare/master...abdulbasithqb:grommet:fix/data-clear-filter-missing?expand=1#diff-8b5dcfbacae3b68a8699e9c7b8e9223674eb02c5010851f616311d048a8f6e28)
#### What testing has been done on this PR?
exported missing DataClearFilters

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
issue #7217

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
