### PR TITLE
Fixes #7231 : Anchor - icon size

### DIFF
--- a/src/js/components/Anchor/Anchor.js
+++ b/src/js/components/Anchor/Anchor.js
@@ -66,16 +66,25 @@ const Anchor = forwardRef(
     }, [children, icon, label]);
 
     let coloredIcon = icon;
-    if (icon && !icon.props.color) {
-      coloredIcon = cloneElement(icon, {
-        color: normalizeColor(
-          color ||
-            theme.anchor?.icon?.color ||
-            theme.anchor?.size?.[sizeProp || size]?.color ||
-            theme.anchor.color,
-          theme,
-        ),
-      });
+    if (icon) {
+      if (!icon.props.color) {
+        coloredIcon = cloneElement(icon, {
+          color: normalizeColor(
+            color ||
+              theme.anchor?.icon?.color ||
+              theme.anchor?.size?.[sizeProp || size]?.color ||
+              theme.anchor.color,
+            theme,
+          ),
+        });
+
+        if (!icon.props.size) {
+          const scaledSize = sizeProp || size || 'medium'; // fallback size
+          coloredIcon = cloneElement(coloredIcon, {
+            size: theme.anchor?.size?.[scaledSize]?.iconSize || scaledSize,
+          });
+        }
+      }
     }
 
     const anchorIcon = useSizedIcon(coloredIcon, sizeProp || size, theme);

--- a/src/js/components/Anchor/__tests__/__snapshots__/Anchor-test.tsx.snap
+++ b/src/js/components/Anchor/__tests__/__snapshots__/Anchor-test.tsx.snap
@@ -920,8 +920,8 @@ exports[`Anchor renders size specific theming 1`] = `
 .c20 {
   display: inline-block;
   flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
+  width: 48px;
+  height: 48px;
   fill: #7D4CDB;
   stroke: #7D4CDB;
 }


### PR DESCRIPTION
#### What does this PR do?

This PR fixes an issue in the Anchor component where the icon size was not properly scaling based on the Anchor size. It ensures that when the icon is not passed an explicit size, it will now scale in accordance with the size of the Anchor.

#### Where should the reviewer start?

The reviewer should begin by looking at the logic related to how the icon size is determined, specifically the changes in the Anchor.js file. Pay close attention to the logic where we check for sizeProp or size, and how the useSizedIcon function is applied.

#### What testing has been done on this PR?

Manual testing was performed to verify that the icon correctly scales with the Anchor size, particularly for xsmall, which was initially not working. Debugging outputs were used to trace the size calculations. Tests were run for all standard sizes (small, medium, etc.) to ensure the fix works across the board.

#### How should this be manually tested?

Manually test by rendering the Anchor component with different size props, including:

- No size passed (default behavior)
- Explicit small, medium, and large sizes. Ensure the icon scales appropriately with the Anchor size and that the component behaves as expected when sizes are dynamically changed.

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### What are the relevant issues?

The main issue addressed is the incorrect scaling of the icon within the Anchor component when an explicit size isn’t provided.

#### Screenshots (if appropriate)

![Screenshot 2024-10-15 at 11 32 55 PM](https://github.com/user-attachments/assets/c8af7926-0bbb-48c7-84ed-042a1af6dac3)

#### Do the grommet docs need to be updated?

No updates to the Grommet docs are necessary as this change fixes existing functionality rather than adding new features.

#### Should this PR be mentioned in the release notes?

Yes, it should be mentioned as a bug fix: "Fixed an issue where icons in the Anchor component did not scale correctly with the Anchor size, including xsmall."

#### Is this change backwards compatible or is it a breaking change?

This change is backwards compatible, as it only fixes the internal logic for size scaling without affecting the existing API.
