### PR TITLE
Fix a11y aria-label for select

### DIFF
--- a/src/js/components/Select/Select.js
+++ b/src/js/components/Select/Select.js
@@ -24,6 +24,7 @@ import {
   getSelectIcon,
   getDisplayLabelKey,
   getIconColor,
+  formatValueForA11y,
 } from './utils';
 import { DefaultSelectTextInput } from './DefaultSelectTextInput';
 import { MessageContext } from '../../contexts/MessageContext';
@@ -289,9 +290,10 @@ const Select = forwardRef(
             value
               ? format({
                   id: 'select.selected',
-                  labelKey,
                   messages,
-                  values: { currentSelectedValue: value },
+                  values: {
+                    currentSelectedValue: formatValueForA11y(value, labelKey),
+                  },
                 })
               : ''
           }`}

--- a/src/js/components/Select/Select.js
+++ b/src/js/components/Select/Select.js
@@ -289,6 +289,7 @@ const Select = forwardRef(
             value
               ? format({
                   id: 'select.selected',
+                  labelKey,
                   messages,
                   values: { currentSelectedValue: value },
                 })

--- a/src/js/components/Select/__tests__/__snapshots__/Select-multiple-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-multiple-test.js.snap
@@ -2795,7 +2795,7 @@ exports[`Select Controlled multiple onChange without labelKey 8`] = `
     <button
       aria-expanded="true"
       aria-haspopup="listbox"
-      aria-label="test select; Selected: [object Object],[object Object]"
+      aria-label="test select; Selected: 1, 2"
       class="c1 c2"
       id="test-select"
       type="button"
@@ -3678,7 +3678,7 @@ exports[`Select Controlled multiple onChange without valueKey 8`] = `
     <button
       aria-expanded="true"
       aria-haspopup="listbox"
-      aria-label="test select; Selected: [object Object],[object Object]"
+      aria-label="test select; Selected: Value1, Value2"
       class="c1 c2"
       id="test-select"
       type="button"
@@ -4559,7 +4559,7 @@ exports[`Select Controlled multiple onChange without valueKey or labelKey 8`] = 
     <button
       aria-expanded="true"
       aria-haspopup="listbox"
-      aria-label="test select; Selected: [object Object],[object Object]"
+      aria-label="test select; Selected: 1, 2"
       class="c1 c2"
       id="test-select"
       type="button"
@@ -4813,7 +4813,7 @@ exports[`Select Controlled multiple values 1`] = `
   <button
     aria-expanded="false"
     aria-haspopup="listbox"
-    aria-label="test select; Selected: one,two"
+    aria-label="test select; Selected: one, two"
     class="c1 c2"
     id="test-select"
     type="button"
@@ -4868,7 +4868,7 @@ exports[`Select Controlled multiple values 2`] = `
   <button
     aria-expanded="true"
     aria-haspopup="listbox"
-    aria-label="test select; Selected: one,two"
+    aria-label="test select; Selected: one, two"
     class="StyledButton-sc-323bzc-0 cWIZhL StyledSelect__StyledSelectDropButton-sc-znp66n-5 fVOJSO"
     id="test-select"
     type="button"

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -8264,7 +8264,7 @@ exports[`Select onChange with valueKey string 4`] = `
     <button
       aria-expanded="false"
       aria-haspopup="listbox"
-      aria-label="test select; Selected: [object Object]"
+      aria-label="test select; Selected: Value1"
       class="c1 c2"
       id="test-select"
       type="button"
@@ -9416,7 +9416,7 @@ exports[`Select onChange without labelKey 4`] = `
     <button
       aria-expanded="false"
       aria-haspopup="listbox"
-      aria-label="test select; Selected: [object Object]"
+      aria-label="test select; Selected: 1"
       class="c1 c2"
       id="test-select"
       type="button"
@@ -10152,7 +10152,7 @@ exports[`Select onChange without labelKey or valueKey 4`] = `
     <button
       aria-expanded="false"
       aria-haspopup="listbox"
-      aria-label="test select; Selected: [object Object]"
+      aria-label="test select; Selected: 1"
       class="c1 c2"
       id="test-select"
       type="button"
@@ -10888,7 +10888,7 @@ exports[`Select onChange without valueKey 4`] = `
     <button
       aria-expanded="false"
       aria-haspopup="listbox"
-      aria-label="test select; Selected: [object Object]"
+      aria-label="test select; Selected: Value1"
       class="c1 c2"
       id="test-select"
       type="button"

--- a/src/js/components/Select/utils.js
+++ b/src/js/components/Select/utils.js
@@ -1,8 +1,8 @@
-import React, { useCallback } from 'react';
+import { useCallback, isValidElement } from 'react';
 import { normalizeColor } from '../../utils';
 
 export const applyKey = (option, key) => {
-  if (React.isValidElement(option)) return option;
+  if (isValidElement(option)) return option;
   if (option === undefined || option === null) return undefined;
   if (typeof key === 'object') return applyKey(option, key.key);
   if (typeof key === 'function') return key(option);
@@ -124,3 +124,12 @@ export const getDisplayLabelKey = (
 
 export const getIconColor = (theme) =>
   normalizeColor(theme.select.icons.color || 'control', theme);
+
+export const formatValueForA11y = (value, labelKey) => {
+  if (typeof value === 'string') return value;
+  if (isValidElement(value)) return value.toString();
+  if (Array.isArray(value)) {
+    return value.map((item) => formatValueForA11y(item, labelKey)).join(', ');
+  }
+  return applyKey(value, labelKey);
+};

--- a/src/js/contexts/MessageContext/MessageContext.js
+++ b/src/js/contexts/MessageContext/MessageContext.js
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import { formatValueForA11y } from '../../components/Select/utils';
 import defaultMessages from '../../languages/default.json';
 
 // options:
@@ -40,13 +39,13 @@ export const format = (options, messages) => {
     messageObj ||
     options.defaultMessage;
 
-  const { labelKey, values } = options;
+  const { values } = options;
 
   let newMessage = message;
   const tokens = message?.match(/\{(.+?)\}/g);
   tokens?.forEach((token) => {
     const names = token.substr(1, token.length - 2);
-    const value = formatValueForA11y(values[names], labelKey);
+    const value = values[names];
     newMessage = newMessage.replace(token, value);
   });
 

--- a/src/js/contexts/MessageContext/MessageContext.js
+++ b/src/js/contexts/MessageContext/MessageContext.js
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { formatValueForA11y } from '../../components/Select/utils';
 import defaultMessages from '../../languages/default.json';
 
 // options:
@@ -39,13 +40,13 @@ export const format = (options, messages) => {
     messageObj ||
     options.defaultMessage;
 
-  const { values } = options;
+  const { labelKey, values } = options;
 
   let newMessage = message;
   const tokens = message?.match(/\{(.+?)\}/g);
   tokens?.forEach((token) => {
     const names = token.substr(1, token.length - 2);
-    const value = values[names];
+    const value = formatValueForA11y(values[names], labelKey);
     newMessage = newMessage.replace(token, value);
   });
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR adds a new function `formatValueForA11y` which uses both the value of the select option(s) and labelKey to extract a Human Readable value for the `aria-label` attribute. [9f986298af444e52777c404e99852fd008f6bd89]
~~Also, as a plus, Button tests were breaking. Updating the snapshot this was properly fixed. [3d5e88750fe4aa53decc992b03b1ba21281634d6]~~

#### Where should the reviewer start?
- Start in the context that runs the replacements over at: [src/js/contexts/MessageContext/MessageContext](https://github.com/grommet/grommet/blob/9f986298af444e52777c404e99852fd008f6bd89/src/js/contexts/MessageContext/MessageContext.js)
- Then check `formatValueForA11y` at the [select utils](https://github.com/grommet/grommet/blob/9f986298af444e52777c404e99852fd008f6bd89/src/js/components/Select/utils.js)

#### What testing has been done on this PR?
- Used npm link to test the components in a test project
- Used Snapshots/Jest to test the output of the components

#### How should this be manually tested?
Using `Select` Component:
- Add options which contain objects
- Use `multiple` prop and select more than one value

#### Do Jest tests follow these best practices?

- [x] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [x] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
- Fixes https://github.com/grommet/grommet/issues/6393

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No
#### Should this PR be mentioned in the release notes?
Not sure
#### Is this change backwards compatible or is it a breaking change?
Yes
