### PR TITLE
Added test for Drop trap focus

### DIFF
--- a/src/js/components/Drop/__tests__/Drop-test.tsx
+++ b/src/js/components/Drop/__tests__/Drop-test.tsx
@@ -149,7 +149,7 @@ const TestButton = ({
   );
 };
 
-const TestRestrictFocus = () => {
+const TestTrapFocus = () => {
   const [showDrop, setShowDrop] = useState<boolean>(false);
 
   const inputRef = useRef<HTMLInputElement | null>(null);
@@ -162,10 +162,13 @@ const TestRestrictFocus = () => {
 
   if (showDrop) {
     drop = (
-      <Drop id="drop-node" restrictFocus target={inputRef.current || undefined}>
-        <button autoFocus aria-label="first-focus">
-          first-focus
-        </button>
+      <Drop
+        id="drop-node"
+        trapFocus
+        restrictFocus
+        target={inputRef.current || undefined}
+      >
+        <button aria-label="first-focus">first-focus</button>
         <button aria-label="second-focus">second-focus</button>
       </Drop>
     );
@@ -312,20 +315,20 @@ describe('Drop', () => {
     });
   });
 
-  test('focus does not leave the dialog when restrictFocus is true', async () => {
+  test('focus does not leave the dialog when trapFocus is true', async () => {
     userEvent.setup();
     window.scrollTo = jest.fn();
-    render(<TestRestrictFocus />);
+    render(<TestTrapFocus />);
 
     // Wait for the button with text 'first-focus'
     const firstButton = await screen.findByText('first-focus');
     const secondButton = await screen.findByText('second-focus');
     expect(firstButton).toBeInTheDocument();
 
+    await userEvent.tab();
+
     // Check that the button is the currently focused element
-    await waitFor(() => {
-      expect(document.activeElement).toBe(firstButton);
-    });
+    expect(document.activeElement).toBe(firstButton);
 
     // Simulate tab
     await userEvent.tab();

--- a/src/js/components/Drop/__tests__/Drop-test.tsx
+++ b/src/js/components/Drop/__tests__/Drop-test.tsx
@@ -341,6 +341,12 @@ describe('Drop', () => {
 
     // Expect the focus to go back to the first button
     expect(document.activeElement).toBe(firstButton);
+    
+     // Simulate backwards tab with Shift key
+    await userEvent.tab({ shift: true });
+    // Expect the focus to be on the second button again
+    expect(document.activeElement).toBe(secondButton);
+    
   });
 
   test('default elevation renders', () => {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds a test for https://github.com/grommet/grommet/pull/7324

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
backwards compatible