### PR TITLE
Revert "upgrade babel-plugin-styled-components (#7269)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^29.7.0",
     "babel-loader": "^9.1.3",
-    "babel-plugin-styled-components": "^2.1.4",
+    "babel-plugin-styled-components": "2.0.6",
     "babel-plugin-transform-imports": "^2.0.0",
     "bundlesize2": "^0.0.31",
     "chromatic": "^11.5.4",

--- a/src/js/components/Data/__tests__/__snapshots__/Data-test.tsx.snap
+++ b/src/js/components/Data/__tests__/__snapshots__/Data-test.tsx.snap
@@ -541,7 +541,7 @@ exports[`Data controlled search 2`] = `
             <input
               aria-label="Search"
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 eMqFEc"
+              class="StyledTextInput-sc-1x30a0s-0 JlFHg"
               id="data--search"
               name="_search"
               type="search"
@@ -5442,7 +5442,7 @@ exports[`Data uncontrolled search 2`] = `
             <input
               aria-label="Search"
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 eMqFEc"
+              class="StyledTextInput-sc-1x30a0s-0 JlFHg"
               id="data--search"
               name="_search"
               type="search"
@@ -6517,7 +6517,7 @@ exports[`Data uncontrolled, when paginated, search should return to page 1 2`] =
             <input
               aria-label="Search"
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 eMqFEc"
+              class="StyledTextInput-sc-1x30a0s-0 JlFHg"
               id="data--search"
               name="_search"
               type="search"
@@ -6843,7 +6843,7 @@ exports[`Data uncontrolled, when paginated, search should return to page 1 3`] =
             <input
               aria-label="Search"
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 eMqFEc"
+              class="StyledTextInput-sc-1x30a0s-0 JlFHg"
               id="data--search"
               name="_search"
               type="search"

--- a/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.tsx.snap
+++ b/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.tsx.snap
@@ -1641,7 +1641,7 @@ exports[`DateInput controlled format inline 2`] = `
       >
         <input
           autocomplete="off"
-          class="StyledMaskedInput-sc-99vkfa-0 cZOoLq"
+          class="StyledMaskedInput-sc-99vkfa-0 khvqrG"
           id="item"
           name="item"
           placeholder="mm/dd/yyyy"
@@ -15174,7 +15174,7 @@ exports[`DateInput select format 2`] = `
     >
       <input
         autocomplete="off"
-        class="StyledMaskedInput-sc-99vkfa-0 cZOoLq"
+        class="StyledMaskedInput-sc-99vkfa-0 khvqrG"
         id="item"
         name="item"
         placeholder="mm/dd/yyyy"
@@ -17770,7 +17770,7 @@ exports[`DateInput select format inline 2`] = `
       >
         <input
           autocomplete="off"
-          class="StyledMaskedInput-sc-99vkfa-0 cZOoLq"
+          class="StyledMaskedInput-sc-99vkfa-0 khvqrG"
           id="item"
           name="item"
           placeholder="mm/dd/yyyy"
@@ -22613,7 +22613,7 @@ exports[`DateInput select format inline range 2`] = `
       >
         <input
           autocomplete="off"
-          class="StyledMaskedInput-sc-99vkfa-0 cZOoLq"
+          class="StyledMaskedInput-sc-99vkfa-0 khvqrG"
           id="item"
           name="item"
           placeholder="mm/dd/yyyy-mm/dd/yyyy"
@@ -31403,7 +31403,7 @@ exports[`DateInput type format inline 2`] = `
       >
         <input
           autocomplete="off"
-          class="StyledMaskedInput-sc-99vkfa-0 cZOoLq"
+          class="StyledMaskedInput-sc-99vkfa-0 khvqrG"
           id="item"
           name="item"
           placeholder="mm/dd/yyyy"
@@ -36168,7 +36168,7 @@ exports[`DateInput type format inline range 2`] = `
       >
         <input
           autocomplete="off"
-          class="StyledMaskedInput-sc-99vkfa-0 cZOoLq"
+          class="StyledMaskedInput-sc-99vkfa-0 khvqrG"
           id="item"
           name="item"
           placeholder="mm/dd/yyyy-mm/dd/yyyy"
@@ -38335,7 +38335,7 @@ exports[`DateInput type format inline range partial 2`] = `
       >
         <input
           autocomplete="off"
-          class="StyledMaskedInput-sc-99vkfa-0 cZOoLq"
+          class="StyledMaskedInput-sc-99vkfa-0 khvqrG"
           id="item"
           name="item"
           placeholder="mm/dd/yyyy-mm/dd/yyyy"
@@ -39195,7 +39195,7 @@ exports[`DateInput type format inline range partial 3`] = `
       >
         <input
           autocomplete="off"
-          class="StyledMaskedInput-sc-99vkfa-0 cZOoLq"
+          class="StyledMaskedInput-sc-99vkfa-0 khvqrG"
           id="item"
           name="item"
           placeholder="mm/dd/yyyy-mm/dd/yyyy"
@@ -47880,7 +47880,7 @@ exports[`DateInput type format inline short 2`] = `
       >
         <input
           autocomplete="off"
-          class="StyledMaskedInput-sc-99vkfa-0 cZOoLq"
+          class="StyledMaskedInput-sc-99vkfa-0 khvqrG"
           id="item"
           name="item"
           placeholder="m/d/yy"

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-controlled.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-controlled.js.snap
@@ -209,7 +209,7 @@ exports[`Form controlled controlled 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 ilKkNn"
+            class="StyledTextInput-sc-1x30a0s-0 kYOXMr"
             name="test"
             placeholder="test input"
             value="v"
@@ -243,7 +243,7 @@ exports[`Form controlled controlled 3`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 ilKkNn"
+            class="StyledTextInput-sc-1x30a0s-0 kYOXMr"
             name="test"
             placeholder="test input"
             value="v"
@@ -591,7 +591,7 @@ exports[`Form controlled controlled Array of Form Fields 2`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 ilKkNn"
+              class="StyledTextInput-sc-1x30a0s-0 kYOXMr"
               name="phones[0].number"
               placeholder="number test input 1"
               value=""
@@ -610,7 +610,7 @@ exports[`Form controlled controlled Array of Form Fields 2`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 ilKkNn"
+              class="StyledTextInput-sc-1x30a0s-0 kYOXMr"
               name="phones[0].ext"
               placeholder="ext test input 1"
               value=""
@@ -633,7 +633,7 @@ exports[`Form controlled controlled Array of Form Fields 2`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 ilKkNn"
+              class="StyledTextInput-sc-1x30a0s-0 kYOXMr"
               name="phones[1].number"
               placeholder="number test input 2"
               value="123456789"
@@ -652,7 +652,7 @@ exports[`Form controlled controlled Array of Form Fields 2`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 ilKkNn"
+              class="StyledTextInput-sc-1x30a0s-0 kYOXMr"
               name="phones[1].ext"
               placeholder="ext test input 2"
               value=""
@@ -675,7 +675,7 @@ exports[`Form controlled controlled Array of Form Fields 2`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 ilKkNn"
+              class="StyledTextInput-sc-1x30a0s-0 kYOXMr"
               name="phones[2].number"
               placeholder="number test input 3"
               value=""
@@ -694,7 +694,7 @@ exports[`Form controlled controlled Array of Form Fields 2`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 ilKkNn"
+              class="StyledTextInput-sc-1x30a0s-0 kYOXMr"
               name="phones[2].ext"
               placeholder="ext test input 3"
               value="999"
@@ -732,7 +732,7 @@ exports[`Form controlled controlled Array of Form Fields 3`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 ilKkNn"
+              class="StyledTextInput-sc-1x30a0s-0 kYOXMr"
               name="phones[0].number"
               placeholder="number test input 1"
               value=""
@@ -751,7 +751,7 @@ exports[`Form controlled controlled Array of Form Fields 3`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 ilKkNn"
+              class="StyledTextInput-sc-1x30a0s-0 kYOXMr"
               name="phones[0].ext"
               placeholder="ext test input 1"
               value=""
@@ -774,7 +774,7 @@ exports[`Form controlled controlled Array of Form Fields 3`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 ilKkNn"
+              class="StyledTextInput-sc-1x30a0s-0 kYOXMr"
               name="phones[1].number"
               placeholder="number test input 2"
               value="123456789"
@@ -793,7 +793,7 @@ exports[`Form controlled controlled Array of Form Fields 3`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 ilKkNn"
+              class="StyledTextInput-sc-1x30a0s-0 kYOXMr"
               name="phones[1].ext"
               placeholder="ext test input 2"
               value=""
@@ -816,7 +816,7 @@ exports[`Form controlled controlled Array of Form Fields 3`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 ilKkNn"
+              class="StyledTextInput-sc-1x30a0s-0 kYOXMr"
               name="phones[2].number"
               placeholder="number test input 3"
               value=""
@@ -835,7 +835,7 @@ exports[`Form controlled controlled Array of Form Fields 3`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 ilKkNn"
+              class="StyledTextInput-sc-1x30a0s-0 kYOXMr"
               name="phones[2].ext"
               placeholder="ext test input 3"
               value="999"
@@ -1142,7 +1142,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate 2`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 ilKkNn"
+              class="StyledTextInput-sc-1x30a0s-0 kYOXMr"
               name="phones[0].number"
               placeholder="number test input 1"
               value=""
@@ -1188,7 +1188,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate 2`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 ilKkNn"
+              class="StyledTextInput-sc-1x30a0s-0 kYOXMr"
               name="phones[0].ext"
               placeholder="ext test input 1"
               value=""
@@ -1211,7 +1211,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate 2`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 ilKkNn"
+              class="StyledTextInput-sc-1x30a0s-0 kYOXMr"
               name="phones[1].number"
               placeholder="number test input 2"
               value=""
@@ -1257,7 +1257,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate 2`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 ilKkNn"
+              class="StyledTextInput-sc-1x30a0s-0 kYOXMr"
               name="phones[1].ext"
               placeholder="ext test input 2"
               value=""
@@ -1564,7 +1564,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate custom error
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 ilKkNn"
+              class="StyledTextInput-sc-1x30a0s-0 kYOXMr"
               name="phones[0].number"
               placeholder="number test input 1"
               value=""
@@ -1583,7 +1583,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate custom error
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 ilKkNn"
+              class="StyledTextInput-sc-1x30a0s-0 kYOXMr"
               name="phones[0].ext"
               placeholder="ext test input 1"
               value=""
@@ -1606,7 +1606,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate custom error
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 ilKkNn"
+              class="StyledTextInput-sc-1x30a0s-0 kYOXMr"
               name="phones[1].number"
               placeholder="number test input 2"
               value="sadasd"
@@ -1652,7 +1652,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate custom error
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 ilKkNn"
+              class="StyledTextInput-sc-1x30a0s-0 kYOXMr"
               name="phones[1].ext"
               placeholder="ext test input 2"
               value=""
@@ -1901,7 +1901,7 @@ exports[`Form controlled controlled FormField deprecated 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 ilKkNn"
+            class="StyledTextInput-sc-1x30a0s-0 kYOXMr"
             id="test"
             name="test"
             value="v"
@@ -1941,7 +1941,7 @@ exports[`Form controlled controlled FormField deprecated 3`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 ilKkNn"
+            class="StyledTextInput-sc-1x30a0s-0 kYOXMr"
             id="test"
             name="test"
             value="v"
@@ -2168,7 +2168,7 @@ exports[`Form controlled controlled input 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 ilKkNn"
+            class="StyledTextInput-sc-1x30a0s-0 kYOXMr"
             name="test"
             placeholder="test input"
             value="v"
@@ -2202,7 +2202,7 @@ exports[`Form controlled controlled input 3`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 ilKkNn"
+            class="StyledTextInput-sc-1x30a0s-0 kYOXMr"
             name="test"
             placeholder="test input"
             value="v"
@@ -2429,7 +2429,7 @@ exports[`Form controlled controlled input lazy 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 ilKkNn"
+            class="StyledTextInput-sc-1x30a0s-0 kYOXMr"
             name="test"
             placeholder="test input"
             value="v"
@@ -2463,7 +2463,7 @@ exports[`Form controlled controlled input lazy 3`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 ilKkNn"
+            class="StyledTextInput-sc-1x30a0s-0 kYOXMr"
             name="test"
             placeholder="test input"
             value="v"
@@ -2690,7 +2690,7 @@ exports[`Form controlled controlled lazy 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 ilKkNn"
+            class="StyledTextInput-sc-1x30a0s-0 kYOXMr"
             name="test"
             placeholder="test input"
             value="v"
@@ -2724,7 +2724,7 @@ exports[`Form controlled controlled lazy 3`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 ilKkNn"
+            class="StyledTextInput-sc-1x30a0s-0 kYOXMr"
             name="test"
             placeholder="test input"
             value="v"
@@ -3144,7 +3144,7 @@ exports[`Form controlled controlled onValidate 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 ilKkNn"
+            class="StyledTextInput-sc-1x30a0s-0 kYOXMr"
             name="test"
             placeholder="test input"
             value=""
@@ -3398,7 +3398,7 @@ exports[`Form controlled controlled onValidate custom error 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 ilKkNn"
+            class="StyledTextInput-sc-1x30a0s-0 kYOXMr"
             name="test"
             placeholder="test input"
             value=""
@@ -3652,7 +3652,7 @@ exports[`Form controlled controlled onValidate custom info 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 ilKkNn"
+            class="StyledTextInput-sc-1x30a0s-0 kYOXMr"
             name="test"
             placeholder="test input"
             value=""
@@ -4250,7 +4250,7 @@ exports[`Form controlled dynamicly removed fields using blur validation
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 ilKkNn"
+            class="StyledTextInput-sc-1x30a0s-0 kYOXMr"
             name="name"
             placeholder="test name"
             value=""
@@ -4479,7 +4479,7 @@ exports[`Form controlled dynamicly removed fields using blur validation
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 ilKkNn"
+            class="StyledTextInput-sc-1x30a0s-0 kYOXMr"
             name="name"
             placeholder="test name"
             value=""

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
@@ -1139,7 +1139,7 @@ exports[`Form uncontrolled dynamicly removed fields should be removed from form 
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 ilKkNn"
+            class="StyledTextInput-sc-1x30a0s-0 kYOXMr"
             name="name"
             placeholder="test name"
           />
@@ -1515,7 +1515,7 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 ilKkNn"
+            class="StyledTextInput-sc-1x30a0s-0 kYOXMr"
             name="name"
             placeholder="test name"
           />
@@ -1742,7 +1742,7 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 ilKkNn"
+            class="StyledTextInput-sc-1x30a0s-0 kYOXMr"
             name="name"
             placeholder="test name"
           />
@@ -2966,7 +2966,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
               >
                 <input
                   autocomplete="off"
-                  class="StyledTextInput-sc-1x30a0s-0 chpnTk StyledSelect__SelectTextInput-sc-znp66n-4 eGvfyO"
+                  class="StyledTextInput-sc-1x30a0s-0 cWCiZI StyledSelect__SelectTextInput-sc-znp66n-4 eGvfyO"
                   id="test-select__input"
                   name="test-select"
                   placeholder="test select"
@@ -3352,7 +3352,7 @@ exports[`Form uncontrolled uncontrolled 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 ilKkNn"
+            class="StyledTextInput-sc-1x30a0s-0 kYOXMr"
             name="test"
             placeholder="test input"
           />
@@ -3385,7 +3385,7 @@ exports[`Form uncontrolled uncontrolled 3`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 ilKkNn"
+            class="StyledTextInput-sc-1x30a0s-0 kYOXMr"
             name="test"
             placeholder="test input"
           />
@@ -3610,7 +3610,7 @@ exports[`Form uncontrolled uncontrolled onValidate 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 ilKkNn"
+            class="StyledTextInput-sc-1x30a0s-0 kYOXMr"
             name="test"
             placeholder="test input"
           />
@@ -3862,7 +3862,7 @@ exports[`Form uncontrolled uncontrolled onValidate custom error 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 ilKkNn"
+            class="StyledTextInput-sc-1x30a0s-0 kYOXMr"
             name="test"
             placeholder="test input"
           />
@@ -4114,7 +4114,7 @@ exports[`Form uncontrolled uncontrolled onValidate custom info 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 ilKkNn"
+            class="StyledTextInput-sc-1x30a0s-0 kYOXMr"
             name="test"
             placeholder="test input"
           />

--- a/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.js.snap
+++ b/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.js.snap
@@ -1149,7 +1149,7 @@ exports[`MaskedInput event target props are available option via mouse 4`] = `
   >
     <input
       autocomplete="off"
-      class="StyledMaskedInput-sc-99vkfa-0 hJBahn"
+      class="StyledMaskedInput-sc-99vkfa-0 fPEzPv"
       data-g-tabindex="none"
       data-testid="test-input"
       id="item"
@@ -2212,7 +2212,7 @@ exports[`MaskedInput next and previous without options 2`] = `
   >
     <input
       autocomplete="off"
-      class="StyledMaskedInput-sc-99vkfa-0 ftXemO"
+      class="StyledMaskedInput-sc-99vkfa-0 fMEjQG"
       data-testid="test-input"
       id="item"
       name="item"
@@ -2629,7 +2629,7 @@ exports[`MaskedInput option via mouse 4`] = `
   >
     <input
       autocomplete="off"
-      class="StyledMaskedInput-sc-99vkfa-0 hJBahn"
+      class="StyledMaskedInput-sc-99vkfa-0 fPEzPv"
       data-g-tabindex="none"
       data-testid="test-input"
       id="item"

--- a/src/js/components/Select/__tests__/__snapshots__/Select-multiple-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-multiple-test.js.snap
@@ -4884,7 +4884,7 @@ exports[`Select Controlled multiple values 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 chpnTk StyledSelect__SelectTextInput-sc-znp66n-4 eGvfyO"
+            class="StyledTextInput-sc-1x30a0s-0 cWCiZI StyledSelect__SelectTextInput-sc-znp66n-4 eGvfyO"
             id="test-select__input"
             placeholder="test select"
             readonly=""

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -2877,7 +2877,7 @@ exports[`Select complex options and children 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 chpnTk StyledSelect__SelectTextInput-sc-znp66n-4 eGvfyO"
+            class="StyledTextInput-sc-1x30a0s-0 cWCiZI StyledSelect__SelectTextInput-sc-znp66n-4 eGvfyO"
             id="test-select__input"
             placeholder="test select"
             readonly=""
@@ -4489,7 +4489,7 @@ exports[`Select disabled 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 chpnTk StyledSelect__SelectTextInput-sc-znp66n-4 lfJWka"
+            class="StyledTextInput-sc-1x30a0s-0 cWCiZI StyledSelect__SelectTextInput-sc-znp66n-4 lfJWka"
             id="test-select__input"
             placeholder="test select"
             readonly=""
@@ -11478,7 +11478,7 @@ exports[`Select prop: onOpen 2`] = `
       >
         <input
           autocomplete="off"
-          class="StyledTextInput-sc-1x30a0s-0 chpnTk StyledSelect__SelectTextInput-sc-znp66n-4 eGvfyO"
+          class="StyledTextInput-sc-1x30a0s-0 cWCiZI StyledSelect__SelectTextInput-sc-znp66n-4 eGvfyO"
           id="test-select__input"
           placeholder="test select"
           readonly=""
@@ -12300,7 +12300,7 @@ exports[`Select renders custom up and down icons 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 chpnTk StyledSelect__SelectTextInput-sc-znp66n-4 eGvfyO"
+            class="StyledTextInput-sc-1x30a0s-0 cWCiZI StyledSelect__SelectTextInput-sc-znp66n-4 eGvfyO"
             placeholder="Select..."
             readonly=""
             tabindex="-1"
@@ -14293,7 +14293,7 @@ exports[`Select search 3`] = `
 exports[`Select search 4`] = `
 <input
   autocomplete="off"
-  class="StyledTextInput-sc-1x30a0s-0 hvJmqi"
+  class="StyledTextInput-sc-1x30a0s-0 hVomuy"
   type="search"
   value=""
 />
@@ -14302,7 +14302,7 @@ exports[`Select search 4`] = `
 exports[`Select search 5`] = `
 <input
   autocomplete="off"
-  class="StyledTextInput-sc-1x30a0s-0 hvJmqi"
+  class="StyledTextInput-sc-1x30a0s-0 hVomuy"
   type="search"
   value="o"
 />
@@ -14880,7 +14880,7 @@ exports[`Select search and select 3`] = `
 exports[`Select search and select 4`] = `
 <input
   autocomplete="off"
-  class="StyledTextInput-sc-1x30a0s-0 hvJmqi"
+  class="StyledTextInput-sc-1x30a0s-0 hVomuy"
   type="search"
   value=""
 />
@@ -14889,7 +14889,7 @@ exports[`Select search and select 4`] = `
 exports[`Select search and select 5`] = `
 <input
   autocomplete="off"
-  class="StyledTextInput-sc-1x30a0s-0 hvJmqi"
+  class="StyledTextInput-sc-1x30a0s-0 hVomuy"
   type="search"
   value="t"
 />
@@ -16629,7 +16629,7 @@ exports[`Select select option by typing should not break if caller passes JSX 2`
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 chpnTk StyledSelect__SelectTextInput-sc-znp66n-4 eGvfyO"
+            class="StyledTextInput-sc-1x30a0s-0 cWCiZI StyledSelect__SelectTextInput-sc-znp66n-4 eGvfyO"
             id="test-select__input"
             placeholder="test select"
             readonly=""

--- a/src/js/components/SelectMultiple/__tests__/__snapshots__/SelectMultiple-test.tsx.snap
+++ b/src/js/components/SelectMultiple/__tests__/__snapshots__/SelectMultiple-test.tsx.snap
@@ -6514,7 +6514,7 @@ exports[`SelectMultiple with portal select all and clear 3`] = `
       >
         <input
           autocomplete="off"
-          class="StyledTextInput-sc-1x30a0s-0 chpnTk StyledSelect__SelectTextInput-sc-znp66n-4 eGvfyO"
+          class="StyledTextInput-sc-1x30a0s-0 cWCiZI StyledSelect__SelectTextInput-sc-znp66n-4 eGvfyO"
           id="test-select__drop__input"
           readonly=""
           tabindex="-1"

--- a/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.tsx.snap
+++ b/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.tsx.snap
@@ -486,7 +486,7 @@ exports[`TextInput calls onSuggestionsClose 4`] = `
       aria-autocomplete="list"
       aria-expanded="false"
       autocomplete="off"
-      class="StyledTextInput-sc-1x30a0s-0 lghwG"
+      class="StyledTextInput-sc-1x30a0s-0 AfSQG"
       data-testid="test-input"
       id="item"
       name="item"
@@ -993,7 +993,7 @@ exports[`TextInput close suggestion drop 4`] = `
       aria-autocomplete="list"
       aria-expanded="false"
       autocomplete="off"
-      class="StyledTextInput-sc-1x30a0s-0 lghwG"
+      class="StyledTextInput-sc-1x30a0s-0 AfSQG"
       data-testid="test-input"
       id="item"
       name="item"
@@ -1573,7 +1573,7 @@ exports[`TextInput handles next and previous without suggestion 2`] = `
   >
     <input
       autocomplete="off"
-      class="StyledTextInput-sc-1x30a0s-0 lghwG"
+      class="StyledTextInput-sc-1x30a0s-0 AfSQG"
       data-testid="test-input"
       id="item"
       name="item"
@@ -4455,7 +4455,7 @@ exports[`TextInput select suggestion 4`] = `
       aria-autocomplete="list"
       aria-expanded="false"
       autocomplete="off"
-      class="StyledTextInput-sc-1x30a0s-0 fGBYHv"
+      class="StyledTextInput-sc-1x30a0s-0 hemPQr"
       data-testid="test-input"
       id="item"
       name="item"
@@ -5053,7 +5053,7 @@ exports[`TextInput should only show default placeholder when placeholder is a
   >
     <input
       autocomplete="off"
-      class="StyledTextInput-sc-1x30a0s-0 lghwG"
+      class="StyledTextInput-sc-1x30a0s-0 AfSQG"
       data-testid="placeholder"
       id="placeholder"
       name="placeholder"

--- a/src/js/components/Video/__tests__/__snapshots__/Video-test.tsx.snap
+++ b/src/js/components/Video/__tests__/__snapshots__/Video-test.tsx.snap
@@ -1428,7 +1428,7 @@ exports[`Video Play and Pause event handlers 2`] = `
     tabindex="-1"
   >
     <video
-      class="StyledVideo-sc-w4v8h9-0 gHFabc"
+      class="StyledVideo-sc-w4v8h9-0 gwOSeM"
     >
       <source
         src="small.mp4"
@@ -5346,7 +5346,7 @@ exports[`Video mouse events handlers of controls 2`] = `
     tabindex="-1"
   >
     <video
-      class="StyledVideo-sc-w4v8h9-0 gHFabc"
+      class="StyledVideo-sc-w4v8h9-0 gwOSeM"
     >
       <source
         src="small.mp4"
@@ -5470,7 +5470,7 @@ exports[`Video mouse events handlers of controls 3`] = `
     tabindex="-1"
   >
     <video
-      class="StyledVideo-sc-w4v8h9-0 gHFabc"
+      class="StyledVideo-sc-w4v8h9-0 gwOSeM"
     >
       <source
         src="small.mp4"
@@ -7470,7 +7470,7 @@ exports[`Video scrubber 2`] = `
     tabindex="-1"
   >
     <video
-      class="StyledVideo-sc-w4v8h9-0 gHFabc"
+      class="StyledVideo-sc-w4v8h9-0 gwOSeM"
     >
       <source
         src="small.mp4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -171,7 +171,7 @@
     "@jridgewell/trace-mapping" "^0.3.17"
     jsesc "^2.5.1"
 
-"@babel/helper-annotate-as-pure@^7.18.6", "@babel/helper-annotate-as-pure@^7.22.5":
+"@babel/helper-annotate-as-pure@^7.16.0", "@babel/helper-annotate-as-pure@^7.18.6", "@babel/helper-annotate-as-pure@^7.22.5":
   version "7.22.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.22.5.tgz#e7f06737b197d580a01edf75d97e2c8be99d3882"
   integrity sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==
@@ -350,14 +350,14 @@
     "@babel/traverse" "^7.24.7"
     "@babel/types" "^7.24.7"
 
-"@babel/helper-module-imports@^7.22.15", "@babel/helper-module-imports@^7.24.1", "@babel/helper-module-imports@^7.24.3":
+"@babel/helper-module-imports@^7.16.0", "@babel/helper-module-imports@^7.22.15", "@babel/helper-module-imports@^7.24.1", "@babel/helper-module-imports@^7.24.3":
   version "7.24.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.24.3.tgz#6ac476e6d168c7c23ff3ba3cf4f7841d46ac8128"
   integrity sha512-viKb0F9f2s0BCS22QSF308z/+1YWKV/76mwt61NBzS5izMzDPwdq1pTrzf+Li3npBWX9KdQbkeCt1jSAM7lZqg==
   dependencies:
     "@babel/types" "^7.24.0"
 
-"@babel/helper-module-imports@^7.22.5", "@babel/helper-module-imports@^7.24.7":
+"@babel/helper-module-imports@^7.24.7":
   version "7.24.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.24.7.tgz#f2f980392de5b84c3328fc71d38bd81bbb83042b"
   integrity sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==
@@ -947,19 +947,19 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-jsx@^7.22.5", "@babel/plugin-syntax-jsx@^7.24.7":
-  version "7.24.7"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.24.7.tgz#39a1fa4a7e3d3d7f34e2acc6be585b718d30e02d"
-  integrity sha512-6ddciUPe/mpMnOKv/U+RSd2vvVy+Yw/JfBB0ZHYjEZt9NLHmCUylNYlsbqCCS1Bffjlb0fCwC9Vqz+sBz6PsiQ==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.24.7"
-
 "@babel/plugin-syntax-jsx@^7.23.3", "@babel/plugin-syntax-jsx@^7.24.1", "@babel/plugin-syntax-jsx@^7.7.2":
   version "7.24.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.24.1.tgz#3f6ca04b8c841811dbc3c5c5f837934e0d626c10"
   integrity sha512-2eCtxZXf+kbkMIsXS4poTvT4Yu5rXiRa+9xGVT56raghjmBTKMpFNc9R4IDiB4emao9eO22Ox7CxuJG7BgExqA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.24.0"
+
+"@babel/plugin-syntax-jsx@^7.24.7":
+  version "7.24.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.24.7.tgz#39a1fa4a7e3d3d7f34e2acc6be585b718d30e02d"
+  integrity sha512-6ddciUPe/mpMnOKv/U+RSd2vvVy+Yw/JfBB0ZHYjEZt9NLHmCUylNYlsbqCCS1Bffjlb0fCwC9Vqz+sBz6PsiQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.24.7"
 
 "@babel/plugin-syntax-logical-assignment-operators@^7.10.4", "@babel/plugin-syntax-logical-assignment-operators@^7.8.3":
   version "7.10.4"
@@ -4944,16 +4944,21 @@ babel-plugin-react-docgen@^4.2.1:
     lodash "^4.17.15"
     react-docgen "^5.0.0"
 
-babel-plugin-styled-components@^2.1.4:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-2.1.4.tgz#9a1f37c7f32ef927b4b008b529feb4a2c82b1092"
-  integrity sha512-Xgp9g+A/cG47sUyRwwYxGM4bR/jDRg5N6it/8+HxCnbT5XNKSKDT9xm4oag/osgqjC2It/vH0yXsomOG6k558g==
+babel-plugin-styled-components@2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.6.tgz#6f76c7f7224b7af7edc24a4910351948c691fc90"
+  integrity sha512-Sk+7o/oa2HfHv3Eh8sxoz75/fFvEdHsXV4grdeHufX0nauCmymlnN0rGhIvfpMQSJMvGutJ85gvCGea4iqmDpg==
   dependencies:
-    "@babel/helper-annotate-as-pure" "^7.22.5"
-    "@babel/helper-module-imports" "^7.22.5"
-    "@babel/plugin-syntax-jsx" "^7.22.5"
-    lodash "^4.17.21"
-    picomatch "^2.3.1"
+    "@babel/helper-annotate-as-pure" "^7.16.0"
+    "@babel/helper-module-imports" "^7.16.0"
+    babel-plugin-syntax-jsx "^6.18.0"
+    lodash "^4.17.11"
+    picomatch "^2.3.0"
+
+babel-plugin-syntax-jsx@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
+  integrity sha512-qrPaCSo9c8RHNRHIotaufGbuOBN8rtdC4QrrFFc43vyWCCz7Kl7GL1PGaXtMGQZUXrkCjNEgxDfmAuAabr/rlw==
 
 babel-plugin-syntax-trailing-function-commas@^6.22.0:
   version "6.22.0"
@@ -9787,7 +9792,7 @@ lodash.merge@4.6.2, lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-"lodash@4.6.1 || ^4.16.1", lodash@^4.14.0, lodash@^4.17.13, lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21:
+"lodash@4.6.1 || ^4.16.1", lodash@^4.14.0, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
This reverts commit d4b5476ce833fb1bd67c46c9508015ffcca113a3.

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
