### PR TITLE
DataTable: changing size of cells does not work in every situation

### DIFF
--- a/src/js/components/Table/StyledTable.js
+++ b/src/js/components/Table/StyledTable.js
@@ -47,6 +47,7 @@ const StyledTableCell = styled.td
   padding: 0;
   font-weight: inherit;
   text-align: inherit;
+  height: 100%;
 
   ${(props) => props.size && sizeStyle}
   ${(props) => props.verticalAlign && `vertical-align: ${props.verticalAlign};`}
@@ -73,7 +74,9 @@ const StyledTableDataCaption = styled.caption
   margin-bottom: ${(props) => props.theme.global.edgeSize.xxsmall};
 `;
 
-const StyledTableRow = styled.tr.withConfig(styledComponentsConfig)``;
+const StyledTableRow = styled.tr.withConfig(styledComponentsConfig)`
+  height: 100%;
+`;
 
 const StyledTableBody = styled.tbody.withConfig(styledComponentsConfig)``;
 
@@ -87,6 +90,7 @@ const StyledTable = styled.table
   border-spacing: 0;
   border-collapse: collapse;
   width: inherit;
+  height: 100%;
   ${genericStyles} ${(props) => props.theme.table && props.theme.table.extend};
 `;
 

--- a/src/js/components/TableCell/TableCell.js
+++ b/src/js/components/TableCell/TableCell.js
@@ -1,10 +1,4 @@
-import React, {
-  forwardRef,
-  useContext,
-  useEffect,
-  useMemo,
-  useRef,
-} from 'react';
+import React, { forwardRef, useContext, useMemo, useRef } from 'react';
 import { ThemeContext } from 'styled-components';
 import { useLayoutEffect } from '../../utils/use-isomorphic-layout-effect';
 
@@ -56,45 +50,6 @@ const TableCell = forwardRef(
       }
     }, [cellRef, onWidth]);
 
-    // if window resizes, recalculate cell height so that content
-    // will continue to fill the height if the dimensions of the cell
-    // have changed
-    useEffect(() => {
-      const updateHeight = () => {
-        if (plain === 'noPad') {
-          const cell = cellRef.current;
-          const container = containerRef.current;
-          if (cell && container) {
-            container.style.height = '';
-            const cellRect = cell.getBoundingClientRect();
-
-            // height must match cell height otherwise table will apply some
-            // margin around the cell content
-            container.style.height = `${Math.max(
-              cellRect.height -
-                (border || theme.table[tableContext].border
-                  ? theme.global.borderSize.xsmall.replace('px', '')
-                  : 0),
-              0,
-            )}px`;
-          }
-        }
-      };
-
-      window.addEventListener('resize', updateHeight);
-      updateHeight();
-      return () => {
-        window.removeEventListener('resize', updateHeight);
-      };
-    }, [
-      border,
-      cellRef,
-      plain,
-      tableContext,
-      theme.global.borderSize,
-      theme.table,
-    ]);
-
     let tableContextTheme;
     if (tableContext === 'header') {
       tableContextTheme = theme.table && theme.table.header;
@@ -126,12 +81,13 @@ const TableCell = forwardRef(
 
     let content = children;
     if (plain === 'noPad' && children) {
-      // a Box with explicitly set height is necessary
+      // a Box with explicitly set height 100% is necessary
       // for the child contents to be able to fill the
-      // TableCell
+      // TableCell and to provide vertical alignment
       content = (
         <Box
           ref={containerRef}
+          style={{ height: '100%' }}
           justify={
             verticalAlign ? verticalAlignToJustify[verticalAlign] : 'center'
           }


### PR DESCRIPTION
#### What does this PR do?

In DataTable the height is calculated in code what does not work on resizing any column's content (see https://github.com/grommet/grommet/issues/7177) if there is another plain-column. This PR is a pure CSS solution for the problem.

#### Where should the reviewer start?

See section "Actual Behavior" of https://github.com/grommet/grommet/issues/7177.

#### What testing has been done on this PR?

We manually tested both situations: On initializing the table and on changing cells content. We use this fork already in production.

#### How should this be manually tested?

In "Steps to reproduce" of https://github.com/grommet/grommet/issues/7177 a sandbox is provided. To test correct sizing on table initialization one can set the default-value to true at https://codesandbox.io/p/sandbox/datatable-collapse-issue-2jq6d9?file=%2Findex.js%3A255%2C1-256%2C1. Additionally, one can remove the line 
https://codesandbox.io/p/sandbox/datatable-collapse-issue-2jq6d9?file=%2Findex.js%3A310%2C1-311%2C1 to also test for non-plain columns.

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

The author of the initial implementation didn't see that there is a pure CSS solution (see comment in https://github.com/grommet/grommet/blob/master/src/js/components/TableCell/TableCell.js#L129). Meanwhile there were changes in the same section https://github.com/grommet/grommet/commit/10c46fd10273788d5ef86c00d46403b537f84d44 which should be tested. I updated the Sandbox to Grommet's current version and the intermediate change does not effect the behavior of this PR.

#### What are the relevant issues?

https://github.com/grommet/grommet/issues/7177

#### Screenshots (if appropriate)

No

#### Do the grommet docs need to be updated?

No

#### Should this PR be mentioned in the release notes?

As you wish

#### Is this change backwards compatible or is it a breaking change?

Was backward compatible before https://github.com/grommet/grommet/commit/10c46fd10273788d5ef86c00d46403b537f84d44. If the underlying issue of this change https://github.com/grommet/grommet/pull/6086 is still solved with the PR in place, then it is confirmed that it still is backward compatible.
