### PR TITLE
Exploring how to trap focus in Drop

### DIFF
--- a/src/js/components/Drop/DropContainer.js
+++ b/src/js/components/Drop/DropContainer.js
@@ -343,6 +343,10 @@ const DropContainer = forwardRef(
       dropOptions,
     ]);
 
+    // this is fighting with the focus event that's called
+    // by focused container in the case of nested drops
+    // because this focus event is called before the previous
+    // container has removed its event listener
     useEffect(() => {
       if (restrictFocus) {
         dropRef.current.focus();

--- a/src/js/components/Drop/stories/Simple.js
+++ b/src/js/components/Drop/stories/Simple.js
@@ -1,36 +1,118 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 
-import { Box, Drop } from 'grommet';
+import { Box, DropButton, Button, Anchor, Layer, Drop } from 'grommet';
+
+const InteractiveContent = () => (
+  <Box gap="medium" pad="large">
+    Drop Contents
+    <Button label="testing button" />
+    <Anchor href="#" label="testing anchor" />
+  </Box>
+);
 
 const align = { top: 'bottom', left: 'left' };
 
 const SimpleDrop = () => {
-  const targetRef = useRef();
+  const [showDrop, setShowDrop] = useState(false);
+  const [showLayer, setShowLayer] = useState(false);
+  const [showDropInModal, setShowDropInModal] = useState(false);
+  const [showRestrictFocusDrop, setShowRestrictFocusDrop] = useState(false);
+  const layerRef = useRef();
+  const buttonRef = useRef();
+  const layerButtonRef = useRef();
+  const restrictFocusButtonRef = useRef();
 
-  const [, setShowDrop] = useState(false);
-  useEffect(() => {
-    setShowDrop(true);
-  }, []);
+  const onClose = () => setShowLayer(false);
 
   return (
     // Uncomment <Grommet> lines when using outside of storybook
     // <Grommet theme={...}>
-    <Box fill align="center" justify="center">
-      <Box
-        background="dark-2"
-        pad="medium"
-        align="center"
-        justify="start"
-        ref={targetRef}
-      >
-        Target
+    <>
+      <Box direction="row" pad="large" gap="small">
+        <DropButton
+          label="Drop button"
+          dropContent={<InteractiveContent />}
+          dropAlign={align}
+        />
+        <Button
+          ref={buttonRef}
+          label="Regular button"
+          onClick={() => setShowDrop(true)}
+        />
+        <Button
+          ref={layerRef}
+          label="Open layer"
+          onClick={() => setShowLayer(true)}
+        />
+        {showLayer && (
+          <Layer
+            position="right"
+            full="vertical"
+            modal
+            onClickOutside={onClose}
+            onEsc={onClose}
+          >
+            <Box
+              fill="vertical"
+              overflow="auto"
+              width="medium"
+              pad="medium"
+              gap="small"
+            >
+              {/* <Anchor href="#" label="testing anchor" /> */}
+              <DropButton
+                label="Another drop button"
+                dropContent={<InteractiveContent />}
+                dropAlign={align}
+              />
+              <Button
+                ref={layerButtonRef}
+                label="Another regular button"
+                onClick={() => setShowDropInModal(true)}
+              />
+              {showDropInModal && (
+                <Drop
+                  target={layerButtonRef.current}
+                  align={align}
+                  onClickOutside={() => setShowDropInModal(false)}
+                  onEsc={() => setShowDropInModal(false)}
+                >
+                  <InteractiveContent />
+                </Drop>
+              )}
+              <Button
+                ref={restrictFocusButtonRef}
+                label="A regular button with restrict focus"
+                onClick={() => setShowDropInModal(true)}
+              />
+              {showRestrictFocusDrop && (
+                <Drop
+                  target={restrictFocusButtonRef.current}
+                  align={align}
+                  onClickOutside={() => setShowRestrictFocusDrop(false)}
+                  onEsc={() => setShowRestrictFocusDrop(false)}
+                  // TO DO onEsc isn't restoring
+                  // focus to the button as I'd expect
+                  restrictFocus
+                >
+                  <InteractiveContent />
+                </Drop>
+              )}
+            </Box>
+          </Layer>
+        )}
       </Box>
-      {targetRef.current && (
-        <Drop align={align} target={targetRef.current}>
-          <Box pad="large">Drop Contents</Box>
+      {showDrop && (
+        <Drop
+          target={buttonRef.current}
+          align={align}
+          onClickOutside={() => setShowDrop(false)}
+          onEsc={() => setShowDrop(false)}
+        >
+          <InteractiveContent />
         </Drop>
       )}
-    </Box>
+    </>
     // </Grommet>
   );
 };

--- a/src/js/components/FocusedContainer.js
+++ b/src/js/components/FocusedContainer.js
@@ -12,13 +12,113 @@ export const FocusedContainer = ({
 }) => {
   const [bodyOverflowStyle, setBodyOverflowStyle] = useState('');
   const ref = useRef(null);
+  const preNodeRef = useRef(null);
+  const postNodeRef = useRef(null);
 
-  const roots = useContext(RootsContext);
-  const [nextRoots, setNextRoots] = useState(roots);
+  const { roots, setRoots } = useContext(RootsContext);
+  const [active, setActive] = useState(true);
+
+  // only the most recent container in roots should be active and listening
+  // for focus events. when active is false, event listeners will be removed
   useEffect(() => {
-    // make sure value of null is not added to array
-    if (ref.current) setNextRoots([...roots, ref.current]);
+    if (ref.current && roots[roots.length - 1] === ref.current) {
+      setActive(true);
+    } else setActive(false);
   }, [roots]);
+
+  useEffect(() => {
+    const container = ref.current;
+    if (container) {
+      // avoid infinite loop by only adding it if it's not already there
+      const nextRoots = !roots.includes(container)
+        ? [...roots, container]
+        : roots;
+      setRoots(nextRoots);
+    }
+    // on unmount, remove this container from roots
+    return () => {
+      const nextRoots = [...roots.filter((root) => root !== container)];
+      setRoots(nextRoots);
+      // ensure ability to focus is restored to what will now be the
+      // top-most container
+      makeNodeFocusable(nextRoots[nextRoots.length - 1]);
+    };
+  }, [roots, setRoots]);
+
+  useEffect(() => {
+    const handleTrapFocus = (e) => {
+      const container = ref.current;
+      if (!container) return;
+
+      const focusableElements = container.querySelectorAll(
+        `button, [href], input, select, textarea,
+         [tabindex]:not([tabindex="-1"])`,
+      );
+
+      if (focusableElements.length === 0) return;
+
+      const firstElement = focusableElements[0];
+      const lastElement = focusableElements[focusableElements.length - 1];
+
+      if (container.contains(e.target)) {
+        container.lastFocus = e.target;
+      } else if (container.lastFocus === firstElement) {
+        lastElement.focus();
+        e.preventDefault();
+      } else {
+        // In the case where the focus hasn't already been placed on or within
+        // the container, this will ensure the next "tab" places focus on the
+        // first focusable element
+        firstElement.focus();
+        e.preventDefault();
+      }
+    };
+
+    const addListeners = () => {
+      document.addEventListener('focus', handleTrapFocus, {
+        capture: true,
+        passive: false,
+      });
+    };
+
+    const removeListeners = () => {
+      document.removeEventListener('focus', handleTrapFocus, {
+        capture: true,
+        passive: false,
+      });
+    };
+
+    // Create and insert focusable nodes to help track when focus
+    // has left this container but without letting focus be noticeably placed
+    // on anything outside the container
+    const preDiv = document.createElement('div');
+    const postDiv = document.createElement('div');
+
+    preNodeRef.current = ref.current.parentNode.insertBefore(
+      preDiv,
+      ref.current,
+    );
+    postNodeRef.current = ref.current.parentNode.insertBefore(
+      postDiv,
+      ref.current.nextSibling,
+    );
+    preNodeRef.current.tabIndex = 0;
+    postNodeRef.current.tabIndex = 0;
+
+    if (!active) {
+      console.log(`remove event listener`);
+      removeListeners();
+    } else {
+      addListeners();
+      console.log(`add event listener`);
+    }
+
+    return () => {
+      removeListeners();
+      preNodeRef.current.remove();
+      postNodeRef.current.remove();
+    };
+  }, [active, roots]);
 
   useEffect(() => {
     if (
@@ -46,22 +146,19 @@ export const FocusedContainer = ({
   useEffect(() => {
     const timer = setTimeout(() => {
       if (!hidden && trapFocus && roots && roots[0]) {
-        roots.forEach(makeNodeUnfocusable);
+        // make every root before this one unfocusable
+        roots.forEach((root, index) => {
+          if (index < roots.length - 1) makeNodeUnfocusable(root);
+        });
       }
     }, 0);
 
-    return () => {
-      // remove trap and restore ability to focus on the last root only
-      if (roots && roots[0]) makeNodeFocusable(roots[roots.length - 1]);
-      clearTimeout(timer);
-    };
+    return () => clearTimeout(timer);
   }, [hidden, roots, trapFocus]);
 
   return (
-    <RootsContext.Provider value={nextRoots}>
-      <div ref={ref} aria-hidden={hidden} {...rest}>
-        {children}
-      </div>
-    </RootsContext.Provider>
+    <div ref={ref} aria-hidden={hidden} {...rest}>
+      {children}
+    </div>
   );
 };

--- a/src/js/components/Grommet/Grommet.js
+++ b/src/js/components/Grommet/Grommet.js
@@ -150,10 +150,16 @@ const Grommet = forwardRef((props, ref) => {
     if (grommetRef.current) setRoots([grommetRef.current]);
   }, [grommetRef]);
 
+  const rootsContextValue = useMemo(() => ({ roots, setRoots }), [roots]);
+
+  // TO DO this global roots approach causes extra re-renders at
+  // this level which isn't ideal given it's global
+  console.log(roots);
+
   return (
     <ThemeContext.Provider value={theme}>
       <ResponsiveContext.Provider value={responsive}>
-        <RootsContext.Provider value={roots}>
+        <RootsContext.Provider value={rootsContextValue}>
           <ContainerTargetContext.Provider value={containerTarget}>
             <OptionsContext.Provider value={options}>
               <MessageContext.Provider value={messages}>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

This is an exploration off of https://github.com/grommet/grommet/pull/7305 of how to trap focus within the "top-most" drop.

There are some issues with re-renders/functionality, but putting this up for people to check out.

The general approach intent is:
1. Track a global array of any "FocusedContainer" that has been added
   - This differs from our current behavior where "RootsContext" only extends the array as nested "FocusedContainers" are added but therefore not all FocusedContainers have access to the same array
   - This updated approach is what the [WCAG pattern ](https://codepen.io/pen) and focus-trap library seem to be doing
2. Use this global array to:
   - Add focus event listener to the most recently opened FocusContainer
   - Remove focus event listener from any other open FocusContainers (this is only possible if FocusContainer has access to a shared global array so it can know when it's no longer the most recently added one)

That said with the approach of storing this global array, I'm running into a few issues with React lifecycle management:
- It's causing more re-renders to the top Grommet component which is not ideal
- State lags one render behind, so running into some competing focus between Drop's `restrictFocus` and the container that triggered the Drop to open (in the cases where a Drop is nested inside of a layer)

I feel like if we could find a way to reliable store the global array of "FocusContainers" (roots) without triggering re-renders from setState then the rest might fall into place.

Open to any feedback/suggestions.
#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
