### PR TITLE
add selected prop to be passed through

### DIFF
--- a/src/js/components/Button/Button.js
+++ b/src/js/components/Button/Button.js
@@ -517,6 +517,7 @@ const Button = forwardRef(
           pad={pad}
           plain={plain || Children.count(children) > 0}
           primary={primary}
+          selected={selected}
           sizeProp={size}
           success={success}
           type={!href ? type : undefined}


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
adds the `selected` prop to be passed through to styledButtonResult
#### Where should the reviewer start?
button.js
#### What testing has been done on this PR?
locally
#### How should this be manually tested?
locally
#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
Users can leverage this `selected` prop. This is passed to styledButton but not to styledButtonResult
#### What are the relevant issues?
Related to https://github.com/grommet/grommet-theme-hpe/issues/390

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible