### PR TITLE
GH-7335: Fix space key interaction for clickable Datatable rows

### DIFF
--- a/src/js/components/DataTable/Body.js
+++ b/src/js/components/DataTable/Body.js
@@ -244,7 +244,7 @@ const Body = forwardRef(
                 if (typeof onClickRow === 'function') {
                   event.persist();
                   const adjustedEvent = event;
-                  adjustedEvent.datum = data[active];
+                  adjustedEvent.datum = data?.[active];
                   onClickRow(adjustedEvent);
                 } else if (onClickRow === 'select') {
                   selectRow();

--- a/src/js/components/DataTable/Body.js
+++ b/src/js/components/DataTable/Body.js
@@ -238,13 +238,20 @@ const Body = forwardRef(
             : undefined
         }
         // The WCAG recommendation for checkboxes is to select them with "Space"
-        onSpace={() => {
-          if (clickableRow) {
-            if (onClickRow === 'select') {
-              selectRow();
-            }
-          }
-        }}
+        onSpace={
+          clickableRow
+            ? (event) => {
+                if (typeof onClickRow === 'function') {
+                  event.persist();
+                  const adjustedEvent = event;
+                  adjustedEvent.datum = data[active];
+                  onClickRow(adjustedEvent);
+                } else if (onClickRow === 'select') {
+                  selectRow();
+                }
+              }
+            : undefined
+        }
         onUp={onClickRow && active ? () => setActive(active - 1) : undefined}
         onDown={
           onClickRow && data.length && active < data.length - 1

--- a/src/js/components/DataTable/Body.js
+++ b/src/js/components/DataTable/Body.js
@@ -241,6 +241,8 @@ const Body = forwardRef(
         onSpace={
           clickableRow
             ? (event) => {
+                event.preventDefault();
+
                 if (typeof onClickRow === 'function') {
                   event.persist();
                   const adjustedEvent = event;

--- a/src/js/components/DataTable/__tests__/DataTable-test.tsx
+++ b/src/js/components/DataTable/__tests__/DataTable-test.tsx
@@ -2024,4 +2024,55 @@ describe('DataTable', () => {
       '': 'all',
     });
   });
+
+  test('row click using space key press', () => {
+    const onClickRow = jest.fn();
+    const { container, getByText } = render(
+      <Grommet>
+        <DataTable
+          columns={[{ property: 'name', header: 'Name' }]}
+          data={[{ name: 'alpha' }]}
+          onClickRow={onClickRow}
+        />
+      </Grommet>,
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+
+    fireEvent.mouseEnter(getByText('alpha'));
+    fireEvent.keyDown(getByText('alpha'), {
+      code: 'Space',
+      keyCode: 32,
+    });
+
+    expect(onClickRow).toHaveBeenCalledWith(
+      expect.objectContaining({ datum: { name: 'alpha' } }),
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test('disable row click using space key press', () => {
+    const onClickRow = jest.fn();
+    const { container, getByText } = render(
+      <Grommet>
+        <DataTable
+          columns={[{ property: 'name', header: 'Name' }]}
+          data={[{ name: 'alpha' }]}
+          disabled={['alpha']}
+          onClickRow={onClickRow}
+        />
+      </Grommet>,
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+
+    fireEvent.mouseEnter(getByText('alpha'));
+    fireEvent.keyDown(getByText('alpha'), {
+      code: 'Space',
+      keyCode: 32,
+    });
+
+    expect(onClickRow).not.toHaveBeenCalled();
+    expect(container.firstChild).toMatchSnapshot();
+  });
 });

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.tsx.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.tsx.snap
@@ -3824,6 +3824,210 @@ exports[`DataTable custom theme 2`] = `
 </div>
 `;
 
+exports[`DataTable disable row click using space key press 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c4 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  flex: 1 0 auto;
+  justify-content: center;
+}
+
+.c9 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.c5 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c10 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c3 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c8 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c1 {
+  border-spacing: 0;
+  border-collapse: collapse;
+  width: inherit;
+}
+
+.c2 {
+  position: relative;
+  border-spacing: 0;
+  border-collapse: separate;
+}
+
+.c7 {
+  cursor: pointer;
+}
+
+.c6:focus {
+  outline: 2px solid #6FFFB0;
+}
+
+.c6:focus:not(:focus-visible) {
+  outline: none;
+}
+
+<div
+  class="c0"
+>
+  <table
+    class="c1 c2"
+  >
+    <thead
+      class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
+    >
+      <tr
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+      >
+        <th
+          class="c3 "
+          scope="col"
+        >
+          <div
+            class="c4"
+          >
+            <span
+              class="c5"
+            >
+              Name
+            </span>
+          </div>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 c6"
+      tabindex="0"
+    >
+      <tr
+        aria-disabled="true"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 c7"
+      >
+        <th
+          class="c8 "
+          scope="row"
+        >
+          <div
+            class="c9"
+          >
+            <span
+              class="c10"
+            >
+              alpha
+            </span>
+          </div>
+        </th>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
+exports[`DataTable disable row click using space key press 2`] = `
+<div
+  class="StyledGrommet-sc-19lkkz7-0 drDzQW"
+>
+  <table
+    class="StyledTable-sc-1m3u5g-6 bUmVhQ StyledDataTable-sc-xrlyjm-0 lfRkCP"
+  >
+    <thead
+      class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
+    >
+      <tr
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 hJqNiB"
+      >
+        <th
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 iWTOtn StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 ksxSsW"
+          scope="col"
+        >
+          <div
+            class="StyledBox-sc-13pk1d4-0 iWtlBN"
+          >
+            <span
+              class="StyledText-sc-1sadyjn-0 fjinKI"
+            >
+              Name
+            </span>
+          </div>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-3 jcOPZD"
+      tabindex="0"
+    >
+      <tr
+        aria-disabled="true"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 vuzUZ"
+      >
+        <th
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksjtzt StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 ksxSsW"
+          scope="row"
+        >
+          <div
+            class="StyledBox-sc-13pk1d4-0 bhFQAJ"
+          >
+            <span
+              class="StyledText-sc-1sadyjn-0 fTPnpC"
+            >
+              alpha
+            </span>
+          </div>
+        </th>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
 exports[`DataTable disabled click 1`] = `
 .c0 {
   font-size: 18px;
@@ -19384,6 +19588,208 @@ exports[`DataTable resizeable 1`] = `
             </span>
           </div>
         </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
+exports[`DataTable row click using space key press 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c4 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  flex: 1 0 auto;
+  justify-content: center;
+}
+
+.c9 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.c5 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c10 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c3 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c8 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c1 {
+  border-spacing: 0;
+  border-collapse: collapse;
+  width: inherit;
+}
+
+.c2 {
+  position: relative;
+  border-spacing: 0;
+  border-collapse: separate;
+}
+
+.c7 {
+  cursor: pointer;
+}
+
+.c6:focus {
+  outline: 2px solid #6FFFB0;
+}
+
+.c6:focus:not(:focus-visible) {
+  outline: none;
+}
+
+<div
+  class="c0"
+>
+  <table
+    class="c1 c2"
+  >
+    <thead
+      class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
+    >
+      <tr
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
+      >
+        <th
+          class="c3 "
+          scope="col"
+        >
+          <div
+            class="c4"
+          >
+            <span
+              class="c5"
+            >
+              Name
+            </span>
+          </div>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 c6"
+      tabindex="0"
+    >
+      <tr
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 c7"
+      >
+        <th
+          class="c8 "
+          scope="row"
+        >
+          <div
+            class="c9"
+          >
+            <span
+              class="c10"
+            >
+              alpha
+            </span>
+          </div>
+        </th>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
+exports[`DataTable row click using space key press 2`] = `
+<div
+  class="StyledGrommet-sc-19lkkz7-0 drDzQW"
+>
+  <table
+    class="StyledTable-sc-1m3u5g-6 bUmVhQ StyledDataTable-sc-xrlyjm-0 lfRkCP"
+  >
+    <thead
+      class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-4"
+    >
+      <tr
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 hJqNiB"
+      >
+        <th
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 iWTOtn StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 ksxSsW"
+          scope="col"
+        >
+          <div
+            class="StyledBox-sc-13pk1d4-0 iWtlBN"
+          >
+            <span
+              class="StyledText-sc-1sadyjn-0 fjinKI"
+            >
+              Name
+            </span>
+          </div>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-3 jcOPZD"
+      tabindex="0"
+    >
+      <tr
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 elLili"
+      >
+        <th
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksjtzt StyledDataTable__StyledDataTableCell-sc-xrlyjm-6 ksxSsW"
+          scope="row"
+        >
+          <div
+            class="StyledBox-sc-13pk1d4-0 bhFQAJ"
+          >
+            <span
+              class="StyledText-sc-1sadyjn-0 fTPnpC"
+            >
+              alpha
+            </span>
+          </div>
+        </th>
       </tr>
     </tbody>
   </table>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
* It fixes the space key interaction for clickable Datatable rows.

#### Where should the reviewer start?
* `src/js/components/DataTable/Body.js`

#### How should this be manually tested?
* Press `Space` key when row is selected.

#### What are the relevant issues?
* Closes #7335

#### Do the grommet docs need to be updated?
* No.

#### Should this PR be mentioned in the release notes?
* May be.

#### Is this change backwards compatible or is it a breaking change?
* It's backwards compatible.