### PR TITLE
fix busy button dots to be smaller when button is small

### DIFF
--- a/src/js/components/Button/BusyAnimation.js
+++ b/src/js/components/Button/BusyAnimation.js
@@ -15,17 +15,18 @@ const bounceDelayRule = css`
   animation: ${bounceDelay} 1.4s infinite ease-in-out both;
 `;
 
+/* When button is small size we need half the dot size to fit properly */
 const Dot = styled(Box)`
   background-color: currentColor;
-  width: 8px;
-  height: 8px;
+  width: ${(props) => (props.size.size === 'small' ? '4px' : '8px')};
+  height: ${(props) => (props.size.size === 'small' ? '4px' : '8px')};
   border-radius: 100%;
   display: inline-block;
   ${bounceDelayRule}
   ${(props) => props.delay && `animation-delay: ${props.delay};`}
 `;
 
-export const EllipsisAnimation = () => (
+export const EllipsisAnimation = (size) => (
   <Box
     style={{ position: 'absolute' }}
     fill
@@ -35,9 +36,9 @@ export const EllipsisAnimation = () => (
     <Box alignSelf="center" direction="row" gap="small">
       {/* A negative delay starts the animation sooner. The first dot
       should begin animating before the second and so on. */}
-      <Dot delay="-0.32s" />
-      <Dot delay="-0.16s" />
-      <Dot />
+      <Dot size={size} delay="-0.32s" />
+      <Dot size={size} delay="-0.16s" />
+      <Dot size={size} />
     </Box>
   </Box>
 );

--- a/src/js/components/Button/Button.js
+++ b/src/js/components/Button/Button.js
@@ -461,7 +461,7 @@ const Button = forwardRef(
         // position relative is necessary to have the animation
         // display over the button content
         <RelativeBox flex={false}>
-          {busy && <EllipsisAnimation />}
+          {busy && <EllipsisAnimation size={sizeProp} />}
           {success && (
             <Box
               style={{ position: 'absolute' }}


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR changes the size of the dots in the busy animation button
#### Where should the reviewer start?
busyAnimation.js
#### What testing has been done on this PR?
storybook
#### How should this be manually tested?
storybook
#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
https://github.com/grommet/grommet/issues/7225
#### What are the relevant issues?
closes https://github.com/grommet/grommet/issues/7225
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
maybe
#### Is this change backwards compatible or is it a breaking change?
backwards compatible