### PR TITLE
Fix drop positioning

### DIFF
--- a/src/js/components/Drop/DropContainer.js
+++ b/src/js/components/Drop/DropContainer.js
@@ -209,59 +209,55 @@ const DropContainer = forwardRef(
             less room in the other direction leave the Drop in its current
             position. */
           if (
-            /* The bottom of the drop is aligned to the top of the target 
-            and the top of the drop is either at the top edge of the viewport
-            or beyond it. If there is room to display the drop below the target
-            change the drop's position so that the top of the drop is aligned 
-            to the bottom of the target. */
             responsive &&
+            // drop is above target
             align.bottom === 'top' &&
+            // drop is overflowing above window
             targetRect.top - containerRect.height <= 0 &&
+            // there is room to display the drop below the target
             targetRect.bottom + containerRect.height < windowHeight
           ) {
+            // top of drop is aligned to bottom of target
             top = targetRect.bottom;
             maxHeight = top;
           } else if (
-            /* The top of the drop is aligned to the top of the target, the 
-            bottom of the drop is either at the bottom edge of the viewport
-            or beyond it, and the height of the drop is larger than the target. 
-            If there is room to display the drop above the target, change the 
-            drop's position so that the bottom of the drop is aligned to the 
-            bottom of the target. */
             responsive &&
+            // top of drop is aligned to top of target
             align.top === 'top' &&
+            // drop is overflowing below window
             targetRect.top + containerRect.height >= windowHeight &&
+            // height of the drop is larger than the target.
             targetRect.top + containerRect.height > targetRect.bottom &&
+            // there is room to display the drop above the target
             targetRect.bottom - containerRect.height > 0
           ) {
+            // bottom of drop is aligned to bottom of target
             bottom = targetRect.bottom;
             maxHeight = top;
           } else if (
-            /* The top of the drop is aligned to the bottom of the target 
-            and the bottom of the drop is either at the bottom edge of the 
-            viewport or beyond it. If there is room to display the drop 
-            above the target change the drop's position so that the bottom 
-            of the drop is aligned to the top of the target. */
             responsive &&
+            // top of drop is aligned to bottom of target
             align.top === 'bottom' &&
+            // drop is overflowing below window
             targetRect.bottom + containerRect.height >= windowHeight &&
+            // there is room to display the drop above the target
             targetRect.top - containerRect.height > 0
           ) {
+            // bottom of drop is aligned to top of target
             bottom = targetRect.top;
             maxHeight = bottom;
           } else if (
-            /* The bottom of the drop is aligned to the bottom of the target, 
-            the top of the drop is either at the top edge of the viewport
-            or beyond it, and the height of the drop is larger than the target. 
-            If there is room to display the drop below the target change the 
-            drop's position so that the top of the drop is aligned  to the top 
-            of the target. */
             responsive &&
+            // bottom of drop is aligned to bottom of target
             align.bottom === 'bottom' &&
+            // drop is overflowing above window
             targetRect.bottom - containerRect.height <= 0 &&
+            // height of the drop is larger than the target.
             targetRect.bottom - containerRect.height > targetRect.top &&
+            // there is room to display the drop below the target
             targetRect.top + containerRect.height > 0
           ) {
+            // top of drop is aligned to top of target
             top = targetRect.top;
             maxHeight = bottom;
           } else if (align.top === 'top') {

--- a/src/js/components/Drop/DropContainer.js
+++ b/src/js/components/Drop/DropContainer.js
@@ -209,22 +209,60 @@ const DropContainer = forwardRef(
             less room in the other direction leave the Drop in its current
             position. */
           if (
+            /* The bottom of the drop is aligned to the top of the target 
+            and the top of the drop is either at the top edge of the viewport
+            or beyond it. If there is room to display the drop below the target
+            change the drop's position so that the top of the drop is aligned 
+            to the bottom of the target. */
             responsive &&
-            ((align.top === 'top' && targetRect.top < 0) ||
-              (align.bottom === 'top' &&
-                targetRect.top - containerRect.height <= 0 &&
-                targetRect.bottom + containerRect.height < windowHeight))
+            align.bottom === 'top' &&
+            targetRect.top - containerRect.height <= 0 &&
+            targetRect.bottom + containerRect.height < windowHeight
           ) {
             top = targetRect.bottom;
             maxHeight = top;
           } else if (
+            /* The top of the drop is aligned to the top of the target, the 
+            bottom of the drop is either at the bottom edge of the viewport
+            or beyond it, and the height of the drop is larger than the target. 
+            If there is room to display the drop above the target, change the 
+            drop's position so that the bottom of the drop is aligned to the 
+            bottom of the target. */
             responsive &&
-            ((align.bottom === 'bottom' && targetRect.bottom > windowHeight) ||
-              (align.top === 'bottom' &&
-                targetRect.bottom + containerRect.height >= windowHeight &&
-                targetRect.top - containerRect.height > 0))
+            align.top === 'top' &&
+            targetRect.top + containerRect.height >= windowHeight &&
+            targetRect.top + containerRect.height > targetRect.bottom &&
+            targetRect.bottom - containerRect.height > 0
+          ) {
+            bottom = targetRect.bottom;
+            maxHeight = top;
+          } else if (
+            /* The top of the drop is aligned to the bottom of the target 
+            and the bottom of the drop is either at the bottom edge of the 
+            viewport or beyond it. If there is room to display the drop 
+            above the target change the drop's position so that the bottom 
+            of the drop is aligned to the top of the target. */
+            responsive &&
+            align.top === 'bottom' &&
+            targetRect.bottom + containerRect.height >= windowHeight &&
+            targetRect.top - containerRect.height > 0
           ) {
             bottom = targetRect.top;
+            maxHeight = bottom;
+          } else if (
+            /* The bottom of the drop is aligned to the bottom of the target, 
+            the top of the drop is either at the top edge of the viewport
+            or beyond it, and the height of the drop is larger than the target. 
+            If there is room to display the drop below the target change the 
+            drop's position so that the top of the drop is aligned  to the top 
+            of the target. */
+            responsive &&
+            align.bottom === 'bottom' &&
+            targetRect.bottom - containerRect.height <= 0 &&
+            targetRect.bottom - containerRect.height > targetRect.top &&
+            targetRect.top + containerRect.height > 0
+          ) {
+            top = targetRect.top;
             maxHeight = bottom;
           } else if (align.top === 'top') {
             top = targetRect.top;

--- a/src/js/components/Menu/Menu.js
+++ b/src/js/components/Menu/Menu.js
@@ -439,7 +439,9 @@ const Menu = forwardRef((props, ref) => {
               background={dropBackground || theme.menu.background}
               {...passThemeFlag}
             >
-              {alignControlMirror === 'top' && align.top === 'top'
+              {alignControlMirror === 'top' &&
+              align.bottom !== 'top' &&
+              align.top !== 'bottom'
                 ? controlMirror
                 : undefined}
               <Box overflow="auto" role="menu" a11yTitle={a11y}>
@@ -452,8 +454,9 @@ const Menu = forwardRef((props, ref) => {
               {!initialAlignTop &&
               // don't show controlMirror if caller is using
               // align.bottom === 'top'
-              ((alignControlMirror === 'bottom' && !align.bottom === 'top') ||
-                align.bottom === 'bottom')
+              alignControlMirror === 'bottom' &&
+              align.bottom !== 'top' &&
+              align.top !== 'bottom'
                 ? controlMirror
                 : undefined}
             </ContainerBox>


### PR DESCRIPTION
#### What does this PR do?
Resolves an issue where drop positioning was not correctly flipping when there was not enough room to display in one direction.

See code comments in DropContainer for a more thorough explanation of what is happening. In cases where the drop has a smaller height than the target and the position is either `top: top` or `bottom: bottom` I decided to not try and flip the drop position. We can change this if we want. I just couldn't think of use cases where we would want this behavior.

This PR covers use cases where the drop doesn't have a scroll within it. Drops that do have a scroll within them don't respond well to the screen size adjusting. The work to address the issues with Drop position when they have a scroll will be handled as a separate issue/PR.

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?
Tested with the existing stories (Drop/All not stretched, List/Action, Form/Controlled) as well as this story:
```
import React from 'react';

import { grommet, Box, Button, Grommet, Tip } from 'grommet';

export const Simple = () => (
  // Uncomment <Grommet> lines when using outside of storybook
  // <Grommet theme={...}>
  <Box align="center" justify="center">
    <Box background="pink" height="large">
      spacer
    </Box>
    <Tip
      defaultVisible
      content={
        <Box width="30px" background="green">
          tip
        </Box>
      }
      dropProps={{
        align: { bottom: 'bottom' },
      }}
      plain
    >
      <Button label="action" size="large" />
    </Tip>
    <Box background="pink" height="large">
      spacer
    </Box>
  </Box>
  //</Grommet>
);

Simple.args = {
  full: true,
};

Simple.parameters = {
  chromatic: { disable: true },
};

export default {
  title: 'Controls/Tip/Simple',
};


```

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes https://github.com/grommet/grommet/issues/6997

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible