### PR TITLE
Fix `trapFocus` unwanted page scroll

### DIFF
--- a/src/js/components/Drop/stories/Simple.js
+++ b/src/js/components/Drop/stories/Simple.js
@@ -1,40 +1,124 @@
 import React, { useEffect, useRef, useState } from 'react';
 
-import { Box, Drop } from 'grommet';
+import { Box, DropButton, Button, Anchor, Layer, Drop } from 'grommet';
+
+const InteractiveContent = () => (
+  <Box gap="medium" pad="large">
+    Drop Contents
+    <Button label="testing button" />
+    <Anchor href="#" label="testing anchor" />
+  </Box>
+);
 
 const align = { top: 'bottom', left: 'left' };
 
 const SimpleDrop = () => {
-  const targetRef = useRef();
+  const [showDrop, setShowDrop] = useState(false);
+  const [showLayer, setShowLayer] = useState(false);
+  const [showDropInModal, setShowDropInModal] = useState(false);
+  const [showRestrictFocusDrop, setShowRestrictFocusDrop] = useState(false);
+  const layerRef = useRef();
+  const buttonRef = useRef();
+  const layerButtonRef = useRef();
+  const restrictFocusButtonRef = useRef();
 
-  const [, setShowDrop] = useState(false);
+  const onClose = () => setShowLayer(false);
+
   useEffect(() => {
-    setShowDrop(true);
+    const timer = setTimeout(() => buttonRef.current.focus(), 5000);
+    return () => clearTimeout(timer);
   }, []);
 
   return (
     // Uncomment <Grommet> lines when using outside of storybook
     // <Grommet theme={...}>
-    <Box fill align="center" justify="center">
-      <Box
-        background="dark-2"
-        pad="medium"
-        align="center"
-        justify="start"
-        ref={targetRef}
-      >
-        Target
+    <>
+      <Box direction="row" pad="large" gap="small">
+        <DropButton
+          label="Drop button"
+          dropContent={<InteractiveContent />}
+          dropAlign={align}
+        />
+        <Button
+          ref={buttonRef}
+          label="Regular button"
+          onClick={() => setShowDrop(true)}
+        />
+        <Button
+          ref={layerRef}
+          label="Open layer"
+          onClick={() => setShowLayer(true)}
+        />
+        {showLayer && (
+          <Layer
+            position="right"
+            full="vertical"
+            modal
+            onClickOutside={onClose}
+            onEsc={onClose}
+          >
+            <Box
+              fill="vertical"
+              overflow="auto"
+              width="medium"
+              pad="medium"
+              gap="small"
+            >
+              {/* <Anchor href="#" label="testing anchor" /> */}
+              <DropButton
+                label="Another drop button"
+                dropContent={<InteractiveContent />}
+                dropAlign={align}
+              />
+              <Button
+                ref={layerButtonRef}
+                label="Another regular button"
+                onClick={() => setShowDropInModal(true)}
+              />
+              {showDropInModal && (
+                <Drop
+                  target={layerButtonRef.current}
+                  align={align}
+                  onClickOutside={() => setShowDropInModal(false)}
+                  onEsc={() => setShowDropInModal(false)}
+                >
+                  <InteractiveContent />
+                </Drop>
+              )}
+              <Button
+                ref={restrictFocusButtonRef}
+                label="A regular button with restrict focus"
+                onClick={() => setShowRestrictFocusDrop(true)}
+              />
+              {showRestrictFocusDrop && (
+                <Drop
+                  target={restrictFocusButtonRef.current}
+                  align={{ top: 'bottom' }}
+                  onClickOutside={() => setShowRestrictFocusDrop(false)}
+                  onEsc={() => setShowRestrictFocusDrop(false)}
+                  restrictFocus
+                >
+                  <InteractiveContent />
+                </Drop>
+              )}
+            </Box>
+          </Layer>
+        )}
       </Box>
-      {targetRef.current && (
-        <Drop align={align} target={targetRef.current}>
-          <Box pad="large">Drop Contents</Box>
+      {showDrop && (
+        <Drop
+          target={buttonRef.current}
+          align={align}
+          onClickOutside={() => setShowDrop(false)}
+          onEsc={() => setShowDrop(false)}
+        >
+          <InteractiveContent />
         </Drop>
       )}
-    </Box>
+    </>
     // </Grommet>
   );
 };
-
 export const Simple = () => <SimpleDrop />;
 Simple.parameters = {
   chromatic: { disable: true },

--- a/src/js/components/Drop/stories/Simple2.js
+++ b/src/js/components/Drop/stories/Simple2.js
@@ -1,0 +1,253 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+import {
+  Box,
+  DropButton,
+  Grommet,
+  Button,
+  Anchor,
+  Form,
+  FormField,
+  Header,
+  TextInput,
+  CheckBoxGroup,
+  Layer,
+  Drop,
+  Text,
+  Heading,
+} from 'grommet';
+import { User, Close } from 'grommet-icons';
+
+const InteractiveContent = () => (
+  <Box gap="medium" pad="large">
+    Drop Contents
+    <Button label="testing button" />
+    <Anchor href="#" label="testing anchor" />
+  </Box>
+);
+
+const darks = [false, true];
+const kinds = [
+  { name: 'default', props: {} },
+  { name: 'primary', props: { primary: true } },
+  { name: 'secondary', props: { secondary: true } },
+];
+const states = [
+  {},
+  { active: true },
+  { disabled: true },
+  { color: 'teal' },
+  { color: '#9999ff' },
+  { color: '#333399' },
+  { hoverIndicator: 'teal' },
+];
+const contents = [
+  { icon: <User /> },
+  { label: 'label' },
+  { icon: <User />, label: 'label' },
+  {
+    plain: true,
+    children: (
+      <Box pad="xsmall">
+        <Text color="orange">label</Text>
+      </Box>
+    ),
+  },
+];
+
+const align = { top: 'bottom', left: 'left' };
+
+const SimpleDrop = () => {
+  const [showDrop, setShowDrop] = useState(false);
+  const [showLayer, setShowLayer] = useState(false);
+  const [showDropInModal, setShowDropInModal] = useState(false);
+  const [showRestrictFocusDrop, setShowRestrictFocusDrop] = useState(false);
+  const layerRef = useRef();
+  const buttonRef = useRef();
+  const layerButtonRef = useRef();
+  const restrictFocusButtonRef = useRef();
+
+  const onClose = () => setShowLayer(false);
+
+  return (
+    // Uncomment <Grommet> lines when using outside of storybook
+    // <Grommet theme={...}>
+    <Box>
+      {/* <Grommet> */}
+      <Box direction="row" pad="large" gap="small">
+        <DropButton
+          label="Drop button"
+          dropContent={<InteractiveContent />}
+          dropAlign={align}
+        />
+        <Button
+          ref={buttonRef}
+          label="Regular button"
+          onClick={() => setShowDrop(true)}
+        />
+        <Button
+          ref={layerRef}
+          label="Open layer"
+          onClick={() => setShowLayer(true)}
+        />
+        {showLayer && (
+          <Layer position="right" full="vertical" onEsc={onClose}>
+            <Header flex={false} align="start" gap="small" justify="between">
+              <Box pad="small">
+                <Heading id="layer-title" level={2} margin="none">
+                  Title
+                </Heading>
+              </Box>
+              {onClose ? (
+                <Button
+                  icon={<Close />}
+                  onClick={onClose}
+                  a11yTitle="Close modal"
+                />
+              ) : null}
+            </Header>
+            <Box pad="medium" gap="medium" overflow="auto">
+              <Box flex={false}>
+                <Form
+                  onSubmit={(event) => {
+                    console.log(event.value);
+                    setShowLayer(false);
+                  }}
+                  messages={{
+                    required: 'This is a required field.',
+                  }}
+                >
+                  <FormField
+                    label="Title"
+                    contentProps={{ width: 'medium' }}
+                    required
+                    name="application-title"
+                    htmlFor="application-title"
+                  >
+                    <TextInput
+                      id="application-title"
+                      name="application-title"
+                    />
+                  </FormField>
+                  <FormField
+                    label="Publisher"
+                    contentProps={{ width: 'medium' }}
+                    required
+                    name="publisher"
+                    htmlFor="publisher"
+                  >
+                    <TextInput name="publisher" id="publisher" />
+                  </FormField>
+                  <FormField
+                    label="Pricing"
+                    contentProps={{ width: 'medium' }}
+                    name="pricing"
+                    htmlFor="pricing"
+                    required
+                  >
+                    <CheckBoxGroup
+                      id="pricing"
+                      name="pricing"
+                      options={[
+                        'Annual license',
+                        'Free',
+                        'Free trial',
+                        'Monthly Subscription',
+                      ]}
+                    />
+                  </FormField>
+                  <FormField
+                    label="Delivery"
+                    contentProps={{ width: 'medium' }}
+                    name="delivery"
+                    htmlFor="delivery"
+                    required
+                  >
+                    <CheckBoxGroup
+                      id="delivery"
+                      name="delivery"
+                      options={[
+                        'License key',
+                        'Package manager',
+                        'Web application',
+                      ]}
+                    />
+                  </FormField>
+                </Form>
+              </Box>
+              <Box direction="row" gap="small" flex={false}>
+                <Button
+                  label="Add application"
+                  primary
+                  type="submit"
+                  form="application-form"
+                />
+                <Button label="Cancel" onClick={onClose} />
+              </Box>
+            </Box>
+          </Layer>
+        )}
+      </Box>
+      {showDrop && (
+        <Drop
+          target={buttonRef.current}
+          align={align}
+          onClickOutside={() => setShowDrop(false)}
+          onEsc={() => setShowDrop(false)}
+        >
+          <InteractiveContent />
+        </Drop>
+      )}
+      <Box pad="large" gap="large">
+        <Box gap="medium">
+          {kinds.map((kind) => (
+            <Box key={kind.name} flex={false}>
+              <Heading level={3} size="small">
+                {kind.name}
+              </Heading>
+              {states.map((state, index) => (
+                // eslint-disable-next-line react/no-array-index-key
+                <Box key={index} direction="row" align="center">
+                  {darks.map((dark) => (
+                    <Box
+                      key={dark}
+                      direction={dark ? 'row-reverse' : 'row'}
+                      align="center"
+                      gap="small"
+                      background={{ color: 'background', dark }}
+                      pad="small"
+                    >
+                      {contents.map((content, index2) => (
+                        <Button
+                          // eslint-disable-next-line react/no-array-index-key
+                          key={index2}
+                          {...kind.props}
+                          {...content}
+                          {...state}
+                        />
+                      ))}
+                    </Box>
+                  ))}
+                </Box>
+              ))}
+            </Box>
+          ))}
+        </Box>
+      </Box>
+      {/* </Grommet> */}
+    </Box>
+    // </Grommet>
+  );
+};
+
+export const Simple = () => <SimpleDrop />;
+Simple.parameters = {
+  chromatic: { disable: true },
+};
+Simple.args = {
+  full: true,
+};
+
+export default {
+  title: 'Controls/Drop/Simple2',
+};

--- a/src/js/components/FocusedContainer.js
+++ b/src/js/components/FocusedContainer.js
@@ -16,6 +16,8 @@ const isFocusable = (element) => {
     case 'SELECT':
     case 'TEXTAREA':
       return true;
+    case 'DIV':
+      return element.tabIndex >= 0;
     default:
       return false;
   }
@@ -90,6 +92,7 @@ export const FocusedContainer = ({
         const child = element.childNodes[index];
         if (isFocusable(child)) return child;
         const tabbable = findFirstTabbable(child);
+        console.log('first tabbable', tabbable);
         if (tabbable) return tabbable;
       }
       return false;
@@ -100,6 +103,7 @@ export const FocusedContainer = ({
         const child = element.childNodes[index];
         if (isFocusable(child)) return child;
         const tabbable = findLastTabbable(child);
+        console.log('last tabbable', tabbable);
         if (tabbable) return tabbable;
       }
       return false;
@@ -112,6 +116,8 @@ export const FocusedContainer = ({
     const checkTabKey = (e) => {
       const firstTabbable = findFirstTabbable(container);
       const lastTabbable = findLastTabbable(container);
+      // Check if the first and last tabbable elements are the same
+      const tabbableElementsEqual = firstTabbable === lastTabbable;
       if (
         !hidden &&
         trapFocus &&
@@ -123,7 +129,8 @@ export const FocusedContainer = ({
           // focus should loop backward to last element
           (tabBackward(e) && document.activeElement === firstTabbable) ||
           // focus should loop forward to first element
-          (tabForward(e) && document.activeElement === lastTabbable))
+          (tabForward(e) && document.activeElement === lastTabbable) ||
+          tabbableElementsEqual)
       ) {
         e.preventDefault();
         if (tabForward(e) && firstTabbable) {

--- a/src/js/components/FocusedContainer.js
+++ b/src/js/components/FocusedContainer.js
@@ -4,10 +4,10 @@ import { makeNodeFocusable, makeNodeUnfocusable } from '../utils';
 import { RootsContext, useRoots } from '../contexts/RootsContext';
 
 const isFocusable = (element) => {
-  if (element.tabIndex < 0 || element.disabled) {
+  if (element?.tabIndex < 0 || element?.disabled) {
     return false;
   }
-  switch (element.nodeName) {
+  switch (element?.nodeName) {
     case 'A':
       return !!element.href && element.rel !== 'ignore';
     case 'INPUT':

--- a/src/js/components/FocusedContainer.js
+++ b/src/js/components/FocusedContainer.js
@@ -138,8 +138,8 @@ export const FocusedContainer = ({
     if (container) roots.push(container);
 
     // Create and insert focusable nodes to help track when focus
-    // has left this container but without letting focus be noticeably placed
-    // on anything outside the container
+    // has left this container but without letting focus be noticeably
+    // placed on anything outside the container
     if (!hidden && trapFocus) {
       const preDiv = document.createElement('div');
       const postDiv = document.createElement('div');

--- a/src/js/components/MaskedInput/MaskedInput.js
+++ b/src/js/components/MaskedInput/MaskedInput.js
@@ -431,6 +431,8 @@ const MaskedInput = forwardRef(
               target={inputRef.current}
               onClickOutside={onHideDrop}
               onEsc={onHideDrop}
+              // MaskedInput manages its own keyboard behavior via Keyboard
+              trapFocus={false}
               {...dropProps}
             >
               <ContainerBox

--- a/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.js.snap
+++ b/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.js.snap
@@ -1141,7 +1141,6 @@ exports[`MaskedInput event target props are available option via mouse 3`] = `""
 
 exports[`MaskedInput event target props are available option via mouse 4`] = `
 <div
-  aria-hidden="true"
   class="StyledGrommet-sc-19lkkz7-0 drDzQW"
 >
   <div
@@ -1150,12 +1149,10 @@ exports[`MaskedInput event target props are available option via mouse 4`] = `
     <input
       autocomplete="off"
       class="StyledMaskedInput-sc-99vkfa-0 gOcpal"
-      data-g-tabindex="none"
       data-testid="test-input"
       id="item"
       name="item"
       placeholder="!"
-      tabindex="-1"
       value="aa!"
     />
   </div>
@@ -2621,7 +2618,6 @@ exports[`MaskedInput option via mouse 3`] = `""`;
 
 exports[`MaskedInput option via mouse 4`] = `
 <div
-  aria-hidden="true"
   class="StyledGrommet-sc-19lkkz7-0 drDzQW"
 >
   <div
@@ -2630,12 +2626,10 @@ exports[`MaskedInput option via mouse 4`] = `
     <input
       autocomplete="off"
       class="StyledMaskedInput-sc-99vkfa-0 gOcpal"
-      data-g-tabindex="none"
       data-testid="test-input"
       id="item"
       name="item"
       placeholder="!"
-      tabindex="-1"
       value="aa!"
     />
   </div>

--- a/storybook/preview.js
+++ b/storybook/preview.js
@@ -79,9 +79,22 @@ export const decorators = [
     }
 
     return (
-      <Grommet theme={THEMES[state]} full={full} dir={dir} options={options}>
-        <Story state={THEMES[state]} />
-      </Grommet>
+      <>
+        <Grommet theme={THEMES[state]} full={full} dir={dir} options={options}>
+          <Story state={THEMES[state]} />
+        </Grommet>
+        <div>
+          <a href="#" aria-label="testing anchor">
+            Testing Anchor 1
+          </a>
+          <a href="#" aria-label="testing anchor">
+            Testing Anchor 2
+          </a>
+          <a href="#" aria-label="testing anchor">
+            Testing Anchor 3
+          </a>
+        </div>
+      </>
     );
   },
 ];


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

NOTE: Drop "Simple" and "Simple2" stories are purely for QA in review. Changes to those stories and `storybook/preview.js` should be reverted before merging.

When an element receives focus, the browser will automatically scroll to attempt to bring that element into view. In the case of `trapFocus`, we don't want this to happen and instead it can cause a confusing/unexpected page scroll. Therefore, these adjustments listen for the `keydown` tab event in the cases where a Drop/Layer has `trapFocus` and the focus is:

- a. not in the container yet (`restrictFocus={false}`)
- b. on the last focusable element and will loop with tab
- c. on the first focusable element and will loop with shift + tab.

In the behavior merged in https://github.com/grommet/grommet/pull/7324, we hadn't tested the scenario where focusable elements existed outside of the Grommet wrapper (aka `makeNodeUnfocusable` wouldn't have been called on them). 

Additionally, the code pattern we referenced from APG always placed focus within the dialog when it opens. In our cases (`restrictFocus={false}`), that isn't guaranteed. When modifying their code to align with our cases, the same behavior can be seen (ensure that the bottom "Add Delivery Address" button is out of view, then press "Enter" on the first Add Delivery Address button, then press "Tab" and see how the page jumps down): https://zzcdcj.csb.app/

Similar to the change made in TextInput in #7324, MaskedInput should have `trapFocus={false}` since it maintains focus on the input itself.

#### Where should the reviewer start?

FocusedContainer.js

#### What testing has been done on this PR?

Locally in the scenario where focusable elements exist outside of the Grommet wrapper.

#### How should this be manually tested?

Using Drop Simple/Simple2 stories.

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

BEFORE (with undesired page scroll)

https://github.com/user-attachments/assets/58d68034-e147-40a8-af4c-297bb67eaca7


AFTER


https://github.com/user-attachments/assets/ae65917f-6fc9-4cf6-a3ef-3e39ff3ff165



https://github.com/user-attachments/assets/ab5b88cf-e2e5-43e4-9487-3866b75f3c4c


#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.