### PR TITLE
Add primary key to composed toolbar story

### DIFF
--- a/src/js/components/Data/stories/ComposedToolbar.js
+++ b/src/js/components/Data/stories/ComposedToolbar.js
@@ -57,7 +57,12 @@ export const ComposedToolbar = () => (
       </Toolbar>
       <DataSummary />
       <Box overflow="auto">
-        <DataTable alignSelf="start" columns={columns} sortable />
+        <DataTable
+          alignSelf="start"
+          columns={columns}
+          sortable
+          primaryKey="name"
+        />
       </Box>
     </Data>
   </Box>


### PR DESCRIPTION
#### What does this PR do?
Adds a primary key to the DataTable in the Data/Composed Toolbar story. This prevents issues when the primary key column visibility is toggled off via DataTableColumns. See screenshot:

![Screenshot 2024-08-13 at 12 13 31 PM](https://github.com/user-attachments/assets/f083000c-014b-4f88-b945-aaca27e23a49)

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
backwards compatible