### PR TITLE
Fix/#6328

### DIFF
--- a/src/js/components/RadioButton/RadioButton.js
+++ b/src/js/components/RadioButton/RadioButton.js
@@ -32,6 +32,9 @@ const RadioButton = forwardRef(
   ) => {
     const { theme, passThemeFlag } = useThemeValue();
     const [hover, setHover] = useState();
+    const [isFocused, setIsFocused] = useState(false);
+    const inputRef = React.useRef(null);
+
     const normalizedLabel =
       typeof label === 'string' ? (
         <StyledRadioButtonLabel {...passThemeFlag}>
@@ -59,21 +62,35 @@ const RadioButton = forwardRef(
       }
     }
 
+    const handleKeyDown = (event) => {
+      if (!disabled && (event.key === 'Enter' || event.key === ' ')) {
+        event.preventDefault();
+        inputRef.current.click();
+      }
+    };
+
     return (
       <StyledRadioButtonContainer
         {...removeUndefined({ htmlFor: id, disabled })}
         onClick={(event) => {
-          // prevents clicking on the label trigging the event twice
-          // https://stackoverflow.com/questions/24501497/why-the-onclick-element-will-trigger-twice-for-label-element
           if (event.target.type !== 'radio') {
             event.stopPropagation();
           }
         }}
-        focus={focus}
         focusIndicator={focusIndicator}
         onMouseEnter={() => setHover(true)}
         onMouseLeave={() => setHover(false)}
         {...passThemeFlag}
+        onFocus={() => {
+          setIsFocused(true);
+          if (inputRef.current) {
+            inputRef.current.focus();
+          }
+        }}
+        onBlur={() => setIsFocused(false)}
+        onKeyDown={handleKeyDown}  
+        tabIndex={disabled ? -1 : 0}
+        focus={focus || isFocused}
       >
         <StyledRadioButton
           flex={false}
@@ -85,8 +102,16 @@ const RadioButton = forwardRef(
           <StyledRadioButtonInput
             aria-label={a11yTitle}
             {...rest}
-            ref={ref}
+            ref={(node) => {
+              inputRef.current = node;
+              if (typeof ref === 'function') {
+                ref(node);
+              } else if (ref && 'current' in ref) {
+                ref.current = node;
+              }
+            }}
             type="radio"
+            tabIndex={disabled ? -1 : 0}
             {...removeUndefined({
               id,
               name,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR improves focus management and accessibility for the RadioButton and RadioButtonGroup components. It ensures that:

- The radio buttons are focusable using the Tab key.
- Focus states are appropriately managed for both active and inactive radio buttons.

#### Where should the reviewer start?

Reviewers should start by examining the RadioButton and RadioButtonGroup components to understand the changes made to focus management and accessibility handling. Specifically, focus on the changes related to handling focus states and ensuring appropriate event handling in the components.

#### What testing has been done on this PR?

Manual testing was conducted to ensure that focus behaves as expected when navigating through radio buttons using keyboard input.

#### How should this be manually tested?

- Render the RadioButtonGroup component with multiple RadioButton components.
- Use the Tab key to navigate through the radio buttons and ensure that all buttons can receive focus.
- Verify that the active radio button is highlighted and that focus is visible for all buttons when using Tab navigation.
- Check that pressing Space or Enter selects the radio button as expected.

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

This enhancement addresses feedback received regarding accessibility concerns and ensures a better user experience for keyboard navigation.

#### What are the relevant issues?

This PR addresses accessibility and focus management issues as part of ongoing efforts to enhance component usability.

#### Screenshots (if appropriate)

https://github.com/user-attachments/assets/face25f6-d5ad-487e-b579-57e8d9387ec9
https://github.com/user-attachments/assets/0d440962-2790-4585-b238-072c541cbbac

#### Do the grommet docs need to be updated?

N/A

#### Should this PR be mentioned in the release notes?

Yes, this PR should be mentioned in the release notes to highlight the improvements in accessibility and focus management.

#### Is this change backwards compatible or is it a breaking change?

This change is backwards compatible. Existing implementations of the RadioButton and RadioButtonGroup will continue to work without requiring changes.
