### PR TITLE
Fixes #6328 - Radio Button lacks focus indicator

### DIFF
--- a/src/js/components/DataSort/__tests__/__snapshots__/DataSort-test.tsx.snap
+++ b/src/js/components/DataSort/__tests__/__snapshots__/DataSort-test.tsx.snap
@@ -790,7 +790,7 @@ exports[`DataSort renders 1`] = `
                       <input
                         class="c20"
                         name="_sort.direction"
-                        tabindex="-1"
+                        tabindex="0"
                         type="radio"
                         value="desc"
                       />
@@ -1283,7 +1283,7 @@ exports[`DataSort sort when data array is empty 1`] = `
                 <input
                   class="c18"
                   name="_sort.direction"
-                  tabindex="-1"
+                  tabindex="0"
                   type="radio"
                   value="desc"
                 />

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-controlled.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-controlled.js.snap
@@ -3892,7 +3892,7 @@ exports[`Form controlled custom theme 1`] = `
                 class="c7"
                 id="dislike"
                 name="test"
-                tabindex="-1"
+                tabindex="0"
                 type="radio"
                 value="dislike"
               />

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.js.snap
@@ -2835,7 +2835,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 1`] =
                 class="c22"
                 id="test-radiobuttongroup-one"
                 name="test-radiobuttongroup"
-                tabindex="-1"
+                tabindex="0"
                 type="radio"
                 value="one"
               />
@@ -2903,7 +2903,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 1`] =
                 class="c22"
                 id="test-radiobuttongroup-three"
                 name="test-radiobuttongroup"
-                tabindex="-1"
+                tabindex="0"
                 type="radio"
                 value="three"
               />
@@ -3089,7 +3089,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
                 class="StyledRadioButton__StyledRadioButtonInput-sc-g1f6ld-1 jTLejj"
                 id="test-radiobuttongroup-two"
                 name="test-radiobuttongroup"
-                tabindex="-1"
+                tabindex="0"
                 type="radio"
                 value="two"
               />
@@ -3117,7 +3117,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
                 class="StyledRadioButton__StyledRadioButtonInput-sc-g1f6ld-1 jTLejj"
                 id="test-radiobuttongroup-three"
                 name="test-radiobuttongroup"
-                tabindex="-1"
+                tabindex="0"
                 type="radio"
                 value="three"
               />

--- a/src/js/components/RadioButton/RadioButton.js
+++ b/src/js/components/RadioButton/RadioButton.js
@@ -31,7 +31,9 @@ const RadioButton = forwardRef(
     ref,
   ) => {
     const { theme, passThemeFlag } = useThemeValue();
-    const [hover, setHover] = useState();
+    const [hover, setHover] = useState(false);
+    const [isFocused, setIsFocused] = useState(false); // State to track focus
+
     const normalizedLabel =
       typeof label === 'string' ? (
         <StyledRadioButtonLabel {...passThemeFlag}>
@@ -87,6 +89,9 @@ const RadioButton = forwardRef(
             {...rest}
             ref={ref}
             type="radio"
+            tabIndex="0" // Ensuring the input is focusable
+            onFocus={() => setIsFocused(true)} // Track when input is focused
+            onBlur={() => setIsFocused(false)} // Track when input loses focus
             {...removeUndefined({
               id,
               name,
@@ -96,10 +101,10 @@ const RadioButton = forwardRef(
             })}
           />
           {children ? (
-            children({ checked, focus: focus && focusIndicator, hover })
+            children({ checked, focus: isFocused && focusIndicator, hover })
           ) : (
             <StyledRadioButtonBox
-              focus={focus && focusIndicator}
+              focus={isFocused}
               align="center"
               justify="center"
               width={theme.radioButton.size}

--- a/src/js/components/RadioButton/__tests__/__snapshots__/RadioButton-test.tsx.snap
+++ b/src/js/components/RadioButton/__tests__/__snapshots__/RadioButton-test.tsx.snap
@@ -77,6 +77,7 @@ exports[`RadioButton background-color check themed 1`] = `
       <input
         class="c3"
         name="test"
+        tabindex="0"
         type="radio"
       />
       <div
@@ -168,6 +169,7 @@ exports[`RadioButton background-color themed 1`] = `
       <input
         class="c3"
         name="test"
+        tabindex="0"
         type="radio"
       />
       <div
@@ -255,6 +257,7 @@ exports[`RadioButton background-color themed symbolic 1`] = `
       <input
         class="c3"
         name="test"
+        tabindex="0"
         type="radio"
       />
       <div
@@ -342,6 +345,7 @@ exports[`RadioButton basic 1`] = `
       <input
         class="c3"
         name="test"
+        tabindex="0"
         type="radio"
         value="1"
       />
@@ -361,6 +365,7 @@ exports[`RadioButton basic 1`] = `
         class="c3"
         id="test id"
         name="test"
+        tabindex="0"
         type="radio"
         value="2"
       />
@@ -436,6 +441,7 @@ exports[`RadioButton basic renders outside grommet wrapper 1`] = `
     <input
       class="c2"
       name="test"
+      tabindex="0"
       type="radio"
       value="1"
     />
@@ -531,6 +537,7 @@ exports[`RadioButton checked 1`] = `
         checked=""
         class="c3"
         name="test"
+        tabindex="0"
         type="radio"
         value="1"
       />
@@ -646,6 +653,7 @@ exports[`RadioButton children 1`] = `
       <input
         class="c3"
         name="test"
+        tabindex="0"
         type="radio"
         value="1"
       />
@@ -664,6 +672,7 @@ exports[`RadioButton children 1`] = `
         checked=""
         class="c3"
         name="test"
+        tabindex="0"
         type="radio"
         value="2"
       />
@@ -782,6 +791,7 @@ exports[`RadioButton disabled 1`] = `
         class="c3"
         disabled=""
         name="test"
+        tabindex="0"
         type="radio"
         value="1"
       />
@@ -802,6 +812,7 @@ exports[`RadioButton disabled 1`] = `
         class="c3"
         disabled=""
         name="test"
+        tabindex="0"
         type="radio"
         value="2"
       />
@@ -909,6 +920,7 @@ exports[`RadioButton label 1`] = `
       <input
         class="c3"
         name="test"
+        tabindex="0"
         type="radio"
         value="1"
       />
@@ -931,6 +943,7 @@ exports[`RadioButton label 1`] = `
       <input
         class="c3"
         name="test"
+        tabindex="0"
         type="radio"
         value="2"
       />
@@ -1033,6 +1046,7 @@ exports[`RadioButton label themed 1`] = `
       <input
         class="c3"
         name="test"
+        tabindex="0"
         type="radio"
       />
       <div
@@ -1126,6 +1140,7 @@ exports[`RadioButton renders custom circle icon 1`] = `
         checked=""
         class="c3"
         name="test"
+        tabindex="0"
         type="radio"
       />
       <div
@@ -1220,6 +1235,7 @@ exports[`RadioButton should apply a11yTitle or aria-label 1`] = `
         aria-label="test"
         class="c3"
         name="test"
+        tabindex="0"
         type="radio"
       />
       <div
@@ -1237,6 +1253,7 @@ exports[`RadioButton should apply a11yTitle or aria-label 1`] = `
         aria-label="test-2"
         class="c3"
         name="test"
+        tabindex="0"
         type="radio"
       />
       <div
@@ -1325,6 +1342,7 @@ exports[`RadioButton should have no accessibility violations 1`] = `
         aria-label="test"
         class="c3"
         name="test"
+        tabindex="0"
         type="radio"
       />
       <div

--- a/src/js/components/RadioButtonGroup/__tests__/__snapshots__/RadioButtonGroup-test.tsx.snap
+++ b/src/js/components/RadioButtonGroup/__tests__/__snapshots__/RadioButtonGroup-test.tsx.snap
@@ -127,7 +127,7 @@ exports[`RadioButtonGroup adding additional props 1`] = `
           class="c4"
           id="TWO"
           name="test"
-          tabindex="-1"
+          tabindex="0"
           type="radio"
           value="2"
         />
@@ -320,7 +320,7 @@ exports[`RadioButtonGroup boolean options 1`] = `
           class="c4"
           id="false"
           name="test"
-          tabindex="-1"
+          tabindex="0"
           type="radio"
           value="false"
         />
@@ -463,7 +463,7 @@ exports[`RadioButtonGroup children 1`] = `
           class="c4"
           id="two"
           name="test"
-          tabindex="-1"
+          tabindex="0"
           type="radio"
           value="two"
         />
@@ -657,7 +657,7 @@ exports[`RadioButtonGroup defaultValue 1`] = `
             class="c4"
             id="two"
             name="test"
-            tabindex="-1"
+            tabindex="0"
             type="radio"
             value="two"
           />
@@ -856,7 +856,7 @@ exports[`RadioButtonGroup number options 1`] = `
           class="c4"
           id="2"
           name="test"
-          tabindex="-1"
+          tabindex="0"
           type="radio"
           value="2"
         />
@@ -1013,7 +1013,7 @@ exports[`RadioButtonGroup object options 1`] = `
           class="c4"
           id="twO"
           name="test"
-          tabindex="-1"
+          tabindex="0"
           type="radio"
           value="two"
         />
@@ -1179,7 +1179,7 @@ exports[`RadioButtonGroup object options disabled 1`] = `
         <input
           class="c8"
           name="test"
-          tabindex="-1"
+          tabindex="0"
           type="radio"
           value="two"
         />
@@ -1322,7 +1322,7 @@ exports[`RadioButtonGroup object options just value 1`] = `
         <input
           class="c4"
           name="test"
-          tabindex="-1"
+          tabindex="0"
           type="radio"
           value="one"
         />
@@ -1536,7 +1536,7 @@ exports[`RadioButtonGroup renders outside grommet wrapper 1`] = `
         class="c3"
         id="two"
         name="test"
-        tabindex="-1"
+        tabindex="0"
         type="radio"
         value="two"
       />
@@ -1852,7 +1852,7 @@ exports[`RadioButtonGroup string options 1`] = `
           class="c4"
           id="two"
           name="test"
-          tabindex="-1"
+          tabindex="0"
           type="radio"
           value="two"
         />

--- a/src/js/components/StarRating/__tests__/__snapshots__/StarRating-tests.tsx.snap
+++ b/src/js/components/StarRating/__tests__/__snapshots__/StarRating-tests.tsx.snap
@@ -147,7 +147,7 @@ exports[`StarRating StarRating has default value 1`] = `
             class="c4"
             id="2"
             name="test"
-            tabindex="-1"
+            tabindex="0"
             type="radio"
             value="2"
           />
@@ -178,7 +178,7 @@ exports[`StarRating StarRating has default value 1`] = `
             class="c4"
             id="3"
             name="test"
-            tabindex="-1"
+            tabindex="0"
             type="radio"
             value="3"
           />
@@ -209,7 +209,7 @@ exports[`StarRating StarRating has default value 1`] = `
             class="c4"
             id="4"
             name="test"
-            tabindex="-1"
+            tabindex="0"
             type="radio"
             value="4"
           />
@@ -241,7 +241,7 @@ exports[`StarRating StarRating has default value 1`] = `
             class="c4"
             id="5"
             name="test"
-            tabindex="-1"
+            tabindex="0"
             type="radio"
             value="5"
           />
@@ -413,7 +413,7 @@ exports[`StarRating StarRating is present 1`] = `
             class="c4"
             id="2"
             name="test"
-            tabindex="-1"
+            tabindex="0"
             type="radio"
             value="2"
           />
@@ -445,7 +445,7 @@ exports[`StarRating StarRating is present 1`] = `
             class="c4"
             id="3"
             name="test"
-            tabindex="-1"
+            tabindex="0"
             type="radio"
             value="3"
           />
@@ -477,7 +477,7 @@ exports[`StarRating StarRating is present 1`] = `
             class="c4"
             id="4"
             name="test"
-            tabindex="-1"
+            tabindex="0"
             type="radio"
             value="4"
           />
@@ -509,7 +509,7 @@ exports[`StarRating StarRating is present 1`] = `
             class="c4"
             id="5"
             name="test"
-            tabindex="-1"
+            tabindex="0"
             type="radio"
             value="5"
           />
@@ -680,7 +680,7 @@ exports[`StarRating StarRating should have no accessibility violations 1`] = `
             class="c4"
             id="2"
             name="test"
-            tabindex="-1"
+            tabindex="0"
             type="radio"
             value="2"
           />
@@ -712,7 +712,7 @@ exports[`StarRating StarRating should have no accessibility violations 1`] = `
             class="c4"
             id="3"
             name="test"
-            tabindex="-1"
+            tabindex="0"
             type="radio"
             value="3"
           />
@@ -744,7 +744,7 @@ exports[`StarRating StarRating should have no accessibility violations 1`] = `
             class="c4"
             id="4"
             name="test"
-            tabindex="-1"
+            tabindex="0"
             type="radio"
             value="4"
           />
@@ -776,7 +776,7 @@ exports[`StarRating StarRating should have no accessibility violations 1`] = `
             class="c4"
             id="5"
             name="test"
-            tabindex="-1"
+            tabindex="0"
             type="radio"
             value="5"
           />
@@ -934,7 +934,7 @@ exports[`StarRating renders without grommet wrapper 1`] = `
         class="c3"
         id="2"
         name="test"
-        tabindex="-1"
+        tabindex="0"
         type="radio"
         value="2"
       />
@@ -966,7 +966,7 @@ exports[`StarRating renders without grommet wrapper 1`] = `
         class="c3"
         id="3"
         name="test"
-        tabindex="-1"
+        tabindex="0"
         type="radio"
         value="3"
       />
@@ -998,7 +998,7 @@ exports[`StarRating renders without grommet wrapper 1`] = `
         class="c3"
         id="4"
         name="test"
-        tabindex="-1"
+        tabindex="0"
         type="radio"
         value="4"
       />
@@ -1030,7 +1030,7 @@ exports[`StarRating renders without grommet wrapper 1`] = `
         class="c3"
         id="5"
         name="test"
-        tabindex="-1"
+        tabindex="0"
         type="radio"
         value="5"
       />
@@ -1316,7 +1316,7 @@ exports[`StarRating value for rating 1`] = `
                 class="c7"
                 id="2"
                 name="test"
-                tabindex="-1"
+                tabindex="0"
                 type="radio"
                 value="2"
               />
@@ -1348,7 +1348,7 @@ exports[`StarRating value for rating 1`] = `
                 class="c7"
                 id="3"
                 name="test"
-                tabindex="-1"
+                tabindex="0"
                 type="radio"
                 value="3"
               />
@@ -1380,7 +1380,7 @@ exports[`StarRating value for rating 1`] = `
                 class="c7"
                 id="4"
                 name="test"
-                tabindex="-1"
+                tabindex="0"
                 type="radio"
                 value="4"
               />
@@ -1412,7 +1412,7 @@ exports[`StarRating value for rating 1`] = `
                 class="c7"
                 id="5"
                 name="test"
-                tabindex="-1"
+                tabindex="0"
                 type="radio"
                 value="5"
               />

--- a/src/js/components/ThumbsRating/__tests__/__snapshots__/ThumbsRating.tsx.snap
+++ b/src/js/components/ThumbsRating/__tests__/__snapshots__/ThumbsRating.tsx.snap
@@ -149,7 +149,7 @@ exports[`ThumbsRating StarRating is present 1`] = `
             class="c4"
             id="dislike"
             name="test"
-            tabindex="-1"
+            tabindex="0"
             type="radio"
             value="dislike"
           />
@@ -306,7 +306,7 @@ exports[`ThumbsRating StarRating renders outside grommet wrapper 1`] = `
         class="c3"
         id="dislike"
         name="test"
-        tabindex="-1"
+        tabindex="0"
         type="radio"
         value="dislike"
       />
@@ -475,7 +475,7 @@ exports[`ThumbsRating StarRating should have no accessibility violations 1`] = `
             class="c4"
             id="dislike"
             name="test"
-            tabindex="-1"
+            tabindex="0"
             type="radio"
             value="dislike"
           />
@@ -763,7 +763,7 @@ exports[`ThumbsRating value for thumbs 1`] = `
                 class="c7"
                 id="dislike"
                 name="test"
-                tabindex="-1"
+                tabindex="0"
                 type="radio"
                 value="dislike"
               />


### PR DESCRIPTION
#### What does this PR do?

This PR improves focus management and accessibility for the RadioButton and RadioButtonGroup components. It ensures that:

- The radio buttons are focusable using the Tab key.

#### Where should the reviewer start?

Reviewers should start by examining the RadioButton  components to understand the changes made to focus management and accessibility handling. Specifically, focus on the changes related to handling focus states and ensuring appropriate event handling in the components.

#### What testing has been done on this PR?

Manual testing was conducted to ensure that focus behaves as expected when navigating through radio buttons using keyboard input.

#### How should this be manually tested?

- Render the RadioButton components.
- Use the Tab key to navigate through the radio buttons and ensure that all buttons can receive focus.
- Verify that the active radio button is highlighted and that focus is visible for all buttons when using Tab navigation.
- Check that pressing Space or Enter selects the radio button as expected.

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

This enhancement addresses feedback received regarding accessibility concerns and ensures a better user experience for keyboard navigation.

#### What are the relevant issues?
Closes #6328 
This PR addresses accessibility and focus management issues as part of ongoing efforts to enhance component usability.

#### Screenshots (if appropriate)

https://github.com/user-attachments/assets/e0e556b4-0e6d-498b-8942-afb810d531ba

#### Do the grommet docs need to be updated?
N/A

#### Should this PR be mentioned in the release notes?
Yes, this PR should be mentioned in the release notes to highlight the improvements in accessibility and focus management.

#### Is this change backwards compatible or is it a breaking change?
This change is backwards compatible. Existing implementations of the RadioButton and RadioButtonGroup will continue to work without requiring changes.
