### PR TITLE
add a check for is user has something inside of drop set to autofocus

### DIFF
--- a/src/js/components/Drop/DropContainer.js
+++ b/src/js/components/Drop/DropContainer.js
@@ -349,10 +349,10 @@ const DropContainer = forwardRef(
     // the focus on the drop container.
     useEffect(() => {
       if (restrictFocus) {
-        const dropElement = dropRef.current;
-        if (dropElement) {
-          if (!dropElement.contains(document.activeElement)) {
-            dropElement.focus();
+        const dropContainer = dropRef.current;
+        if (dropContainer) {
+          if (!dropContainer.contains(document.activeElement)) {
+            dropContainer.focus();
           }
         }
       }

--- a/src/js/components/Drop/DropContainer.js
+++ b/src/js/components/Drop/DropContainer.js
@@ -343,11 +343,20 @@ const DropContainer = forwardRef(
       dropOptions,
     ]);
 
+    // Once drop is open the focus will be put on the drop container
+    // if restrictFocus is true. If the caller put focus
+    // on an element already, we honor that. Otherwise, we put
+    // the focus on the drop container.
     useEffect(() => {
       if (restrictFocus) {
-        dropRef.current.focus();
+        const dropElement = dropRef.current;
+        if (dropElement) {
+          if (!dropElement.contains(document.activeElement)) {
+            dropElement.focus();
+          }
+        }
       }
-    }, [dropRef, restrictFocus]);
+    }, [restrictFocus, dropRef]);
 
     let content = (
       <StyledDrop

--- a/src/js/components/Drop/DropContainer.js
+++ b/src/js/components/Drop/DropContainer.js
@@ -356,7 +356,7 @@ const DropContainer = forwardRef(
           }
         }
       }
-    }, [restrictFocus, dropRef]);
+    }, [dropRef, restrictFocus]);
 
     let content = (
       <StyledDrop

--- a/src/js/components/Drop/__tests__/Drop-test.tsx
+++ b/src/js/components/Drop/__tests__/Drop-test.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import 'jest-styled-components';
 import 'jest-axe/extend-expect';
 import 'regenerator-runtime/runtime';
+import '@testing-library/jest-dom';
 
 import { axe } from 'jest-axe';
 import {
@@ -30,6 +31,44 @@ const customTheme = {
   },
 };
 
+const TestFocus = ({
+  theme,
+  containerTarget,
+  message = 'this is a test',
+  ...rest
+}: TestInputProps) => {
+  const [showDrop, setShowDrop] = useState<boolean>(false);
+
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    setShowDrop(true);
+  }, []);
+
+  let drop;
+
+  if (showDrop) {
+    drop = (
+      <Drop
+        id="drop-node"
+        restrictFocus
+        target={inputRef.current || undefined}
+        {...rest}
+      >
+        <button autoFocus aria-label="first-focus">
+          first-focus
+        </button>
+        {message}
+      </Drop>
+    );
+  }
+  return (
+    <Grommet theme={theme} containerTarget={containerTarget}>
+      <input ref={inputRef} aria-label="test" />
+      {drop}
+    </Grommet>
+  );
+};
 interface TestInputProps extends DropExtendedProps {
   theme?: ThemeType;
   containerTarget?: HTMLElement;
@@ -228,6 +267,19 @@ describe('Drop', () => {
     await waitFor(() => cleanup());
 
     expect(document.activeElement).toMatchSnapshot();
+  });
+
+  test('restrict focus with auto focus on element inside', async () => {
+    render(<TestFocus />);
+
+    // Wait for the button with text 'first-focus'
+    const button = await screen.findByText('first-focus');
+    expect(button).toBeInTheDocument();
+
+    // Check that the button is the currently focused element
+    await waitFor(() => {
+      expect(document.activeElement).toBe(button);
+    });
   });
 
   test('default elevation renders', () => {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR provides another option for users to be able to have `restrictFocus` set to true but also have a `autoFocus` in side the drop
#### Where should the reviewer start?
dropContainer.js
#### What testing has been done on this PR?
```
import React, { useRef, useState } from 'react';

import { Drop, Button, Paragraph, Text, Box } from 'grommet';
import { CircleInformation, Close } from 'grommet-icons';

const Popover = ({
  a11yTitle,
  title,
  children,
  footer,
  target,
  onClose,
  ...rest
}) => {
  return (
    <Drop
      role="dialog"
      elevation="medium"
      stretch={false}
      target={target}
      onClose={onClose}
      restrictFocus
      // need this for drop to control focus
      {...rest}
    >
      <Box
        gap="xsmall"
        pad={{ vertical: 'small', left: 'small', right: 'xsmall' }}
        direction="row"
      >
        <Box flex gap="small">
          {title}
          {children}
          {footer}
        </Box>
        <Button
          size="small"
          icon={<Close size="small" />}
          onClick={onClose}
          autoFocus
          alignSelf="start"
          // need to align with text
          margin={{ top: '-2px' }}
          a11yTitle={
            a11yTitle ||
            `You are in a popover,
            to close this popover, press Enter.`
          }
        />
      </Box>
    </Drop>
  );
};

const SimpleDrop = () => {
  const [showPopover, setShowPopover] = useState(false);
  const targetRef = useRef();

  const handleButtonClick = () => {
    setShowPopover((prev) => !prev);
  };

  const handleClosePopover = () => {
    setShowPopover(false);
  };
  return (
    // Uncomment <Grommet> lines when using outside of storybook
    // <Grommet theme={...}>
    <Box direction="row" justify="center" align="center">
      <Text>Click for Popover.</Text>
      <Button
        align="center"
        justify="start"
        icon={<CircleInformation />}
        onClick={handleButtonClick}
        ref={targetRef}
        aria-expanded={showPopover}
        a11yTitle="informational help"
        aria-haspopup="true"
        aria-controls="simple-popover"
      />
      {showPopover && (
        <Popover
          id="simple-popover"
          title={<Text>I am a Popover</Text>}
          target={targetRef.current}
          onClickOutside={handleClosePopover}
          onEsc={handleClosePopover}
          onClose={handleClosePopover}
          align={{ bottom: 'top', left: 'left' }}
        >
          <Paragraph size="small" margin="none">
            The Popover body provides contextual information related to the
            trigger
          </Paragraph>
        </Popover>
      )}
    </Box>
    // </Grommet>
  );
};

export const Simple = () => <SimpleDrop />;
Simple.parameters = {
  chromatic: { disable: true },
};
Simple.args = {
  full: true,
};

export default {
  title: 'Controls/Drop/Simple',
};
```
#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

We need `restrictFocus` set to true in some examples like popover in DS site. However when this is set to true it 
allows the drop to control the focus which is what is stated in the docs however is someone has `autoFocus` inside of the drop then we should respect that.

This is another approach along with https://github.com/grommet/grommet/pull/7308

reference from the APG pattern: "The focus notes mentions "Generally, focus is initially set on the first focusable element. However, the most appropriate focus placement will depend on the nature and size of the content."

https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/
#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
