### PR TITLE
Update circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 defaults: &defaults
   working_directory: ~/grommet-ci
   docker:
-    - image: cimg/node:18.13.0-browsers
+    - image: cimg/node:20.16.0-browsers
 jobs:
   checkout:
     <<: *defaults
@@ -90,12 +90,7 @@ jobs:
       - attach_workspace:
           at: ~/grommet-ci
       - run: sudo apt-get update
-      - browser-tools/install-chrome:
-          replace-existing: true
-          chrome-version: 116.0.5845.96
-          # temporary solution until
-          # https://github.com/CircleCI-Public/browser-tools-orb/issues/90
-          # is fixed. Once fixed remove chrome-version.
+      - browser-tools/install-chrome
       - browser-tools/install-chromedriver
       - run:
           name: Start project

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "storybook": "cross-env NODE_ENV=development storybook dev -p 9001 -c storybook",
     "start": "webpack serve --config ./e2e/webpack.config.js --mode development",
     "test-e2e": "testcafe chrome:headless e2e/tests",
-    "test-e2e-ci": "testcafe chrome:headless e2e/tests -r xunit:/tmp/test-results/testcafe/results.xml",
+    "test-e2e-ci": "testcafe chromium --headless=new e2e/tests -r xunit:/tmp/test-results/testcafe/results.xml",
     "build-storybook": "storybook build -c storybook -o storybook-static",
     "prettier": "pretty-quick --staged",
     "chromatic": "chromatic"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "storybook": "cross-env NODE_ENV=development storybook dev -p 9001 -c storybook",
     "start": "webpack serve --config ./e2e/webpack.config.js --mode development",
     "test-e2e": "testcafe chrome:headless e2e/tests",
-    "test-e2e-ci": "testcafe chromium --headless=new e2e/tests -r xunit:/tmp/test-results/testcafe/results.xml",
+    "test-e2e-ci": "testcafe chrome --headless=new e2e/tests -r xunit:/tmp/test-results/testcafe/results.xml",
     "build-storybook": "storybook build -c storybook -o storybook-static",
     "prettier": "pretty-quick --staged",
     "chromatic": "chromatic"


### PR DESCRIPTION
#### What does this PR do?
Update circleci config to use newer node version and remove workaround for chrome install

I had to add `chrome --headless=new` to the package.json command until we can upgrade our test cafe version. See https://github.com/DevExpress/testcafe/issues/8145 for more details.

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
backwards compatible