### PR TITLE
Update circleci browser tools

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,10 @@
 version: 2.1
 orbs:
-  browser-tools: circleci/browser-tools@1.4.4
+  browser-tools: circleci/browser-tools@1.4.8
 defaults: &defaults
   working_directory: ~/grommet-ci
   docker:
-    - image: cimg/node:20.16.0-browsers
+    - image: cimg/node:20.18.0-browsers
 jobs:
   checkout:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,10 @@ jobs:
       - attach_workspace:
           at: ~/grommet-ci
       - run: sudo apt-get update
-      - browser-tools/install-chrome
+      - browser-tools/install-chrome:
+          replace-existing: true
+          chrome-version: 129.0.6668.100
+          # temporary solution, v130 is causing websocket connection issue
       - browser-tools/install-chromedriver
       - run:
           name: Start project


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Update browser tools and temporarily freeze chrome version at 129 because v130 is causing problems with the tests failing on circleci because if a websocket connection issue

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
backwards compatible