### PR TITLE
fix selectAll showing when limit

### DIFF
--- a/src/js/components/SelectMultiple/SelectionSummary.js
+++ b/src/js/components/SelectMultiple/SelectionSummary.js
@@ -68,7 +68,7 @@ const SelectionSummary = ({
     value?.length === 0 ||
     selectedValuesDisabled() ||
     !value ||
-    selectedInSearch().length === 0
+    (!limit && selectedInSearch().length === 0)
   );
 
   const messageId =
@@ -129,10 +129,10 @@ const SelectionSummary = ({
       height={{ min: 'xxsmall' }}
     >
       <Text size="small">{summaryText}</Text>
-      {(options.length &&
+      {options.length > 0 &&
         (!limit ||
-          !(!value || (value?.length === 0 && selectedValuesDisabled())))) >
-        0 &&
+          !(!value || (value?.length === 0 && selectedValuesDisabled()))) &&
+        (selectedInSearch().length !== 0 || !limit) &&
         (!onMore || (onMore && value?.length !== 0)) && (
           <Button
             a11yTitle={

--- a/src/js/components/SelectMultiple/__tests__/SelectMultiple-test.tsx
+++ b/src/js/components/SelectMultiple/__tests__/SelectMultiple-test.tsx
@@ -548,4 +548,49 @@ describe('SelectMultiple with portal', () => {
 
     expectPortal('test-select__drop').toMatchSnapshot();
   });
+
+  const TestOnLimit = () => {
+    const defaultOptions = ['0', '1', '2', '3', '01', '02'];
+    const [options, setOptions] = useState(defaultOptions);
+    return (
+      <SelectMultiple
+        onSearch={(text) => {
+          const escapedText = text.replace(/[-\\^$*+?.()|[\]{}]/g, '\\$&');
+          const exp = new RegExp(escapedText, 'i');
+          setOptions(defaultOptions.filter((o) => exp.test(o)));
+        }}
+        id="test-select__drop"
+        options={options}
+        limit={2}
+      />
+    );
+  };
+
+  test.only('limit with SelectAll', async () => {
+    window.HTMLElement.prototype.scrollIntoView = jest.fn();
+    render(
+      <Grommet>
+        <TestOnLimit />
+      </Grommet>,
+    );
+    // Open SelectMultiple
+    fireEvent.click(screen.getByRole('button', { name: /Open Drop/i }));
+
+    // Check if selectAll buttons exist
+    const selectAllButton = screen.queryByRole('button', {
+      name: /Select All/i,
+    });
+
+    expect(selectAllButton).toBeNull();
+
+    // Select an option
+    fireEvent.click(screen.getByRole('option', { name: /3/i }));
+    // open search
+    const input = screen.getByRole('searchbox');
+    // type 0
+    fireEvent.change(input, { target: { value: '0' } });
+    expect(selectAllButton).toBeNull();
+    fireEvent.change(input, { target: { value: '05' } });
+    expect(selectAllButton).toBeNull();
+  });
 });


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR fixes `selectAll` being shown when there is a limit. 
#### Where should the reviewer start?
SelectionSummary
#### What testing has been done on this PR?
storybook & jest test
#### How should this be manually tested?
Create a SelectMultiple component where limit property is provided
Don't select anything. Search something that exists, the Select All does not get displayed.
Clear the search and select any option from dropdown.
Search with a keyword that does not match the selected value but matches other values in the list.
Select All option gets displayed.
#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
closes #7219 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible