### PR TITLE
add support for border image

### DIFF
--- a/src/js/components/Box/__tests__/Box-style-test.tsx
+++ b/src/js/components/Box/__tests__/Box-style-test.tsx
@@ -247,36 +247,33 @@ describe('Box', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test('borderImage', () => {
+  test('test if image', () => {
     const { container } = render(
       <Grommet>
-        <Box border={{ borderImage: 'linear-gradient(#f6b73c, #4d9f0c) 30' }} />
-        <Box
-          border={{ borderImage: 'linear-gradient(to right, red, blue) 50' }}
-        />
-        <Box border={{ borderImage: 'beige' }} />
+        <Box border={{ image: 'linear-gradient(#f6b73c, #4d9f0c) 30' }} />
+        <Box border={{ image: 'linear-gradient(to right, red, blue) 50' }} />
         <Box
           border={{
             size: 'medium',
-            borderImage: 'linear-gradient(#f6b73c, #4d9f0c) 30',
+            image: 'linear-gradient(#f6b73c, #4d9f0c) 30',
           }}
         />
         <Box
           border={{
             size: 'small',
-            borderImage: 'linear-gradient(to bottom, green, yellow) 20',
+            image: 'linear-gradient(to bottom, green, yellow) 20',
           }}
         />
         <Box
           border={{
             side: 'top',
-            borderImage: 'linear-gradient(45deg, blue, green) 40',
+            image: 'linear-gradient(45deg, blue, green) 40',
           }}
         />
         <Box
           border={{
             side: 'left',
-            borderImage: 'linear-gradient(135deg, black, white) 50',
+            image: 'linear-gradient(135deg, black, white) 50',
           }}
         />
       </Grommet>,

--- a/src/js/components/Box/__tests__/Box-style-test.tsx
+++ b/src/js/components/Box/__tests__/Box-style-test.tsx
@@ -276,6 +276,16 @@ describe('Box', () => {
             image: 'linear-gradient(135deg, black, white) 50',
           }}
         />
+        <Box
+          border={{
+            image: {
+              source: 'linear-gradient(#f6b73c, #4d9f0c)',
+              slice: 30,
+            },
+          }}
+        >
+          hi
+        </Box>
       </Grommet>,
     );
 

--- a/src/js/components/Box/__tests__/Box-style-test.tsx
+++ b/src/js/components/Box/__tests__/Box-style-test.tsx
@@ -250,30 +250,45 @@ describe('Box', () => {
   test('test if image', () => {
     const { container } = render(
       <Grommet>
-        <Box border={{ image: 'linear-gradient(#f6b73c, #4d9f0c) 30' }} />
-        <Box border={{ image: 'linear-gradient(to right, red, blue) 50' }} />
+        <Box
+          border={{ image: { source: 'linear-gradient(#f6b73c, #4d9f0c)' } }}
+        />
+        <Box
+          border={{ image: { source: 'linear-gradient(to right, red, blue)' } }}
+        />
         <Box
           border={{
             size: 'medium',
-            image: 'linear-gradient(#f6b73c, #4d9f0c) 30',
+            image: {
+              source: 'linear-gradient(#f6b73c, #4d9f0c)',
+              slice: 30,
+            },
           }}
         />
         <Box
           border={{
             size: 'small',
-            image: 'linear-gradient(to bottom, green, yellow) 20',
+            image: {
+              source: 'linear-gradient(to bottom, green, yellow)',
+              slice: 20,
+            },
           }}
         />
         <Box
           border={{
             side: 'top',
-            image: 'linear-gradient(45deg, blue, green) 40',
+            image: {
+              source: 'linear-gradient(45deg, blue, green)',
+            },
           }}
         />
         <Box
           border={{
             side: 'left',
-            image: 'linear-gradient(135deg, black, white) 50',
+            image: {
+              source: 'linear-gradient(135deg, black, white)',
+              slice: 50,
+            },
           }}
         />
         <Box

--- a/src/js/components/Box/__tests__/Box-style-test.tsx
+++ b/src/js/components/Box/__tests__/Box-style-test.tsx
@@ -247,6 +247,44 @@ describe('Box', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  test('borderImage', () => {
+    const { container } = render(
+      <Grommet>
+        <Box border={{ borderImage: 'linear-gradient(#f6b73c, #4d9f0c) 30' }} />
+        <Box
+          border={{ borderImage: 'linear-gradient(to right, red, blue) 50' }}
+        />
+        <Box border={{ borderImage: 'beige' }} />
+        <Box
+          border={{
+            size: 'medium',
+            borderImage: 'linear-gradient(#f6b73c, #4d9f0c) 30',
+          }}
+        />
+        <Box
+          border={{
+            size: 'small',
+            borderImage: 'linear-gradient(to bottom, green, yellow) 20',
+          }}
+        />
+        <Box
+          border={{
+            side: 'top',
+            borderImage: 'linear-gradient(45deg, blue, green) 40',
+          }}
+        />
+        <Box
+          border={{
+            side: 'left',
+            borderImage: 'linear-gradient(135deg, black, white) 50',
+          }}
+        />
+      </Grommet>,
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
   test('elevation', () => {
     const { container } = render(
       <Grommet>

--- a/src/js/components/Box/__tests__/__snapshots__/Box-style-test.tsx.snap
+++ b/src/js/components/Box/__tests__/__snapshots__/Box-style-test.tsx.snap
@@ -1198,6 +1198,170 @@ exports[`Box border 1`] = `
 </div>
 `;
 
+exports[`Box borderImage 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border: solid 1px rgba(0, 0, 0, 0.33);
+  border-image: linear-gradient(#f6b73c, #4d9f0c) 30;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.c2 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border: solid 1px rgba(0, 0, 0, 0.33);
+  border-image: linear-gradient(to right, red, blue) 50;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.c3 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border: solid 1px rgba(0, 0, 0, 0.33);
+  border-image: beige;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.c4 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border: solid 4px rgba(0, 0, 0, 0.33);
+  border-image: linear-gradient(#f6b73c, #4d9f0c) 30;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.c5 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border: solid 2px rgba(0, 0, 0, 0.33);
+  border-image: linear-gradient(to bottom, green, yellow) 20;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.c6 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border-top: solid 1px rgba(0, 0, 0, 0.33);
+  border-image: linear-gradient(45deg, blue, green) 40;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.c7 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border-left: solid 1px rgba(0, 0, 0, 0.33);
+  border-image: linear-gradient(135deg, black, white) 50;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+}
+
+@media only screen and (max-width: 768px) {
+  .c1 {
+    border: solid 1px rgba(0, 0, 0, 0.33);
+    border-image: linear-gradient(#f6b73c, #4d9f0c) 30;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    border: solid 1px rgba(0, 0, 0, 0.33);
+    border-image: linear-gradient(to right, red, blue) 50;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c3 {
+    border: solid 1px rgba(0, 0, 0, 0.33);
+    border-image: beige;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c4 {
+    border: solid 4px rgba(0, 0, 0, 0.33);
+    border-image: linear-gradient(#f6b73c, #4d9f0c) 30;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c5 {
+    border: solid 2px rgba(0, 0, 0, 0.33);
+    border-image: linear-gradient(to bottom, green, yellow) 20;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c6 {
+    border-top: solid 1px rgba(0, 0, 0, 0.33);
+    border-image: linear-gradient(45deg, blue, green) 40;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c7 {
+    border-left: solid 1px rgba(0, 0, 0, 0.33);
+    border-image: linear-gradient(135deg, black, white) 50;
+  }
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+  />
+  <div
+    class="c2"
+  />
+  <div
+    class="c3"
+  />
+  <div
+    class="c4"
+  />
+  <div
+    class="c5"
+  />
+  <div
+    class="c6"
+  />
+  <div
+    class="c7"
+  />
+</div>
+`;
+
 exports[`Box elevation 1`] = `
 .c0 {
   font-size: 18px;

--- a/src/js/components/Box/__tests__/__snapshots__/Box-style-test.tsx.snap
+++ b/src/js/components/Box/__tests__/__snapshots__/Box-style-test.tsx.snap
@@ -1790,7 +1790,7 @@ exports[`Box test if image 1`] = `
   box-sizing: border-box;
   max-width: 100%;
   border: solid 1px rgba(0, 0, 0, 0.33);
-  border-image: linear-gradient(#f6b73c, #4d9f0c) 30;
+  border-image-source: linear-gradient(#f6b73c, #4d9f0c);
   min-width: 0;
   min-height: 0;
   flex-direction: column;
@@ -1801,7 +1801,7 @@ exports[`Box test if image 1`] = `
   box-sizing: border-box;
   max-width: 100%;
   border: solid 1px rgba(0, 0, 0, 0.33);
-  border-image: linear-gradient(to right, red, blue) 50;
+  border-image-source: linear-gradient(to right, red, blue);
   min-width: 0;
   min-height: 0;
   flex-direction: column;
@@ -1812,7 +1812,8 @@ exports[`Box test if image 1`] = `
   box-sizing: border-box;
   max-width: 100%;
   border: solid 4px rgba(0, 0, 0, 0.33);
-  border-image: linear-gradient(#f6b73c, #4d9f0c) 30;
+  border-image-source: linear-gradient(#f6b73c, #4d9f0c);
+  border-image-slice: 30;
   min-width: 0;
   min-height: 0;
   flex-direction: column;
@@ -1823,7 +1824,8 @@ exports[`Box test if image 1`] = `
   box-sizing: border-box;
   max-width: 100%;
   border: solid 2px rgba(0, 0, 0, 0.33);
-  border-image: linear-gradient(to bottom, green, yellow) 20;
+  border-image-source: linear-gradient(to bottom, green, yellow);
+  border-image-slice: 20;
   min-width: 0;
   min-height: 0;
   flex-direction: column;
@@ -1834,7 +1836,7 @@ exports[`Box test if image 1`] = `
   box-sizing: border-box;
   max-width: 100%;
   border-top: solid 1px rgba(0, 0, 0, 0.33);
-  border-image: linear-gradient(45deg, blue, green) 40;
+  border-image-source: linear-gradient(45deg, blue, green);
   min-width: 0;
   min-height: 0;
   flex-direction: column;
@@ -1845,7 +1847,8 @@ exports[`Box test if image 1`] = `
   box-sizing: border-box;
   max-width: 100%;
   border-left: solid 1px rgba(0, 0, 0, 0.33);
-  border-image: linear-gradient(135deg, black, white) 50;
+  border-image-source: linear-gradient(135deg, black, white);
+  border-image-slice: 50;
   min-width: 0;
   min-height: 0;
   flex-direction: column;
@@ -1866,42 +1869,45 @@ exports[`Box test if image 1`] = `
 @media only screen and (max-width: 768px) {
   .c1 {
     border: solid 1px rgba(0, 0, 0, 0.33);
-    border-image: linear-gradient(#f6b73c, #4d9f0c) 30;
+    border-image-source: linear-gradient(#f6b73c, #4d9f0c);
   }
 }
 
 @media only screen and (max-width: 768px) {
   .c2 {
     border: solid 1px rgba(0, 0, 0, 0.33);
-    border-image: linear-gradient(to right, red, blue) 50;
+    border-image-source: linear-gradient(to right, red, blue);
   }
 }
 
 @media only screen and (max-width: 768px) {
   .c3 {
     border: solid 4px rgba(0, 0, 0, 0.33);
-    border-image: linear-gradient(#f6b73c, #4d9f0c) 30;
+    border-image-source: linear-gradient(#f6b73c, #4d9f0c);
+    border-image-slice: 30;
   }
 }
 
 @media only screen and (max-width: 768px) {
   .c4 {
     border: solid 2px rgba(0, 0, 0, 0.33);
-    border-image: linear-gradient(to bottom, green, yellow) 20;
+    border-image-source: linear-gradient(to bottom, green, yellow);
+    border-image-slice: 20;
   }
 }
 
 @media only screen and (max-width: 768px) {
   .c5 {
     border-top: solid 1px rgba(0, 0, 0, 0.33);
-    border-image: linear-gradient(45deg, blue, green) 40;
+    border-image-source: linear-gradient(45deg, blue, green);
   }
 }
 
 @media only screen and (max-width: 768px) {
   .c6 {
     border-left: solid 1px rgba(0, 0, 0, 0.33);
-    border-image: linear-gradient(135deg, black, white) 50;
+    border-image-source: linear-gradient(135deg, black, white);
+    border-image-slice: 50;
   }
 }
 

--- a/src/js/components/Box/__tests__/__snapshots__/Box-style-test.tsx.snap
+++ b/src/js/components/Box/__tests__/__snapshots__/Box-style-test.tsx.snap
@@ -1851,6 +1851,18 @@ exports[`Box test if image 1`] = `
   flex-direction: column;
 }
 
+.c7 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border: solid 1px rgba(0, 0, 0, 0.33);
+  border-image-source: linear-gradient(#f6b73c, #4d9f0c);
+  border-image-slice: 30;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+}
+
 @media only screen and (max-width: 768px) {
   .c1 {
     border: solid 1px rgba(0, 0, 0, 0.33);
@@ -1893,6 +1905,14 @@ exports[`Box test if image 1`] = `
   }
 }
 
+@media only screen and (max-width: 768px) {
+  .c7 {
+    border: solid 1px rgba(0, 0, 0, 0.33);
+    border-image-source: linear-gradient(#f6b73c, #4d9f0c);
+    border-image-slice: 30;
+  }
+}
+
 <div
   class="c0"
 >
@@ -1914,5 +1934,10 @@ exports[`Box test if image 1`] = `
   <div
     class="c6"
   />
+  <div
+    class="c7"
+  >
+    hi
+  </div>
 </div>
 `;

--- a/src/js/components/Box/__tests__/__snapshots__/Box-style-test.tsx.snap
+++ b/src/js/components/Box/__tests__/__snapshots__/Box-style-test.tsx.snap
@@ -1198,170 +1198,6 @@ exports[`Box border 1`] = `
 </div>
 `;
 
-exports[`Box borderImage 1`] = `
-.c0 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
-.c1 {
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  border: solid 1px rgba(0, 0, 0, 0.33);
-  border-image: linear-gradient(#f6b73c, #4d9f0c) 30;
-  min-width: 0;
-  min-height: 0;
-  flex-direction: column;
-}
-
-.c2 {
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  border: solid 1px rgba(0, 0, 0, 0.33);
-  border-image: linear-gradient(to right, red, blue) 50;
-  min-width: 0;
-  min-height: 0;
-  flex-direction: column;
-}
-
-.c3 {
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  border: solid 1px rgba(0, 0, 0, 0.33);
-  border-image: beige;
-  min-width: 0;
-  min-height: 0;
-  flex-direction: column;
-}
-
-.c4 {
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  border: solid 4px rgba(0, 0, 0, 0.33);
-  border-image: linear-gradient(#f6b73c, #4d9f0c) 30;
-  min-width: 0;
-  min-height: 0;
-  flex-direction: column;
-}
-
-.c5 {
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  border: solid 2px rgba(0, 0, 0, 0.33);
-  border-image: linear-gradient(to bottom, green, yellow) 20;
-  min-width: 0;
-  min-height: 0;
-  flex-direction: column;
-}
-
-.c6 {
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  border-top: solid 1px rgba(0, 0, 0, 0.33);
-  border-image: linear-gradient(45deg, blue, green) 40;
-  min-width: 0;
-  min-height: 0;
-  flex-direction: column;
-}
-
-.c7 {
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  border-left: solid 1px rgba(0, 0, 0, 0.33);
-  border-image: linear-gradient(135deg, black, white) 50;
-  min-width: 0;
-  min-height: 0;
-  flex-direction: column;
-}
-
-@media only screen and (max-width: 768px) {
-  .c1 {
-    border: solid 1px rgba(0, 0, 0, 0.33);
-    border-image: linear-gradient(#f6b73c, #4d9f0c) 30;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c2 {
-    border: solid 1px rgba(0, 0, 0, 0.33);
-    border-image: linear-gradient(to right, red, blue) 50;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c3 {
-    border: solid 1px rgba(0, 0, 0, 0.33);
-    border-image: beige;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c4 {
-    border: solid 4px rgba(0, 0, 0, 0.33);
-    border-image: linear-gradient(#f6b73c, #4d9f0c) 30;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c5 {
-    border: solid 2px rgba(0, 0, 0, 0.33);
-    border-image: linear-gradient(to bottom, green, yellow) 20;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c6 {
-    border-top: solid 1px rgba(0, 0, 0, 0.33);
-    border-image: linear-gradient(45deg, blue, green) 40;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c7 {
-    border-left: solid 1px rgba(0, 0, 0, 0.33);
-    border-image: linear-gradient(135deg, black, white) 50;
-  }
-}
-
-<div
-  class="c0"
->
-  <div
-    class="c1"
-  />
-  <div
-    class="c2"
-  />
-  <div
-    class="c3"
-  />
-  <div
-    class="c4"
-  />
-  <div
-    class="c5"
-  />
-  <div
-    class="c6"
-  />
-  <div
-    class="c7"
-  />
-</div>
-`;
-
 exports[`Box elevation 1`] = `
 .c0 {
   font-size: 18px;
@@ -1936,4 +1772,147 @@ exports[`Box round with responive equal to false 1`] = `
     />
   </div>
 </DocumentFragment>
+`;
+
+exports[`Box test if image 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border: solid 1px rgba(0, 0, 0, 0.33);
+  border-image: linear-gradient(#f6b73c, #4d9f0c) 30;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.c2 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border: solid 1px rgba(0, 0, 0, 0.33);
+  border-image: linear-gradient(to right, red, blue) 50;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.c3 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border: solid 4px rgba(0, 0, 0, 0.33);
+  border-image: linear-gradient(#f6b73c, #4d9f0c) 30;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.c4 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border: solid 2px rgba(0, 0, 0, 0.33);
+  border-image: linear-gradient(to bottom, green, yellow) 20;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.c5 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border-top: solid 1px rgba(0, 0, 0, 0.33);
+  border-image: linear-gradient(45deg, blue, green) 40;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.c6 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border-left: solid 1px rgba(0, 0, 0, 0.33);
+  border-image: linear-gradient(135deg, black, white) 50;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+}
+
+@media only screen and (max-width: 768px) {
+  .c1 {
+    border: solid 1px rgba(0, 0, 0, 0.33);
+    border-image: linear-gradient(#f6b73c, #4d9f0c) 30;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    border: solid 1px rgba(0, 0, 0, 0.33);
+    border-image: linear-gradient(to right, red, blue) 50;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c3 {
+    border: solid 4px rgba(0, 0, 0, 0.33);
+    border-image: linear-gradient(#f6b73c, #4d9f0c) 30;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c4 {
+    border: solid 2px rgba(0, 0, 0, 0.33);
+    border-image: linear-gradient(to bottom, green, yellow) 20;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c5 {
+    border-top: solid 1px rgba(0, 0, 0, 0.33);
+    border-image: linear-gradient(45deg, blue, green) 40;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c6 {
+    border-left: solid 1px rgba(0, 0, 0, 0.33);
+    border-image: linear-gradient(135deg, black, white) 50;
+  }
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+  />
+  <div
+    class="c2"
+  />
+  <div
+    class="c3"
+  />
+  <div
+    class="c4"
+  />
+  <div
+    class="c5"
+  />
+  <div
+    class="c6"
+  />
+</div>
 `;

--- a/src/js/components/Box/propTypes.js
+++ b/src/js/components/Box/propTypes.js
@@ -10,53 +10,10 @@ import {
   roundPropType,
   skeletonPropType,
   widthPropType,
+  BORDER_SHAPE,
 } from '../../utils/general-prop-types';
 
 const OVERFLOW_VALUES = ['auto', 'hidden', 'scroll', 'visible'];
-
-const BORDER_SHAPE = PropTypes.shape({
-  color: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.shape({
-      dark: PropTypes.string,
-      light: PropTypes.string,
-    }),
-  ]),
-  image: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.shape({
-      source: PropTypes.string,
-      slice: PropTypes.number,
-    }),
-  ]),
-  side: PropTypes.oneOf([
-    'top',
-    'left',
-    'bottom',
-    'right',
-    'start',
-    'end',
-    'horizontal',
-    'vertical',
-    'all',
-    'between',
-  ]),
-  size: PropTypes.oneOfType([
-    PropTypes.oneOf(['xsmall', 'small', 'medium', 'large', 'xlarge']),
-    PropTypes.string,
-  ]),
-  style: PropTypes.oneOf([
-    'solid',
-    'dashed',
-    'dotted',
-    'double',
-    'groove',
-    'ridge',
-    'inset',
-    'outset',
-    'hidden',
-  ]),
-});
 
 // if you update values here, make sure to update in Drop/doc too.
 const overflowPropType = PropTypes.oneOfType([

--- a/src/js/components/Box/propTypes.js
+++ b/src/js/components/Box/propTypes.js
@@ -22,6 +22,13 @@ const BORDER_SHAPE = PropTypes.shape({
       light: PropTypes.string,
     }),
   ]),
+  image: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.shape({
+      source: PropTypes.string,
+      slice: PropTypes.number,
+    }),
+  ]),
   side: PropTypes.oneOf([
     'top',
     'left',

--- a/src/js/components/Box/stories/Border.js
+++ b/src/js/components/Box/stories/Border.js
@@ -100,7 +100,7 @@ export const BorderBox = () => (
         size: 'small',
         style: 'solid',
         color: 'transparent',
-        borderImage: 'linear-gradient(#f6b73c, #4d9f0c) 10',
+        image: 'linear-gradient(#f6b73c, #4d9f0c) 10',
       }}
     >
       border-image

--- a/src/js/components/Box/stories/Border.js
+++ b/src/js/components/Box/stories/Border.js
@@ -94,6 +94,17 @@ export const BorderBox = () => (
       <Text>Multiple Border</Text>
       <Text>With Between</Text>
     </Box>
+    <Box
+      pad="small"
+      border={{
+        size: 'small',
+        style: 'solid',
+        color: 'transparent',
+        borderImage: 'linear-gradient(#f6b73c, #4d9f0c) 10',
+      }}
+    >
+      border-image
+    </Box>
   </Box>
   // </Grommet>
 );

--- a/src/js/components/Box/stories/Border.js
+++ b/src/js/components/Box/stories/Border.js
@@ -100,7 +100,7 @@ export const BorderBox = () => (
         size: 'small',
         style: 'solid',
         color: 'transparent',
-        image: 'linear-gradient(#f6b73c, #4d9f0c) 10',
+        image: { source: 'linear-gradient(#f6b73c, #4d9f0c)', slice: 10 },
       }}
     >
       border-image

--- a/src/js/components/Grid/propTypes.js
+++ b/src/js/components/Grid/propTypes.js
@@ -5,6 +5,7 @@ import {
   heightPropType,
   padPropType,
   widthPropType,
+  BORDER_SHAPE,
 } from '../../utils/general-prop-types';
 
 const fixedSizes = ['xsmall', 'small', 'medium', 'large', 'xlarge'];
@@ -33,43 +34,6 @@ const edgeSizes = [
   'xlarge',
   'none',
 ];
-
-const BORDER_SHAPE = PropTypes.shape({
-  color: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.shape({
-      dark: PropTypes.string,
-      light: PropTypes.string,
-    }),
-  ]),
-  side: PropTypes.oneOf([
-    'top',
-    'left',
-    'bottom',
-    'right',
-    'start',
-    'end',
-    'horizontal',
-    'vertical',
-    'all',
-    'between',
-  ]),
-  size: PropTypes.oneOfType([
-    PropTypes.oneOf(['xsmall', 'small', 'medium', 'large', 'xlarge']),
-    PropTypes.string,
-  ]),
-  style: PropTypes.oneOf([
-    'solid',
-    'dashed',
-    'dotted',
-    'double',
-    'groove',
-    'ridge',
-    'inset',
-    'outset',
-    'hidden',
-  ]),
-});
 
 let PropType = {};
 if (process.env.NODE_ENV !== 'production') {

--- a/src/js/utils/border.js
+++ b/src/js/utils/border.js
@@ -42,8 +42,8 @@ export const responsiveBorderStyle = (data, theme) => {
     styles.push(`border: ${value};`);
   }
 
-  if (data.borderImage) {
-    styles.push(`border-image: ${data.borderImage};`);
+  if (data.image) {
+    styles.push(`border-image: ${data.image};`);
   }
   return styles.join('\n');
 };
@@ -108,8 +108,8 @@ export const borderStyle = (borderData, responsive, theme) => {
         styles.push(breakpointStyle(breakpoint, responsiveStyle));
       }
     }
-    if (data.borderImage) {
-      styles.push(`border-image: ${data.borderImage};`);
+    if (data.image) {
+      styles.push(`border-image: ${data.image};`);
     }
     borderStyles.push(styles);
   });

--- a/src/js/utils/border.js
+++ b/src/js/utils/border.js
@@ -8,7 +8,7 @@ export const responsiveBorderStyle = (data, theme) => {
   const style = data.style || 'solid';
   const side = typeof data === 'string' ? data : data.side || 'all';
 
-  let styles = [];
+  const styles = [];
 
   const breakpoint =
     theme.box.responsiveBreakpoint &&

--- a/src/js/utils/border.js
+++ b/src/js/utils/border.js
@@ -51,8 +51,6 @@ export const responsiveBorderStyle = (data, theme) => {
       if (slice) {
         styles.push(`border-image-slice: ${slice};`);
       }
-    } else {
-      styles.push(`border-image: ${data.image};`);
     }
   }
   return styles.join('\n');
@@ -127,8 +125,6 @@ export const borderStyle = (borderData, responsive, theme) => {
         if (slice) {
           styles.push(`border-image-slice: ${slice};`);
         }
-      } else {
-        styles.push(`border-image: ${data.image};`);
       }
     }
     borderStyles.push(styles);

--- a/src/js/utils/border.js
+++ b/src/js/utils/border.js
@@ -43,7 +43,17 @@ export const responsiveBorderStyle = (data, theme) => {
   }
 
   if (data.image) {
-    styles.push(`border-image: ${data.image};`);
+    if (typeof data.image === 'object') {
+      const { slice, source } = data.image;
+      if (source) {
+        styles.push(`border-image-source: ${source};`);
+      }
+      if (slice) {
+        styles.push(`border-image-slice: ${slice};`);
+      }
+    } else {
+      styles.push(`border-image: ${data.image};`);
+    }
   }
   return styles.join('\n');
 };
@@ -109,7 +119,17 @@ export const borderStyle = (borderData, responsive, theme) => {
       }
     }
     if (data.image) {
-      styles.push(`border-image: ${data.image};`);
+      if (typeof data.image === 'object') {
+        const { slice, source } = data.image;
+        if (source) {
+          styles.push(`border-image-source: ${source};`);
+        }
+        if (slice) {
+          styles.push(`border-image-slice: ${slice};`);
+        }
+      } else {
+        styles.push(`border-image: ${data.image};`);
+      }
     }
     borderStyles.push(styles);
   });

--- a/src/js/utils/border.js
+++ b/src/js/utils/border.js
@@ -7,6 +7,9 @@ export const responsiveBorderStyle = (data, theme) => {
   const borderSize = data.size || 'xsmall';
   const style = data.style || 'solid';
   const side = typeof data === 'string' ? data : data.side || 'all';
+
+  let styles = [];
+
   const breakpoint =
     theme.box.responsiveBreakpoint &&
     theme.global.breakpoints[theme.box.responsiveBreakpoint];
@@ -21,22 +24,28 @@ export const responsiveBorderStyle = (data, theme) => {
     side === 'bottom' ||
     side === 'left' ||
     side === 'right'
-  )
-    return `border-${side}: ${value};`;
-  if (side === 'end' || side === 'start')
-    return `border-inline-${side}: ${value};`;
-  if (side === 'vertical')
-    return `
+  ) {
+    styles.push(`border-${side}: ${value};`);
+  } else if (side === 'end' || side === 'start') {
+    styles.push(`border-inline-${side}: ${value};`);
+  } else if (side === 'vertical') {
+    styles.push(`
       border-left: ${value};
       border-right: ${value};
-    `;
-  if (side === 'horizontal')
-    return `
+    `);
+  } else if (side === 'horizontal') {
+    styles.push(`
       border-top: ${value};
       border-bottom: ${value};
-    `;
-  if (side === 'between') return undefined; // no-op
-  return `border: ${value};`;
+    `);
+  } else if (side !== 'between') {
+    styles.push(`border: ${value};`);
+  }
+
+  if (data.borderImage) {
+    styles.push(`border-image: ${data.borderImage};`);
+  }
+  return styles.join('\n');
 };
 
 export const borderStyle = (borderData, responsive, theme) => {
@@ -98,6 +107,9 @@ export const borderStyle = (borderData, responsive, theme) => {
       if (responsiveStyle) {
         styles.push(breakpointStyle(breakpoint, responsiveStyle));
       }
+    }
+    if (data.borderImage) {
+      styles.push(`border-image: ${data.borderImage};`);
     }
     borderStyles.push(styles);
   });

--- a/src/js/utils/general-prop-types.js
+++ b/src/js/utils/general-prop-types.js
@@ -257,13 +257,7 @@ export const BORDER_SHAPE = PropTypes.shape({
       light: PropTypes.string,
     }),
   ]),
-  image: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.shape({
-      source: PropTypes.string,
-      slice: PropTypes.number,
-    }),
-  ]),
+  image: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   side: PropTypes.oneOf([
     'top',
     'left',

--- a/src/js/utils/general-prop-types.js
+++ b/src/js/utils/general-prop-types.js
@@ -248,3 +248,47 @@ export const widthPropType = PropTypes.oneOfType([
 ]);
 
 export const OVERFLOW_VALUES = ['auto', 'hidden', 'scroll', 'visible'];
+
+export const BORDER_SHAPE = PropTypes.shape({
+  color: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.shape({
+      dark: PropTypes.string,
+      light: PropTypes.string,
+    }),
+  ]),
+  image: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.shape({
+      source: PropTypes.string,
+      slice: PropTypes.number,
+    }),
+  ]),
+  side: PropTypes.oneOf([
+    'top',
+    'left',
+    'bottom',
+    'right',
+    'start',
+    'end',
+    'horizontal',
+    'vertical',
+    'all',
+    'between',
+  ]),
+  size: PropTypes.oneOfType([
+    PropTypes.oneOf(['xsmall', 'small', 'medium', 'large', 'xlarge']),
+    PropTypes.string,
+  ]),
+  style: PropTypes.oneOf([
+    'solid',
+    'dashed',
+    'dotted',
+    'double',
+    'groove',
+    'ridge',
+    'inset',
+    'outset',
+    'hidden',
+  ]),
+});

--- a/src/js/utils/general-prop-types.js
+++ b/src/js/utils/general-prop-types.js
@@ -257,7 +257,7 @@ export const BORDER_SHAPE = PropTypes.shape({
       light: PropTypes.string,
     }),
   ]),
-  image: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+  image: PropTypes.oneOfType([PropTypes.object]),
   side: PropTypes.oneOf([
     'top',
     'left',

--- a/src/js/utils/general-prop-types.js
+++ b/src/js/utils/general-prop-types.js
@@ -257,7 +257,10 @@ export const BORDER_SHAPE = PropTypes.shape({
       light: PropTypes.string,
     }),
   ]),
-  image: PropTypes.oneOfType([PropTypes.object]),
+  image: PropTypes.shape({
+    source: PropTypes.string,
+    slice: PropTypes.number,
+  }),
   side: PropTypes.oneOf([
     'top',
     'left',

--- a/src/js/utils/index.d.ts
+++ b/src/js/utils/index.d.ts
@@ -191,7 +191,7 @@ export type BorderType =
       side?: BoxSideType;
       size?: BoxSizeType;
       style?: BoxStyleType;
-      borderImage?: string;
+      image?: string;
     }
   | {
       color?: ColorType;
@@ -200,7 +200,7 @@ export type BorderType =
       side?: BoxSideType;
       size?: BoxSizeType;
       style?: BoxStyleType;
-      borderImage?: string;
+      image?: string;
     }[];
 export type ColorType = string | { dark?: string; light?: string } | undefined;
 export type DirectionType =

--- a/src/js/utils/index.d.ts
+++ b/src/js/utils/index.d.ts
@@ -191,7 +191,7 @@ export type BorderType =
       side?: BoxSideType;
       size?: BoxSizeType;
       style?: BoxStyleType;
-      image?: string | { source?: string; slice?: number };
+      image?: {};
     }
   | {
       color?: ColorType;
@@ -200,7 +200,7 @@ export type BorderType =
       side?: BoxSideType;
       size?: BoxSizeType;
       style?: BoxStyleType;
-      image?: string | {};
+      image?: {};
     }[];
 export type ColorType = string | { dark?: string; light?: string } | undefined;
 export type DirectionType =

--- a/src/js/utils/index.d.ts
+++ b/src/js/utils/index.d.ts
@@ -77,7 +77,13 @@ export type BoxSideType =
   | 'vertical'
   | 'all'
   | 'between';
-export type BoxSizeType = 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | string;
+export type BoxSizeType =
+  | 'xsmall'
+  | 'small'
+  | 'medium'
+  | 'large'
+  | 'xlarge'
+  | string;
 export type BoxStyleType =
   | 'solid'
   | 'dashed'
@@ -185,6 +191,7 @@ export type BorderType =
       side?: BoxSideType;
       size?: BoxSizeType;
       style?: BoxStyleType;
+      borderImage?: string;
     }
   | {
       color?: ColorType;
@@ -193,6 +200,7 @@ export type BorderType =
       side?: BoxSideType;
       size?: BoxSizeType;
       style?: BoxStyleType;
+      borderImage?: string;
     }[];
 export type ColorType = string | { dark?: string; light?: string } | undefined;
 export type DirectionType =

--- a/src/js/utils/index.d.ts
+++ b/src/js/utils/index.d.ts
@@ -200,7 +200,7 @@ export type BorderType =
       side?: BoxSideType;
       size?: BoxSizeType;
       style?: BoxStyleType;
-      image?: string | { source?: string; slice?: number };
+      image?: string | {};
     }[];
 export type ColorType = string | { dark?: string; light?: string } | undefined;
 export type DirectionType =

--- a/src/js/utils/index.d.ts
+++ b/src/js/utils/index.d.ts
@@ -191,7 +191,7 @@ export type BorderType =
       side?: BoxSideType;
       size?: BoxSizeType;
       style?: BoxStyleType;
-      image?: {};
+      image?: { source?: string; slice?: number };
     }
   | {
       color?: ColorType;
@@ -200,7 +200,7 @@ export type BorderType =
       side?: BoxSideType;
       size?: BoxSizeType;
       style?: BoxStyleType;
-      image?: {};
+      image?: { source?: string; slice?: number };
     }[];
 export type ColorType = string | { dark?: string; light?: string } | undefined;
 export type DirectionType =

--- a/src/js/utils/index.d.ts
+++ b/src/js/utils/index.d.ts
@@ -191,7 +191,7 @@ export type BorderType =
       side?: BoxSideType;
       size?: BoxSizeType;
       style?: BoxStyleType;
-      image?: string;
+      image?: string | { source?: string; slice?: number };
     }
   | {
       color?: ColorType;
@@ -200,7 +200,7 @@ export type BorderType =
       side?: BoxSideType;
       size?: BoxSizeType;
       style?: BoxStyleType;
-      image?: string;
+      image?: string | { source?: string; slice?: number };
     }[];
 export type ColorType = string | { dark?: string; light?: string } | undefined;
 export type DirectionType =


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR adds support for `borderImage` 
#### Where should the reviewer start?
utilz/border.js
#### What testing has been done on this PR?
added a test and story
#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
need for DS system
#### What are the relevant issues?
closes #7317 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
yes
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
 backwards compatible