### PR TITLE
add a check to see if target is clicked

### DIFF
--- a/src/js/components/Drop/DropContainer.js
+++ b/src/js/components/Drop/DropContainer.js
@@ -111,7 +111,7 @@ const DropContainer = forwardRef(
         }
         // Check if the click happened within the dropTarget
         const clickInsideDropTarget =
-          (dropTarget.current && dropTarget.current.contains(event.target)) ||
+          (dropTarget?.current && dropTarget.current.contains(event.target)) ||
           (dropTarget &&
             typeof dropTarget.contains === 'function' &&
             dropTarget.contains(event.target));

--- a/src/js/components/Drop/DropContainer.js
+++ b/src/js/components/Drop/DropContainer.js
@@ -109,8 +109,12 @@ const DropContainer = forwardRef(
           if (attr !== null) clickedPortalId = parseInt(attr, 10);
           node = node.parentNode;
         }
+        // Check if the click happened within the dropTarget
+        const isDropTargetValid =
+          dropTarget?.current && dropTarget.current.contains(event.target);
+
         if (
-          clickedPortalId === null ||
+          (!isDropTargetValid && clickedPortalId === null) ||
           portalContext.indexOf(clickedPortalId) !== -1
         ) {
           onClickOutside(event);
@@ -126,7 +130,7 @@ const DropContainer = forwardRef(
           document.removeEventListener('mousedown', onClickDocument);
         }
       };
-    }, [onClickOutside, containerTarget, portalContext]);
+    }, [onClickOutside, containerTarget, portalContext, dropTarget]);
 
     useEffect(() => {
       const target = dropTarget?.current || dropTarget;

--- a/src/js/components/Drop/DropContainer.js
+++ b/src/js/components/Drop/DropContainer.js
@@ -110,11 +110,14 @@ const DropContainer = forwardRef(
           node = node.parentNode;
         }
         // Check if the click happened within the dropTarget
-        const isDropTargetValid =
-          dropTarget?.current && dropTarget.current.contains(event.target);
+        const clickInsideDropTarget =
+          (dropTarget.current && dropTarget.current.contains(event.target)) ||
+          (dropTarget &&
+            typeof dropTarget.contains === 'function' &&
+            dropTarget.contains(event.target));
 
         if (
-          (!isDropTargetValid && clickedPortalId === null) ||
+          (!clickInsideDropTarget && clickedPortalId === null) ||
           portalContext.indexOf(clickedPortalId) !== -1
         ) {
           onClickOutside(event);

--- a/src/js/components/Drop/__tests__/Drop-test.tsx
+++ b/src/js/components/Drop/__tests__/Drop-test.tsx
@@ -194,7 +194,7 @@ describe('Drop', () => {
     expect(onClickOutside).toBeCalled();
   });
 
-  test.only('does not invoke onClickOutside when clicking inside Drop', () => {
+  test.only('does not invoke onClickOutside when clicking the target', () => {
     const onClickOutside = jest.fn();
     render(<TestInput onClickOutside={onClickOutside} />);
 

--- a/src/js/components/Drop/__tests__/Drop-test.tsx
+++ b/src/js/components/Drop/__tests__/Drop-test.tsx
@@ -4,7 +4,13 @@ import 'jest-axe/extend-expect';
 import 'regenerator-runtime/runtime';
 
 import { axe } from 'jest-axe';
-import { cleanup, fireEvent, render, waitFor } from '@testing-library/react';
+import {
+  cleanup,
+  fireEvent,
+  render,
+  waitFor,
+  screen,
+} from '@testing-library/react';
 
 import { expectPortal } from '../../../utils/portal';
 
@@ -186,6 +192,16 @@ describe('Drop', () => {
       new MouseEvent('mousedown', { bubbles: true, cancelable: true }),
     );
     expect(onClickOutside).toBeCalled();
+  });
+
+  test.only('does not invoke onClickOutside when clicking inside Drop', () => {
+    const onClickOutside = jest.fn();
+    render(<TestInput onClickOutside={onClickOutside} />);
+
+    // Click the target
+    const inputElement = screen.getByLabelText('test');
+    fireEvent.click(inputElement);
+    expect(onClickOutside).not.toHaveBeenCalled();
   });
 
   test('resize', () => {

--- a/src/js/components/Drop/__tests__/Drop-test.tsx
+++ b/src/js/components/Drop/__tests__/Drop-test.tsx
@@ -194,7 +194,7 @@ describe('Drop', () => {
     expect(onClickOutside).toBeCalled();
   });
 
-  test.only('does not invoke onClickOutside when clicking the target', () => {
+  test('does not invoke onClickOutside when clicking the target', () => {
     const onClickOutside = jest.fn();
     render(<TestInput onClickOutside={onClickOutside} />);
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR checks to see if the user clicks on the target and then will not invoke the `onClickOutside` func
#### Where should the reviewer start?
dropContainer
#### What testing has been done on this PR?
Added a test 

local story 

```
import React, { useRef, useState } from 'react';
import { Box, Button, Drop, DropButton, Layer, TextInput } from 'grommet';

const alignRight = { left: 'right' };
const alignLeft = { right: 'left' };

const MultipleDrop = () => {
  const [showDrop, setShowDrop] = useState(false);
  const targetRef = useRef();

  return (
    // Uncomment <Grommet> lines when using outside of storybook
    // <Grommet theme={...}>
    <Box gap="medium" fill align="center" justify="center">
      <Button
        ref={targetRef}
        label="button"
        onClick={() => setShowDrop(!showDrop)}
      />
      {showDrop && (
        <Drop
          align={alignRight}
          target={targetRef.current}
          onClickOutside={() => setShowDrop(false)}
        >
          <Box pad="large">
            <TextInput
              value=""
              onChange={() => {}}
              suggestions={['one', 'two']}
            />
          </Box>
        </Drop>
      )}
    </Box>
    // </Grommet>
  );
};

export const Multiple = () => <MultipleDrop />;
Multiple.parameters = {
  chromatic: { disable: true },
};
Multiple.args = {
  full: true,
};

export default {
  title: 'Controls/Drop/Multiple',
};
```
#### How should this be manually tested?
use the above code to test locally 
#### Do Jest tests follow these best practices?

- [x] `screen` is used for querying.
- [x] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
When you click on the target in which opens the drop if you have it set in your local state to close the drop this was not working properly when `onClickOutside` was present 
see codesandbox
https://codesandbox.io/p/sandbox/jovial-mopsa-4ry469?file=%2Fsrc%2Findex.js%3A28%2C1-28%2C52
#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible 