### PR TITLE
Fix using div gaps inside pagination lists

### DIFF
--- a/src/js/components/Data/__tests__/__snapshots__/Data-test.tsx.snap
+++ b/src/js/components/Data/__tests__/__snapshots__/Data-test.tsx.snap
@@ -1814,12 +1814,7 @@ exports[`Data pagination 1`] = `
   min-height: 0;
   flex-direction: row;
   padding: 0px;
-}
-
-.c15 {
-  flex: 0 0 auto;
-  align-self: stretch;
-  width: 3px;
+  column-gap: 3px;
 }
 
 .c9 {
@@ -1904,7 +1899,7 @@ exports[`Data pagination 1`] = `
   border: 0;
 }
 
-.c16 {
+.c15 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -1930,47 +1925,47 @@ exports[`Data pagination 1`] = `
   flex: 1 0 auto;
 }
 
-.c16:hover {
+.c15:hover {
   background-color: rgba(51, 51, 51, 0.06274509803921569);
 }
 
-.c16:focus {
+.c15:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c16:focus >circle,
-.c16:focus >ellipse,
-.c16:focus >line,
-.c16:focus >path,
-.c16:focus >polygon,
-.c16:focus >polyline,
-.c16:focus >rect {
+.c15:focus >circle,
+.c15:focus >ellipse,
+.c15:focus >line,
+.c15:focus >path,
+.c15:focus >polygon,
+.c15:focus >polyline,
+.c15:focus >rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c16:focus ::-moz-focus-inner {
+.c15:focus ::-moz-focus-inner {
   border: 0;
 }
 
-.c16:focus:not(:focus-visible) {
+.c15:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c16:focus:not(:focus-visible) >circle,
-.c16:focus:not(:focus-visible) >ellipse,
-.c16:focus:not(:focus-visible) >line,
-.c16:focus:not(:focus-visible) >path,
-.c16:focus:not(:focus-visible) >polygon,
-.c16:focus:not(:focus-visible) >polyline,
-.c16:focus:not(:focus-visible) >rect {
+.c15:focus:not(:focus-visible) >circle,
+.c15:focus:not(:focus-visible) >ellipse,
+.c15:focus:not(:focus-visible) >line,
+.c15:focus:not(:focus-visible) >path,
+.c15:focus:not(:focus-visible) >polygon,
+.c15:focus:not(:focus-visible) >polyline,
+.c15:focus:not(:focus-visible) >rect {
   outline: none;
   box-shadow: none;
 }
 
-.c16:focus:not(:focus-visible) ::-moz-focus-inner {
+.c15:focus:not(:focus-visible) ::-moz-focus-inner {
   border: 0;
 }
 
@@ -2050,8 +2045,8 @@ exports[`Data pagination 1`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c15 {
-    width: 2px;
+  .c10 {
+    column-gap: 2px;
   }
 }
 
@@ -2154,23 +2149,17 @@ exports[`Data pagination 1`] = `
               </svg>
             </button>
           </li>
-          <div
-            class="c15"
-          />
           <li
             class="c11"
           >
             <button
               aria-label="Go to page 1"
-              class="c16 c13"
+              class="c15 c13"
               type="button"
             >
               1
             </button>
           </li>
-          <div
-            class="c15"
-          />
           <li
             class="c11"
           >
@@ -2283,12 +2272,7 @@ exports[`Data pagination step 1`] = `
   min-height: 0;
   flex-direction: row;
   padding: 0px;
-}
-
-.c15 {
-  flex: 0 0 auto;
-  align-self: stretch;
-  width: 3px;
+  column-gap: 3px;
 }
 
 .c9 {
@@ -2373,7 +2357,7 @@ exports[`Data pagination step 1`] = `
   border: 0;
 }
 
-.c16 {
+.c15 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -2399,47 +2383,47 @@ exports[`Data pagination step 1`] = `
   flex: 1 0 auto;
 }
 
-.c16:hover {
+.c15:hover {
   background-color: rgba(51, 51, 51, 0.06274509803921569);
 }
 
-.c16:focus {
+.c15:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c16:focus >circle,
-.c16:focus >ellipse,
-.c16:focus >line,
-.c16:focus >path,
-.c16:focus >polygon,
-.c16:focus >polyline,
-.c16:focus >rect {
+.c15:focus >circle,
+.c15:focus >ellipse,
+.c15:focus >line,
+.c15:focus >path,
+.c15:focus >polygon,
+.c15:focus >polyline,
+.c15:focus >rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c16:focus ::-moz-focus-inner {
+.c15:focus ::-moz-focus-inner {
   border: 0;
 }
 
-.c16:focus:not(:focus-visible) {
+.c15:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c16:focus:not(:focus-visible) >circle,
-.c16:focus:not(:focus-visible) >ellipse,
-.c16:focus:not(:focus-visible) >line,
-.c16:focus:not(:focus-visible) >path,
-.c16:focus:not(:focus-visible) >polygon,
-.c16:focus:not(:focus-visible) >polyline,
-.c16:focus:not(:focus-visible) >rect {
+.c15:focus:not(:focus-visible) >circle,
+.c15:focus:not(:focus-visible) >ellipse,
+.c15:focus:not(:focus-visible) >line,
+.c15:focus:not(:focus-visible) >path,
+.c15:focus:not(:focus-visible) >polygon,
+.c15:focus:not(:focus-visible) >polyline,
+.c15:focus:not(:focus-visible) >rect {
   outline: none;
   box-shadow: none;
 }
 
-.c16:focus:not(:focus-visible) ::-moz-focus-inner {
+.c15:focus:not(:focus-visible) ::-moz-focus-inner {
   border: 0;
 }
 
@@ -2519,8 +2503,8 @@ exports[`Data pagination step 1`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c15 {
-    width: 2px;
+  .c10 {
+    column-gap: 2px;
   }
 }
 
@@ -2623,23 +2607,17 @@ exports[`Data pagination step 1`] = `
               </svg>
             </button>
           </li>
-          <div
-            class="c15"
-          />
           <li
             class="c11"
           >
             <button
               aria-label="Go to page 1"
-              class="c16 c13"
+              class="c15 c13"
               type="button"
             >
               1
             </button>
           </li>
-          <div
-            class="c15"
-          />
           <li
             class="c11"
           >
@@ -6614,6 +6592,7 @@ exports[`Data uncontrolled, when paginated, search should return to page 1 1`] =
   min-height: 0;
   flex-direction: row;
   padding: 0px;
+  column-gap: 3px;
 }
 
 .c2 {
@@ -6642,12 +6621,6 @@ exports[`Data uncontrolled, when paginated, search should return to page 1 1`] =
   flex-wrap: wrap;
   column-gap: 12px;
   row-gap: 12px;
-}
-
-.c25 {
-  flex: 0 0 auto;
-  align-self: stretch;
-  width: 3px;
 }
 
 .c11 {
@@ -6727,7 +6700,7 @@ exports[`Data uncontrolled, when paginated, search should return to page 1 1`] =
   border: 0;
 }
 
-.c28 {
+.c27 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -6754,83 +6727,10 @@ exports[`Data uncontrolled, when paginated, search should return to page 1 1`] =
   flex: 1 0 auto;
 }
 
-.c28 >svg {
+.c27 >svg {
   display: flex;
   align-self: center;
   vertical-align: middle;
-}
-
-.c28:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c28:focus >circle,
-.c28:focus >ellipse,
-.c28:focus >line,
-.c28:focus >path,
-.c28:focus >polygon,
-.c28:focus >polyline,
-.c28:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c28:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c28:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c28:focus:not(:focus-visible) >circle,
-.c28:focus:not(:focus-visible) >ellipse,
-.c28:focus:not(:focus-visible) >line,
-.c28:focus:not(:focus-visible) >path,
-.c28:focus:not(:focus-visible) >polygon,
-.c28:focus:not(:focus-visible) >polyline,
-.c28:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c28:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c27 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  background-color: rgba(221, 221, 221, 0.4);
-  color: #000000;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 24px;
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-  color: #444444;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c27:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
 }
 
 .c27:focus {
@@ -6883,12 +6783,15 @@ exports[`Data uncontrolled, when paginated, search should return to page 1 1`] =
   background: transparent;
   overflow: visible;
   text-transform: none;
+  background-color: rgba(221, 221, 221, 0.4);
+  color: #000000;
   border: none;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
   line-height: 24px;
-  color: #000000;
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+  color: #444444;
   text-align: center;
   transition-property: color,background-color,border-color,box-shadow;
   transition-duration: 0.1s;
@@ -6940,6 +6843,76 @@ exports[`Data uncontrolled, when paginated, search should return to page 1 1`] =
 }
 
 .c26:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c25 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  color: #000000;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c25:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c25:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c25:focus >circle,
+.c25:focus >ellipse,
+.c25:focus >line,
+.c25:focus >path,
+.c25:focus >polygon,
+.c25:focus >polyline,
+.c25:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c25:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c25:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c25:focus:not(:focus-visible) >circle,
+.c25:focus:not(:focus-visible) >ellipse,
+.c25:focus:not(:focus-visible) >line,
+.c25:focus:not(:focus-visible) >path,
+.c25:focus:not(:focus-visible) >polygon,
+.c25:focus:not(:focus-visible) >polyline,
+.c25:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c25:focus:not(:focus-visible) ::-moz-focus-inner {
   border: 0;
 }
 
@@ -7187,6 +7160,12 @@ exports[`Data uncontrolled, when paginated, search should return to page 1 1`] =
 }
 
 @media only screen and (max-width: 768px) {
+  .c20 {
+    column-gap: 2px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
   .c2 {
     column-gap: 12px;
   }
@@ -7195,12 +7174,6 @@ exports[`Data uncontrolled, when paginated, search should return to page 1 1`] =
 @media only screen and (max-width: 768px) {
   .c3 {
     column-gap: 6px;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c25 {
-    width: 2px;
   }
 }
 
@@ -7378,45 +7351,36 @@ exports[`Data uncontrolled, when paginated, search should return to page 1 1`] =
               </svg>
             </button>
           </li>
-          <div
-            class="c25"
-          />
           <li
             class="c21"
           >
             <button
               aria-label="Go to page 1"
-              class="c26 c23"
+              class="c25 c23"
               type="button"
             >
               1
             </button>
           </li>
-          <div
-            class="c25"
-          />
           <li
             class="c21"
           >
             <button
               aria-current="page"
               aria-label="Go to page 2"
-              class="c27 c23"
+              class="c26 c23"
               type="button"
             >
               2
             </button>
           </li>
-          <div
-            class="c25"
-          />
           <li
             class="c21"
           >
             <button
               aria-disabled="true"
               aria-label="Go to next page"
-              class="c28 c23"
+              class="c27 c23"
               disabled=""
               type="button"
             >
@@ -7632,7 +7596,7 @@ exports[`Data uncontrolled, when paginated, search should return to page 1 2`] =
         class="StyledBox-sc-13pk1d4-0 euJJjo"
       >
         <ul
-          class="StyledBox-sc-13pk1d4-0 kOcABF"
+          class="StyledBox-sc-13pk1d4-0 gkMlIT"
         >
           <li
             class="StyledPageControl__StyledContainer-sc-1vlfaez-1 bjXWCk"
@@ -7658,9 +7622,6 @@ exports[`Data uncontrolled, when paginated, search should return to page 1 2`] =
               </svg>
             </button>
           </li>
-          <div
-            class="StyledBox__StyledBoxGap-sc-13pk1d4-1 fsEMPj"
-          />
           <li
             class="StyledPageControl__StyledContainer-sc-1vlfaez-1 bjXWCk"
           >
@@ -7673,9 +7634,6 @@ exports[`Data uncontrolled, when paginated, search should return to page 1 2`] =
               1
             </button>
           </li>
-          <div
-            class="StyledBox__StyledBoxGap-sc-13pk1d4-1 fsEMPj"
-          />
           <li
             class="StyledPageControl__StyledContainer-sc-1vlfaez-1 bjXWCk"
           >
@@ -7976,7 +7934,7 @@ exports[`Data uncontrolled, when paginated, search should return to page 1 3`] =
         class="StyledBox-sc-13pk1d4-0 euJJjo"
       >
         <ul
-          class="StyledBox-sc-13pk1d4-0 kOcABF"
+          class="StyledBox-sc-13pk1d4-0 gkMlIT"
         >
           <li
             class="StyledPageControl__StyledContainer-sc-1vlfaez-1 bjXWCk"
@@ -8002,9 +7960,6 @@ exports[`Data uncontrolled, when paginated, search should return to page 1 3`] =
               </svg>
             </button>
           </li>
-          <div
-            class="StyledBox__StyledBoxGap-sc-13pk1d4-1 fsEMPj"
-          />
           <li
             class="StyledPageControl__StyledContainer-sc-1vlfaez-1 bjXWCk"
           >
@@ -8017,9 +7972,6 @@ exports[`Data uncontrolled, when paginated, search should return to page 1 3`] =
               1
             </button>
           </li>
-          <div
-            class="StyledBox__StyledBoxGap-sc-13pk1d4-1 fsEMPj"
-          />
           <li
             class="StyledPageControl__StyledContainer-sc-1vlfaez-1 bjXWCk"
           >
@@ -8031,45 +7983,6 @@ exports[`Data uncontrolled, when paginated, search should return to page 1 3`] =
               2
             </button>
           </li>
-          .c0 {
-  flex: 0 0 auto;
-  align-self: stretch;
-  width: 3px;
-}
-
-@media only screen and (max-width: 768px) {
-
-}
-
-@media only screen and (max-width: 768px) {
-
-}
-
-@media only screen and (max-width: 768px) {
-
-}
-
-@media only screen and (max-width: 768px) {
-
-}
-
-@media only screen and (max-width: 768px) {
-
-}
-
-@media only screen and (max-width: 768px) {
-
-}
-
-@media only screen and (max-width: 768px) {
-  .c0 {
-    width: 2px;
-  }
-}
-
-<div
-            class="c0"
-          />
           .c3 {
   display: inline-block;
   flex: 0 0 auto;

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.tsx.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.tsx.snap
@@ -23366,7 +23366,7 @@ exports[`DataTable should apply pagination styling 1`] = `
   stroke: none;
 }
 
-.c23 {
+.c22 {
   display: inline-block;
   flex: 0 0 auto;
   width: 24px;
@@ -23375,25 +23375,25 @@ exports[`DataTable should apply pagination styling 1`] = `
   stroke: #000000;
 }
 
-.c23 g {
+.c22 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c23 *:not([stroke])[fill='none'] {
+.c22 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c23 *[stroke*='#'],
-.c23 *[STROKE*='#'] {
+.c22 *[stroke*='#'],
+.c22 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c23 *[fill-rule],
-.c23 *[FILL-RULE],
-.c23 *[fill*='#'],
-.c23 *[FILL*='#'] {
+.c22 *[fill-rule],
+.c22 *[FILL-RULE],
+.c22 *[fill*='#'],
+.c22 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -23471,18 +23471,13 @@ exports[`DataTable should apply pagination styling 1`] = `
   min-height: 0;
   flex-direction: row;
   padding: 0px;
+  column-gap: 3px;
 }
 
 .c11 {
   flex: 0 0 auto;
   align-self: stretch;
   height: 6px;
-}
-
-.c19 {
-  flex: 0 0 auto;
-  align-self: stretch;
-  width: 3px;
 }
 
 .c7 {
@@ -23569,7 +23564,7 @@ exports[`DataTable should apply pagination styling 1`] = `
   border: 0;
 }
 
-.c20 {
+.c19 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -23588,6 +23583,76 @@ exports[`DataTable should apply pagination styling 1`] = `
   line-height: 24px;
   background-color: rgba(51, 51, 51, 0.06274509803921569);
   color: #444444;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c19:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c19:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c19:focus >circle,
+.c19:focus >ellipse,
+.c19:focus >line,
+.c19:focus >path,
+.c19:focus >polygon,
+.c19:focus >polyline,
+.c19:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c19:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c19:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c19:focus:not(:focus-visible) >circle,
+.c19:focus:not(:focus-visible) >ellipse,
+.c19:focus:not(:focus-visible) >line,
+.c19:focus:not(:focus-visible) >path,
+.c19:focus:not(:focus-visible) >polygon,
+.c19:focus:not(:focus-visible) >polyline,
+.c19:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c19:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c20 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  color: #000000;
   text-align: center;
   transition-property: color,background-color,border-color,box-shadow;
   transition-duration: 0.1s;
@@ -23656,7 +23721,7 @@ exports[`DataTable should apply pagination styling 1`] = `
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   color: #000000;
   text-align: center;
   transition-property: color,background-color,border-color,box-shadow;
@@ -23666,6 +23731,12 @@ exports[`DataTable should apply pagination styling 1`] = `
   height: 100%;
   max-width: none;
   flex: 1 0 auto;
+}
+
+.c21 >svg {
+  display: flex;
+  align-self: center;
+  vertical-align: middle;
 }
 
 .c21:hover {
@@ -23709,82 +23780,6 @@ exports[`DataTable should apply pagination styling 1`] = `
 }
 
 .c21:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c22 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 0;
-  color: #000000;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c22 >svg {
-  display: flex;
-  align-self: center;
-  vertical-align: middle;
-}
-
-.c22:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-}
-
-.c22:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c22:focus >circle,
-.c22:focus >ellipse,
-.c22:focus >line,
-.c22:focus >path,
-.c22:focus >polygon,
-.c22:focus >polyline,
-.c22:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c22:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c22:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c22:focus:not(:focus-visible) >circle,
-.c22:focus:not(:focus-visible) >ellipse,
-.c22:focus:not(:focus-visible) >line,
-.c22:focus:not(:focus-visible) >path,
-.c22:focus:not(:focus-visible) >polygon,
-.c22:focus:not(:focus-visible) >polyline,
-.c22:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c22:focus:not(:focus-visible) ::-moz-focus-inner {
   border: 0;
 }
 
@@ -23870,14 +23865,14 @@ exports[`DataTable should apply pagination styling 1`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c11 {
-    height: 3px;
+  .c14 {
+    column-gap: 2px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c19 {
-    width: 2px;
+  .c11 {
+    height: 3px;
   }
 }
 
@@ -25522,49 +25517,40 @@ exports[`DataTable should apply pagination styling 1`] = `
               </svg>
             </button>
           </li>
-          <div
-            class="c19"
-          />
           <li
             class="c15"
           >
             <button
               aria-current="page"
               aria-label="Go to page 1"
-              class="c20 c17"
+              class="c19 c17"
               type="button"
             >
               1
             </button>
           </li>
-          <div
-            class="c19"
-          />
           <li
             class="c15"
           >
             <button
               aria-label="Go to page 2"
-              class="c21 c17"
+              class="c20 c17"
               type="button"
             >
               2
             </button>
           </li>
-          <div
-            class="c19"
-          />
           <li
             class="c15"
           >
             <button
               aria-label="Go to next page"
-              class="c22 c17"
+              class="c21 c17"
               type="button"
             >
               <svg
                 aria-label="Next"
-                class="c23"
+                class="c22"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -26438,7 +26424,7 @@ exports[`DataTable should paginate 1`] = `
   stroke: none;
 }
 
-.c23 {
+.c22 {
   display: inline-block;
   flex: 0 0 auto;
   width: 24px;
@@ -26447,25 +26433,25 @@ exports[`DataTable should paginate 1`] = `
   stroke: #000000;
 }
 
-.c23 g {
+.c22 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c23 *:not([stroke])[fill='none'] {
+.c22 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c23 *[stroke*='#'],
-.c23 *[STROKE*='#'] {
+.c22 *[stroke*='#'],
+.c22 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c23 *[fill-rule],
-.c23 *[FILL-RULE],
-.c23 *[fill*='#'],
-.c23 *[FILL*='#'] {
+.c22 *[fill-rule],
+.c22 *[FILL-RULE],
+.c22 *[fill*='#'],
+.c22 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -26541,18 +26527,13 @@ exports[`DataTable should paginate 1`] = `
   min-height: 0;
   flex-direction: row;
   padding: 0px;
+  column-gap: 3px;
 }
 
 .c11 {
   flex: 0 0 auto;
   align-self: stretch;
   height: 6px;
-}
-
-.c19 {
-  flex: 0 0 auto;
-  align-self: stretch;
-  width: 3px;
 }
 
 .c7 {
@@ -26639,7 +26620,7 @@ exports[`DataTable should paginate 1`] = `
   border: 0;
 }
 
-.c20 {
+.c19 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -26658,6 +26639,76 @@ exports[`DataTable should paginate 1`] = `
   line-height: 24px;
   background-color: rgba(51, 51, 51, 0.06274509803921569);
   color: #444444;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c19:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c19:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c19:focus >circle,
+.c19:focus >ellipse,
+.c19:focus >line,
+.c19:focus >path,
+.c19:focus >polygon,
+.c19:focus >polyline,
+.c19:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c19:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c19:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c19:focus:not(:focus-visible) >circle,
+.c19:focus:not(:focus-visible) >ellipse,
+.c19:focus:not(:focus-visible) >line,
+.c19:focus:not(:focus-visible) >path,
+.c19:focus:not(:focus-visible) >polygon,
+.c19:focus:not(:focus-visible) >polyline,
+.c19:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c19:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c20 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  color: #000000;
   text-align: center;
   transition-property: color,background-color,border-color,box-shadow;
   transition-duration: 0.1s;
@@ -26726,7 +26777,7 @@ exports[`DataTable should paginate 1`] = `
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   color: #000000;
   text-align: center;
   transition-property: color,background-color,border-color,box-shadow;
@@ -26736,6 +26787,12 @@ exports[`DataTable should paginate 1`] = `
   height: 100%;
   max-width: none;
   flex: 1 0 auto;
+}
+
+.c21 >svg {
+  display: flex;
+  align-self: center;
+  vertical-align: middle;
 }
 
 .c21:hover {
@@ -26779,82 +26836,6 @@ exports[`DataTable should paginate 1`] = `
 }
 
 .c21:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c22 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 0;
-  color: #000000;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c22 >svg {
-  display: flex;
-  align-self: center;
-  vertical-align: middle;
-}
-
-.c22:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-}
-
-.c22:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c22:focus >circle,
-.c22:focus >ellipse,
-.c22:focus >line,
-.c22:focus >path,
-.c22:focus >polygon,
-.c22:focus >polyline,
-.c22:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c22:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c22:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c22:focus:not(:focus-visible) >circle,
-.c22:focus:not(:focus-visible) >ellipse,
-.c22:focus:not(:focus-visible) >line,
-.c22:focus:not(:focus-visible) >path,
-.c22:focus:not(:focus-visible) >polygon,
-.c22:focus:not(:focus-visible) >polyline,
-.c22:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c22:focus:not(:focus-visible) ::-moz-focus-inner {
   border: 0;
 }
 
@@ -26934,14 +26915,14 @@ exports[`DataTable should paginate 1`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c11 {
-    height: 3px;
+  .c14 {
+    column-gap: 2px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c19 {
-    width: 2px;
+  .c11 {
+    height: 3px;
   }
 }
 
@@ -28586,49 +28567,40 @@ exports[`DataTable should paginate 1`] = `
               </svg>
             </button>
           </li>
-          <div
-            class="c19"
-          />
           <li
             class="c15"
           >
             <button
               aria-current="page"
               aria-label="Go to page 1"
-              class="c20 c17"
+              class="c19 c17"
               type="button"
             >
               1
             </button>
           </li>
-          <div
-            class="c19"
-          />
           <li
             class="c15"
           >
             <button
               aria-label="Go to page 2"
-              class="c21 c17"
+              class="c20 c17"
               type="button"
             >
               2
             </button>
           </li>
-          <div
-            class="c19"
-          />
           <li
             class="c15"
           >
             <button
               aria-label="Go to next page"
-              class="c22 c17"
+              class="c21 c17"
               type="button"
             >
               <svg
                 aria-label="Next"
-                class="c23"
+                class="c22"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -28680,7 +28652,7 @@ exports[`DataTable should pin and paginate 1`] = `
   stroke: none;
 }
 
-.c24 {
+.c23 {
   display: inline-block;
   flex: 0 0 auto;
   width: 24px;
@@ -28689,25 +28661,25 @@ exports[`DataTable should pin and paginate 1`] = `
   stroke: #000000;
 }
 
-.c24 g {
+.c23 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c24 *:not([stroke])[fill='none'] {
+.c23 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c24 *[stroke*='#'],
-.c24 *[STROKE*='#'] {
+.c23 *[stroke*='#'],
+.c23 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c24 *[fill-rule],
-.c24 *[FILL-RULE],
-.c24 *[fill*='#'],
-.c24 *[FILL*='#'] {
+.c23 *[fill-rule],
+.c23 *[FILL-RULE],
+.c23 *[fill*='#'],
+.c23 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -28783,18 +28755,13 @@ exports[`DataTable should pin and paginate 1`] = `
   min-height: 0;
   flex-direction: row;
   padding: 0px;
+  column-gap: 3px;
 }
 
 .c12 {
   flex: 0 0 auto;
   align-self: stretch;
   height: 6px;
-}
-
-.c20 {
-  flex: 0 0 auto;
-  align-self: stretch;
-  width: 3px;
 }
 
 .c8 {
@@ -28881,7 +28848,7 @@ exports[`DataTable should pin and paginate 1`] = `
   border: 0;
 }
 
-.c21 {
+.c20 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -28900,6 +28867,76 @@ exports[`DataTable should pin and paginate 1`] = `
   line-height: 24px;
   background-color: rgba(51, 51, 51, 0.06274509803921569);
   color: #444444;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c20:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c20:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c20:focus >circle,
+.c20:focus >ellipse,
+.c20:focus >line,
+.c20:focus >path,
+.c20:focus >polygon,
+.c20:focus >polyline,
+.c20:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c20:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c20:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c20:focus:not(:focus-visible) >circle,
+.c20:focus:not(:focus-visible) >ellipse,
+.c20:focus:not(:focus-visible) >line,
+.c20:focus:not(:focus-visible) >path,
+.c20:focus:not(:focus-visible) >polygon,
+.c20:focus:not(:focus-visible) >polyline,
+.c20:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c20:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c21 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  color: #000000;
   text-align: center;
   transition-property: color,background-color,border-color,box-shadow;
   transition-duration: 0.1s;
@@ -28968,7 +29005,7 @@ exports[`DataTable should pin and paginate 1`] = `
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   color: #000000;
   text-align: center;
   transition-property: color,background-color,border-color,box-shadow;
@@ -28978,6 +29015,12 @@ exports[`DataTable should pin and paginate 1`] = `
   height: 100%;
   max-width: none;
   flex: 1 0 auto;
+}
+
+.c22 >svg {
+  display: flex;
+  align-self: center;
+  vertical-align: middle;
 }
 
 .c22:hover {
@@ -29021,82 +29064,6 @@ exports[`DataTable should pin and paginate 1`] = `
 }
 
 .c22:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c23 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 0;
-  color: #000000;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c23 >svg {
-  display: flex;
-  align-self: center;
-  vertical-align: middle;
-}
-
-.c23:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-}
-
-.c23:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c23:focus >circle,
-.c23:focus >ellipse,
-.c23:focus >line,
-.c23:focus >path,
-.c23:focus >polygon,
-.c23:focus >polyline,
-.c23:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c23:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c23:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c23:focus:not(:focus-visible) >circle,
-.c23:focus:not(:focus-visible) >ellipse,
-.c23:focus:not(:focus-visible) >line,
-.c23:focus:not(:focus-visible) >path,
-.c23:focus:not(:focus-visible) >polygon,
-.c23:focus:not(:focus-visible) >polyline,
-.c23:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c23:focus:not(:focus-visible) ::-moz-focus-inner {
   border: 0;
 }
 
@@ -29184,14 +29151,14 @@ exports[`DataTable should pin and paginate 1`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c12 {
-    height: 3px;
+  .c15 {
+    column-gap: 2px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c20 {
-    width: 2px;
+  .c12 {
+    height: 3px;
   }
 }
 
@@ -30836,49 +30803,40 @@ exports[`DataTable should pin and paginate 1`] = `
               </svg>
             </button>
           </li>
-          <div
-            class="c20"
-          />
           <li
             class="c16"
           >
             <button
               aria-current="page"
               aria-label="Go to page 1"
-              class="c21 c18"
+              class="c20 c18"
               type="button"
             >
               1
             </button>
           </li>
-          <div
-            class="c20"
-          />
           <li
             class="c16"
           >
             <button
               aria-label="Go to page 2"
-              class="c22 c18"
+              class="c21 c18"
               type="button"
             >
               2
             </button>
           </li>
-          <div
-            class="c20"
-          />
           <li
             class="c16"
           >
             <button
               aria-label="Go to next page"
-              class="c23 c18"
+              class="c22 c18"
               type="button"
             >
               <svg
                 aria-label="Next"
-                class="c24"
+                class="c23"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -30930,7 +30888,7 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
   stroke: none;
 }
 
-.c23 {
+.c22 {
   display: inline-block;
   flex: 0 0 auto;
   width: 24px;
@@ -30939,25 +30897,25 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
   stroke: #000000;
 }
 
-.c23 g {
+.c22 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c23 *:not([stroke])[fill='none'] {
+.c22 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c23 *[stroke*='#'],
-.c23 *[STROKE*='#'] {
+.c22 *[stroke*='#'],
+.c22 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c23 *[fill-rule],
-.c23 *[FILL-RULE],
-.c23 *[fill*='#'],
-.c23 *[FILL*='#'] {
+.c22 *[fill-rule],
+.c22 *[FILL-RULE],
+.c22 *[fill*='#'],
+.c22 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -31033,18 +30991,13 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
   min-height: 0;
   flex-direction: row;
   padding: 0px;
+  column-gap: 3px;
 }
 
 .c11 {
   flex: 0 0 auto;
   align-self: stretch;
   height: 6px;
-}
-
-.c19 {
-  flex: 0 0 auto;
-  align-self: stretch;
-  width: 3px;
 }
 
 .c7 {
@@ -31131,7 +31084,7 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
   border: 0;
 }
 
-.c20 {
+.c19 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -31150,6 +31103,76 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
   line-height: 24px;
   background-color: rgba(51, 51, 51, 0.06274509803921569);
   color: #444444;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c19:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c19:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c19:focus >circle,
+.c19:focus >ellipse,
+.c19:focus >line,
+.c19:focus >path,
+.c19:focus >polygon,
+.c19:focus >polyline,
+.c19:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c19:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c19:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c19:focus:not(:focus-visible) >circle,
+.c19:focus:not(:focus-visible) >ellipse,
+.c19:focus:not(:focus-visible) >line,
+.c19:focus:not(:focus-visible) >path,
+.c19:focus:not(:focus-visible) >polygon,
+.c19:focus:not(:focus-visible) >polyline,
+.c19:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c19:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c20 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  color: #000000;
   text-align: center;
   transition-property: color,background-color,border-color,box-shadow;
   transition-duration: 0.1s;
@@ -31218,7 +31241,7 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   color: #000000;
   text-align: center;
   transition-property: color,background-color,border-color,box-shadow;
@@ -31228,6 +31251,12 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
   height: 100%;
   max-width: none;
   flex: 1 0 auto;
+}
+
+.c21 >svg {
+  display: flex;
+  align-self: center;
+  vertical-align: middle;
 }
 
 .c21:hover {
@@ -31271,82 +31300,6 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
 }
 
 .c21:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c22 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 0;
-  color: #000000;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c22 >svg {
-  display: flex;
-  align-self: center;
-  vertical-align: middle;
-}
-
-.c22:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-}
-
-.c22:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c22:focus >circle,
-.c22:focus >ellipse,
-.c22:focus >line,
-.c22:focus >path,
-.c22:focus >polygon,
-.c22:focus >polyline,
-.c22:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c22:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c22:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c22:focus:not(:focus-visible) >circle,
-.c22:focus:not(:focus-visible) >ellipse,
-.c22:focus:not(:focus-visible) >line,
-.c22:focus:not(:focus-visible) >path,
-.c22:focus:not(:focus-visible) >polygon,
-.c22:focus:not(:focus-visible) >polyline,
-.c22:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c22:focus:not(:focus-visible) ::-moz-focus-inner {
   border: 0;
 }
 
@@ -31426,14 +31379,14 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c11 {
-    height: 3px;
+  .c14 {
+    column-gap: 2px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c19 {
-    width: 2px;
+  .c11 {
+    height: 3px;
   }
 }
 
@@ -31962,119 +31915,95 @@ exports[`DataTable should render correct num items per page (step) 1`] = `
               </svg>
             </button>
           </li>
-          <div
-            class="c19"
-          />
           <li
             class="c15"
           >
             <button
               aria-current="page"
               aria-label="Go to page 1"
-              class="c20 c17"
+              class="c19 c17"
               type="button"
             >
               1
             </button>
           </li>
-          <div
-            class="c19"
-          />
           <li
             class="c15"
           >
             <button
               aria-label="Go to page 2"
-              class="c21 c17"
+              class="c20 c17"
               type="button"
             >
               2
             </button>
           </li>
-          <div
-            class="c19"
-          />
           <li
             class="c15"
           >
             <button
               aria-label="Go to page 3"
-              class="c21 c17"
+              class="c20 c17"
               type="button"
             >
               3
             </button>
           </li>
-          <div
-            class="c19"
-          />
           <li
             class="c15"
           >
             <button
               aria-label="Go to page 4"
-              class="c21 c17"
+              class="c20 c17"
               type="button"
             >
               4
             </button>
           </li>
-          <div
-            class="c19"
-          />
           <li
             class="c15"
           >
             <button
               aria-label="Go to page 5"
-              class="c21 c17"
+              class="c20 c17"
               type="button"
             >
               5
             </button>
           </li>
-          <div
-            class="c19"
-          />
           <li
             class="c15"
           >
             <button
               aria-label="Go to page 6"
-              class="c21 c17"
+              class="c20 c17"
               type="button"
             >
               6
             </button>
           </li>
-          <div
-            class="c19"
-          />
           <li
             class="c15"
           >
             <button
               aria-label="Go to page 7"
-              class="c21 c17"
+              class="c20 c17"
               type="button"
             >
               7
             </button>
           </li>
-          <div
-            class="c19"
-          />
           <li
             class="c15"
           >
             <button
               aria-label="Go to next page"
-              class="c22 c17"
+              class="c21 c17"
               type="button"
             >
               <svg
                 aria-label="Next"
-                class="c23"
+                class="c22"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -32126,7 +32055,7 @@ exports[`DataTable should render new data when page changes 1`] = `
   stroke: none;
 }
 
-.c23 {
+.c22 {
   display: inline-block;
   flex: 0 0 auto;
   width: 24px;
@@ -32135,25 +32064,25 @@ exports[`DataTable should render new data when page changes 1`] = `
   stroke: #000000;
 }
 
-.c23 g {
+.c22 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c23 *:not([stroke])[fill='none'] {
+.c22 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c23 *[stroke*='#'],
-.c23 *[STROKE*='#'] {
+.c22 *[stroke*='#'],
+.c22 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c23 *[fill-rule],
-.c23 *[FILL-RULE],
-.c23 *[fill*='#'],
-.c23 *[FILL*='#'] {
+.c22 *[fill-rule],
+.c22 *[FILL-RULE],
+.c22 *[fill*='#'],
+.c22 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -32229,18 +32158,13 @@ exports[`DataTable should render new data when page changes 1`] = `
   min-height: 0;
   flex-direction: row;
   padding: 0px;
+  column-gap: 3px;
 }
 
 .c11 {
   flex: 0 0 auto;
   align-self: stretch;
   height: 6px;
-}
-
-.c19 {
-  flex: 0 0 auto;
-  align-self: stretch;
-  width: 3px;
 }
 
 .c7 {
@@ -32327,7 +32251,7 @@ exports[`DataTable should render new data when page changes 1`] = `
   border: 0;
 }
 
-.c20 {
+.c19 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -32346,6 +32270,76 @@ exports[`DataTable should render new data when page changes 1`] = `
   line-height: 24px;
   background-color: rgba(51, 51, 51, 0.06274509803921569);
   color: #444444;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c19:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c19:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c19:focus >circle,
+.c19:focus >ellipse,
+.c19:focus >line,
+.c19:focus >path,
+.c19:focus >polygon,
+.c19:focus >polyline,
+.c19:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c19:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c19:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c19:focus:not(:focus-visible) >circle,
+.c19:focus:not(:focus-visible) >ellipse,
+.c19:focus:not(:focus-visible) >line,
+.c19:focus:not(:focus-visible) >path,
+.c19:focus:not(:focus-visible) >polygon,
+.c19:focus:not(:focus-visible) >polyline,
+.c19:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c19:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c20 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  color: #000000;
   text-align: center;
   transition-property: color,background-color,border-color,box-shadow;
   transition-duration: 0.1s;
@@ -32414,7 +32408,7 @@ exports[`DataTable should render new data when page changes 1`] = `
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   color: #000000;
   text-align: center;
   transition-property: color,background-color,border-color,box-shadow;
@@ -32424,6 +32418,12 @@ exports[`DataTable should render new data when page changes 1`] = `
   height: 100%;
   max-width: none;
   flex: 1 0 auto;
+}
+
+.c21 >svg {
+  display: flex;
+  align-self: center;
+  vertical-align: middle;
 }
 
 .c21:hover {
@@ -32467,82 +32467,6 @@ exports[`DataTable should render new data when page changes 1`] = `
 }
 
 .c21:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c22 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 0;
-  color: #000000;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c22 >svg {
-  display: flex;
-  align-self: center;
-  vertical-align: middle;
-}
-
-.c22:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-}
-
-.c22:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c22:focus >circle,
-.c22:focus >ellipse,
-.c22:focus >line,
-.c22:focus >path,
-.c22:focus >polygon,
-.c22:focus >polyline,
-.c22:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c22:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c22:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c22:focus:not(:focus-visible) >circle,
-.c22:focus:not(:focus-visible) >ellipse,
-.c22:focus:not(:focus-visible) >line,
-.c22:focus:not(:focus-visible) >path,
-.c22:focus:not(:focus-visible) >polygon,
-.c22:focus:not(:focus-visible) >polyline,
-.c22:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c22:focus:not(:focus-visible) ::-moz-focus-inner {
   border: 0;
 }
 
@@ -32622,14 +32546,14 @@ exports[`DataTable should render new data when page changes 1`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c11 {
-    height: 3px;
+  .c14 {
+    column-gap: 2px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c19 {
-    width: 2px;
+  .c11 {
+    height: 3px;
   }
 }
 
@@ -34274,49 +34198,40 @@ exports[`DataTable should render new data when page changes 1`] = `
               </svg>
             </button>
           </li>
-          <div
-            class="c19"
-          />
           <li
             class="c15"
           >
             <button
               aria-current="page"
               aria-label="Go to page 1"
-              class="c20 c17"
+              class="c19 c17"
               type="button"
             >
               1
             </button>
           </li>
-          <div
-            class="c19"
-          />
           <li
             class="c15"
           >
             <button
               aria-label="Go to page 2"
-              class="c21 c17"
+              class="c20 c17"
               type="button"
             >
               2
             </button>
           </li>
-          <div
-            class="c19"
-          />
           <li
             class="c15"
           >
             <button
               aria-label="Go to next page"
-              class="c22 c17"
+              class="c21 c17"
               type="button"
             >
               <svg
                 aria-label="Next"
-                class="c23"
+                class="c22"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -37956,7 +37871,7 @@ exports[`DataTable should render new data when page changes 2`] = `
         class="StyledBox-sc-13pk1d4-0 euJJjo"
       >
         <ul
-          class="StyledBox-sc-13pk1d4-0 kOcABF"
+          class="StyledBox-sc-13pk1d4-0 gkMlIT"
         >
           <li
             class="StyledPageControl__StyledContainer-sc-1vlfaez-1 bjXWCk"
@@ -37980,9 +37895,6 @@ exports[`DataTable should render new data when page changes 2`] = `
               </svg>
             </button>
           </li>
-          <div
-            class="StyledBox__StyledBoxGap-sc-13pk1d4-1 fsEMPj"
-          />
           <li
             class="StyledPageControl__StyledContainer-sc-1vlfaez-1 bjXWCk"
           >
@@ -37994,9 +37906,6 @@ exports[`DataTable should render new data when page changes 2`] = `
               1
             </button>
           </li>
-          <div
-            class="StyledBox__StyledBoxGap-sc-13pk1d4-1 fsEMPj"
-          />
           <li
             class="StyledPageControl__StyledContainer-sc-1vlfaez-1 bjXWCk"
           >
@@ -38009,9 +37918,6 @@ exports[`DataTable should render new data when page changes 2`] = `
               2
             </button>
           </li>
-          <div
-            class="StyledBox__StyledBoxGap-sc-13pk1d4-1 fsEMPj"
-          />
           <li
             class="StyledPageControl__StyledContainer-sc-1vlfaez-1 bjXWCk"
           >
@@ -38076,7 +37982,7 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
   stroke: none;
 }
 
-.c23 {
+.c22 {
   display: inline-block;
   flex: 0 0 auto;
   width: 24px;
@@ -38085,25 +37991,25 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
   stroke: #000000;
 }
 
-.c23 g {
+.c22 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c23 *:not([stroke])[fill='none'] {
+.c22 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c23 *[stroke*='#'],
-.c23 *[STROKE*='#'] {
+.c22 *[stroke*='#'],
+.c22 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c23 *[fill-rule],
-.c23 *[FILL-RULE],
-.c23 *[fill*='#'],
-.c23 *[FILL*='#'] {
+.c22 *[fill-rule],
+.c22 *[FILL-RULE],
+.c22 *[fill*='#'],
+.c22 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -38179,18 +38085,13 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
   min-height: 0;
   flex-direction: row;
   padding: 0px;
+  column-gap: 3px;
 }
 
 .c11 {
   flex: 0 0 auto;
   align-self: stretch;
   height: 6px;
-}
-
-.c19 {
-  flex: 0 0 auto;
-  align-self: stretch;
-  width: 3px;
 }
 
 .c7 {
@@ -38277,7 +38178,7 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
   border: 0;
 }
 
-.c20 {
+.c19 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -38296,6 +38197,76 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
   line-height: 24px;
   background-color: rgba(51, 51, 51, 0.06274509803921569);
   color: #444444;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c19:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c19:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c19:focus >circle,
+.c19:focus >ellipse,
+.c19:focus >line,
+.c19:focus >path,
+.c19:focus >polygon,
+.c19:focus >polyline,
+.c19:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c19:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c19:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c19:focus:not(:focus-visible) >circle,
+.c19:focus:not(:focus-visible) >ellipse,
+.c19:focus:not(:focus-visible) >line,
+.c19:focus:not(:focus-visible) >path,
+.c19:focus:not(:focus-visible) >polygon,
+.c19:focus:not(:focus-visible) >polyline,
+.c19:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c19:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c20 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  color: #000000;
   text-align: center;
   transition-property: color,background-color,border-color,box-shadow;
   transition-duration: 0.1s;
@@ -38364,7 +38335,7 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   color: #000000;
   text-align: center;
   transition-property: color,background-color,border-color,box-shadow;
@@ -38374,6 +38345,12 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
   height: 100%;
   max-width: none;
   flex: 1 0 auto;
+}
+
+.c21 >svg {
+  display: flex;
+  align-self: center;
+  vertical-align: middle;
 }
 
 .c21:hover {
@@ -38417,82 +38394,6 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
 }
 
 .c21:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c22 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 0;
-  color: #000000;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c22 >svg {
-  display: flex;
-  align-self: center;
-  vertical-align: middle;
-}
-
-.c22:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-}
-
-.c22:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c22:focus >circle,
-.c22:focus >ellipse,
-.c22:focus >line,
-.c22:focus >path,
-.c22:focus >polygon,
-.c22:focus >polyline,
-.c22:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c22:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c22:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c22:focus:not(:focus-visible) >circle,
-.c22:focus:not(:focus-visible) >ellipse,
-.c22:focus:not(:focus-visible) >line,
-.c22:focus:not(:focus-visible) >path,
-.c22:focus:not(:focus-visible) >polygon,
-.c22:focus:not(:focus-visible) >polyline,
-.c22:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c22:focus:not(:focus-visible) ::-moz-focus-inner {
   border: 0;
 }
 
@@ -38572,14 +38473,14 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
 }
 
 @media only screen and (max-width: 768px) {
-  .c11 {
-    height: 3px;
+  .c14 {
+    column-gap: 2px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c19 {
-    width: 2px;
+  .c11 {
+    height: 3px;
   }
 }
 
@@ -40224,49 +40125,40 @@ exports[`DataTable should show correct item index when "show" is a number 1`] = 
               </svg>
             </button>
           </li>
-          <div
-            class="c19"
-          />
           <li
             class="c15"
           >
             <button
               aria-current="page"
               aria-label="Go to page 1"
-              class="c20 c17"
+              class="c19 c17"
               type="button"
             >
               1
             </button>
           </li>
-          <div
-            class="c19"
-          />
           <li
             class="c15"
           >
             <button
               aria-label="Go to page 2"
-              class="c21 c17"
+              class="c20 c17"
               type="button"
             >
               2
             </button>
           </li>
-          <div
-            class="c19"
-          />
           <li
             class="c15"
           >
             <button
               aria-label="Go to next page"
-              class="c22 c17"
+              class="c21 c17"
               type="button"
             >
               <svg
                 aria-label="Next"
-                class="c23"
+                class="c22"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -40318,7 +40210,7 @@ exports[`DataTable should show correct page when "show" is { page: # } 1`] = `
   stroke: none;
 }
 
-.c23 {
+.c22 {
   display: inline-block;
   flex: 0 0 auto;
   width: 24px;
@@ -40327,25 +40219,25 @@ exports[`DataTable should show correct page when "show" is { page: # } 1`] = `
   stroke: #666666;
 }
 
-.c23 g {
+.c22 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c23 *:not([stroke])[fill='none'] {
+.c22 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c23 *[stroke*='#'],
-.c23 *[STROKE*='#'] {
+.c22 *[stroke*='#'],
+.c22 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c23 *[fill-rule],
-.c23 *[FILL-RULE],
-.c23 *[fill*='#'],
-.c23 *[FILL*='#'] {
+.c22 *[fill-rule],
+.c22 *[FILL-RULE],
+.c22 *[fill*='#'],
+.c22 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -40421,18 +40313,13 @@ exports[`DataTable should show correct page when "show" is { page: # } 1`] = `
   min-height: 0;
   flex-direction: row;
   padding: 0px;
+  column-gap: 3px;
 }
 
 .c11 {
   flex: 0 0 auto;
   align-self: stretch;
   height: 6px;
-}
-
-.c19 {
-  flex: 0 0 auto;
-  align-self: stretch;
-  width: 3px;
 }
 
 .c7 {
@@ -40522,7 +40409,7 @@ exports[`DataTable should show correct page when "show" is { page: # } 1`] = `
   border: 0;
 }
 
-.c20 {
+.c19 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -40538,6 +40425,79 @@ exports[`DataTable should show correct page when "show" is { page: # } 1`] = `
   font-size: 18px;
   line-height: 24px;
   color: #000000;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c19:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c19:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c19:focus >circle,
+.c19:focus >ellipse,
+.c19:focus >line,
+.c19:focus >path,
+.c19:focus >polygon,
+.c19:focus >polyline,
+.c19:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c19:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c19:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c19:focus:not(:focus-visible) >circle,
+.c19:focus:not(:focus-visible) >ellipse,
+.c19:focus:not(:focus-visible) >line,
+.c19:focus:not(:focus-visible) >path,
+.c19:focus:not(:focus-visible) >polygon,
+.c19:focus:not(:focus-visible) >polyline,
+.c19:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c19:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c20 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  background-color: rgba(221, 221, 221, 0.4);
+  color: #000000;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+  color: #444444;
   text-align: center;
   transition-property: color,background-color,border-color,box-shadow;
   transition-duration: 0.1s;
@@ -40602,16 +40562,14 @@ exports[`DataTable should show correct page when "show" is { page: # } 1`] = `
   background: transparent;
   overflow: visible;
   text-transform: none;
-  background-color: rgba(221, 221, 221, 0.4);
-  color: #000000;
   border: none;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-  color: #444444;
+  line-height: 0;
   text-align: center;
+  opacity: 0.3;
+  cursor: default;
   transition-property: color,background-color,border-color,box-shadow;
   transition-duration: 0.1s;
   transition-timing-function: ease-in-out;
@@ -40621,8 +40579,10 @@ exports[`DataTable should show correct page when "show" is { page: # } 1`] = `
   flex: 1 0 auto;
 }
 
-.c21:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
+.c21 >svg {
+  display: flex;
+  align-self: center;
+  vertical-align: middle;
 }
 
 .c21:focus {
@@ -40662,79 +40622,6 @@ exports[`DataTable should show correct page when "show" is { page: # } 1`] = `
 }
 
 .c21:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c22 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 0;
-  text-align: center;
-  opacity: 0.3;
-  cursor: default;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c22 >svg {
-  display: flex;
-  align-self: center;
-  vertical-align: middle;
-}
-
-.c22:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c22:focus >circle,
-.c22:focus >ellipse,
-.c22:focus >line,
-.c22:focus >path,
-.c22:focus >polygon,
-.c22:focus >polyline,
-.c22:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c22:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c22:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c22:focus:not(:focus-visible) >circle,
-.c22:focus:not(:focus-visible) >ellipse,
-.c22:focus:not(:focus-visible) >line,
-.c22:focus:not(:focus-visible) >path,
-.c22:focus:not(:focus-visible) >polygon,
-.c22:focus:not(:focus-visible) >polyline,
-.c22:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c22:focus:not(:focus-visible) ::-moz-focus-inner {
   border: 0;
 }
 
@@ -40814,14 +40701,14 @@ exports[`DataTable should show correct page when "show" is { page: # } 1`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c11 {
-    height: 3px;
+  .c14 {
+    column-gap: 2px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c19 {
-    width: 2px;
+  .c11 {
+    height: 3px;
   }
 }
 
@@ -42309,51 +42196,42 @@ exports[`DataTable should show correct page when "show" is { page: # } 1`] = `
               </svg>
             </button>
           </li>
-          <div
-            class="c19"
-          />
           <li
             class="c15"
           >
             <button
               aria-label="Go to page 1"
-              class="c20 c17"
+              class="c19 c17"
               type="button"
             >
               1
             </button>
           </li>
-          <div
-            class="c19"
-          />
           <li
             class="c15"
           >
             <button
               aria-current="page"
               aria-label="Go to page 2"
-              class="c21 c17"
+              class="c20 c17"
               type="button"
             >
               2
             </button>
           </li>
-          <div
-            class="c19"
-          />
           <li
             class="c15"
           >
             <button
               aria-disabled="true"
               aria-label="Go to next page"
-              class="c22 c17"
+              class="c21 c17"
               disabled=""
               type="button"
             >
               <svg
                 aria-label="Next"
-                class="c23"
+                class="c22"
                 viewBox="0 0 24 24"
               >
                 <path

--- a/src/js/components/List/__tests__/__snapshots__/List-test.tsx.snap
+++ b/src/js/components/List/__tests__/__snapshots__/List-test.tsx.snap
@@ -3853,7 +3853,7 @@ exports[`List events should apply pagination styling 1`] = `
   stroke: none;
 }
 
-.c18 {
+.c17 {
   display: inline-block;
   flex: 0 0 auto;
   width: 24px;
@@ -3862,25 +3862,25 @@ exports[`List events should apply pagination styling 1`] = `
   stroke: #000000;
 }
 
-.c18 g {
+.c17 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c18 *:not([stroke])[fill='none'] {
+.c17 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c18 *[stroke*='#'],
-.c18 *[STROKE*='#'] {
+.c17 *[stroke*='#'],
+.c17 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c18 *[fill-rule],
-.c18 *[FILL-RULE],
-.c18 *[fill*='#'],
-.c18 *[FILL*='#'] {
+.c17 *[fill-rule],
+.c17 *[FILL-RULE],
+.c17 *[fill*='#'],
+.c17 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -3967,18 +3967,13 @@ exports[`List events should apply pagination styling 1`] = `
   min-height: 0;
   flex-direction: row;
   padding: 0px;
+  column-gap: 3px;
 }
 
 .c6 {
   flex: 0 0 auto;
   align-self: stretch;
   height: 6px;
-}
-
-.c14 {
-  flex: 0 0 auto;
-  align-self: stretch;
-  width: 3px;
 }
 
 .c11 {
@@ -4054,7 +4049,7 @@ exports[`List events should apply pagination styling 1`] = `
   border: 0;
 }
 
-.c15 {
+.c14 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -4073,6 +4068,76 @@ exports[`List events should apply pagination styling 1`] = `
   line-height: 24px;
   background-color: rgba(51, 51, 51, 0.06274509803921569);
   color: #444444;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c14:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c14:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c14:focus >circle,
+.c14:focus >ellipse,
+.c14:focus >line,
+.c14:focus >path,
+.c14:focus >polygon,
+.c14:focus >polyline,
+.c14:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c14:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c14:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c14:focus:not(:focus-visible) >circle,
+.c14:focus:not(:focus-visible) >ellipse,
+.c14:focus:not(:focus-visible) >line,
+.c14:focus:not(:focus-visible) >path,
+.c14:focus:not(:focus-visible) >polygon,
+.c14:focus:not(:focus-visible) >polyline,
+.c14:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c14:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c15 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  color: #000000;
   text-align: center;
   transition-property: color,background-color,border-color,box-shadow;
   transition-duration: 0.1s;
@@ -4141,7 +4206,7 @@ exports[`List events should apply pagination styling 1`] = `
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   color: #000000;
   text-align: center;
   transition-property: color,background-color,border-color,box-shadow;
@@ -4151,6 +4216,12 @@ exports[`List events should apply pagination styling 1`] = `
   height: 100%;
   max-width: none;
   flex: 1 0 auto;
+}
+
+.c16 >svg {
+  display: flex;
+  align-self: center;
+  vertical-align: middle;
 }
 
 .c16:hover {
@@ -4194,82 +4265,6 @@ exports[`List events should apply pagination styling 1`] = `
 }
 
 .c16:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c17 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 0;
-  color: #000000;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c17 >svg {
-  display: flex;
-  align-self: center;
-  vertical-align: middle;
-}
-
-.c17:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-}
-
-.c17:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c17:focus >circle,
-.c17:focus >ellipse,
-.c17:focus >line,
-.c17:focus >path,
-.c17:focus >polygon,
-.c17:focus >polyline,
-.c17:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c17:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c17:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c17:focus:not(:focus-visible) >circle,
-.c17:focus:not(:focus-visible) >ellipse,
-.c17:focus:not(:focus-visible) >line,
-.c17:focus:not(:focus-visible) >path,
-.c17:focus:not(:focus-visible) >polygon,
-.c17:focus:not(:focus-visible) >polyline,
-.c17:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c17:focus:not(:focus-visible) ::-moz-focus-inner {
   border: 0;
 }
 
@@ -4361,14 +4356,14 @@ exports[`List events should apply pagination styling 1`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c6 {
-    height: 3px;
+  .c9 {
+    column-gap: 2px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c14 {
-    width: 2px;
+  .c6 {
+    height: 3px;
   }
 }
 
@@ -4670,49 +4665,40 @@ exports[`List events should apply pagination styling 1`] = `
               </svg>
             </button>
           </li>
-          <div
-            class="c14"
-          />
           <li
             class="c10"
           >
             <button
               aria-current="page"
               aria-label="Go to page 1"
-              class="c15 c12"
+              class="c14 c12"
               type="button"
             >
               1
             </button>
           </li>
-          <div
-            class="c14"
-          />
           <li
             class="c10"
           >
             <button
               aria-label="Go to page 2"
-              class="c16 c12"
+              class="c15 c12"
               type="button"
             >
               2
             </button>
           </li>
-          <div
-            class="c14"
-          />
           <li
             class="c10"
           >
             <button
               aria-label="Go to next page"
-              class="c17 c12"
+              class="c16 c12"
               type="button"
             >
               <svg
                 aria-label="Next"
-                class="c18"
+                class="c17"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -4896,7 +4882,7 @@ exports[`List events should paginate 1`] = `
   stroke: none;
 }
 
-.c18 {
+.c17 {
   display: inline-block;
   flex: 0 0 auto;
   width: 24px;
@@ -4905,25 +4891,25 @@ exports[`List events should paginate 1`] = `
   stroke: #000000;
 }
 
-.c18 g {
+.c17 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c18 *:not([stroke])[fill='none'] {
+.c17 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c18 *[stroke*='#'],
-.c18 *[STROKE*='#'] {
+.c17 *[stroke*='#'],
+.c17 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c18 *[fill-rule],
-.c18 *[FILL-RULE],
-.c18 *[fill*='#'],
-.c18 *[FILL*='#'] {
+.c17 *[fill-rule],
+.c17 *[FILL-RULE],
+.c17 *[fill*='#'],
+.c17 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -5009,18 +4995,13 @@ exports[`List events should paginate 1`] = `
   min-height: 0;
   flex-direction: row;
   padding: 0px;
+  column-gap: 3px;
 }
 
 .c6 {
   flex: 0 0 auto;
   align-self: stretch;
   height: 6px;
-}
-
-.c14 {
-  flex: 0 0 auto;
-  align-self: stretch;
-  width: 3px;
 }
 
 .c11 {
@@ -5096,7 +5077,7 @@ exports[`List events should paginate 1`] = `
   border: 0;
 }
 
-.c15 {
+.c14 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -5115,6 +5096,76 @@ exports[`List events should paginate 1`] = `
   line-height: 24px;
   background-color: rgba(51, 51, 51, 0.06274509803921569);
   color: #444444;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c14:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c14:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c14:focus >circle,
+.c14:focus >ellipse,
+.c14:focus >line,
+.c14:focus >path,
+.c14:focus >polygon,
+.c14:focus >polyline,
+.c14:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c14:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c14:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c14:focus:not(:focus-visible) >circle,
+.c14:focus:not(:focus-visible) >ellipse,
+.c14:focus:not(:focus-visible) >line,
+.c14:focus:not(:focus-visible) >path,
+.c14:focus:not(:focus-visible) >polygon,
+.c14:focus:not(:focus-visible) >polyline,
+.c14:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c14:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c15 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  color: #000000;
   text-align: center;
   transition-property: color,background-color,border-color,box-shadow;
   transition-duration: 0.1s;
@@ -5183,7 +5234,7 @@ exports[`List events should paginate 1`] = `
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   color: #000000;
   text-align: center;
   transition-property: color,background-color,border-color,box-shadow;
@@ -5193,6 +5244,12 @@ exports[`List events should paginate 1`] = `
   height: 100%;
   max-width: none;
   flex: 1 0 auto;
+}
+
+.c16 >svg {
+  display: flex;
+  align-self: center;
+  vertical-align: middle;
 }
 
 .c16:hover {
@@ -5236,82 +5293,6 @@ exports[`List events should paginate 1`] = `
 }
 
 .c16:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c17 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 0;
-  color: #000000;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c17 >svg {
-  display: flex;
-  align-self: center;
-  vertical-align: middle;
-}
-
-.c17:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-}
-
-.c17:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c17:focus >circle,
-.c17:focus >ellipse,
-.c17:focus >line,
-.c17:focus >path,
-.c17:focus >polygon,
-.c17:focus >polyline,
-.c17:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c17:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c17:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c17:focus:not(:focus-visible) >circle,
-.c17:focus:not(:focus-visible) >ellipse,
-.c17:focus:not(:focus-visible) >line,
-.c17:focus:not(:focus-visible) >path,
-.c17:focus:not(:focus-visible) >polygon,
-.c17:focus:not(:focus-visible) >polyline,
-.c17:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c17:focus:not(:focus-visible) ::-moz-focus-inner {
   border: 0;
 }
 
@@ -5397,14 +5378,14 @@ exports[`List events should paginate 1`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c6 {
-    height: 3px;
+  .c9 {
+    column-gap: 2px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c14 {
-    width: 2px;
+  .c6 {
+    height: 3px;
   }
 }
 
@@ -5706,49 +5687,40 @@ exports[`List events should paginate 1`] = `
               </svg>
             </button>
           </li>
-          <div
-            class="c14"
-          />
           <li
             class="c10"
           >
             <button
               aria-current="page"
               aria-label="Go to page 1"
-              class="c15 c12"
+              class="c14 c12"
               type="button"
             >
               1
             </button>
           </li>
-          <div
-            class="c14"
-          />
           <li
             class="c10"
           >
             <button
               aria-label="Go to page 2"
-              class="c16 c12"
+              class="c15 c12"
               type="button"
             >
               2
             </button>
           </li>
-          <div
-            class="c14"
-          />
           <li
             class="c10"
           >
             <button
               aria-label="Go to next page"
-              class="c17 c12"
+              class="c16 c12"
               type="button"
             >
               <svg
                 aria-label="Next"
-                class="c18"
+                class="c17"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -5800,7 +5772,7 @@ exports[`List events should render correct num items per page (step) 1`] = `
   stroke: none;
 }
 
-.c18 {
+.c17 {
   display: inline-block;
   flex: 0 0 auto;
   width: 24px;
@@ -5809,25 +5781,25 @@ exports[`List events should render correct num items per page (step) 1`] = `
   stroke: #000000;
 }
 
-.c18 g {
+.c17 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c18 *:not([stroke])[fill='none'] {
+.c17 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c18 *[stroke*='#'],
-.c18 *[STROKE*='#'] {
+.c17 *[stroke*='#'],
+.c17 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c18 *[fill-rule],
-.c18 *[FILL-RULE],
-.c18 *[fill*='#'],
-.c18 *[FILL*='#'] {
+.c17 *[fill-rule],
+.c17 *[FILL-RULE],
+.c17 *[fill*='#'],
+.c17 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -5913,18 +5885,13 @@ exports[`List events should render correct num items per page (step) 1`] = `
   min-height: 0;
   flex-direction: row;
   padding: 0px;
+  column-gap: 3px;
 }
 
 .c6 {
   flex: 0 0 auto;
   align-self: stretch;
   height: 6px;
-}
-
-.c14 {
-  flex: 0 0 auto;
-  align-self: stretch;
-  width: 3px;
 }
 
 .c11 {
@@ -6000,7 +5967,7 @@ exports[`List events should render correct num items per page (step) 1`] = `
   border: 0;
 }
 
-.c15 {
+.c14 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -6019,6 +5986,76 @@ exports[`List events should render correct num items per page (step) 1`] = `
   line-height: 24px;
   background-color: rgba(51, 51, 51, 0.06274509803921569);
   color: #444444;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c14:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c14:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c14:focus >circle,
+.c14:focus >ellipse,
+.c14:focus >line,
+.c14:focus >path,
+.c14:focus >polygon,
+.c14:focus >polyline,
+.c14:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c14:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c14:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c14:focus:not(:focus-visible) >circle,
+.c14:focus:not(:focus-visible) >ellipse,
+.c14:focus:not(:focus-visible) >line,
+.c14:focus:not(:focus-visible) >path,
+.c14:focus:not(:focus-visible) >polygon,
+.c14:focus:not(:focus-visible) >polyline,
+.c14:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c14:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c15 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  color: #000000;
   text-align: center;
   transition-property: color,background-color,border-color,box-shadow;
   transition-duration: 0.1s;
@@ -6087,7 +6124,7 @@ exports[`List events should render correct num items per page (step) 1`] = `
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   color: #000000;
   text-align: center;
   transition-property: color,background-color,border-color,box-shadow;
@@ -6097,6 +6134,12 @@ exports[`List events should render correct num items per page (step) 1`] = `
   height: 100%;
   max-width: none;
   flex: 1 0 auto;
+}
+
+.c16 >svg {
+  display: flex;
+  align-self: center;
+  vertical-align: middle;
 }
 
 .c16:hover {
@@ -6140,82 +6183,6 @@ exports[`List events should render correct num items per page (step) 1`] = `
 }
 
 .c16:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c17 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 0;
-  color: #000000;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c17 >svg {
-  display: flex;
-  align-self: center;
-  vertical-align: middle;
-}
-
-.c17:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-}
-
-.c17:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c17:focus >circle,
-.c17:focus >ellipse,
-.c17:focus >line,
-.c17:focus >path,
-.c17:focus >polygon,
-.c17:focus >polyline,
-.c17:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c17:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c17:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c17:focus:not(:focus-visible) >circle,
-.c17:focus:not(:focus-visible) >ellipse,
-.c17:focus:not(:focus-visible) >line,
-.c17:focus:not(:focus-visible) >path,
-.c17:focus:not(:focus-visible) >polygon,
-.c17:focus:not(:focus-visible) >polyline,
-.c17:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c17:focus:not(:focus-visible) ::-moz-focus-inner {
   border: 0;
 }
 
@@ -6301,14 +6268,14 @@ exports[`List events should render correct num items per page (step) 1`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c6 {
-    height: 3px;
+  .c9 {
+    column-gap: 2px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c14 {
-    width: 2px;
+  .c6 {
+    height: 3px;
   }
 }
 
@@ -6430,119 +6397,95 @@ exports[`List events should render correct num items per page (step) 1`] = `
               </svg>
             </button>
           </li>
-          <div
-            class="c14"
-          />
           <li
             class="c10"
           >
             <button
               aria-current="page"
               aria-label="Go to page 1"
-              class="c15 c12"
+              class="c14 c12"
               type="button"
             >
               1
             </button>
           </li>
-          <div
-            class="c14"
-          />
           <li
             class="c10"
           >
             <button
               aria-label="Go to page 2"
-              class="c16 c12"
+              class="c15 c12"
               type="button"
             >
               2
             </button>
           </li>
-          <div
-            class="c14"
-          />
           <li
             class="c10"
           >
             <button
               aria-label="Go to page 3"
-              class="c16 c12"
+              class="c15 c12"
               type="button"
             >
               3
             </button>
           </li>
-          <div
-            class="c14"
-          />
           <li
             class="c10"
           >
             <button
               aria-label="Go to page 4"
-              class="c16 c12"
+              class="c15 c12"
               type="button"
             >
               4
             </button>
           </li>
-          <div
-            class="c14"
-          />
           <li
             class="c10"
           >
             <button
               aria-label="Go to page 5"
-              class="c16 c12"
+              class="c15 c12"
               type="button"
             >
               5
             </button>
           </li>
-          <div
-            class="c14"
-          />
           <li
             class="c10"
           >
             <button
               aria-label="Go to page 6"
-              class="c16 c12"
+              class="c15 c12"
               type="button"
             >
               6
             </button>
           </li>
-          <div
-            class="c14"
-          />
           <li
             class="c10"
           >
             <button
               aria-label="Go to page 7"
-              class="c16 c12"
+              class="c15 c12"
               type="button"
             >
               7
             </button>
           </li>
-          <div
-            class="c14"
-          />
           <li
             class="c10"
           >
             <button
               aria-label="Go to next page"
-              class="c17 c12"
+              class="c16 c12"
               type="button"
             >
               <svg
                 aria-label="Next"
-                class="c18"
+                class="c17"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -6594,7 +6537,7 @@ exports[`List events should render new data when page changes 1`] = `
   stroke: none;
 }
 
-.c18 {
+.c17 {
   display: inline-block;
   flex: 0 0 auto;
   width: 24px;
@@ -6603,25 +6546,25 @@ exports[`List events should render new data when page changes 1`] = `
   stroke: #000000;
 }
 
-.c18 g {
+.c17 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c18 *:not([stroke])[fill='none'] {
+.c17 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c18 *[stroke*='#'],
-.c18 *[STROKE*='#'] {
+.c17 *[stroke*='#'],
+.c17 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c18 *[fill-rule],
-.c18 *[FILL-RULE],
-.c18 *[fill*='#'],
-.c18 *[FILL*='#'] {
+.c17 *[fill-rule],
+.c17 *[FILL-RULE],
+.c17 *[fill*='#'],
+.c17 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -6707,18 +6650,13 @@ exports[`List events should render new data when page changes 1`] = `
   min-height: 0;
   flex-direction: row;
   padding: 0px;
+  column-gap: 3px;
 }
 
 .c6 {
   flex: 0 0 auto;
   align-self: stretch;
   height: 6px;
-}
-
-.c14 {
-  flex: 0 0 auto;
-  align-self: stretch;
-  width: 3px;
 }
 
 .c11 {
@@ -6794,7 +6732,7 @@ exports[`List events should render new data when page changes 1`] = `
   border: 0;
 }
 
-.c15 {
+.c14 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -6813,6 +6751,76 @@ exports[`List events should render new data when page changes 1`] = `
   line-height: 24px;
   background-color: rgba(51, 51, 51, 0.06274509803921569);
   color: #444444;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c14:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c14:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c14:focus >circle,
+.c14:focus >ellipse,
+.c14:focus >line,
+.c14:focus >path,
+.c14:focus >polygon,
+.c14:focus >polyline,
+.c14:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c14:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c14:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c14:focus:not(:focus-visible) >circle,
+.c14:focus:not(:focus-visible) >ellipse,
+.c14:focus:not(:focus-visible) >line,
+.c14:focus:not(:focus-visible) >path,
+.c14:focus:not(:focus-visible) >polygon,
+.c14:focus:not(:focus-visible) >polyline,
+.c14:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c14:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c15 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  color: #000000;
   text-align: center;
   transition-property: color,background-color,border-color,box-shadow;
   transition-duration: 0.1s;
@@ -6881,7 +6889,7 @@ exports[`List events should render new data when page changes 1`] = `
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   color: #000000;
   text-align: center;
   transition-property: color,background-color,border-color,box-shadow;
@@ -6891,6 +6899,12 @@ exports[`List events should render new data when page changes 1`] = `
   height: 100%;
   max-width: none;
   flex: 1 0 auto;
+}
+
+.c16 >svg {
+  display: flex;
+  align-self: center;
+  vertical-align: middle;
 }
 
 .c16:hover {
@@ -6934,82 +6948,6 @@ exports[`List events should render new data when page changes 1`] = `
 }
 
 .c16:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c17 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 0;
-  color: #000000;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c17 >svg {
-  display: flex;
-  align-self: center;
-  vertical-align: middle;
-}
-
-.c17:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-}
-
-.c17:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c17:focus >circle,
-.c17:focus >ellipse,
-.c17:focus >line,
-.c17:focus >path,
-.c17:focus >polygon,
-.c17:focus >polyline,
-.c17:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c17:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c17:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c17:focus:not(:focus-visible) >circle,
-.c17:focus:not(:focus-visible) >ellipse,
-.c17:focus:not(:focus-visible) >line,
-.c17:focus:not(:focus-visible) >path,
-.c17:focus:not(:focus-visible) >polygon,
-.c17:focus:not(:focus-visible) >polyline,
-.c17:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c17:focus:not(:focus-visible) ::-moz-focus-inner {
   border: 0;
 }
 
@@ -7095,14 +7033,14 @@ exports[`List events should render new data when page changes 1`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c6 {
-    height: 3px;
+  .c9 {
+    column-gap: 2px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c14 {
-    width: 2px;
+  .c6 {
+    height: 3px;
   }
 }
 
@@ -7404,49 +7342,40 @@ exports[`List events should render new data when page changes 1`] = `
               </svg>
             </button>
           </li>
-          <div
-            class="c14"
-          />
           <li
             class="c10"
           >
             <button
               aria-current="page"
               aria-label="Go to page 1"
-              class="c15 c12"
+              class="c14 c12"
               type="button"
             >
               1
             </button>
           </li>
-          <div
-            class="c14"
-          />
           <li
             class="c10"
           >
             <button
               aria-label="Go to page 2"
-              class="c16 c12"
+              class="c15 c12"
               type="button"
             >
               2
             </button>
           </li>
-          <div
-            class="c14"
-          />
           <li
             class="c10"
           >
             <button
               aria-label="Go to next page"
-              class="c17 c12"
+              class="c16 c12"
               type="button"
             >
               <svg
                 aria-label="Next"
-                class="c18"
+                class="c17"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -10730,7 +10659,7 @@ exports[`List events should render new data when page changes 2`] = `
         class="StyledBox-sc-13pk1d4-0 euJJjo"
       >
         <ul
-          class="StyledBox-sc-13pk1d4-0 kOcABF"
+          class="StyledBox-sc-13pk1d4-0 gkMlIT"
         >
           <li
             class="StyledPageControl__StyledContainer-sc-1vlfaez-1 bjXWCk"
@@ -10754,9 +10683,6 @@ exports[`List events should render new data when page changes 2`] = `
               </svg>
             </button>
           </li>
-          <div
-            class="StyledBox__StyledBoxGap-sc-13pk1d4-1 fsEMPj"
-          />
           <li
             class="StyledPageControl__StyledContainer-sc-1vlfaez-1 bjXWCk"
           >
@@ -10768,9 +10694,6 @@ exports[`List events should render new data when page changes 2`] = `
               1
             </button>
           </li>
-          <div
-            class="StyledBox__StyledBoxGap-sc-13pk1d4-1 fsEMPj"
-          />
           <li
             class="StyledPageControl__StyledContainer-sc-1vlfaez-1 bjXWCk"
           >
@@ -10783,9 +10706,6 @@ exports[`List events should render new data when page changes 2`] = `
               2
             </button>
           </li>
-          <div
-            class="StyledBox__StyledBoxGap-sc-13pk1d4-1 fsEMPj"
-          />
           <li
             class="StyledPageControl__StyledContainer-sc-1vlfaez-1 bjXWCk"
           >
@@ -10850,7 +10770,7 @@ exports[`List events should show correct item index when "show" is a number 1`] 
   stroke: none;
 }
 
-.c18 {
+.c17 {
   display: inline-block;
   flex: 0 0 auto;
   width: 24px;
@@ -10859,25 +10779,25 @@ exports[`List events should show correct item index when "show" is a number 1`] 
   stroke: #000000;
 }
 
-.c18 g {
+.c17 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c18 *:not([stroke])[fill='none'] {
+.c17 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c18 *[stroke*='#'],
-.c18 *[STROKE*='#'] {
+.c17 *[stroke*='#'],
+.c17 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c18 *[fill-rule],
-.c18 *[FILL-RULE],
-.c18 *[fill*='#'],
-.c18 *[FILL*='#'] {
+.c17 *[fill-rule],
+.c17 *[FILL-RULE],
+.c17 *[fill*='#'],
+.c17 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -10963,18 +10883,13 @@ exports[`List events should show correct item index when "show" is a number 1`] 
   min-height: 0;
   flex-direction: row;
   padding: 0px;
+  column-gap: 3px;
 }
 
 .c6 {
   flex: 0 0 auto;
   align-self: stretch;
   height: 6px;
-}
-
-.c14 {
-  flex: 0 0 auto;
-  align-self: stretch;
-  width: 3px;
 }
 
 .c11 {
@@ -11050,7 +10965,7 @@ exports[`List events should show correct item index when "show" is a number 1`] 
   border: 0;
 }
 
-.c15 {
+.c14 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -11069,6 +10984,76 @@ exports[`List events should show correct item index when "show" is a number 1`] 
   line-height: 24px;
   background-color: rgba(51, 51, 51, 0.06274509803921569);
   color: #444444;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c14:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c14:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c14:focus >circle,
+.c14:focus >ellipse,
+.c14:focus >line,
+.c14:focus >path,
+.c14:focus >polygon,
+.c14:focus >polyline,
+.c14:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c14:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c14:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c14:focus:not(:focus-visible) >circle,
+.c14:focus:not(:focus-visible) >ellipse,
+.c14:focus:not(:focus-visible) >line,
+.c14:focus:not(:focus-visible) >path,
+.c14:focus:not(:focus-visible) >polygon,
+.c14:focus:not(:focus-visible) >polyline,
+.c14:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c14:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c15 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  color: #000000;
   text-align: center;
   transition-property: color,background-color,border-color,box-shadow;
   transition-duration: 0.1s;
@@ -11137,7 +11122,7 @@ exports[`List events should show correct item index when "show" is a number 1`] 
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   color: #000000;
   text-align: center;
   transition-property: color,background-color,border-color,box-shadow;
@@ -11147,6 +11132,12 @@ exports[`List events should show correct item index when "show" is a number 1`] 
   height: 100%;
   max-width: none;
   flex: 1 0 auto;
+}
+
+.c16 >svg {
+  display: flex;
+  align-self: center;
+  vertical-align: middle;
 }
 
 .c16:hover {
@@ -11190,82 +11181,6 @@ exports[`List events should show correct item index when "show" is a number 1`] 
 }
 
 .c16:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c17 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 0;
-  color: #000000;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c17 >svg {
-  display: flex;
-  align-self: center;
-  vertical-align: middle;
-}
-
-.c17:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-}
-
-.c17:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c17:focus >circle,
-.c17:focus >ellipse,
-.c17:focus >line,
-.c17:focus >path,
-.c17:focus >polygon,
-.c17:focus >polyline,
-.c17:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c17:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c17:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c17:focus:not(:focus-visible) >circle,
-.c17:focus:not(:focus-visible) >ellipse,
-.c17:focus:not(:focus-visible) >line,
-.c17:focus:not(:focus-visible) >path,
-.c17:focus:not(:focus-visible) >polygon,
-.c17:focus:not(:focus-visible) >polyline,
-.c17:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c17:focus:not(:focus-visible) ::-moz-focus-inner {
   border: 0;
 }
 
@@ -11351,14 +11266,14 @@ exports[`List events should show correct item index when "show" is a number 1`] 
 }
 
 @media only screen and (max-width: 768px) {
-  .c6 {
-    height: 3px;
+  .c9 {
+    column-gap: 2px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c14 {
-    width: 2px;
+  .c6 {
+    height: 3px;
   }
 }
 
@@ -11660,49 +11575,40 @@ exports[`List events should show correct item index when "show" is a number 1`] 
               </svg>
             </button>
           </li>
-          <div
-            class="c14"
-          />
           <li
             class="c10"
           >
             <button
               aria-current="page"
               aria-label="Go to page 1"
-              class="c15 c12"
+              class="c14 c12"
               type="button"
             >
               1
             </button>
           </li>
-          <div
-            class="c14"
-          />
           <li
             class="c10"
           >
             <button
               aria-label="Go to page 2"
-              class="c16 c12"
+              class="c15 c12"
               type="button"
             >
               2
             </button>
           </li>
-          <div
-            class="c14"
-          />
           <li
             class="c10"
           >
             <button
               aria-label="Go to next page"
-              class="c17 c12"
+              class="c16 c12"
               type="button"
             >
               <svg
                 aria-label="Next"
-                class="c18"
+                class="c17"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -11754,7 +11660,7 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
   stroke: none;
 }
 
-.c18 {
+.c17 {
   display: inline-block;
   flex: 0 0 auto;
   width: 24px;
@@ -11763,25 +11669,25 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
   stroke: #666666;
 }
 
-.c18 g {
+.c17 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c18 *:not([stroke])[fill='none'] {
+.c17 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c18 *[stroke*='#'],
-.c18 *[STROKE*='#'] {
+.c17 *[stroke*='#'],
+.c17 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c18 *[fill-rule],
-.c18 *[FILL-RULE],
-.c18 *[fill*='#'],
-.c18 *[FILL*='#'] {
+.c17 *[fill-rule],
+.c17 *[FILL-RULE],
+.c17 *[fill*='#'],
+.c17 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -11867,18 +11773,13 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
   min-height: 0;
   flex-direction: row;
   padding: 0px;
+  column-gap: 3px;
 }
 
 .c6 {
   flex: 0 0 auto;
   align-self: stretch;
   height: 6px;
-}
-
-.c14 {
-  flex: 0 0 auto;
-  align-self: stretch;
-  width: 3px;
 }
 
 .c11 {
@@ -11957,7 +11858,7 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
   border: 0;
 }
 
-.c15 {
+.c14 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -11973,6 +11874,79 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
   font-size: 18px;
   line-height: 24px;
   color: #000000;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c14:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c14:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c14:focus >circle,
+.c14:focus >ellipse,
+.c14:focus >line,
+.c14:focus >path,
+.c14:focus >polygon,
+.c14:focus >polyline,
+.c14:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c14:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c14:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c14:focus:not(:focus-visible) >circle,
+.c14:focus:not(:focus-visible) >ellipse,
+.c14:focus:not(:focus-visible) >line,
+.c14:focus:not(:focus-visible) >path,
+.c14:focus:not(:focus-visible) >polygon,
+.c14:focus:not(:focus-visible) >polyline,
+.c14:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c14:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c15 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  background-color: rgba(221, 221, 221, 0.4);
+  color: #000000;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+  color: #444444;
   text-align: center;
   transition-property: color,background-color,border-color,box-shadow;
   transition-duration: 0.1s;
@@ -12037,16 +12011,14 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
   background: transparent;
   overflow: visible;
   text-transform: none;
-  background-color: rgba(221, 221, 221, 0.4);
-  color: #000000;
   border: none;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-  color: #444444;
+  line-height: 0;
   text-align: center;
+  opacity: 0.3;
+  cursor: default;
   transition-property: color,background-color,border-color,box-shadow;
   transition-duration: 0.1s;
   transition-timing-function: ease-in-out;
@@ -12056,8 +12028,10 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
   flex: 1 0 auto;
 }
 
-.c16:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
+.c16 >svg {
+  display: flex;
+  align-self: center;
+  vertical-align: middle;
 }
 
 .c16:focus {
@@ -12097,79 +12071,6 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
 }
 
 .c16:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c17 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 0;
-  text-align: center;
-  opacity: 0.3;
-  cursor: default;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c17 >svg {
-  display: flex;
-  align-self: center;
-  vertical-align: middle;
-}
-
-.c17:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c17:focus >circle,
-.c17:focus >ellipse,
-.c17:focus >line,
-.c17:focus >path,
-.c17:focus >polygon,
-.c17:focus >polyline,
-.c17:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c17:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c17:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c17:focus:not(:focus-visible) >circle,
-.c17:focus:not(:focus-visible) >ellipse,
-.c17:focus:not(:focus-visible) >line,
-.c17:focus:not(:focus-visible) >path,
-.c17:focus:not(:focus-visible) >polygon,
-.c17:focus:not(:focus-visible) >polyline,
-.c17:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c17:focus:not(:focus-visible) ::-moz-focus-inner {
   border: 0;
 }
 
@@ -12255,14 +12156,14 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c6 {
-    height: 3px;
+  .c9 {
+    column-gap: 2px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c14 {
-    width: 2px;
+  .c6 {
+    height: 3px;
   }
 }
 
@@ -12537,51 +12438,42 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
               </svg>
             </button>
           </li>
-          <div
-            class="c14"
-          />
           <li
             class="c10"
           >
             <button
               aria-label="Go to page 1"
-              class="c15 c12"
+              class="c14 c12"
               type="button"
             >
               1
             </button>
           </li>
-          <div
-            class="c14"
-          />
           <li
             class="c10"
           >
             <button
               aria-current="page"
               aria-label="Go to page 2"
-              class="c16 c12"
+              class="c15 c12"
               type="button"
             >
               2
             </button>
           </li>
-          <div
-            class="c14"
-          />
           <li
             class="c10"
           >
             <button
               aria-disabled="true"
               aria-label="Go to next page"
-              class="c17 c12"
+              class="c16 c12"
               disabled=""
               type="button"
             >
               <svg
                 aria-label="Next"
-                class="c18"
+                class="c17"
                 viewBox="0 0 24 24"
               >
                 <path

--- a/src/js/components/Pagination/Pagination.js
+++ b/src/js/components/Pagination/Pagination.js
@@ -213,7 +213,7 @@ const Pagination = forwardRef(
         a11yTitle={ariaLabel || a11yTitle || 'Pagination Navigation'}
         ref={ref}
       >
-        <Box as="ul" {...theme.pagination.controls}>
+        <Box as="ul" {...theme.pagination.controls} cssGap>
           {controls.map((control, index) => (
             /* Using index as key (as opposed to a unique id) seems to
              * help React prioritize rendering the updated controls as

--- a/src/js/components/Pagination/__tests__/__snapshots__/Pagination-test.tsx.snap
+++ b/src/js/components/Pagination/__tests__/__snapshots__/Pagination-test.tsx.snap
@@ -64,20 +64,15 @@ exports[`Pagination should allow user to control page via state with page +
   min-height: 0;
   flex-direction: row;
   padding: 0px;
+  column-gap: 3px;
 }
 
-.c7 {
-  flex: 0 0 auto;
-  align-self: stretch;
-  width: 3px;
-}
-
-.c10 {
+.c9 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c9 {
+.c8 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -96,76 +91,6 @@ exports[`Pagination should allow user to control page via state with page +
   line-height: 24px;
   background-color: rgba(51, 51, 51, 0.06274509803921569);
   color: #444444;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c9:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-}
-
-.c9:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c9:focus >circle,
-.c9:focus >ellipse,
-.c9:focus >line,
-.c9:focus >path,
-.c9:focus >polygon,
-.c9:focus >polyline,
-.c9:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c9:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c9:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c9:focus:not(:focus-visible) >circle,
-.c9:focus:not(:focus-visible) >ellipse,
-.c9:focus:not(:focus-visible) >line,
-.c9:focus:not(:focus-visible) >path,
-.c9:focus:not(:focus-visible) >polygon,
-.c9:focus:not(:focus-visible) >polyline,
-.c9:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c9:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c8 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 24px;
-  color: #000000;
   text-align: center;
   transition-property: color,background-color,border-color,box-shadow;
   transition-duration: 0.1s;
@@ -217,6 +142,76 @@ exports[`Pagination should allow user to control page via state with page +
 }
 
 .c8:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c7 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  color: #000000;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c7:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c7:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c7:focus >circle,
+.c7:focus >ellipse,
+.c7:focus >line,
+.c7:focus >path,
+.c7:focus >polygon,
+.c7:focus >polyline,
+.c7:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c7:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c7:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c7:focus:not(:focus-visible) >circle,
+.c7:focus:not(:focus-visible) >ellipse,
+.c7:focus:not(:focus-visible) >line,
+.c7:focus:not(:focus-visible) >path,
+.c7:focus:not(:focus-visible) >polygon,
+.c7:focus:not(:focus-visible) >polyline,
+.c7:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c7:focus:not(:focus-visible) ::-moz-focus-inner {
   border: 0;
 }
 
@@ -314,7 +309,7 @@ exports[`Pagination should allow user to control page via state with page +
   min-width: 36px;
 }
 
-.c11 {
+.c10 {
   font-weight: bold;
   font-size: 18px;
   line-height: 0;
@@ -333,8 +328,8 @@ exports[`Pagination should allow user to control page via state with page +
 }
 
 @media only screen and (max-width: 768px) {
-  .c7 {
-    width: 2px;
+  .c2 {
+    column-gap: 2px;
   }
 }
 
@@ -373,106 +368,82 @@ exports[`Pagination should allow user to control page via state with page +
             </svg>
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <button
             aria-label="Go to page 1"
-            class="c8 c5"
+            class="c7 c5"
             type="button"
           >
             1
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <button
             aria-current="page"
             aria-label="Go to page 2"
-            class="c9 c5"
+            class="c8 c5"
             type="button"
           >
             2
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <button
             aria-label="Go to page 3"
-            class="c8 c5"
+            class="c7 c5"
             type="button"
           >
             3
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <button
             aria-label="Go to page 4"
-            class="c8 c5"
+            class="c7 c5"
             type="button"
           >
             4
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <button
             aria-label="Go to page 5"
-            class="c8 c5"
+            class="c7 c5"
             type="button"
           >
             5
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <span
-            class="c10 c11"
+            class="c9 c10"
           >
             …
           </span>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <button
             aria-label="Go to page 24"
-            class="c8 c5"
+            class="c7 c5"
             type="button"
           >
             24
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
@@ -535,7 +506,7 @@ exports[`Pagination should apply a text component with summary 1`] = `
   stroke: none;
 }
 
-.c17 {
+.c16 {
   display: inline-block;
   flex: 0 0 auto;
   width: 24px;
@@ -544,25 +515,25 @@ exports[`Pagination should apply a text component with summary 1`] = `
   stroke: #000000;
 }
 
-.c17 g {
+.c16 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c17 *:not([stroke])[fill='none'] {
+.c16 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c17 *[stroke*='#'],
-.c17 *[STROKE*='#'] {
+.c16 *[stroke*='#'],
+.c16 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c17 *[fill-rule],
-.c17 *[FILL-RULE],
-.c17 *[fill*='#'],
-.c17 *[FILL*='#'] {
+.c16 *[fill-rule],
+.c16 *[FILL-RULE],
+.c16 *[fill*='#'],
+.c16 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -641,12 +612,7 @@ exports[`Pagination should apply a text component with summary 1`] = `
   min-height: 0;
   flex-direction: row;
   padding: 0px;
-}
-
-.c12 {
-  flex: 0 0 auto;
-  align-self: stretch;
-  width: 3px;
+  column-gap: 3px;
 }
 
 .c4 {
@@ -727,7 +693,7 @@ exports[`Pagination should apply a text component with summary 1`] = `
   border: 0;
 }
 
-.c13 {
+.c12 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -746,6 +712,76 @@ exports[`Pagination should apply a text component with summary 1`] = `
   line-height: 24px;
   background-color: rgba(51, 51, 51, 0.06274509803921569);
   color: #444444;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c12:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c12:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c12:focus >circle,
+.c12:focus >ellipse,
+.c12:focus >line,
+.c12:focus >path,
+.c12:focus >polygon,
+.c12:focus >polyline,
+.c12:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c12:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c12:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c12:focus:not(:focus-visible) >circle,
+.c12:focus:not(:focus-visible) >ellipse,
+.c12:focus:not(:focus-visible) >line,
+.c12:focus:not(:focus-visible) >path,
+.c12:focus:not(:focus-visible) >polygon,
+.c12:focus:not(:focus-visible) >polyline,
+.c12:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c12:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c13 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  color: #000000;
   text-align: center;
   transition-property: color,background-color,border-color,box-shadow;
   transition-duration: 0.1s;
@@ -800,77 +836,7 @@ exports[`Pagination should apply a text component with summary 1`] = `
   border: 0;
 }
 
-.c14 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 24px;
-  color: #000000;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c14:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-}
-
-.c14:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c14:focus >circle,
-.c14:focus >ellipse,
-.c14:focus >line,
-.c14:focus >path,
-.c14:focus >polygon,
-.c14:focus >polyline,
-.c14:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c14:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c14:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c14:focus:not(:focus-visible) >circle,
-.c14:focus:not(:focus-visible) >ellipse,
-.c14:focus:not(:focus-visible) >line,
-.c14:focus:not(:focus-visible) >path,
-.c14:focus:not(:focus-visible) >polygon,
-.c14:focus:not(:focus-visible) >polyline,
-.c14:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c14:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c16 {
+.c15 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -896,53 +862,53 @@ exports[`Pagination should apply a text component with summary 1`] = `
   flex: 1 0 auto;
 }
 
-.c16 >svg {
+.c15 >svg {
   display: flex;
   align-self: center;
   vertical-align: middle;
 }
 
-.c16:hover {
+.c15:hover {
   background-color: rgba(51, 51, 51, 0.06274509803921569);
 }
 
-.c16:focus {
+.c15:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c16:focus >circle,
-.c16:focus >ellipse,
-.c16:focus >line,
-.c16:focus >path,
-.c16:focus >polygon,
-.c16:focus >polyline,
-.c16:focus >rect {
+.c15:focus >circle,
+.c15:focus >ellipse,
+.c15:focus >line,
+.c15:focus >path,
+.c15:focus >polygon,
+.c15:focus >polyline,
+.c15:focus >rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c16:focus ::-moz-focus-inner {
+.c15:focus ::-moz-focus-inner {
   border: 0;
 }
 
-.c16:focus:not(:focus-visible) {
+.c15:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c16:focus:not(:focus-visible) >circle,
-.c16:focus:not(:focus-visible) >ellipse,
-.c16:focus:not(:focus-visible) >line,
-.c16:focus:not(:focus-visible) >path,
-.c16:focus:not(:focus-visible) >polygon,
-.c16:focus:not(:focus-visible) >polyline,
-.c16:focus:not(:focus-visible) >rect {
+.c15:focus:not(:focus-visible) >circle,
+.c15:focus:not(:focus-visible) >ellipse,
+.c15:focus:not(:focus-visible) >line,
+.c15:focus:not(:focus-visible) >path,
+.c15:focus:not(:focus-visible) >polygon,
+.c15:focus:not(:focus-visible) >polyline,
+.c15:focus:not(:focus-visible) >rect {
   outline: none;
   box-shadow: none;
 }
 
-.c16:focus:not(:focus-visible) ::-moz-focus-inner {
+.c15:focus:not(:focus-visible) ::-moz-focus-inner {
   border: 0;
 }
 
@@ -964,7 +930,7 @@ exports[`Pagination should apply a text component with summary 1`] = `
   min-width: 36px;
 }
 
-.c15 {
+.c14 {
   font-weight: bold;
   font-size: 18px;
   line-height: 0;
@@ -983,8 +949,8 @@ exports[`Pagination should apply a text component with summary 1`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c12 {
-    width: 2px;
+  .c7 {
+    column-gap: 2px;
   }
 }
 
@@ -1041,117 +1007,93 @@ exports[`Pagination should apply a text component with summary 1`] = `
                 </svg>
               </button>
             </li>
-            <div
-              class="c12"
-            />
             <li
               class="c8"
             >
               <button
                 aria-current="page"
                 aria-label="Go to page 1"
-                class="c13 c10"
+                class="c12 c10"
                 type="button"
               >
                 1
               </button>
             </li>
-            <div
-              class="c12"
-            />
             <li
               class="c8"
             >
               <button
                 aria-label="Go to page 2"
-                class="c14 c10"
+                class="c13 c10"
                 type="button"
               >
                 2
               </button>
             </li>
-            <div
-              class="c12"
-            />
             <li
               class="c8"
             >
               <button
                 aria-label="Go to page 3"
-                class="c14 c10"
+                class="c13 c10"
                 type="button"
               >
                 3
               </button>
             </li>
-            <div
-              class="c12"
-            />
             <li
               class="c8"
             >
               <button
                 aria-label="Go to page 4"
-                class="c14 c10"
+                class="c13 c10"
                 type="button"
               >
                 4
               </button>
             </li>
-            <div
-              class="c12"
-            />
             <li
               class="c8"
             >
               <button
                 aria-label="Go to page 5"
-                class="c14 c10"
+                class="c13 c10"
                 type="button"
               >
                 5
               </button>
             </li>
-            <div
-              class="c12"
-            />
             <li
               class="c8"
             >
               <span
-                class="c4 c15"
+                class="c4 c14"
               >
                 …
               </span>
             </li>
-            <div
-              class="c12"
-            />
             <li
               class="c8"
             >
               <button
                 aria-label="Go to page 24"
-                class="c14 c10"
+                class="c13 c10"
                 type="button"
               >
                 24
               </button>
             </li>
-            <div
-              class="c12"
-            />
             <li
               class="c8"
             >
               <button
                 aria-label="Go to next page"
-                class="c16 c10"
+                class="c15 c10"
                 type="button"
               >
                 <svg
                   aria-label="Next"
-                  class="c17"
+                  class="c16"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -1204,7 +1146,7 @@ exports[`Pagination should apply a11yTitle and aria-label 1`] = `
   stroke: none;
 }
 
-.c13 {
+.c12 {
   display: inline-block;
   flex: 0 0 auto;
   width: 24px;
@@ -1213,25 +1155,25 @@ exports[`Pagination should apply a11yTitle and aria-label 1`] = `
   stroke: #000000;
 }
 
-.c13 g {
+.c12 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c13 *:not([stroke])[fill='none'] {
+.c12 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c13 *[stroke*='#'],
-.c13 *[STROKE*='#'] {
+.c12 *[stroke*='#'],
+.c12 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c13 *[fill-rule],
-.c13 *[FILL-RULE],
-.c13 *[fill*='#'],
-.c13 *[FILL*='#'] {
+.c12 *[fill-rule],
+.c12 *[FILL-RULE],
+.c12 *[fill*='#'],
+.c12 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -1266,15 +1208,10 @@ exports[`Pagination should apply a11yTitle and aria-label 1`] = `
   min-height: 0;
   flex-direction: row;
   padding: 0px;
+  column-gap: 3px;
 }
 
-.c7 {
-  flex: 0 0 auto;
-  align-self: stretch;
-  width: 3px;
-}
-
-.c10 {
+.c9 {
   font-size: 18px;
   line-height: 24px;
 }
@@ -1352,7 +1289,7 @@ exports[`Pagination should apply a11yTitle and aria-label 1`] = `
   border: 0;
 }
 
-.c8 {
+.c7 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -1371,6 +1308,76 @@ exports[`Pagination should apply a11yTitle and aria-label 1`] = `
   line-height: 24px;
   background-color: rgba(51, 51, 51, 0.06274509803921569);
   color: #444444;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c7:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c7:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c7:focus >circle,
+.c7:focus >ellipse,
+.c7:focus >line,
+.c7:focus >path,
+.c7:focus >polygon,
+.c7:focus >polyline,
+.c7:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c7:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c7:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c7:focus:not(:focus-visible) >circle,
+.c7:focus:not(:focus-visible) >ellipse,
+.c7:focus:not(:focus-visible) >line,
+.c7:focus:not(:focus-visible) >path,
+.c7:focus:not(:focus-visible) >polygon,
+.c7:focus:not(:focus-visible) >polyline,
+.c7:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c7:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c8 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  color: #000000;
   text-align: center;
   transition-property: color,background-color,border-color,box-shadow;
   transition-duration: 0.1s;
@@ -1425,77 +1432,7 @@ exports[`Pagination should apply a11yTitle and aria-label 1`] = `
   border: 0;
 }
 
-.c9 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 24px;
-  color: #000000;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c9:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-}
-
-.c9:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c9:focus >circle,
-.c9:focus >ellipse,
-.c9:focus >line,
-.c9:focus >path,
-.c9:focus >polygon,
-.c9:focus >polyline,
-.c9:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c9:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c9:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c9:focus:not(:focus-visible) >circle,
-.c9:focus:not(:focus-visible) >ellipse,
-.c9:focus:not(:focus-visible) >line,
-.c9:focus:not(:focus-visible) >path,
-.c9:focus:not(:focus-visible) >polygon,
-.c9:focus:not(:focus-visible) >polyline,
-.c9:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c9:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c12 {
+.c11 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -1521,53 +1458,53 @@ exports[`Pagination should apply a11yTitle and aria-label 1`] = `
   flex: 1 0 auto;
 }
 
-.c12 >svg {
+.c11 >svg {
   display: flex;
   align-self: center;
   vertical-align: middle;
 }
 
-.c12:hover {
+.c11:hover {
   background-color: rgba(51, 51, 51, 0.06274509803921569);
 }
 
-.c12:focus {
+.c11:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus >circle,
-.c12:focus >ellipse,
-.c12:focus >line,
-.c12:focus >path,
-.c12:focus >polygon,
-.c12:focus >polyline,
-.c12:focus >rect {
+.c11:focus >circle,
+.c11:focus >ellipse,
+.c11:focus >line,
+.c11:focus >path,
+.c11:focus >polygon,
+.c11:focus >polyline,
+.c11:focus >rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus ::-moz-focus-inner {
+.c11:focus ::-moz-focus-inner {
   border: 0;
 }
 
-.c12:focus:not(:focus-visible) {
+.c11:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible) >circle,
-.c12:focus:not(:focus-visible) >ellipse,
-.c12:focus:not(:focus-visible) >line,
-.c12:focus:not(:focus-visible) >path,
-.c12:focus:not(:focus-visible) >polygon,
-.c12:focus:not(:focus-visible) >polyline,
-.c12:focus:not(:focus-visible) >rect {
+.c11:focus:not(:focus-visible) >circle,
+.c11:focus:not(:focus-visible) >ellipse,
+.c11:focus:not(:focus-visible) >line,
+.c11:focus:not(:focus-visible) >path,
+.c11:focus:not(:focus-visible) >polygon,
+.c11:focus:not(:focus-visible) >polyline,
+.c11:focus:not(:focus-visible) >rect {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible) ::-moz-focus-inner {
+.c11:focus:not(:focus-visible) ::-moz-focus-inner {
   border: 0;
 }
 
@@ -1589,7 +1526,7 @@ exports[`Pagination should apply a11yTitle and aria-label 1`] = `
   min-width: 36px;
 }
 
-.c11 {
+.c10 {
   font-weight: bold;
   font-size: 18px;
   line-height: 0;
@@ -1608,8 +1545,8 @@ exports[`Pagination should apply a11yTitle and aria-label 1`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c7 {
-    width: 2px;
+  .c2 {
+    column-gap: 2px;
   }
 }
 
@@ -1650,117 +1587,93 @@ exports[`Pagination should apply a11yTitle and aria-label 1`] = `
             </svg>
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <button
             aria-current="page"
             aria-label="Go to page 1"
-            class="c8 c5"
+            class="c7 c5"
             type="button"
           >
             1
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <button
             aria-label="Go to page 2"
-            class="c9 c5"
+            class="c8 c5"
             type="button"
           >
             2
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <button
             aria-label="Go to page 3"
-            class="c9 c5"
+            class="c8 c5"
             type="button"
           >
             3
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <button
             aria-label="Go to page 4"
-            class="c9 c5"
+            class="c8 c5"
             type="button"
           >
             4
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <button
             aria-label="Go to page 5"
-            class="c9 c5"
+            class="c8 c5"
             type="button"
           >
             5
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <span
-            class="c10 c11"
+            class="c9 c10"
           >
             …
           </span>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <button
             aria-label="Go to page 24"
-            class="c9 c5"
+            class="c8 c5"
             type="button"
           >
             24
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <button
             aria-label="Go to next page"
-            class="c12 c5"
+            class="c11 c5"
             type="button"
           >
             <svg
               aria-label="Next"
-              class="c13"
+              class="c12"
               viewBox="0 0 24 24"
             >
               <path
@@ -1809,117 +1722,93 @@ exports[`Pagination should apply a11yTitle and aria-label 1`] = `
             </svg>
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <button
             aria-current="page"
             aria-label="Go to page 1"
-            class="c8 c5"
+            class="c7 c5"
             type="button"
           >
             1
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <button
             aria-label="Go to page 2"
-            class="c9 c5"
+            class="c8 c5"
             type="button"
           >
             2
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <button
             aria-label="Go to page 3"
-            class="c9 c5"
+            class="c8 c5"
             type="button"
           >
             3
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <button
             aria-label="Go to page 4"
-            class="c9 c5"
+            class="c8 c5"
             type="button"
           >
             4
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <button
             aria-label="Go to page 5"
-            class="c9 c5"
+            class="c8 c5"
             type="button"
           >
             5
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <span
-            class="c10 c11"
+            class="c9 c10"
           >
             …
           </span>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <button
             aria-label="Go to page 24"
-            class="c9 c5"
+            class="c8 c5"
             type="button"
           >
             24
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <button
             aria-label="Go to next page"
-            class="c12 c5"
+            class="c11 c5"
             type="button"
           >
             <svg
               aria-label="Next"
-              class="c13"
+              class="c12"
               viewBox="0 0 24 24"
             >
               <path
@@ -2000,15 +1889,10 @@ exports[`Pagination should apply button kind style when referenced by a string 1
   min-height: 0;
   flex-direction: row;
   padding: 0px;
+  column-gap: 3px;
 }
 
-.c7 {
-  flex: 0 0 auto;
-  align-self: stretch;
-  width: 3px;
-}
-
-.c10 {
+.c9 {
   font-size: 18px;
   line-height: 24px;
 }
@@ -2092,7 +1976,7 @@ exports[`Pagination should apply button kind style when referenced by a string 1
   border: 0;
 }
 
-.c8 {
+.c7 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -2119,6 +2003,76 @@ exports[`Pagination should apply button kind style when referenced by a string 1
   background-color: rgba(202, 156, 234, 1);
   color: #444444;
   border-color: transparent;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c7:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c7:focus >circle,
+.c7:focus >ellipse,
+.c7:focus >line,
+.c7:focus >path,
+.c7:focus >polygon,
+.c7:focus >polyline,
+.c7:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c7:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c7:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c7:focus:not(:focus-visible) >circle,
+.c7:focus:not(:focus-visible) >ellipse,
+.c7:focus:not(:focus-visible) >line,
+.c7:focus:not(:focus-visible) >path,
+.c7:focus:not(:focus-visible) >polygon,
+.c7:focus:not(:focus-visible) >polyline,
+.c7:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c7:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c8 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 18px;
+  padding: 4px 22px;
+  font-size: 18px;
+  line-height: 24px;
+  color: #000000;
+  border-style: solid;
+  border-width: 2px;
+  border-color: skyblue;
+  padding: 2px 20px;
   text-align: center;
   transition-property: color,background-color,border-color,box-shadow;
   transition-duration: 0.1s;
@@ -2169,77 +2123,7 @@ exports[`Pagination should apply button kind style when referenced by a string 1
   border: 0;
 }
 
-.c9 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 18px;
-  padding: 4px 22px;
-  font-size: 18px;
-  line-height: 24px;
-  color: #000000;
-  border-style: solid;
-  border-width: 2px;
-  border-color: skyblue;
-  padding: 2px 20px;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c9:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c9:focus >circle,
-.c9:focus >ellipse,
-.c9:focus >line,
-.c9:focus >path,
-.c9:focus >polygon,
-.c9:focus >polyline,
-.c9:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c9:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c9:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c9:focus:not(:focus-visible) >circle,
-.c9:focus:not(:focus-visible) >ellipse,
-.c9:focus:not(:focus-visible) >line,
-.c9:focus:not(:focus-visible) >path,
-.c9:focus:not(:focus-visible) >polygon,
-.c9:focus:not(:focus-visible) >polyline,
-.c9:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c9:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c12 {
+.c11 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -2269,49 +2153,49 @@ exports[`Pagination should apply button kind style when referenced by a string 1
   flex: 1 0 auto;
 }
 
-.c12 >svg {
+.c11 >svg {
   display: flex;
   align-self: center;
   vertical-align: middle;
 }
 
-.c12:focus {
+.c11:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus >circle,
-.c12:focus >ellipse,
-.c12:focus >line,
-.c12:focus >path,
-.c12:focus >polygon,
-.c12:focus >polyline,
-.c12:focus >rect {
+.c11:focus >circle,
+.c11:focus >ellipse,
+.c11:focus >line,
+.c11:focus >path,
+.c11:focus >polygon,
+.c11:focus >polyline,
+.c11:focus >rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus ::-moz-focus-inner {
+.c11:focus ::-moz-focus-inner {
   border: 0;
 }
 
-.c12:focus:not(:focus-visible) {
+.c11:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible) >circle,
-.c12:focus:not(:focus-visible) >ellipse,
-.c12:focus:not(:focus-visible) >line,
-.c12:focus:not(:focus-visible) >path,
-.c12:focus:not(:focus-visible) >polygon,
-.c12:focus:not(:focus-visible) >polyline,
-.c12:focus:not(:focus-visible) >rect {
+.c11:focus:not(:focus-visible) >circle,
+.c11:focus:not(:focus-visible) >ellipse,
+.c11:focus:not(:focus-visible) >line,
+.c11:focus:not(:focus-visible) >path,
+.c11:focus:not(:focus-visible) >polygon,
+.c11:focus:not(:focus-visible) >polyline,
+.c11:focus:not(:focus-visible) >rect {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible) ::-moz-focus-inner {
+.c11:focus:not(:focus-visible) ::-moz-focus-inner {
   border: 0;
 }
 
@@ -2326,7 +2210,7 @@ exports[`Pagination should apply button kind style when referenced by a string 1
   max-width: 100%;
 }
 
-.c11 {
+.c10 {
   font-weight: bold;
   font-size: undefined;
   line-height: undefined;
@@ -2345,8 +2229,8 @@ exports[`Pagination should apply button kind style when referenced by a string 1
 }
 
 @media only screen and (max-width: 768px) {
-  .c7 {
-    width: 2px;
+  .c2 {
+    column-gap: 2px;
   }
 }
 
@@ -2387,112 +2271,88 @@ exports[`Pagination should apply button kind style when referenced by a string 1
             </svg>
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <button
             aria-current="page"
             aria-label="Go to page 1"
-            class="c8 c5"
+            class="c7 c5"
             type="button"
           >
             1
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <button
             aria-label="Go to page 2"
-            class="c9 c5"
+            class="c8 c5"
             type="button"
           >
             2
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <button
             aria-label="Go to page 3"
-            class="c9 c5"
+            class="c8 c5"
             type="button"
           >
             3
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <button
             aria-label="Go to page 4"
-            class="c9 c5"
+            class="c8 c5"
             type="button"
           >
             4
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <button
             aria-label="Go to page 5"
-            class="c9 c5"
+            class="c8 c5"
             type="button"
           >
             5
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <span
-            class="c10 c11"
+            class="c9 c10"
           >
             …
           </span>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <button
             aria-label="Go to page 24"
-            class="c9 c5"
+            class="c8 c5"
             type="button"
           >
             24
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <button
             aria-label="Go to next page"
-            class="c12 c5"
+            class="c11 c5"
             type="button"
           >
             <svg
@@ -2548,7 +2408,7 @@ exports[`Pagination should apply custom theme 1`] = `
   stroke: none;
 }
 
-.c14 {
+.c13 {
   display: inline-block;
   flex: 0 0 auto;
   width: 24px;
@@ -2557,25 +2417,25 @@ exports[`Pagination should apply custom theme 1`] = `
   stroke: #000000;
 }
 
-.c14 g {
+.c13 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c14 *:not([stroke])[fill='none'] {
+.c13 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c14 *[stroke*='#'],
-.c14 *[STROKE*='#'] {
+.c13 *[stroke*='#'],
+.c13 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c14 *[fill-rule],
-.c14 *[FILL-RULE],
-.c14 *[fill*='#'],
-.c14 *[FILL*='#'] {
+.c13 *[fill-rule],
+.c13 *[FILL-RULE],
+.c13 *[fill*='#'],
+.c13 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -2610,15 +2470,10 @@ exports[`Pagination should apply custom theme 1`] = `
   min-height: 0;
   flex-direction: row;
   padding: 0px;
+  column-gap: 3px;
 }
 
-.c8 {
-  flex: 0 0 auto;
-  align-self: stretch;
-  width: 3px;
-}
-
-.c11 {
+.c10 {
   font-size: 18px;
   line-height: 24px;
 }
@@ -2693,627 +2548,6 @@ exports[`Pagination should apply custom theme 1`] = `
 }
 
 .c5:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c9 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  background-color: rgba(221, 221, 221, 0.4);
-  color: #000000;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 24px;
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-  color: #444444;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c9:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-}
-
-.c9:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c9:focus >circle,
-.c9:focus >ellipse,
-.c9:focus >line,
-.c9:focus >path,
-.c9:focus >polygon,
-.c9:focus >polyline,
-.c9:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c9:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c9:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c9:focus:not(:focus-visible) >circle,
-.c9:focus:not(:focus-visible) >ellipse,
-.c9:focus:not(:focus-visible) >line,
-.c9:focus:not(:focus-visible) >path,
-.c9:focus:not(:focus-visible) >polygon,
-.c9:focus:not(:focus-visible) >polyline,
-.c9:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c9:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c10 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 24px;
-  color: #000000;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c10:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-}
-
-.c10:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c10:focus >circle,
-.c10:focus >ellipse,
-.c10:focus >line,
-.c10:focus >path,
-.c10:focus >polygon,
-.c10:focus >polyline,
-.c10:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c10:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c10:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c10:focus:not(:focus-visible) >circle,
-.c10:focus:not(:focus-visible) >ellipse,
-.c10:focus:not(:focus-visible) >line,
-.c10:focus:not(:focus-visible) >path,
-.c10:focus:not(:focus-visible) >polygon,
-.c10:focus:not(:focus-visible) >polyline,
-.c10:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c10:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c13 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 0;
-  color: #000000;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c13 >svg {
-  display: flex;
-  align-self: center;
-  vertical-align: middle;
-}
-
-.c13:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-}
-
-.c13:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c13:focus >circle,
-.c13:focus >ellipse,
-.c13:focus >line,
-.c13:focus >path,
-.c13:focus >polygon,
-.c13:focus >polyline,
-.c13:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c13:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c13:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c13:focus:not(:focus-visible) >circle,
-.c13:focus:not(:focus-visible) >ellipse,
-.c13:focus:not(:focus-visible) >line,
-.c13:focus:not(:focus-visible) >path,
-.c13:focus:not(:focus-visible) >polygon,
-.c13:focus:not(:focus-visible) >polyline,
-.c13:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c13:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c6 {
-  font-size: 18px;
-  line-height: 0;
-}
-
-.c6 >svg {
-  margin: 0 auto;
-}
-
-.c4 {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  max-width: 100%;
-  height: 36px;
-  min-width: 36px;
-}
-
-.c12 {
-  font-weight: bold;
-  font-size: 18px;
-  line-height: 0;
-}
-
-.c2 {
-  background: red;
-}
-
-@media only screen and (max-width: 768px) {
-  .c3 {
-    margin: 0px;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c3 {
-    padding: 0px;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c8 {
-    width: 2px;
-  }
-}
-
-<div
-  class="c0"
->
-  <div
-    class="c1 c2"
-  >
-    <nav
-      aria-label="Pagination Navigation"
-      class="c1"
-    >
-      <ul
-        class="c3"
-      >
-        <li
-          class="c4"
-        >
-          <button
-            aria-disabled="true"
-            aria-label="Go to previous page"
-            class="c5 c6"
-            disabled=""
-            type="button"
-          >
-            <svg
-              aria-label="Previous"
-              class="c7"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M17 2 7 12l10 10"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </button>
-        </li>
-        <div
-          class="c8"
-        />
-        <li
-          class="c4"
-        >
-          <button
-            aria-current="page"
-            aria-label="Go to page 1"
-            class="c9 c6"
-            type="button"
-          >
-            1
-          </button>
-        </li>
-        <div
-          class="c8"
-        />
-        <li
-          class="c4"
-        >
-          <button
-            aria-label="Go to page 2"
-            class="c10 c6"
-            type="button"
-          >
-            2
-          </button>
-        </li>
-        <div
-          class="c8"
-        />
-        <li
-          class="c4"
-        >
-          <button
-            aria-label="Go to page 3"
-            class="c10 c6"
-            type="button"
-          >
-            3
-          </button>
-        </li>
-        <div
-          class="c8"
-        />
-        <li
-          class="c4"
-        >
-          <button
-            aria-label="Go to page 4"
-            class="c10 c6"
-            type="button"
-          >
-            4
-          </button>
-        </li>
-        <div
-          class="c8"
-        />
-        <li
-          class="c4"
-        >
-          <button
-            aria-label="Go to page 5"
-            class="c10 c6"
-            type="button"
-          >
-            5
-          </button>
-        </li>
-        <div
-          class="c8"
-        />
-        <li
-          class="c4"
-        >
-          <span
-            class="c11 c12"
-          >
-            …
-          </span>
-        </li>
-        <div
-          class="c8"
-        />
-        <li
-          class="c4"
-        >
-          <button
-            aria-label="Go to page 24"
-            class="c10 c6"
-            type="button"
-          >
-            24
-          </button>
-        </li>
-        <div
-          class="c8"
-        />
-        <li
-          class="c4"
-        >
-          <button
-            aria-label="Go to next page"
-            class="c13 c6"
-            type="button"
-          >
-            <svg
-              aria-label="Next"
-              class="c14"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="m7 2 10 10L7 22"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </button>
-        </li>
-      </ul>
-    </nav>
-  </div>
-</div>
-`;
-
-exports[`Pagination should apply size 1`] = `
-.c6 {
-  display: inline-block;
-  flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
-  fill: #666666;
-  stroke: #666666;
-}
-
-.c6 g {
-  fill: inherit;
-  stroke: inherit;
-}
-
-.c6 *:not([stroke])[fill='none'] {
-  stroke-width: 0;
-}
-
-.c6 *[stroke*='#'],
-.c6 *[STROKE*='#'] {
-  stroke: inherit;
-  fill: none;
-}
-
-.c6 *[fill-rule],
-.c6 *[FILL-RULE],
-.c6 *[fill*='#'],
-.c6 *[FILL*='#'] {
-  fill: inherit;
-  stroke: none;
-}
-
-.c13 {
-  display: inline-block;
-  flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
-  fill: #000000;
-  stroke: #000000;
-}
-
-.c13 g {
-  fill: inherit;
-  stroke: inherit;
-}
-
-.c13 *:not([stroke])[fill='none'] {
-  stroke-width: 0;
-}
-
-.c13 *[stroke*='#'],
-.c13 *[STROKE*='#'] {
-  stroke: inherit;
-  fill: none;
-}
-
-.c13 *[fill-rule],
-.c13 *[FILL-RULE],
-.c13 *[fill*='#'],
-.c13 *[FILL*='#'] {
-  fill: inherit;
-  stroke: none;
-}
-
-.c0 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
-.c1 {
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  flex-direction: column;
-  flex: 0 0 auto;
-}
-
-.c2 {
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  margin: 0px;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  flex-direction: row;
-  padding: 0px;
-}
-
-.c7 {
-  flex: 0 0 auto;
-  align-self: stretch;
-  width: 3px;
-}
-
-.c10 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c19 {
-  font-size: 14px;
-  line-height: 20px;
-}
-
-.c27 {
-  font-size: 22px;
-  line-height: 28px;
-}
-
-.c4 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 0;
-  text-align: center;
-  opacity: 0.3;
-  cursor: default;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c4 >svg {
-  display: flex;
-  align-self: center;
-  vertical-align: middle;
-}
-
-.c4:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c4:focus >circle,
-.c4:focus >ellipse,
-.c4:focus >line,
-.c4:focus >path,
-.c4:focus >polygon,
-.c4:focus >polyline,
-.c4:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c4:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c4:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c4:focus:not(:focus-visible) >circle,
-.c4:focus:not(:focus-visible) >ellipse,
-.c4:focus:not(:focus-visible) >line,
-.c4:focus:not(:focus-visible) >path,
-.c4:focus:not(:focus-visible) >polygon,
-.c4:focus:not(:focus-visible) >polyline,
-.c4:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c4:focus:not(:focus-visible) ::-moz-focus-inner {
   border: 0;
 }
 
@@ -3536,7 +2770,599 @@ exports[`Pagination should apply size 1`] = `
   border: 0;
 }
 
-.c15 {
+.c6 {
+  font-size: 18px;
+  line-height: 0;
+}
+
+.c6 >svg {
+  margin: 0 auto;
+}
+
+.c4 {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  max-width: 100%;
+  height: 36px;
+  min-width: 36px;
+}
+
+.c11 {
+  font-weight: bold;
+  font-size: 18px;
+  line-height: 0;
+}
+
+.c2 {
+  background: red;
+}
+
+@media only screen and (max-width: 768px) {
+  .c3 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c3 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c3 {
+    column-gap: 2px;
+  }
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1 c2"
+  >
+    <nav
+      aria-label="Pagination Navigation"
+      class="c1"
+    >
+      <ul
+        class="c3"
+      >
+        <li
+          class="c4"
+        >
+          <button
+            aria-disabled="true"
+            aria-label="Go to previous page"
+            class="c5 c6"
+            disabled=""
+            type="button"
+          >
+            <svg
+              aria-label="Previous"
+              class="c7"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M17 2 7 12l10 10"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </li>
+        <li
+          class="c4"
+        >
+          <button
+            aria-current="page"
+            aria-label="Go to page 1"
+            class="c8 c6"
+            type="button"
+          >
+            1
+          </button>
+        </li>
+        <li
+          class="c4"
+        >
+          <button
+            aria-label="Go to page 2"
+            class="c9 c6"
+            type="button"
+          >
+            2
+          </button>
+        </li>
+        <li
+          class="c4"
+        >
+          <button
+            aria-label="Go to page 3"
+            class="c9 c6"
+            type="button"
+          >
+            3
+          </button>
+        </li>
+        <li
+          class="c4"
+        >
+          <button
+            aria-label="Go to page 4"
+            class="c9 c6"
+            type="button"
+          >
+            4
+          </button>
+        </li>
+        <li
+          class="c4"
+        >
+          <button
+            aria-label="Go to page 5"
+            class="c9 c6"
+            type="button"
+          >
+            5
+          </button>
+        </li>
+        <li
+          class="c4"
+        >
+          <span
+            class="c10 c11"
+          >
+            …
+          </span>
+        </li>
+        <li
+          class="c4"
+        >
+          <button
+            aria-label="Go to page 24"
+            class="c9 c6"
+            type="button"
+          >
+            24
+          </button>
+        </li>
+        <li
+          class="c4"
+        >
+          <button
+            aria-label="Go to next page"
+            class="c12 c6"
+            type="button"
+          >
+            <svg
+              aria-label="Next"
+              class="c13"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m7 2 10 10L7 22"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</div>
+`;
+
+exports[`Pagination should apply size 1`] = `
+.c6 {
+  display: inline-block;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #666666;
+  stroke: #666666;
+}
+
+.c6 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c6 *:not([stroke])[fill='none'] {
+  stroke-width: 0;
+}
+
+.c6 *[stroke*='#'],
+.c6 *[STROKE*='#'] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c6 *[fill-rule],
+.c6 *[FILL-RULE],
+.c6 *[fill*='#'],
+.c6 *[FILL*='#'] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c12 {
+  display: inline-block;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #000000;
+  stroke: #000000;
+}
+
+.c12 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c12 *:not([stroke])[fill='none'] {
+  stroke-width: 0;
+}
+
+.c12 *[stroke*='#'],
+.c12 *[STROKE*='#'] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c12 *[fill-rule],
+.c12 *[FILL-RULE],
+.c12 *[fill*='#'],
+.c12 *[FILL*='#'] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  flex: 0 0 auto;
+}
+
+.c2 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin: 0px;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  padding: 0px;
+  column-gap: 3px;
+}
+
+.c9 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c18 {
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.c26 {
+  font-size: 22px;
+  line-height: 28px;
+}
+
+.c4 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 0;
+  text-align: center;
+  opacity: 0.3;
+  cursor: default;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c4 >svg {
+  display: flex;
+  align-self: center;
+  vertical-align: middle;
+}
+
+.c4:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus >circle,
+.c4:focus >ellipse,
+.c4:focus >line,
+.c4:focus >path,
+.c4:focus >polygon,
+.c4:focus >polyline,
+.c4:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c4:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c4:focus:not(:focus-visible) >circle,
+.c4:focus:not(:focus-visible) >ellipse,
+.c4:focus:not(:focus-visible) >line,
+.c4:focus:not(:focus-visible) >path,
+.c4:focus:not(:focus-visible) >polygon,
+.c4:focus:not(:focus-visible) >polyline,
+.c4:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c4:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c7 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  background-color: rgba(221, 221, 221, 0.4);
+  color: #000000;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+  color: #444444;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c7:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c7:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c7:focus >circle,
+.c7:focus >ellipse,
+.c7:focus >line,
+.c7:focus >path,
+.c7:focus >polygon,
+.c7:focus >polyline,
+.c7:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c7:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c7:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c7:focus:not(:focus-visible) >circle,
+.c7:focus:not(:focus-visible) >ellipse,
+.c7:focus:not(:focus-visible) >line,
+.c7:focus:not(:focus-visible) >path,
+.c7:focus:not(:focus-visible) >polygon,
+.c7:focus:not(:focus-visible) >polyline,
+.c7:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c7:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c8 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  color: #000000;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c8:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c8:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus >circle,
+.c8:focus >ellipse,
+.c8:focus >line,
+.c8:focus >path,
+.c8:focus >polygon,
+.c8:focus >polyline,
+.c8:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c8:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c8:focus:not(:focus-visible) >circle,
+.c8:focus:not(:focus-visible) >ellipse,
+.c8:focus:not(:focus-visible) >line,
+.c8:focus:not(:focus-visible) >path,
+.c8:focus:not(:focus-visible) >polygon,
+.c8:focus:not(:focus-visible) >polyline,
+.c8:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c8:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c11 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 0;
+  color: #000000;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c11 >svg {
+  display: flex;
+  align-self: center;
+  vertical-align: middle;
+}
+
+.c11:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c11:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus >circle,
+.c11:focus >ellipse,
+.c11:focus >line,
+.c11:focus >path,
+.c11:focus >polygon,
+.c11:focus >polyline,
+.c11:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c11:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c11:focus:not(:focus-visible) >circle,
+.c11:focus:not(:focus-visible) >ellipse,
+.c11:focus:not(:focus-visible) >line,
+.c11:focus:not(:focus-visible) >path,
+.c11:focus:not(:focus-visible) >polygon,
+.c11:focus:not(:focus-visible) >polyline,
+.c11:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c11:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c14 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -3563,53 +3389,53 @@ exports[`Pagination should apply size 1`] = `
   flex: 1 0 auto;
 }
 
-.c15 >svg {
+.c14 >svg {
   display: flex;
   align-self: center;
   vertical-align: middle;
 }
 
-.c15:focus {
+.c14:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c15:focus >circle,
-.c15:focus >ellipse,
-.c15:focus >line,
-.c15:focus >path,
-.c15:focus >polygon,
-.c15:focus >polyline,
-.c15:focus >rect {
+.c14:focus >circle,
+.c14:focus >ellipse,
+.c14:focus >line,
+.c14:focus >path,
+.c14:focus >polygon,
+.c14:focus >polyline,
+.c14:focus >rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c15:focus ::-moz-focus-inner {
+.c14:focus ::-moz-focus-inner {
   border: 0;
 }
 
-.c15:focus:not(:focus-visible) {
+.c14:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c15:focus:not(:focus-visible) >circle,
-.c15:focus:not(:focus-visible) >ellipse,
-.c15:focus:not(:focus-visible) >line,
-.c15:focus:not(:focus-visible) >path,
-.c15:focus:not(:focus-visible) >polygon,
-.c15:focus:not(:focus-visible) >polyline,
-.c15:focus:not(:focus-visible) >rect {
+.c14:focus:not(:focus-visible) >circle,
+.c14:focus:not(:focus-visible) >ellipse,
+.c14:focus:not(:focus-visible) >line,
+.c14:focus:not(:focus-visible) >path,
+.c14:focus:not(:focus-visible) >polygon,
+.c14:focus:not(:focus-visible) >polyline,
+.c14:focus:not(:focus-visible) >rect {
   outline: none;
   box-shadow: none;
 }
 
-.c15:focus:not(:focus-visible) ::-moz-focus-inner {
+.c14:focus:not(:focus-visible) ::-moz-focus-inner {
   border: 0;
 }
 
-.c17 {
+.c16 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -3628,6 +3454,76 @@ exports[`Pagination should apply size 1`] = `
   line-height: 20px;
   background-color: rgba(51, 51, 51, 0.06274509803921569);
   color: #444444;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c16:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c16:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c16:focus >circle,
+.c16:focus >ellipse,
+.c16:focus >line,
+.c16:focus >path,
+.c16:focus >polygon,
+.c16:focus >polyline,
+.c16:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c16:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c16:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c16:focus:not(:focus-visible) >circle,
+.c16:focus:not(:focus-visible) >ellipse,
+.c16:focus:not(:focus-visible) >line,
+.c16:focus:not(:focus-visible) >path,
+.c16:focus:not(:focus-visible) >polygon,
+.c16:focus:not(:focus-visible) >polyline,
+.c16:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c16:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c17 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 3px;
+  padding: 4px 4px;
+  font-size: 14px;
+  line-height: 20px;
+  color: #000000;
   text-align: center;
   transition-property: color,background-color,border-color,box-shadow;
   transition-duration: 0.1s;
@@ -3682,77 +3578,7 @@ exports[`Pagination should apply size 1`] = `
   border: 0;
 }
 
-.c18 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 3px;
-  padding: 4px 4px;
-  font-size: 14px;
-  line-height: 20px;
-  color: #000000;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c18:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-}
-
-.c18:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c18:focus >circle,
-.c18:focus >ellipse,
-.c18:focus >line,
-.c18:focus >path,
-.c18:focus >polygon,
-.c18:focus >polyline,
-.c18:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c18:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c18:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c18:focus:not(:focus-visible) >circle,
-.c18:focus:not(:focus-visible) >ellipse,
-.c18:focus:not(:focus-visible) >line,
-.c18:focus:not(:focus-visible) >path,
-.c18:focus:not(:focus-visible) >polygon,
-.c18:focus:not(:focus-visible) >polyline,
-.c18:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c18:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c21 {
+.c20 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -3778,57 +3604,57 @@ exports[`Pagination should apply size 1`] = `
   flex: 1 0 auto;
 }
 
-.c21 >svg {
+.c20 >svg {
   display: flex;
   align-self: center;
   vertical-align: middle;
 }
 
-.c21:hover {
+.c20:hover {
   background-color: rgba(51, 51, 51, 0.06274509803921569);
 }
 
-.c21:focus {
+.c20:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c21:focus >circle,
-.c21:focus >ellipse,
-.c21:focus >line,
-.c21:focus >path,
-.c21:focus >polygon,
-.c21:focus >polyline,
-.c21:focus >rect {
+.c20:focus >circle,
+.c20:focus >ellipse,
+.c20:focus >line,
+.c20:focus >path,
+.c20:focus >polygon,
+.c20:focus >polyline,
+.c20:focus >rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c21:focus ::-moz-focus-inner {
+.c20:focus ::-moz-focus-inner {
   border: 0;
 }
 
-.c21:focus:not(:focus-visible) {
+.c20:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c21:focus:not(:focus-visible) >circle,
-.c21:focus:not(:focus-visible) >ellipse,
-.c21:focus:not(:focus-visible) >line,
-.c21:focus:not(:focus-visible) >path,
-.c21:focus:not(:focus-visible) >polygon,
-.c21:focus:not(:focus-visible) >polyline,
-.c21:focus:not(:focus-visible) >rect {
+.c20:focus:not(:focus-visible) >circle,
+.c20:focus:not(:focus-visible) >ellipse,
+.c20:focus:not(:focus-visible) >line,
+.c20:focus:not(:focus-visible) >path,
+.c20:focus:not(:focus-visible) >polygon,
+.c20:focus:not(:focus-visible) >polyline,
+.c20:focus:not(:focus-visible) >rect {
   outline: none;
   box-shadow: none;
 }
 
-.c21:focus:not(:focus-visible) ::-moz-focus-inner {
+.c20:focus:not(:focus-visible) ::-moz-focus-inner {
   border: 0;
 }
 
-.c23 {
+.c22 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -3855,53 +3681,53 @@ exports[`Pagination should apply size 1`] = `
   flex: 1 0 auto;
 }
 
-.c23 >svg {
+.c22 >svg {
   display: flex;
   align-self: center;
   vertical-align: middle;
 }
 
-.c23:focus {
+.c22:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c23:focus >circle,
-.c23:focus >ellipse,
-.c23:focus >line,
-.c23:focus >path,
-.c23:focus >polygon,
-.c23:focus >polyline,
-.c23:focus >rect {
+.c22:focus >circle,
+.c22:focus >ellipse,
+.c22:focus >line,
+.c22:focus >path,
+.c22:focus >polygon,
+.c22:focus >polyline,
+.c22:focus >rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c23:focus ::-moz-focus-inner {
+.c22:focus ::-moz-focus-inner {
   border: 0;
 }
 
-.c23:focus:not(:focus-visible) {
+.c22:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c23:focus:not(:focus-visible) >circle,
-.c23:focus:not(:focus-visible) >ellipse,
-.c23:focus:not(:focus-visible) >line,
-.c23:focus:not(:focus-visible) >path,
-.c23:focus:not(:focus-visible) >polygon,
-.c23:focus:not(:focus-visible) >polyline,
-.c23:focus:not(:focus-visible) >rect {
+.c22:focus:not(:focus-visible) >circle,
+.c22:focus:not(:focus-visible) >ellipse,
+.c22:focus:not(:focus-visible) >line,
+.c22:focus:not(:focus-visible) >path,
+.c22:focus:not(:focus-visible) >polygon,
+.c22:focus:not(:focus-visible) >polyline,
+.c22:focus:not(:focus-visible) >rect {
   outline: none;
   box-shadow: none;
 }
 
-.c23:focus:not(:focus-visible) ::-moz-focus-inner {
+.c22:focus:not(:focus-visible) ::-moz-focus-inner {
   border: 0;
 }
 
-.c25 {
+.c24 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -3920,6 +3746,76 @@ exports[`Pagination should apply size 1`] = `
   line-height: 28px;
   background-color: rgba(51, 51, 51, 0.06274509803921569);
   color: #444444;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c24:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c24:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c24:focus >circle,
+.c24:focus >ellipse,
+.c24:focus >line,
+.c24:focus >path,
+.c24:focus >polygon,
+.c24:focus >polyline,
+.c24:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c24:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c24:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c24:focus:not(:focus-visible) >circle,
+.c24:focus:not(:focus-visible) >ellipse,
+.c24:focus:not(:focus-visible) >line,
+.c24:focus:not(:focus-visible) >path,
+.c24:focus:not(:focus-visible) >polygon,
+.c24:focus:not(:focus-visible) >polyline,
+.c24:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c24:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c25 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 6px;
+  padding: 4px 4px;
+  font-size: 22px;
+  line-height: 28px;
+  color: #000000;
   text-align: center;
   transition-property: color,background-color,border-color,box-shadow;
   transition-duration: 0.1s;
@@ -3974,77 +3870,7 @@ exports[`Pagination should apply size 1`] = `
   border: 0;
 }
 
-.c26 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 6px;
-  padding: 4px 4px;
-  font-size: 22px;
-  line-height: 28px;
-  color: #000000;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c26:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-}
-
-.c26:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c26:focus >circle,
-.c26:focus >ellipse,
-.c26:focus >line,
-.c26:focus >path,
-.c26:focus >polygon,
-.c26:focus >polyline,
-.c26:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c26:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c26:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c26:focus:not(:focus-visible) >circle,
-.c26:focus:not(:focus-visible) >ellipse,
-.c26:focus:not(:focus-visible) >line,
-.c26:focus:not(:focus-visible) >path,
-.c26:focus:not(:focus-visible) >polygon,
-.c26:focus:not(:focus-visible) >polyline,
-.c26:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c26:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c29 {
+.c28 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -4070,53 +3896,53 @@ exports[`Pagination should apply size 1`] = `
   flex: 1 0 auto;
 }
 
-.c29 >svg {
+.c28 >svg {
   display: flex;
   align-self: center;
   vertical-align: middle;
 }
 
-.c29:hover {
+.c28:hover {
   background-color: rgba(51, 51, 51, 0.06274509803921569);
 }
 
-.c29:focus {
+.c28:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c29:focus >circle,
-.c29:focus >ellipse,
-.c29:focus >line,
-.c29:focus >path,
-.c29:focus >polygon,
-.c29:focus >polyline,
-.c29:focus >rect {
+.c28:focus >circle,
+.c28:focus >ellipse,
+.c28:focus >line,
+.c28:focus >path,
+.c28:focus >polygon,
+.c28:focus >polyline,
+.c28:focus >rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c29:focus ::-moz-focus-inner {
+.c28:focus ::-moz-focus-inner {
   border: 0;
 }
 
-.c29:focus:not(:focus-visible) {
+.c28:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c29:focus:not(:focus-visible) >circle,
-.c29:focus:not(:focus-visible) >ellipse,
-.c29:focus:not(:focus-visible) >line,
-.c29:focus:not(:focus-visible) >path,
-.c29:focus:not(:focus-visible) >polygon,
-.c29:focus:not(:focus-visible) >polyline,
-.c29:focus:not(:focus-visible) >rect {
+.c28:focus:not(:focus-visible) >circle,
+.c28:focus:not(:focus-visible) >ellipse,
+.c28:focus:not(:focus-visible) >line,
+.c28:focus:not(:focus-visible) >path,
+.c28:focus:not(:focus-visible) >polygon,
+.c28:focus:not(:focus-visible) >polyline,
+.c28:focus:not(:focus-visible) >rect {
   outline: none;
   box-shadow: none;
 }
 
-.c29:focus:not(:focus-visible) ::-moz-focus-inner {
+.c28:focus:not(:focus-visible) ::-moz-focus-inner {
   border: 0;
 }
 
@@ -4129,21 +3955,21 @@ exports[`Pagination should apply size 1`] = `
   margin: 0 auto;
 }
 
-.c16 {
+.c15 {
   font-size: 14px;
   line-height: 0;
 }
 
-.c16 >svg {
+.c15 >svg {
   margin: 0 auto;
 }
 
-.c24 {
+.c23 {
   font-size: 22px;
   line-height: 0;
 }
 
-.c24 >svg {
+.c23 >svg {
   margin: 0 auto;
 }
 
@@ -4156,7 +3982,7 @@ exports[`Pagination should apply size 1`] = `
   min-width: 36px;
 }
 
-.c14 {
+.c13 {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -4165,7 +3991,7 @@ exports[`Pagination should apply size 1`] = `
   min-width: 30px;
 }
 
-.c22 {
+.c21 {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -4174,19 +4000,19 @@ exports[`Pagination should apply size 1`] = `
   min-width: 48px;
 }
 
-.c11 {
+.c10 {
   font-weight: bold;
   font-size: 18px;
   line-height: 0;
 }
 
-.c20 {
+.c19 {
   font-weight: bold;
   font-size: 14px;
   line-height: 0;
 }
 
-.c28 {
+.c27 {
   font-weight: bold;
   font-size: 22px;
   line-height: 0;
@@ -4205,8 +4031,8 @@ exports[`Pagination should apply size 1`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c7 {
-    width: 2px;
+  .c2 {
+    column-gap: 2px;
   }
 }
 
@@ -4247,117 +4073,93 @@ exports[`Pagination should apply size 1`] = `
             </svg>
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <button
             aria-current="page"
             aria-label="Go to page 1"
+            class="c7 c5"
+            type="button"
+          >
+            1
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 2"
             class="c8 c5"
             type="button"
           >
-            1
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to page 2"
-            class="c9 c5"
-            type="button"
-          >
             2
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <button
             aria-label="Go to page 3"
-            class="c9 c5"
+            class="c8 c5"
             type="button"
           >
             3
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <button
             aria-label="Go to page 4"
-            class="c9 c5"
+            class="c8 c5"
             type="button"
           >
             4
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <button
             aria-label="Go to page 5"
-            class="c9 c5"
+            class="c8 c5"
             type="button"
           >
             5
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <span
-            class="c10 c11"
+            class="c9 c10"
           >
             …
           </span>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <button
             aria-label="Go to page 24"
-            class="c9 c5"
+            class="c8 c5"
             type="button"
           >
             24
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <button
             aria-label="Go to next page"
-            class="c12 c5"
+            class="c11 c5"
             type="button"
           >
             <svg
               aria-label="Next"
-              class="c13"
+              class="c12"
               viewBox="0 0 24 24"
             >
               <path
@@ -4383,12 +4185,12 @@ exports[`Pagination should apply size 1`] = `
         class="c2"
       >
         <li
-          class="c14"
+          class="c13"
         >
           <button
             aria-disabled="true"
             aria-label="Go to previous page"
-            class="c15 c16"
+            class="c14 c15"
             disabled=""
             type="button"
           >
@@ -4406,117 +4208,93 @@ exports[`Pagination should apply size 1`] = `
             </svg>
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
-          class="c14"
+          class="c13"
         >
           <button
             aria-current="page"
             aria-label="Go to page 1"
-            class="c17 c16"
+            class="c16 c15"
             type="button"
           >
             1
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
-          class="c14"
+          class="c13"
         >
           <button
             aria-label="Go to page 2"
-            class="c18 c16"
+            class="c17 c15"
             type="button"
           >
             2
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
-          class="c14"
+          class="c13"
         >
           <button
             aria-label="Go to page 3"
-            class="c18 c16"
+            class="c17 c15"
             type="button"
           >
             3
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
-          class="c14"
+          class="c13"
         >
           <button
             aria-label="Go to page 4"
-            class="c18 c16"
+            class="c17 c15"
             type="button"
           >
             4
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
-          class="c14"
+          class="c13"
         >
           <button
             aria-label="Go to page 5"
-            class="c18 c16"
+            class="c17 c15"
             type="button"
           >
             5
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
-          class="c14"
+          class="c13"
         >
           <span
-            class="c19 c20"
+            class="c18 c19"
           >
             …
           </span>
         </li>
-        <div
-          class="c7"
-        />
         <li
-          class="c14"
+          class="c13"
         >
           <button
             aria-label="Go to page 24"
-            class="c18 c16"
+            class="c17 c15"
             type="button"
           >
             24
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
-          class="c14"
+          class="c13"
         >
           <button
             aria-label="Go to next page"
-            class="c21 c16"
+            class="c20 c15"
             type="button"
           >
             <svg
               aria-label="Next"
-              class="c13"
+              class="c12"
               viewBox="0 0 24 24"
             >
               <path
@@ -4542,12 +4320,12 @@ exports[`Pagination should apply size 1`] = `
         class="c2"
       >
         <li
-          class="c22"
+          class="c21"
         >
           <button
             aria-disabled="true"
             aria-label="Go to previous page"
-            class="c23 c24"
+            class="c22 c23"
             disabled=""
             type="button"
           >
@@ -4565,117 +4343,93 @@ exports[`Pagination should apply size 1`] = `
             </svg>
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
-          class="c22"
+          class="c21"
         >
           <button
             aria-current="page"
             aria-label="Go to page 1"
-            class="c25 c24"
+            class="c24 c23"
             type="button"
           >
             1
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
-          class="c22"
+          class="c21"
         >
           <button
             aria-label="Go to page 2"
-            class="c26 c24"
+            class="c25 c23"
             type="button"
           >
             2
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
-          class="c22"
+          class="c21"
         >
           <button
             aria-label="Go to page 3"
-            class="c26 c24"
+            class="c25 c23"
             type="button"
           >
             3
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
-          class="c22"
+          class="c21"
         >
           <button
             aria-label="Go to page 4"
-            class="c26 c24"
+            class="c25 c23"
             type="button"
           >
             4
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
-          class="c22"
+          class="c21"
         >
           <button
             aria-label="Go to page 5"
-            class="c26 c24"
+            class="c25 c23"
             type="button"
           >
             5
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
-          class="c22"
+          class="c21"
         >
           <span
-            class="c27 c28"
+            class="c26 c27"
           >
             …
           </span>
         </li>
-        <div
-          class="c7"
-        />
         <li
-          class="c22"
+          class="c21"
         >
           <button
             aria-label="Go to page 24"
-            class="c26 c24"
+            class="c25 c23"
             type="button"
           >
             24
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
-          class="c22"
+          class="c21"
         >
           <button
             aria-label="Go to next page"
-            class="c29 c24"
+            class="c28 c23"
             type="button"
           >
             <svg
               aria-label="Next"
-              class="c13"
+              class="c12"
               viewBox="0 0 24 24"
             >
               <path
@@ -4756,20 +4510,15 @@ exports[`Pagination should change the page on prop change 1`] = `
   min-height: 0;
   flex-direction: row;
   padding: 0px;
+  column-gap: 3px;
 }
 
-.c7 {
-  flex: 0 0 auto;
-  align-self: stretch;
-  width: 3px;
-}
-
-.c10 {
+.c9 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c9 {
+.c8 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -4788,76 +4537,6 @@ exports[`Pagination should change the page on prop change 1`] = `
   line-height: 24px;
   background-color: rgba(51, 51, 51, 0.06274509803921569);
   color: #444444;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c9:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-}
-
-.c9:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c9:focus >circle,
-.c9:focus >ellipse,
-.c9:focus >line,
-.c9:focus >path,
-.c9:focus >polygon,
-.c9:focus >polyline,
-.c9:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c9:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c9:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c9:focus:not(:focus-visible) >circle,
-.c9:focus:not(:focus-visible) >ellipse,
-.c9:focus:not(:focus-visible) >line,
-.c9:focus:not(:focus-visible) >path,
-.c9:focus:not(:focus-visible) >polygon,
-.c9:focus:not(:focus-visible) >polyline,
-.c9:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c9:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c8 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 24px;
-  color: #000000;
   text-align: center;
   transition-property: color,background-color,border-color,box-shadow;
   transition-duration: 0.1s;
@@ -4909,6 +4588,76 @@ exports[`Pagination should change the page on prop change 1`] = `
 }
 
 .c8:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c7 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  color: #000000;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c7:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c7:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c7:focus >circle,
+.c7:focus >ellipse,
+.c7:focus >line,
+.c7:focus >path,
+.c7:focus >polygon,
+.c7:focus >polyline,
+.c7:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c7:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c7:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c7:focus:not(:focus-visible) >circle,
+.c7:focus:not(:focus-visible) >ellipse,
+.c7:focus:not(:focus-visible) >line,
+.c7:focus:not(:focus-visible) >path,
+.c7:focus:not(:focus-visible) >polygon,
+.c7:focus:not(:focus-visible) >polyline,
+.c7:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c7:focus:not(:focus-visible) ::-moz-focus-inner {
   border: 0;
 }
 
@@ -5006,7 +4755,7 @@ exports[`Pagination should change the page on prop change 1`] = `
   min-width: 36px;
 }
 
-.c11 {
+.c10 {
   font-weight: bold;
   font-size: 18px;
   line-height: 0;
@@ -5025,8 +4774,8 @@ exports[`Pagination should change the page on prop change 1`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c7 {
-    width: 2px;
+  .c2 {
+    column-gap: 2px;
   }
 }
 
@@ -5065,106 +4814,82 @@ exports[`Pagination should change the page on prop change 1`] = `
             </svg>
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <button
             aria-label="Go to page 1"
-            class="c8 c5"
+            class="c7 c5"
             type="button"
           >
             1
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <button
             aria-current="page"
             aria-label="Go to page 2"
-            class="c9 c5"
+            class="c8 c5"
             type="button"
           >
             2
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <button
             aria-label="Go to page 3"
-            class="c8 c5"
+            class="c7 c5"
             type="button"
           >
             3
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <button
             aria-label="Go to page 4"
-            class="c8 c5"
+            class="c7 c5"
             type="button"
           >
             4
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <button
             aria-label="Go to page 5"
-            class="c8 c5"
+            class="c7 c5"
             type="button"
           >
             5
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <span
-            class="c10 c11"
+            class="c9 c10"
           >
             …
           </span>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <button
             aria-label="Go to page 24"
-            class="c8 c5"
+            class="c7 c5"
             type="button"
           >
             24
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
@@ -5226,584 +4951,8 @@ exports[`Pagination should disable next button if on last page 1`] = `
   stroke: none;
 }
 
-.c13 {
-  display: inline-block;
-  flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
-  fill: #666666;
-  stroke: #666666;
-}
-
-.c13 g {
-  fill: inherit;
-  stroke: inherit;
-}
-
-.c13 *:not([stroke])[fill='none'] {
-  stroke-width: 0;
-}
-
-.c13 *[stroke*='#'],
-.c13 *[STROKE*='#'] {
-  stroke: inherit;
-  fill: none;
-}
-
-.c13 *[fill-rule],
-.c13 *[FILL-RULE],
-.c13 *[fill*='#'],
-.c13 *[FILL*='#'] {
-  fill: inherit;
-  stroke: none;
-}
-
-.c0 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
-.c1 {
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  flex-direction: column;
-  flex: 0 0 auto;
-}
-
-.c2 {
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  margin: 0px;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  flex-direction: row;
-  padding: 0px;
-}
-
-.c7 {
-  flex: 0 0 auto;
-  align-self: stretch;
-  width: 3px;
-}
-
-.c9 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c4 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 0;
-  color: #000000;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c4 >svg {
-  display: flex;
-  align-self: center;
-  vertical-align: middle;
-}
-
-.c4:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-}
-
-.c4:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c4:focus >circle,
-.c4:focus >ellipse,
-.c4:focus >line,
-.c4:focus >path,
-.c4:focus >polygon,
-.c4:focus >polyline,
-.c4:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c4:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c4:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c4:focus:not(:focus-visible) >circle,
-.c4:focus:not(:focus-visible) >ellipse,
-.c4:focus:not(:focus-visible) >line,
-.c4:focus:not(:focus-visible) >path,
-.c4:focus:not(:focus-visible) >polygon,
-.c4:focus:not(:focus-visible) >polyline,
-.c4:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c4:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c8 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 24px;
-  color: #000000;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c8:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-}
-
-.c8:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c8:focus >circle,
-.c8:focus >ellipse,
-.c8:focus >line,
-.c8:focus >path,
-.c8:focus >polygon,
-.c8:focus >polyline,
-.c8:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c8:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c8:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c8:focus:not(:focus-visible) >circle,
-.c8:focus:not(:focus-visible) >ellipse,
-.c8:focus:not(:focus-visible) >line,
-.c8:focus:not(:focus-visible) >path,
-.c8:focus:not(:focus-visible) >polygon,
-.c8:focus:not(:focus-visible) >polyline,
-.c8:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c8:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c11 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  background-color: rgba(221, 221, 221, 0.4);
-  color: #000000;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 24px;
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-  color: #444444;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c11:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-}
-
-.c11:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c11:focus >circle,
-.c11:focus >ellipse,
-.c11:focus >line,
-.c11:focus >path,
-.c11:focus >polygon,
-.c11:focus >polyline,
-.c11:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c11:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c11:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c11:focus:not(:focus-visible) >circle,
-.c11:focus:not(:focus-visible) >ellipse,
-.c11:focus:not(:focus-visible) >line,
-.c11:focus:not(:focus-visible) >path,
-.c11:focus:not(:focus-visible) >polygon,
-.c11:focus:not(:focus-visible) >polyline,
-.c11:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c11:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
 .c12 {
   display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 0;
-  text-align: center;
-  opacity: 0.3;
-  cursor: default;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c12 >svg {
-  display: flex;
-  align-self: center;
-  vertical-align: middle;
-}
-
-.c12:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c12:focus >circle,
-.c12:focus >ellipse,
-.c12:focus >line,
-.c12:focus >path,
-.c12:focus >polygon,
-.c12:focus >polyline,
-.c12:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c12:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c12:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c12:focus:not(:focus-visible) >circle,
-.c12:focus:not(:focus-visible) >ellipse,
-.c12:focus:not(:focus-visible) >line,
-.c12:focus:not(:focus-visible) >path,
-.c12:focus:not(:focus-visible) >polygon,
-.c12:focus:not(:focus-visible) >polyline,
-.c12:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c12:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c5 {
-  font-size: 18px;
-  line-height: 0;
-}
-
-.c5 >svg {
-  margin: 0 auto;
-}
-
-.c3 {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  max-width: 100%;
-  height: 36px;
-  min-width: 36px;
-}
-
-.c10 {
-  font-weight: bold;
-  font-size: 18px;
-  line-height: 0;
-}
-
-@media only screen and (max-width: 768px) {
-  .c2 {
-    margin: 0px;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c2 {
-    padding: 0px;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c7 {
-    width: 2px;
-  }
-}
-
-<div
-  class="c0"
->
-  <div
-    class="c1 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
-  >
-    <nav
-      aria-label="Pagination Navigation"
-      class="c1"
-    >
-      <ul
-        class="c2"
-      >
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to previous page"
-            class="c4 c5"
-            type="button"
-          >
-            <svg
-              aria-label="Previous"
-              class="c6"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M17 2 7 12l10 10"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to page 1"
-            class="c8 c5"
-            type="button"
-          >
-            1
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <span
-            class="c9 c10"
-          >
-            …
-          </span>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to page 20"
-            class="c8 c5"
-            type="button"
-          >
-            20
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to page 21"
-            class="c8 c5"
-            type="button"
-          >
-            21
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to page 22"
-            class="c8 c5"
-            type="button"
-          >
-            22
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to page 23"
-            class="c8 c5"
-            type="button"
-          >
-            23
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-current="page"
-            aria-label="Go to page 24"
-            class="c11 c5"
-            type="button"
-          >
-            24
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-disabled="true"
-            aria-label="Go to next page"
-            class="c12 c5"
-            disabled=""
-            type="button"
-          >
-            <svg
-              aria-label="Next"
-              class="c13"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="m7 2 10 10L7 22"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </button>
-        </li>
-      </ul>
-    </nav>
-  </div>
-</div>
-`;
-
-exports[`Pagination should disable previous and next controls when numberItems
-  < step 1`] = `
-.c6 {
-  display: inline-block;
   flex: 0 0 auto;
   width: 24px;
   height: 24px;
@@ -5811,25 +4960,25 @@ exports[`Pagination should disable previous and next controls when numberItems
   stroke: #666666;
 }
 
-.c6 g {
+.c12 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c6 *:not([stroke])[fill='none'] {
+.c12 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c6 *[stroke*='#'],
-.c6 *[STROKE*='#'] {
+.c12 *[stroke*='#'],
+.c12 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c6 *[fill-rule],
-.c6 *[FILL-RULE],
-.c6 *[fill*='#'],
-.c6 *[FILL*='#'] {
+.c12 *[fill-rule],
+.c12 *[FILL-RULE],
+.c12 *[fill*='#'],
+.c12 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -5864,2717 +5013,10 @@ exports[`Pagination should disable previous and next controls when numberItems
   min-height: 0;
   flex-direction: row;
   padding: 0px;
-}
-
-.c7 {
-  flex: 0 0 auto;
-  align-self: stretch;
-  width: 3px;
-}
-
-.c4 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 0;
-  text-align: center;
-  opacity: 0.3;
-  cursor: default;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c4 >svg {
-  display: flex;
-  align-self: center;
-  vertical-align: middle;
-}
-
-.c4:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c4:focus >circle,
-.c4:focus >ellipse,
-.c4:focus >line,
-.c4:focus >path,
-.c4:focus >polygon,
-.c4:focus >polyline,
-.c4:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c4:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c4:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c4:focus:not(:focus-visible) >circle,
-.c4:focus:not(:focus-visible) >ellipse,
-.c4:focus:not(:focus-visible) >line,
-.c4:focus:not(:focus-visible) >path,
-.c4:focus:not(:focus-visible) >polygon,
-.c4:focus:not(:focus-visible) >polyline,
-.c4:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c4:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
+  column-gap: 3px;
 }
 
 .c8 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  background-color: rgba(221, 221, 221, 0.4);
-  color: #000000;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 24px;
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-  color: #444444;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c8:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-}
-
-.c8:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c8:focus >circle,
-.c8:focus >ellipse,
-.c8:focus >line,
-.c8:focus >path,
-.c8:focus >polygon,
-.c8:focus >polyline,
-.c8:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c8:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c8:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c8:focus:not(:focus-visible) >circle,
-.c8:focus:not(:focus-visible) >ellipse,
-.c8:focus:not(:focus-visible) >line,
-.c8:focus:not(:focus-visible) >path,
-.c8:focus:not(:focus-visible) >polygon,
-.c8:focus:not(:focus-visible) >polyline,
-.c8:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c8:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c5 {
-  font-size: 18px;
-  line-height: 0;
-}
-
-.c5 >svg {
-  margin: 0 auto;
-}
-
-.c3 {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  max-width: 100%;
-  height: 36px;
-  min-width: 36px;
-}
-
-@media only screen and (max-width: 768px) {
-  .c2 {
-    margin: 0px;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c2 {
-    padding: 0px;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c7 {
-    width: 2px;
-  }
-}
-
-<div
-  class="c0"
->
-  <div
-    class="c1 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
-  >
-    <nav
-      aria-label="Pagination Navigation"
-      class="c1"
-    >
-      <ul
-        class="c2"
-      >
-        <li
-          class="c3"
-        >
-          <button
-            aria-disabled="true"
-            aria-label="Go to previous page"
-            class="c4 c5"
-            disabled=""
-            type="button"
-          >
-            <svg
-              aria-label="Previous"
-              class="c6"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M17 2 7 12l10 10"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-current="page"
-            aria-label="Go to page 1"
-            class="c8 c5"
-            type="button"
-          >
-            1
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-disabled="true"
-            aria-label="Go to next page"
-            class="c4 c5"
-            disabled=""
-            type="button"
-          >
-            <svg
-              aria-label="Next"
-              class="c6"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="m7 2 10 10L7 22"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </button>
-        </li>
-      </ul>
-    </nav>
-  </div>
-</div>
-`;
-
-exports[`Pagination should disable previous and next controls when numberItems
-  === 0 1`] = `
-.c6 {
-  display: inline-block;
-  flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
-  fill: #666666;
-  stroke: #666666;
-}
-
-.c6 g {
-  fill: inherit;
-  stroke: inherit;
-}
-
-.c6 *:not([stroke])[fill='none'] {
-  stroke-width: 0;
-}
-
-.c6 *[stroke*='#'],
-.c6 *[STROKE*='#'] {
-  stroke: inherit;
-  fill: none;
-}
-
-.c6 *[fill-rule],
-.c6 *[FILL-RULE],
-.c6 *[fill*='#'],
-.c6 *[FILL*='#'] {
-  fill: inherit;
-  stroke: none;
-}
-
-.c0 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
-.c1 {
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  flex-direction: column;
-  flex: 0 0 auto;
-}
-
-.c2 {
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  margin: 0px;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  flex-direction: row;
-  padding: 0px;
-}
-
-.c7 {
-  flex: 0 0 auto;
-  align-self: stretch;
-  width: 3px;
-}
-
-.c4 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 0;
-  text-align: center;
-  opacity: 0.3;
-  cursor: default;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c4 >svg {
-  display: flex;
-  align-self: center;
-  vertical-align: middle;
-}
-
-.c4:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c4:focus >circle,
-.c4:focus >ellipse,
-.c4:focus >line,
-.c4:focus >path,
-.c4:focus >polygon,
-.c4:focus >polyline,
-.c4:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c4:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c4:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c4:focus:not(:focus-visible) >circle,
-.c4:focus:not(:focus-visible) >ellipse,
-.c4:focus:not(:focus-visible) >line,
-.c4:focus:not(:focus-visible) >path,
-.c4:focus:not(:focus-visible) >polygon,
-.c4:focus:not(:focus-visible) >polyline,
-.c4:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c4:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c5 {
-  font-size: 18px;
-  line-height: 0;
-}
-
-.c5 >svg {
-  margin: 0 auto;
-}
-
-.c3 {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  max-width: 100%;
-  height: 36px;
-  min-width: 36px;
-}
-
-@media only screen and (max-width: 768px) {
-  .c2 {
-    margin: 0px;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c2 {
-    padding: 0px;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c7 {
-    width: 2px;
-  }
-}
-
-<div
-  class="c0"
->
-  <div
-    class="c1 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
-  >
-    <nav
-      aria-label="Pagination Navigation"
-      class="c1"
-    >
-      <ul
-        class="c2"
-      >
-        <li
-          class="c3"
-        >
-          <button
-            aria-disabled="true"
-            aria-label="Go to previous page"
-            class="c4 c5"
-            disabled=""
-            type="button"
-          >
-            <svg
-              aria-label="Previous"
-              class="c6"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M17 2 7 12l10 10"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to next page"
-            class="c4 c5"
-            disabled=""
-            type="button"
-          >
-            <svg
-              aria-label="Next"
-              class="c6"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="m7 2 10 10L7 22"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </button>
-        </li>
-      </ul>
-    </nav>
-  </div>
-</div>
-`;
-
-exports[`Pagination should disable previous and next controls when numberItems
-  === step 1`] = `
-.c6 {
-  display: inline-block;
-  flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
-  fill: #666666;
-  stroke: #666666;
-}
-
-.c6 g {
-  fill: inherit;
-  stroke: inherit;
-}
-
-.c6 *:not([stroke])[fill='none'] {
-  stroke-width: 0;
-}
-
-.c6 *[stroke*='#'],
-.c6 *[STROKE*='#'] {
-  stroke: inherit;
-  fill: none;
-}
-
-.c6 *[fill-rule],
-.c6 *[FILL-RULE],
-.c6 *[fill*='#'],
-.c6 *[FILL*='#'] {
-  fill: inherit;
-  stroke: none;
-}
-
-.c0 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
-.c1 {
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  flex-direction: column;
-  flex: 0 0 auto;
-}
-
-.c2 {
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  margin: 0px;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  flex-direction: row;
-  padding: 0px;
-}
-
-.c7 {
-  flex: 0 0 auto;
-  align-self: stretch;
-  width: 3px;
-}
-
-.c4 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 0;
-  text-align: center;
-  opacity: 0.3;
-  cursor: default;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c4 >svg {
-  display: flex;
-  align-self: center;
-  vertical-align: middle;
-}
-
-.c4:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c4:focus >circle,
-.c4:focus >ellipse,
-.c4:focus >line,
-.c4:focus >path,
-.c4:focus >polygon,
-.c4:focus >polyline,
-.c4:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c4:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c4:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c4:focus:not(:focus-visible) >circle,
-.c4:focus:not(:focus-visible) >ellipse,
-.c4:focus:not(:focus-visible) >line,
-.c4:focus:not(:focus-visible) >path,
-.c4:focus:not(:focus-visible) >polygon,
-.c4:focus:not(:focus-visible) >polyline,
-.c4:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c4:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c8 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  background-color: rgba(221, 221, 221, 0.4);
-  color: #000000;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 24px;
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-  color: #444444;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c8:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-}
-
-.c8:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c8:focus >circle,
-.c8:focus >ellipse,
-.c8:focus >line,
-.c8:focus >path,
-.c8:focus >polygon,
-.c8:focus >polyline,
-.c8:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c8:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c8:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c8:focus:not(:focus-visible) >circle,
-.c8:focus:not(:focus-visible) >ellipse,
-.c8:focus:not(:focus-visible) >line,
-.c8:focus:not(:focus-visible) >path,
-.c8:focus:not(:focus-visible) >polygon,
-.c8:focus:not(:focus-visible) >polyline,
-.c8:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c8:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c5 {
-  font-size: 18px;
-  line-height: 0;
-}
-
-.c5 >svg {
-  margin: 0 auto;
-}
-
-.c3 {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  max-width: 100%;
-  height: 36px;
-  min-width: 36px;
-}
-
-@media only screen and (max-width: 768px) {
-  .c2 {
-    margin: 0px;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c2 {
-    padding: 0px;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c7 {
-    width: 2px;
-  }
-}
-
-<div
-  class="c0"
->
-  <div
-    class="c1 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
-  >
-    <nav
-      aria-label="Pagination Navigation"
-      class="c1"
-    >
-      <ul
-        class="c2"
-      >
-        <li
-          class="c3"
-        >
-          <button
-            aria-disabled="true"
-            aria-label="Go to previous page"
-            class="c4 c5"
-            disabled=""
-            type="button"
-          >
-            <svg
-              aria-label="Previous"
-              class="c6"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M17 2 7 12l10 10"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-current="page"
-            aria-label="Go to page 1"
-            class="c8 c5"
-            type="button"
-          >
-            1
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-disabled="true"
-            aria-label="Go to next page"
-            class="c4 c5"
-            disabled=""
-            type="button"
-          >
-            <svg
-              aria-label="Next"
-              class="c6"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="m7 2 10 10L7 22"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </button>
-        </li>
-      </ul>
-    </nav>
-  </div>
-</div>
-`;
-
-exports[`Pagination should disable previous button if on first page 1`] = `
-.c6 {
-  display: inline-block;
-  flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
-  fill: #666666;
-  stroke: #666666;
-}
-
-.c6 g {
-  fill: inherit;
-  stroke: inherit;
-}
-
-.c6 *:not([stroke])[fill='none'] {
-  stroke-width: 0;
-}
-
-.c6 *[stroke*='#'],
-.c6 *[STROKE*='#'] {
-  stroke: inherit;
-  fill: none;
-}
-
-.c6 *[fill-rule],
-.c6 *[FILL-RULE],
-.c6 *[fill*='#'],
-.c6 *[FILL*='#'] {
-  fill: inherit;
-  stroke: none;
-}
-
-.c13 {
-  display: inline-block;
-  flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
-  fill: #000000;
-  stroke: #000000;
-}
-
-.c13 g {
-  fill: inherit;
-  stroke: inherit;
-}
-
-.c13 *:not([stroke])[fill='none'] {
-  stroke-width: 0;
-}
-
-.c13 *[stroke*='#'],
-.c13 *[STROKE*='#'] {
-  stroke: inherit;
-  fill: none;
-}
-
-.c13 *[fill-rule],
-.c13 *[FILL-RULE],
-.c13 *[fill*='#'],
-.c13 *[FILL*='#'] {
-  fill: inherit;
-  stroke: none;
-}
-
-.c0 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
-.c1 {
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  flex-direction: column;
-  flex: 0 0 auto;
-}
-
-.c2 {
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  margin: 0px;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  flex-direction: row;
-  padding: 0px;
-}
-
-.c7 {
-  flex: 0 0 auto;
-  align-self: stretch;
-  width: 3px;
-}
-
-.c10 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c4 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 0;
-  text-align: center;
-  opacity: 0.3;
-  cursor: default;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c4 >svg {
-  display: flex;
-  align-self: center;
-  vertical-align: middle;
-}
-
-.c4:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c4:focus >circle,
-.c4:focus >ellipse,
-.c4:focus >line,
-.c4:focus >path,
-.c4:focus >polygon,
-.c4:focus >polyline,
-.c4:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c4:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c4:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c4:focus:not(:focus-visible) >circle,
-.c4:focus:not(:focus-visible) >ellipse,
-.c4:focus:not(:focus-visible) >line,
-.c4:focus:not(:focus-visible) >path,
-.c4:focus:not(:focus-visible) >polygon,
-.c4:focus:not(:focus-visible) >polyline,
-.c4:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c4:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c8 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  background-color: rgba(221, 221, 221, 0.4);
-  color: #000000;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 24px;
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-  color: #444444;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c8:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-}
-
-.c8:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c8:focus >circle,
-.c8:focus >ellipse,
-.c8:focus >line,
-.c8:focus >path,
-.c8:focus >polygon,
-.c8:focus >polyline,
-.c8:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c8:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c8:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c8:focus:not(:focus-visible) >circle,
-.c8:focus:not(:focus-visible) >ellipse,
-.c8:focus:not(:focus-visible) >line,
-.c8:focus:not(:focus-visible) >path,
-.c8:focus:not(:focus-visible) >polygon,
-.c8:focus:not(:focus-visible) >polyline,
-.c8:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c8:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c9 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 24px;
-  color: #000000;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c9:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-}
-
-.c9:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c9:focus >circle,
-.c9:focus >ellipse,
-.c9:focus >line,
-.c9:focus >path,
-.c9:focus >polygon,
-.c9:focus >polyline,
-.c9:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c9:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c9:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c9:focus:not(:focus-visible) >circle,
-.c9:focus:not(:focus-visible) >ellipse,
-.c9:focus:not(:focus-visible) >line,
-.c9:focus:not(:focus-visible) >path,
-.c9:focus:not(:focus-visible) >polygon,
-.c9:focus:not(:focus-visible) >polyline,
-.c9:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c9:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c12 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 0;
-  color: #000000;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c12 >svg {
-  display: flex;
-  align-self: center;
-  vertical-align: middle;
-}
-
-.c12:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-}
-
-.c12:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c12:focus >circle,
-.c12:focus >ellipse,
-.c12:focus >line,
-.c12:focus >path,
-.c12:focus >polygon,
-.c12:focus >polyline,
-.c12:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c12:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c12:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c12:focus:not(:focus-visible) >circle,
-.c12:focus:not(:focus-visible) >ellipse,
-.c12:focus:not(:focus-visible) >line,
-.c12:focus:not(:focus-visible) >path,
-.c12:focus:not(:focus-visible) >polygon,
-.c12:focus:not(:focus-visible) >polyline,
-.c12:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c12:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c5 {
-  font-size: 18px;
-  line-height: 0;
-}
-
-.c5 >svg {
-  margin: 0 auto;
-}
-
-.c3 {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  max-width: 100%;
-  height: 36px;
-  min-width: 36px;
-}
-
-.c11 {
-  font-weight: bold;
-  font-size: 18px;
-  line-height: 0;
-}
-
-@media only screen and (max-width: 768px) {
-  .c2 {
-    margin: 0px;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c2 {
-    padding: 0px;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c7 {
-    width: 2px;
-  }
-}
-
-<div
-  class="c0"
->
-  <div
-    class="c1 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
-  >
-    <nav
-      aria-label="Pagination Navigation"
-      class="c1"
-    >
-      <ul
-        class="c2"
-      >
-        <li
-          class="c3"
-        >
-          <button
-            aria-disabled="true"
-            aria-label="Go to previous page"
-            class="c4 c5"
-            disabled=""
-            type="button"
-          >
-            <svg
-              aria-label="Previous"
-              class="c6"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M17 2 7 12l10 10"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-current="page"
-            aria-label="Go to page 1"
-            class="c8 c5"
-            type="button"
-          >
-            1
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to page 2"
-            class="c9 c5"
-            type="button"
-          >
-            2
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to page 3"
-            class="c9 c5"
-            type="button"
-          >
-            3
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to page 4"
-            class="c9 c5"
-            type="button"
-          >
-            4
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to page 5"
-            class="c9 c5"
-            type="button"
-          >
-            5
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <span
-            class="c10 c11"
-          >
-            …
-          </span>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to page 24"
-            class="c9 c5"
-            type="button"
-          >
-            24
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to next page"
-            class="c12 c5"
-            type="button"
-          >
-            <svg
-              aria-label="Next"
-              class="c13"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="m7 2 10 10L7 22"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </button>
-        </li>
-      </ul>
-    </nav>
-  </div>
-</div>
-`;
-
-exports[`Pagination should display next page of results when "next" is
-  selected 1`] = `
-.c6 {
-  display: inline-block;
-  flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
-  fill: #000000;
-  stroke: #000000;
-}
-
-.c6 g {
-  fill: inherit;
-  stroke: inherit;
-}
-
-.c6 *:not([stroke])[fill='none'] {
-  stroke-width: 0;
-}
-
-.c6 *[stroke*='#'],
-.c6 *[STROKE*='#'] {
-  stroke: inherit;
-  fill: none;
-}
-
-.c6 *[fill-rule],
-.c6 *[FILL-RULE],
-.c6 *[fill*='#'],
-.c6 *[FILL*='#'] {
-  fill: inherit;
-  stroke: none;
-}
-
-.c0 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
-.c1 {
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  flex-direction: column;
-  flex: 0 0 auto;
-}
-
-.c2 {
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  margin: 0px;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  flex-direction: row;
-  padding: 0px;
-}
-
-.c7 {
-  flex: 0 0 auto;
-  align-self: stretch;
-  width: 3px;
-}
-
-.c10 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c9 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  background-color: rgba(221, 221, 221, 0.4);
-  color: #000000;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 24px;
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-  color: #444444;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c9:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-}
-
-.c9:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c9:focus >circle,
-.c9:focus >ellipse,
-.c9:focus >line,
-.c9:focus >path,
-.c9:focus >polygon,
-.c9:focus >polyline,
-.c9:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c9:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c9:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c9:focus:not(:focus-visible) >circle,
-.c9:focus:not(:focus-visible) >ellipse,
-.c9:focus:not(:focus-visible) >line,
-.c9:focus:not(:focus-visible) >path,
-.c9:focus:not(:focus-visible) >polygon,
-.c9:focus:not(:focus-visible) >polyline,
-.c9:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c9:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c8 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 24px;
-  color: #000000;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c8:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-}
-
-.c8:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c8:focus >circle,
-.c8:focus >ellipse,
-.c8:focus >line,
-.c8:focus >path,
-.c8:focus >polygon,
-.c8:focus >polyline,
-.c8:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c8:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c8:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c8:focus:not(:focus-visible) >circle,
-.c8:focus:not(:focus-visible) >ellipse,
-.c8:focus:not(:focus-visible) >line,
-.c8:focus:not(:focus-visible) >path,
-.c8:focus:not(:focus-visible) >polygon,
-.c8:focus:not(:focus-visible) >polyline,
-.c8:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c8:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c4 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 0;
-  color: #000000;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c4 >svg {
-  display: flex;
-  align-self: center;
-  vertical-align: middle;
-}
-
-.c4:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-}
-
-.c4:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c4:focus >circle,
-.c4:focus >ellipse,
-.c4:focus >line,
-.c4:focus >path,
-.c4:focus >polygon,
-.c4:focus >polyline,
-.c4:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c4:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c4:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c4:focus:not(:focus-visible) >circle,
-.c4:focus:not(:focus-visible) >ellipse,
-.c4:focus:not(:focus-visible) >line,
-.c4:focus:not(:focus-visible) >path,
-.c4:focus:not(:focus-visible) >polygon,
-.c4:focus:not(:focus-visible) >polyline,
-.c4:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c4:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c5 {
-  font-size: 18px;
-  line-height: 0;
-}
-
-.c5 >svg {
-  margin: 0 auto;
-}
-
-.c3 {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  max-width: 100%;
-  height: 36px;
-  min-width: 36px;
-}
-
-.c11 {
-  font-weight: bold;
-  font-size: 18px;
-  line-height: 0;
-}
-
-@media only screen and (max-width: 768px) {
-  .c2 {
-    margin: 0px;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c2 {
-    padding: 0px;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c7 {
-    width: 2px;
-  }
-}
-
-<div
-  class="c0"
->
-  <div
-    class="c1 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
-  >
-    <nav
-      aria-label="Pagination Navigation"
-      class="c1"
-    >
-      <ul
-        class="c2"
-      >
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to previous page"
-            class="c4 c5"
-            type="button"
-          >
-            <svg
-              aria-label="Previous"
-              class="c6"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M17 2 7 12l10 10"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to page 1"
-            class="c8 c5"
-            type="button"
-          >
-            1
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-current="page"
-            aria-label="Go to page 2"
-            class="c9 c5"
-            type="button"
-          >
-            2
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to page 3"
-            class="c8 c5"
-            type="button"
-          >
-            3
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to page 4"
-            class="c8 c5"
-            type="button"
-          >
-            4
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to page 5"
-            class="c8 c5"
-            type="button"
-          >
-            5
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <span
-            class="c10 c11"
-          >
-            …
-          </span>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to page 24"
-            class="c8 c5"
-            type="button"
-          >
-            24
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to next page"
-            class="c4 c5"
-            type="button"
-          >
-            <svg
-              aria-label="Next"
-              class="c6"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="m7 2 10 10L7 22"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </button>
-        </li>
-      </ul>
-    </nav>
-  </div>
-</div>
-`;
-
-exports[`Pagination should display next page of results when "next" is
-  selected 2`] = `
-<div
-  class="StyledGrommet-sc-19lkkz7-0 drDzQW"
->
-  <div
-    class="StyledBox-sc-13pk1d4-0 euJJjo Pagination__StyledPaginationContainer-sc-rnlw6m-0"
-  >
-    <nav
-      aria-label="Pagination Navigation"
-      class="StyledBox-sc-13pk1d4-0 euJJjo"
-    >
-      <ul
-        class="StyledBox-sc-13pk1d4-0 kOcABF"
-      >
-        <li
-          class="StyledPageControl__StyledContainer-sc-1vlfaez-1 bjXWCk"
-        >
-          <button
-            aria-label="Go to previous page"
-            class="StyledButtonKind-sc-1vhfpnt-0 eSmHiu StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jrdXPY"
-            type="button"
-          >
-            <svg
-              aria-label="Previous"
-              class="StyledIcon-sc-ofa7kd-0 itWvUq"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M17 2 7 12l10 10"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </button>
-        </li>
-        <div
-          class="StyledBox__StyledBoxGap-sc-13pk1d4-1 fsEMPj"
-        />
-        <li
-          class="StyledPageControl__StyledContainer-sc-1vlfaez-1 bjXWCk"
-        >
-          <button
-            aria-label="Go to page 1"
-            class="StyledButtonKind-sc-1vhfpnt-0 hsdMMS StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jrdXPY"
-            type="button"
-          >
-            1
-          </button>
-        </li>
-        <div
-          class="StyledBox__StyledBoxGap-sc-13pk1d4-1 fsEMPj"
-        />
-        <li
-          class="StyledPageControl__StyledContainer-sc-1vlfaez-1 bjXWCk"
-        >
-          <button
-            aria-current="page"
-            aria-label="Go to page 2"
-            class="StyledButtonKind-sc-1vhfpnt-0 eYeISA StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jrdXPY"
-            type="button"
-          >
-            2
-          </button>
-        </li>
-        <div
-          class="StyledBox__StyledBoxGap-sc-13pk1d4-1 fsEMPj"
-        />
-        <li
-          class="StyledPageControl__StyledContainer-sc-1vlfaez-1 bjXWCk"
-        >
-          <button
-            aria-label="Go to page 3"
-            class="StyledButtonKind-sc-1vhfpnt-0 hsdMMS StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jrdXPY"
-            type="button"
-          >
-            3
-          </button>
-        </li>
-        <div
-          class="StyledBox__StyledBoxGap-sc-13pk1d4-1 fsEMPj"
-        />
-        <li
-          class="StyledPageControl__StyledContainer-sc-1vlfaez-1 bjXWCk"
-        >
-          <button
-            aria-label="Go to page 4"
-            class="StyledButtonKind-sc-1vhfpnt-0 hsdMMS StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jrdXPY"
-            type="button"
-          >
-            4
-          </button>
-        </li>
-        <div
-          class="StyledBox__StyledBoxGap-sc-13pk1d4-1 fsEMPj"
-        />
-        <li
-          class="StyledPageControl__StyledContainer-sc-1vlfaez-1 bjXWCk"
-        >
-          <button
-            aria-label="Go to page 5"
-            class="StyledButtonKind-sc-1vhfpnt-0 hsdMMS StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jrdXPY"
-            type="button"
-          >
-            5
-          </button>
-        </li>
-        <div
-          class="StyledBox__StyledBoxGap-sc-13pk1d4-1 fsEMPj"
-        />
-        <li
-          class="StyledPageControl__StyledContainer-sc-1vlfaez-1 bjXWCk"
-        >
-          <span
-            class="StyledText-sc-1sadyjn-0 fjinKI StyledPageControl__StyledSeparator-sc-1vlfaez-2 iaZUel"
-          >
-            …
-          </span>
-        </li>
-        <div
-          class="StyledBox__StyledBoxGap-sc-13pk1d4-1 fsEMPj"
-        />
-        <li
-          class="StyledPageControl__StyledContainer-sc-1vlfaez-1 bjXWCk"
-        >
-          <button
-            aria-label="Go to page 24"
-            class="StyledButtonKind-sc-1vhfpnt-0 hsdMMS StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jrdXPY"
-            type="button"
-          >
-            24
-          </button>
-        </li>
-        <div
-          class="StyledBox__StyledBoxGap-sc-13pk1d4-1 fsEMPj"
-        />
-        <li
-          class="StyledPageControl__StyledContainer-sc-1vlfaez-1 bjXWCk"
-        >
-          <button
-            aria-label="Go to next page"
-            class="StyledButtonKind-sc-1vhfpnt-0 eSmHiu StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jrdXPY"
-            type="button"
-          >
-            <svg
-              aria-label="Next"
-              class="StyledIcon-sc-ofa7kd-0 itWvUq"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="m7 2 10 10L7 22"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </button>
-        </li>
-      </ul>
-    </nav>
-  </div>
-</div>
-`;
-
-exports[`Pagination should display page 'n' of results when "page n" is
-  selected 1`] = `
-.c6 {
-  display: inline-block;
-  flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
-  fill: #000000;
-  stroke: #000000;
-}
-
-.c6 g {
-  fill: inherit;
-  stroke: inherit;
-}
-
-.c6 *:not([stroke])[fill='none'] {
-  stroke-width: 0;
-}
-
-.c6 *[stroke*='#'],
-.c6 *[STROKE*='#'] {
-  stroke: inherit;
-  fill: none;
-}
-
-.c6 *[fill-rule],
-.c6 *[FILL-RULE],
-.c6 *[fill*='#'],
-.c6 *[FILL*='#'] {
-  fill: inherit;
-  stroke: none;
-}
-
-.c0 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
-.c1 {
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  flex-direction: column;
-  flex: 0 0 auto;
-}
-
-.c2 {
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  margin: 0px;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  flex-direction: row;
-  padding: 0px;
-}
-
-.c7 {
-  flex: 0 0 auto;
-  align-self: stretch;
-  width: 3px;
-}
-
-.c10 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c9 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  background-color: rgba(221, 221, 221, 0.4);
-  color: #000000;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 24px;
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-  color: #444444;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c9:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-}
-
-.c9:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c9:focus >circle,
-.c9:focus >ellipse,
-.c9:focus >line,
-.c9:focus >path,
-.c9:focus >polygon,
-.c9:focus >polyline,
-.c9:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c9:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c9:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c9:focus:not(:focus-visible) >circle,
-.c9:focus:not(:focus-visible) >ellipse,
-.c9:focus:not(:focus-visible) >line,
-.c9:focus:not(:focus-visible) >path,
-.c9:focus:not(:focus-visible) >polygon,
-.c9:focus:not(:focus-visible) >polyline,
-.c9:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c9:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c8 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 24px;
-  color: #000000;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c8:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-}
-
-.c8:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c8:focus >circle,
-.c8:focus >ellipse,
-.c8:focus >line,
-.c8:focus >path,
-.c8:focus >polygon,
-.c8:focus >polyline,
-.c8:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c8:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c8:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c8:focus:not(:focus-visible) >circle,
-.c8:focus:not(:focus-visible) >ellipse,
-.c8:focus:not(:focus-visible) >line,
-.c8:focus:not(:focus-visible) >path,
-.c8:focus:not(:focus-visible) >polygon,
-.c8:focus:not(:focus-visible) >polyline,
-.c8:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c8:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c4 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 0;
-  color: #000000;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c4 >svg {
-  display: flex;
-  align-self: center;
-  vertical-align: middle;
-}
-
-.c4:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-}
-
-.c4:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c4:focus >circle,
-.c4:focus >ellipse,
-.c4:focus >line,
-.c4:focus >path,
-.c4:focus >polygon,
-.c4:focus >polyline,
-.c4:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c4:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c4:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c4:focus:not(:focus-visible) >circle,
-.c4:focus:not(:focus-visible) >ellipse,
-.c4:focus:not(:focus-visible) >line,
-.c4:focus:not(:focus-visible) >path,
-.c4:focus:not(:focus-visible) >polygon,
-.c4:focus:not(:focus-visible) >polyline,
-.c4:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c4:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c5 {
-  font-size: 18px;
-  line-height: 0;
-}
-
-.c5 >svg {
-  margin: 0 auto;
-}
-
-.c3 {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  max-width: 100%;
-  height: 36px;
-  min-width: 36px;
-}
-
-.c11 {
-  font-weight: bold;
-  font-size: 18px;
-  line-height: 0;
-}
-
-@media only screen and (max-width: 768px) {
-  .c2 {
-    margin: 0px;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c2 {
-    padding: 0px;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c7 {
-    width: 2px;
-  }
-}
-
-<div
-  class="c0"
->
-  <div
-    class="c1 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
-  >
-    <nav
-      aria-label="Pagination Navigation"
-      class="c1"
-    >
-      <ul
-        class="c2"
-      >
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to previous page"
-            class="c4 c5"
-            type="button"
-          >
-            <svg
-              aria-label="Previous"
-              class="c6"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M17 2 7 12l10 10"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to page 1"
-            class="c8 c5"
-            type="button"
-          >
-            1
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-current="page"
-            aria-label="Go to page 2"
-            class="c9 c5"
-            type="button"
-          >
-            2
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to page 3"
-            class="c8 c5"
-            type="button"
-          >
-            3
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to page 4"
-            class="c8 c5"
-            type="button"
-          >
-            4
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to page 5"
-            class="c8 c5"
-            type="button"
-          >
-            5
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <span
-            class="c10 c11"
-          >
-            …
-          </span>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to page 24"
-            class="c8 c5"
-            type="button"
-          >
-            24
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to next page"
-            class="c4 c5"
-            type="button"
-          >
-            <svg
-              aria-label="Next"
-              class="c6"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="m7 2 10 10L7 22"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </button>
-        </li>
-      </ul>
-    </nav>
-  </div>
-</div>
-`;
-
-exports[`Pagination should display previous page of results when "previous" is
-  selected 1`] = `
-.c6 {
-  display: inline-block;
-  flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
-  fill: #000000;
-  stroke: #000000;
-}
-
-.c6 g {
-  fill: inherit;
-  stroke: inherit;
-}
-
-.c6 *:not([stroke])[fill='none'] {
-  stroke-width: 0;
-}
-
-.c6 *[stroke*='#'],
-.c6 *[STROKE*='#'] {
-  stroke: inherit;
-  fill: none;
-}
-
-.c6 *[fill-rule],
-.c6 *[FILL-RULE],
-.c6 *[fill*='#'],
-.c6 *[FILL*='#'] {
-  fill: inherit;
-  stroke: none;
-}
-
-.c0 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
-.c1 {
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  flex-direction: column;
-  flex: 0 0 auto;
-}
-
-.c2 {
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  margin: 0px;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  flex-direction: row;
-  padding: 0px;
-}
-
-.c7 {
-  flex: 0 0 auto;
-  align-self: stretch;
-  width: 3px;
-}
-
-.c10 {
   font-size: 18px;
   line-height: 24px;
 }
@@ -8652,3178 +5094,6 @@ exports[`Pagination should display previous page of results when "previous" is
 }
 
 .c4:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c8 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 24px;
-  color: #000000;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c8:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-}
-
-.c8:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c8:focus >circle,
-.c8:focus >ellipse,
-.c8:focus >line,
-.c8:focus >path,
-.c8:focus >polygon,
-.c8:focus >polyline,
-.c8:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c8:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c8:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c8:focus:not(:focus-visible) >circle,
-.c8:focus:not(:focus-visible) >ellipse,
-.c8:focus:not(:focus-visible) >line,
-.c8:focus:not(:focus-visible) >path,
-.c8:focus:not(:focus-visible) >polygon,
-.c8:focus:not(:focus-visible) >polyline,
-.c8:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c8:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c9 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  background-color: rgba(221, 221, 221, 0.4);
-  color: #000000;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 24px;
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-  color: #444444;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c9:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-}
-
-.c9:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c9:focus >circle,
-.c9:focus >ellipse,
-.c9:focus >line,
-.c9:focus >path,
-.c9:focus >polygon,
-.c9:focus >polyline,
-.c9:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c9:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c9:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c9:focus:not(:focus-visible) >circle,
-.c9:focus:not(:focus-visible) >ellipse,
-.c9:focus:not(:focus-visible) >line,
-.c9:focus:not(:focus-visible) >path,
-.c9:focus:not(:focus-visible) >polygon,
-.c9:focus:not(:focus-visible) >polyline,
-.c9:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c9:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c5 {
-  font-size: 18px;
-  line-height: 0;
-}
-
-.c5 >svg {
-  margin: 0 auto;
-}
-
-.c3 {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  max-width: 100%;
-  height: 36px;
-  min-width: 36px;
-}
-
-.c11 {
-  font-weight: bold;
-  font-size: 18px;
-  line-height: 0;
-}
-
-@media only screen and (max-width: 768px) {
-  .c2 {
-    margin: 0px;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c2 {
-    padding: 0px;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c7 {
-    width: 2px;
-  }
-}
-
-<div
-  class="c0"
->
-  <div
-    class="c1 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
-  >
-    <nav
-      aria-label="Pagination Navigation"
-      class="c1"
-    >
-      <ul
-        class="c2"
-      >
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to previous page"
-            class="c4 c5"
-            type="button"
-          >
-            <svg
-              aria-label="Previous"
-              class="c6"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M17 2 7 12l10 10"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to page 1"
-            class="c8 c5"
-            type="button"
-          >
-            1
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-current="page"
-            aria-label="Go to page 2"
-            class="c9 c5"
-            type="button"
-          >
-            2
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to page 3"
-            class="c8 c5"
-            type="button"
-          >
-            3
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to page 4"
-            class="c8 c5"
-            type="button"
-          >
-            4
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to page 5"
-            class="c8 c5"
-            type="button"
-          >
-            5
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <span
-            class="c10 c11"
-          >
-            …
-          </span>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to page 24"
-            class="c8 c5"
-            type="button"
-          >
-            24
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to next page"
-            class="c4 c5"
-            type="button"
-          >
-            <svg
-              aria-label="Next"
-              class="c6"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="m7 2 10 10L7 22"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </button>
-        </li>
-      </ul>
-    </nav>
-  </div>
-</div>
-`;
-
-exports[`Pagination should display previous page of results when "previous" is
-  selected 2`] = `
-<div
-  class="StyledGrommet-sc-19lkkz7-0 drDzQW"
->
-  <div
-    class="StyledBox-sc-13pk1d4-0 euJJjo Pagination__StyledPaginationContainer-sc-rnlw6m-0"
-  >
-    <nav
-      aria-label="Pagination Navigation"
-      class="StyledBox-sc-13pk1d4-0 euJJjo"
-    >
-      <ul
-        class="StyledBox-sc-13pk1d4-0 kOcABF"
-      >
-        <li
-          class="StyledPageControl__StyledContainer-sc-1vlfaez-1 bjXWCk"
-        >
-          <button
-            aria-label="Go to previous page"
-            class="StyledButtonKind-sc-1vhfpnt-0 eSmHiu StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jrdXPY"
-            type="button"
-          >
-            <svg
-              aria-label="Previous"
-              class="StyledIcon-sc-ofa7kd-0 itWvUq"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M17 2 7 12l10 10"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </button>
-        </li>
-        <div
-          class="StyledBox__StyledBoxGap-sc-13pk1d4-1 fsEMPj"
-        />
-        <li
-          class="StyledPageControl__StyledContainer-sc-1vlfaez-1 bjXWCk"
-        >
-          <button
-            aria-label="Go to page 1"
-            class="StyledButtonKind-sc-1vhfpnt-0 hsdMMS StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jrdXPY"
-            type="button"
-          >
-            1
-          </button>
-        </li>
-        <div
-          class="StyledBox__StyledBoxGap-sc-13pk1d4-1 fsEMPj"
-        />
-        <li
-          class="StyledPageControl__StyledContainer-sc-1vlfaez-1 bjXWCk"
-        >
-          <button
-            aria-current="page"
-            aria-label="Go to page 2"
-            class="StyledButtonKind-sc-1vhfpnt-0 eYeISA StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jrdXPY"
-            type="button"
-          >
-            2
-          </button>
-        </li>
-        <div
-          class="StyledBox__StyledBoxGap-sc-13pk1d4-1 fsEMPj"
-        />
-        <li
-          class="StyledPageControl__StyledContainer-sc-1vlfaez-1 bjXWCk"
-        >
-          <button
-            aria-label="Go to page 3"
-            class="StyledButtonKind-sc-1vhfpnt-0 hsdMMS StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jrdXPY"
-            type="button"
-          >
-            3
-          </button>
-        </li>
-        <div
-          class="StyledBox__StyledBoxGap-sc-13pk1d4-1 fsEMPj"
-        />
-        <li
-          class="StyledPageControl__StyledContainer-sc-1vlfaez-1 bjXWCk"
-        >
-          <button
-            aria-label="Go to page 4"
-            class="StyledButtonKind-sc-1vhfpnt-0 hsdMMS StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jrdXPY"
-            type="button"
-          >
-            4
-          </button>
-        </li>
-        <div
-          class="StyledBox__StyledBoxGap-sc-13pk1d4-1 fsEMPj"
-        />
-        <li
-          class="StyledPageControl__StyledContainer-sc-1vlfaez-1 bjXWCk"
-        >
-          <button
-            aria-label="Go to page 5"
-            class="StyledButtonKind-sc-1vhfpnt-0 hsdMMS StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jrdXPY"
-            type="button"
-          >
-            5
-          </button>
-        </li>
-        <div
-          class="StyledBox__StyledBoxGap-sc-13pk1d4-1 fsEMPj"
-        />
-        <li
-          class="StyledPageControl__StyledContainer-sc-1vlfaez-1 bjXWCk"
-        >
-          <span
-            class="StyledText-sc-1sadyjn-0 fjinKI StyledPageControl__StyledSeparator-sc-1vlfaez-2 iaZUel"
-          >
-            …
-          </span>
-        </li>
-        <div
-          class="StyledBox__StyledBoxGap-sc-13pk1d4-1 fsEMPj"
-        />
-        <li
-          class="StyledPageControl__StyledContainer-sc-1vlfaez-1 bjXWCk"
-        >
-          <button
-            aria-label="Go to page 24"
-            class="StyledButtonKind-sc-1vhfpnt-0 hsdMMS StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jrdXPY"
-            type="button"
-          >
-            24
-          </button>
-        </li>
-        <div
-          class="StyledBox__StyledBoxGap-sc-13pk1d4-1 fsEMPj"
-        />
-        <li
-          class="StyledPageControl__StyledContainer-sc-1vlfaez-1 bjXWCk"
-        >
-          <button
-            aria-label="Go to next page"
-            class="StyledButtonKind-sc-1vhfpnt-0 eSmHiu StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jrdXPY"
-            type="button"
-          >
-            <svg
-              aria-label="Next"
-              class="StyledIcon-sc-ofa7kd-0 itWvUq"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="m7 2 10 10L7 22"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </button>
-        </li>
-      </ul>
-    </nav>
-  </div>
-</div>
-`;
-
-exports[`Pagination should display the correct last page based on items length
-  and step 1`] = `
-.c6 {
-  display: inline-block;
-  flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
-  fill: #666666;
-  stroke: #666666;
-}
-
-.c6 g {
-  fill: inherit;
-  stroke: inherit;
-}
-
-.c6 *:not([stroke])[fill='none'] {
-  stroke-width: 0;
-}
-
-.c6 *[stroke*='#'],
-.c6 *[STROKE*='#'] {
-  stroke: inherit;
-  fill: none;
-}
-
-.c6 *[fill-rule],
-.c6 *[FILL-RULE],
-.c6 *[fill*='#'],
-.c6 *[FILL*='#'] {
-  fill: inherit;
-  stroke: none;
-}
-
-.c13 {
-  display: inline-block;
-  flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
-  fill: #000000;
-  stroke: #000000;
-}
-
-.c13 g {
-  fill: inherit;
-  stroke: inherit;
-}
-
-.c13 *:not([stroke])[fill='none'] {
-  stroke-width: 0;
-}
-
-.c13 *[stroke*='#'],
-.c13 *[STROKE*='#'] {
-  stroke: inherit;
-  fill: none;
-}
-
-.c13 *[fill-rule],
-.c13 *[FILL-RULE],
-.c13 *[fill*='#'],
-.c13 *[FILL*='#'] {
-  fill: inherit;
-  stroke: none;
-}
-
-.c0 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
-.c1 {
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  flex-direction: column;
-  flex: 0 0 auto;
-}
-
-.c2 {
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  margin: 0px;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  flex-direction: row;
-  padding: 0px;
-}
-
-.c7 {
-  flex: 0 0 auto;
-  align-self: stretch;
-  width: 3px;
-}
-
-.c10 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c4 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 0;
-  text-align: center;
-  opacity: 0.3;
-  cursor: default;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c4 >svg {
-  display: flex;
-  align-self: center;
-  vertical-align: middle;
-}
-
-.c4:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c4:focus >circle,
-.c4:focus >ellipse,
-.c4:focus >line,
-.c4:focus >path,
-.c4:focus >polygon,
-.c4:focus >polyline,
-.c4:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c4:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c4:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c4:focus:not(:focus-visible) >circle,
-.c4:focus:not(:focus-visible) >ellipse,
-.c4:focus:not(:focus-visible) >line,
-.c4:focus:not(:focus-visible) >path,
-.c4:focus:not(:focus-visible) >polygon,
-.c4:focus:not(:focus-visible) >polyline,
-.c4:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c4:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c8 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  background-color: rgba(221, 221, 221, 0.4);
-  color: #000000;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 24px;
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-  color: #444444;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c8:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-}
-
-.c8:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c8:focus >circle,
-.c8:focus >ellipse,
-.c8:focus >line,
-.c8:focus >path,
-.c8:focus >polygon,
-.c8:focus >polyline,
-.c8:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c8:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c8:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c8:focus:not(:focus-visible) >circle,
-.c8:focus:not(:focus-visible) >ellipse,
-.c8:focus:not(:focus-visible) >line,
-.c8:focus:not(:focus-visible) >path,
-.c8:focus:not(:focus-visible) >polygon,
-.c8:focus:not(:focus-visible) >polyline,
-.c8:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c8:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c9 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 24px;
-  color: #000000;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c9:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-}
-
-.c9:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c9:focus >circle,
-.c9:focus >ellipse,
-.c9:focus >line,
-.c9:focus >path,
-.c9:focus >polygon,
-.c9:focus >polyline,
-.c9:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c9:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c9:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c9:focus:not(:focus-visible) >circle,
-.c9:focus:not(:focus-visible) >ellipse,
-.c9:focus:not(:focus-visible) >line,
-.c9:focus:not(:focus-visible) >path,
-.c9:focus:not(:focus-visible) >polygon,
-.c9:focus:not(:focus-visible) >polyline,
-.c9:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c9:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c12 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 0;
-  color: #000000;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c12 >svg {
-  display: flex;
-  align-self: center;
-  vertical-align: middle;
-}
-
-.c12:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-}
-
-.c12:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c12:focus >circle,
-.c12:focus >ellipse,
-.c12:focus >line,
-.c12:focus >path,
-.c12:focus >polygon,
-.c12:focus >polyline,
-.c12:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c12:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c12:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c12:focus:not(:focus-visible) >circle,
-.c12:focus:not(:focus-visible) >ellipse,
-.c12:focus:not(:focus-visible) >line,
-.c12:focus:not(:focus-visible) >path,
-.c12:focus:not(:focus-visible) >polygon,
-.c12:focus:not(:focus-visible) >polyline,
-.c12:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c12:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c5 {
-  font-size: 18px;
-  line-height: 0;
-}
-
-.c5 >svg {
-  margin: 0 auto;
-}
-
-.c3 {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  max-width: 100%;
-  height: 36px;
-  min-width: 36px;
-}
-
-.c11 {
-  font-weight: bold;
-  font-size: 18px;
-  line-height: 0;
-}
-
-@media only screen and (max-width: 768px) {
-  .c2 {
-    margin: 0px;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c2 {
-    padding: 0px;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c7 {
-    width: 2px;
-  }
-}
-
-<div
-  class="c0"
->
-  <div
-    class="c1 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
-  >
-    <nav
-      aria-label="Pagination Navigation"
-      class="c1"
-    >
-      <ul
-        class="c2"
-      >
-        <li
-          class="c3"
-        >
-          <button
-            aria-disabled="true"
-            aria-label="Go to previous page"
-            class="c4 c5"
-            disabled=""
-            type="button"
-          >
-            <svg
-              aria-label="Previous"
-              class="c6"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M17 2 7 12l10 10"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-current="page"
-            aria-label="Go to page 1"
-            class="c8 c5"
-            type="button"
-          >
-            1
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to page 2"
-            class="c9 c5"
-            type="button"
-          >
-            2
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to page 3"
-            class="c9 c5"
-            type="button"
-          >
-            3
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to page 4"
-            class="c9 c5"
-            type="button"
-          >
-            4
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to page 5"
-            class="c9 c5"
-            type="button"
-          >
-            5
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <span
-            class="c10 c11"
-          >
-            …
-          </span>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to page 24"
-            class="c9 c5"
-            type="button"
-          >
-            24
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to next page"
-            class="c12 c5"
-            type="button"
-          >
-            <svg
-              aria-label="Next"
-              class="c13"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="m7 2 10 10L7 22"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </button>
-        </li>
-      </ul>
-    </nav>
-  </div>
-</div>
-`;
-
-exports[`Pagination should have no items 1`] = `
-<DocumentFragment>
-  .c11 {
-  display: inline-block;
-  flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
-  fill: #666666;
-  stroke: #666666;
-}
-
-.c11 g {
-  fill: inherit;
-  stroke: inherit;
-}
-
-.c11 *:not([stroke])[fill='none'] {
-  stroke-width: 0;
-}
-
-.c11 *[stroke*='#'],
-.c11 *[STROKE*='#'] {
-  stroke: inherit;
-  fill: none;
-}
-
-.c11 *[fill-rule],
-.c11 *[FILL-RULE],
-.c11 *[fill*='#'],
-.c11 *[FILL*='#'] {
-  fill: inherit;
-  stroke: none;
-}
-
-.c0 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
-.c1 {
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  flex-direction: row;
-  flex: 0 0 auto;
-  flex-wrap: wrap;
-  gap: 12px 6px;
-}
-
-.c2 {
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  flex-direction: column;
-  flex: 1 0 auto;
-}
-
-.c3 {
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  flex-direction: column;
-}
-
-.c5 {
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  flex-direction: row;
-  flex-wrap: wrap;
-  gap: 12px 6px;
-}
-
-.c6 {
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  flex-direction: column;
-  flex: 0 0 auto;
-}
-
-.c7 {
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  margin: 0px;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  flex-direction: row;
-  padding: 0px;
-}
-
-.c12 {
-  flex: 0 0 auto;
-  align-self: stretch;
-  width: 3px;
-}
-
-.c4 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c9 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 0;
-  text-align: center;
-  opacity: 0.3;
-  cursor: default;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c9 >svg {
-  display: flex;
-  align-self: center;
-  vertical-align: middle;
-}
-
-.c9:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c9:focus >circle,
-.c9:focus >ellipse,
-.c9:focus >line,
-.c9:focus >path,
-.c9:focus >polygon,
-.c9:focus >polyline,
-.c9:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c9:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c9:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c9:focus:not(:focus-visible) >circle,
-.c9:focus:not(:focus-visible) >ellipse,
-.c9:focus:not(:focus-visible) >line,
-.c9:focus:not(:focus-visible) >path,
-.c9:focus:not(:focus-visible) >polygon,
-.c9:focus:not(:focus-visible) >polyline,
-.c9:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c9:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c10 {
-  font-size: 18px;
-  line-height: 0;
-}
-
-.c10 >svg {
-  margin: 0 auto;
-}
-
-.c8 {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  max-width: 100%;
-  height: 36px;
-  min-width: 36px;
-}
-
-@media only screen and (max-width: 768px) {
-  .c7 {
-    margin: 0px;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c7 {
-    padding: 0px;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c12 {
-    width: 2px;
-  }
-}
-
-<div
-    class="c0"
-  >
-    <div
-      class="c1 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
-    >
-      <div
-        class="c2"
-      >
-        <div
-          class="c3"
-        >
-          <span
-            class="c4"
-          >
-            0 items
-          </span>
-        </div>
-      </div>
-      <div
-        class="c5"
-      >
-        <nav
-          aria-label="Pagination Navigation"
-          class="c6"
-        >
-          <ul
-            class="c7"
-          >
-            <li
-              class="c8"
-            >
-              <button
-                aria-disabled="true"
-                aria-label="Go to previous page"
-                class="c9 c10"
-                disabled=""
-                type="button"
-              >
-                <svg
-                  aria-label="Previous"
-                  class="c11"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="M17 2 7 12l10 10"
-                    fill="none"
-                    stroke="#000"
-                    stroke-width="2"
-                  />
-                </svg>
-              </button>
-            </li>
-            <div
-              class="c12"
-            />
-            <li
-              class="c8"
-            >
-              <button
-                aria-label="Go to next page"
-                class="c9 c10"
-                disabled=""
-                type="button"
-              >
-                <svg
-                  aria-label="Next"
-                  class="c11"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="m7 2 10 10L7 22"
-                    fill="none"
-                    stroke="#000"
-                    stroke-width="2"
-                  />
-                </svg>
-              </button>
-            </li>
-          </ul>
-        </nav>
-      </div>
-    </div>
-  </div>
-</DocumentFragment>
-`;
-
-exports[`Pagination should render correct numberEdgePages 1`] = `
-.c6 {
-  display: inline-block;
-  flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
-  fill: #000000;
-  stroke: #000000;
-}
-
-.c6 g {
-  fill: inherit;
-  stroke: inherit;
-}
-
-.c6 *:not([stroke])[fill='none'] {
-  stroke-width: 0;
-}
-
-.c6 *[stroke*='#'],
-.c6 *[STROKE*='#'] {
-  stroke: inherit;
-  fill: none;
-}
-
-.c6 *[fill-rule],
-.c6 *[FILL-RULE],
-.c6 *[fill*='#'],
-.c6 *[FILL*='#'] {
-  fill: inherit;
-  stroke: none;
-}
-
-.c0 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
-.c1 {
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  flex-direction: column;
-  flex: 0 0 auto;
-}
-
-.c2 {
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  margin: 0px;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  flex-direction: row;
-  padding: 0px;
-}
-
-.c7 {
-  flex: 0 0 auto;
-  align-self: stretch;
-  width: 3px;
-}
-
-.c9 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c4 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 0;
-  color: #000000;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c4 >svg {
-  display: flex;
-  align-self: center;
-  vertical-align: middle;
-}
-
-.c4:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-}
-
-.c4:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c4:focus >circle,
-.c4:focus >ellipse,
-.c4:focus >line,
-.c4:focus >path,
-.c4:focus >polygon,
-.c4:focus >polyline,
-.c4:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c4:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c4:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c4:focus:not(:focus-visible) >circle,
-.c4:focus:not(:focus-visible) >ellipse,
-.c4:focus:not(:focus-visible) >line,
-.c4:focus:not(:focus-visible) >path,
-.c4:focus:not(:focus-visible) >polygon,
-.c4:focus:not(:focus-visible) >polyline,
-.c4:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c4:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c8 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 24px;
-  color: #000000;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c8:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-}
-
-.c8:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c8:focus >circle,
-.c8:focus >ellipse,
-.c8:focus >line,
-.c8:focus >path,
-.c8:focus >polygon,
-.c8:focus >polyline,
-.c8:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c8:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c8:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c8:focus:not(:focus-visible) >circle,
-.c8:focus:not(:focus-visible) >ellipse,
-.c8:focus:not(:focus-visible) >line,
-.c8:focus:not(:focus-visible) >path,
-.c8:focus:not(:focus-visible) >polygon,
-.c8:focus:not(:focus-visible) >polyline,
-.c8:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c8:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c11 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  background-color: rgba(221, 221, 221, 0.4);
-  color: #000000;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 24px;
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-  color: #444444;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c11:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-}
-
-.c11:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c11:focus >circle,
-.c11:focus >ellipse,
-.c11:focus >line,
-.c11:focus >path,
-.c11:focus >polygon,
-.c11:focus >polyline,
-.c11:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c11:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c11:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c11:focus:not(:focus-visible) >circle,
-.c11:focus:not(:focus-visible) >ellipse,
-.c11:focus:not(:focus-visible) >line,
-.c11:focus:not(:focus-visible) >path,
-.c11:focus:not(:focus-visible) >polygon,
-.c11:focus:not(:focus-visible) >polyline,
-.c11:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c11:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c5 {
-  font-size: 18px;
-  line-height: 0;
-}
-
-.c5 >svg {
-  margin: 0 auto;
-}
-
-.c3 {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  max-width: 100%;
-  height: 36px;
-  min-width: 36px;
-}
-
-.c10 {
-  font-weight: bold;
-  font-size: 18px;
-  line-height: 0;
-}
-
-@media only screen and (max-width: 768px) {
-  .c2 {
-    margin: 0px;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c2 {
-    padding: 0px;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c7 {
-    width: 2px;
-  }
-}
-
-<div
-  class="c0"
->
-  <div
-    class="c1 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
-  >
-    <nav
-      aria-label="Pagination Navigation"
-      class="c1"
-    >
-      <ul
-        class="c2"
-      >
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to previous page"
-            class="c4 c5"
-            type="button"
-          >
-            <svg
-              aria-label="Previous"
-              class="c6"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M17 2 7 12l10 10"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to page 1"
-            class="c8 c5"
-            type="button"
-          >
-            1
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to page 2"
-            class="c8 c5"
-            type="button"
-          >
-            2
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to page 3"
-            class="c8 c5"
-            type="button"
-          >
-            3
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <span
-            class="c9 c10"
-          >
-            …
-          </span>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to page 9"
-            class="c8 c5"
-            type="button"
-          >
-            9
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-current="page"
-            aria-label="Go to page 10"
-            class="c11 c5"
-            type="button"
-          >
-            10
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to page 11"
-            class="c8 c5"
-            type="button"
-          >
-            11
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <span
-            class="c9 c10"
-          >
-            …
-          </span>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to page 22"
-            class="c8 c5"
-            type="button"
-          >
-            22
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to page 23"
-            class="c8 c5"
-            type="button"
-          >
-            23
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to page 24"
-            class="c8 c5"
-            type="button"
-          >
-            24
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to next page"
-            class="c4 c5"
-            type="button"
-          >
-            <svg
-              aria-label="Next"
-              class="c6"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="m7 2 10 10L7 22"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </button>
-        </li>
-      </ul>
-    </nav>
-  </div>
-</div>
-`;
-
-exports[`Pagination should render correct numberMiddlePages when even 1`] = `
-.c6 {
-  display: inline-block;
-  flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
-  fill: #000000;
-  stroke: #000000;
-}
-
-.c6 g {
-  fill: inherit;
-  stroke: inherit;
-}
-
-.c6 *:not([stroke])[fill='none'] {
-  stroke-width: 0;
-}
-
-.c6 *[stroke*='#'],
-.c6 *[STROKE*='#'] {
-  stroke: inherit;
-  fill: none;
-}
-
-.c6 *[fill-rule],
-.c6 *[FILL-RULE],
-.c6 *[fill*='#'],
-.c6 *[FILL*='#'] {
-  fill: inherit;
-  stroke: none;
-}
-
-.c0 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
-.c1 {
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  flex-direction: column;
-  flex: 0 0 auto;
-}
-
-.c2 {
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  margin: 0px;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  flex-direction: row;
-  padding: 0px;
-}
-
-.c7 {
-  flex: 0 0 auto;
-  align-self: stretch;
-  width: 3px;
-}
-
-.c9 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c4 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 0;
-  color: #000000;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c4 >svg {
-  display: flex;
-  align-self: center;
-  vertical-align: middle;
-}
-
-.c4:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-}
-
-.c4:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c4:focus >circle,
-.c4:focus >ellipse,
-.c4:focus >line,
-.c4:focus >path,
-.c4:focus >polygon,
-.c4:focus >polyline,
-.c4:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c4:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c4:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c4:focus:not(:focus-visible) >circle,
-.c4:focus:not(:focus-visible) >ellipse,
-.c4:focus:not(:focus-visible) >line,
-.c4:focus:not(:focus-visible) >path,
-.c4:focus:not(:focus-visible) >polygon,
-.c4:focus:not(:focus-visible) >polyline,
-.c4:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c4:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c8 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 24px;
-  color: #000000;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c8:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-}
-
-.c8:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c8:focus >circle,
-.c8:focus >ellipse,
-.c8:focus >line,
-.c8:focus >path,
-.c8:focus >polygon,
-.c8:focus >polyline,
-.c8:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c8:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c8:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c8:focus:not(:focus-visible) >circle,
-.c8:focus:not(:focus-visible) >ellipse,
-.c8:focus:not(:focus-visible) >line,
-.c8:focus:not(:focus-visible) >path,
-.c8:focus:not(:focus-visible) >polygon,
-.c8:focus:not(:focus-visible) >polyline,
-.c8:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c8:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c11 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  background-color: rgba(221, 221, 221, 0.4);
-  color: #000000;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 24px;
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-  color: #444444;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c11:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-}
-
-.c11:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c11:focus >circle,
-.c11:focus >ellipse,
-.c11:focus >line,
-.c11:focus >path,
-.c11:focus >polygon,
-.c11:focus >polyline,
-.c11:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c11:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c11:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c11:focus:not(:focus-visible) >circle,
-.c11:focus:not(:focus-visible) >ellipse,
-.c11:focus:not(:focus-visible) >line,
-.c11:focus:not(:focus-visible) >path,
-.c11:focus:not(:focus-visible) >polygon,
-.c11:focus:not(:focus-visible) >polyline,
-.c11:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c11:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c5 {
-  font-size: 18px;
-  line-height: 0;
-}
-
-.c5 >svg {
-  margin: 0 auto;
-}
-
-.c3 {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  max-width: 100%;
-  height: 36px;
-  min-width: 36px;
-}
-
-.c10 {
-  font-weight: bold;
-  font-size: 18px;
-  line-height: 0;
-}
-
-@media only screen and (max-width: 768px) {
-  .c2 {
-    margin: 0px;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c2 {
-    padding: 0px;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c7 {
-    width: 2px;
-  }
-}
-
-<div
-  class="c0"
->
-  <div
-    class="c1 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
-  >
-    <nav
-      aria-label="Pagination Navigation"
-      class="c1"
-    >
-      <ul
-        class="c2"
-      >
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to previous page"
-            class="c4 c5"
-            type="button"
-          >
-            <svg
-              aria-label="Previous"
-              class="c6"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M17 2 7 12l10 10"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to page 1"
-            class="c8 c5"
-            type="button"
-          >
-            1
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <span
-            class="c9 c10"
-          >
-            …
-          </span>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to page 9"
-            class="c8 c5"
-            type="button"
-          >
-            9
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-current="page"
-            aria-label="Go to page 10"
-            class="c11 c5"
-            type="button"
-          >
-            10
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to page 11"
-            class="c8 c5"
-            type="button"
-          >
-            11
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to page 12"
-            class="c8 c5"
-            type="button"
-          >
-            12
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <span
-            class="c9 c10"
-          >
-            …
-          </span>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to page 24"
-            class="c8 c5"
-            type="button"
-          >
-            24
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to next page"
-            class="c4 c5"
-            type="button"
-          >
-            <svg
-              aria-label="Next"
-              class="c6"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="m7 2 10 10L7 22"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </button>
-        </li>
-      </ul>
-    </nav>
-  </div>
-</div>
-`;
-
-exports[`Pagination should render correct numberMiddlePages when odd 1`] = `
-.c6 {
-  display: inline-block;
-  flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
-  fill: #000000;
-  stroke: #000000;
-}
-
-.c6 g {
-  fill: inherit;
-  stroke: inherit;
-}
-
-.c6 *:not([stroke])[fill='none'] {
-  stroke-width: 0;
-}
-
-.c6 *[stroke*='#'],
-.c6 *[STROKE*='#'] {
-  stroke: inherit;
-  fill: none;
-}
-
-.c6 *[fill-rule],
-.c6 *[FILL-RULE],
-.c6 *[fill*='#'],
-.c6 *[FILL*='#'] {
-  fill: inherit;
-  stroke: none;
-}
-
-.c0 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
-.c1 {
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  flex-direction: column;
-  flex: 0 0 auto;
-}
-
-.c2 {
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  margin: 0px;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  flex-direction: row;
-  padding: 0px;
-}
-
-.c7 {
-  flex: 0 0 auto;
-  align-self: stretch;
-  width: 3px;
-}
-
-.c9 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c4 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 0;
-  color: #000000;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c4 >svg {
-  display: flex;
-  align-self: center;
-  vertical-align: middle;
-}
-
-.c4:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-}
-
-.c4:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c4:focus >circle,
-.c4:focus >ellipse,
-.c4:focus >line,
-.c4:focus >path,
-.c4:focus >polygon,
-.c4:focus >polyline,
-.c4:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c4:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c4:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c4:focus:not(:focus-visible) >circle,
-.c4:focus:not(:focus-visible) >ellipse,
-.c4:focus:not(:focus-visible) >line,
-.c4:focus:not(:focus-visible) >path,
-.c4:focus:not(:focus-visible) >polygon,
-.c4:focus:not(:focus-visible) >polyline,
-.c4:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c4:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c8 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 24px;
-  color: #000000;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c8:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-}
-
-.c8:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c8:focus >circle,
-.c8:focus >ellipse,
-.c8:focus >line,
-.c8:focus >path,
-.c8:focus >polygon,
-.c8:focus >polyline,
-.c8:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c8:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c8:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c8:focus:not(:focus-visible) >circle,
-.c8:focus:not(:focus-visible) >ellipse,
-.c8:focus:not(:focus-visible) >line,
-.c8:focus:not(:focus-visible) >path,
-.c8:focus:not(:focus-visible) >polygon,
-.c8:focus:not(:focus-visible) >polyline,
-.c8:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c8:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c11 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  background-color: rgba(221, 221, 221, 0.4);
-  color: #000000;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 24px;
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-  color: #444444;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c11:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-}
-
-.c11:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c11:focus >circle,
-.c11:focus >ellipse,
-.c11:focus >line,
-.c11:focus >path,
-.c11:focus >polygon,
-.c11:focus >polyline,
-.c11:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c11:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c11:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c11:focus:not(:focus-visible) >circle,
-.c11:focus:not(:focus-visible) >ellipse,
-.c11:focus:not(:focus-visible) >line,
-.c11:focus:not(:focus-visible) >path,
-.c11:focus:not(:focus-visible) >polygon,
-.c11:focus:not(:focus-visible) >polyline,
-.c11:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c11:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c5 {
-  font-size: 18px;
-  line-height: 0;
-}
-
-.c5 >svg {
-  margin: 0 auto;
-}
-
-.c3 {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  max-width: 100%;
-  height: 36px;
-  min-width: 36px;
-}
-
-.c10 {
-  font-weight: bold;
-  font-size: 18px;
-  line-height: 0;
-}
-
-@media only screen and (max-width: 768px) {
-  .c2 {
-    margin: 0px;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c2 {
-    padding: 0px;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c7 {
-    width: 2px;
-  }
-}
-
-<div
-  class="c0"
->
-  <div
-    class="c1 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
-  >
-    <nav
-      aria-label="Pagination Navigation"
-      class="c1"
-    >
-      <ul
-        class="c2"
-      >
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to previous page"
-            class="c4 c5"
-            type="button"
-          >
-            <svg
-              aria-label="Previous"
-              class="c6"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M17 2 7 12l10 10"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to page 1"
-            class="c8 c5"
-            type="button"
-          >
-            1
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <span
-            class="c9 c10"
-          >
-            …
-          </span>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to page 8"
-            class="c8 c5"
-            type="button"
-          >
-            8
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to page 9"
-            class="c8 c5"
-            type="button"
-          >
-            9
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-current="page"
-            aria-label="Go to page 10"
-            class="c11 c5"
-            type="button"
-          >
-            10
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to page 11"
-            class="c8 c5"
-            type="button"
-          >
-            11
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to page 12"
-            class="c8 c5"
-            type="button"
-          >
-            12
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <span
-            class="c9 c10"
-          >
-            …
-          </span>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to page 24"
-            class="c8 c5"
-            type="button"
-          >
-            24
-          </button>
-        </li>
-        <div
-          class="c7"
-        />
-        <li
-          class="c3"
-        >
-          <button
-            aria-label="Go to next page"
-            class="c4 c5"
-            type="button"
-          >
-            <svg
-              aria-label="Next"
-              class="c6"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="m7 2 10 10L7 22"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-            </svg>
-          </button>
-        </li>
-      </ul>
-    </nav>
-  </div>
-</div>
-`;
-
-exports[`Pagination should render outside grommet wrapper 1`] = `
-.c5 {
-  display: inline-block;
-  flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
-  fill: #000000;
-  stroke: #000000;
-}
-
-.c5 g {
-  fill: inherit;
-  stroke: inherit;
-}
-
-.c5 *:not([stroke])[fill='none'] {
-  stroke-width: 0;
-}
-
-.c5 *[stroke*='#'],
-.c5 *[STROKE*='#'] {
-  stroke: inherit;
-  fill: none;
-}
-
-.c5 *[fill-rule],
-.c5 *[FILL-RULE],
-.c5 *[fill*='#'],
-.c5 *[FILL*='#'] {
-  fill: inherit;
-  stroke: none;
-}
-
-.c0 {
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  flex-direction: column;
-  flex: 0 0 auto;
-}
-
-.c1 {
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  margin: 0px;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  flex-direction: row;
-  padding: 0px;
-}
-
-.c6 {
-  flex: 0 0 auto;
-  align-self: stretch;
-  width: 3px;
-}
-
-.c8 {
-  font-size: 18px;
-  line-height: 24px;
-}
-
-.c3 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 0;
-  color: #000000;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c3 >svg {
-  display: flex;
-  align-self: center;
-  vertical-align: middle;
-}
-
-.c3:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-}
-
-.c3:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c3:focus >circle,
-.c3:focus >ellipse,
-.c3:focus >line,
-.c3:focus >path,
-.c3:focus >polygon,
-.c3:focus >polyline,
-.c3:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c3:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c3:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c3:focus:not(:focus-visible) >circle,
-.c3:focus:not(:focus-visible) >ellipse,
-.c3:focus:not(:focus-visible) >line,
-.c3:focus:not(:focus-visible) >path,
-.c3:focus:not(:focus-visible) >polygon,
-.c3:focus:not(:focus-visible) >polyline,
-.c3:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c3:focus:not(:focus-visible) ::-moz-focus-inner {
   border: 0;
 }
 
@@ -11970,16 +5240,89 @@ exports[`Pagination should render outside grommet wrapper 1`] = `
   border: 0;
 }
 
-.c4 {
+.c11 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 0;
+  text-align: center;
+  opacity: 0.3;
+  cursor: default;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c11 >svg {
+  display: flex;
+  align-self: center;
+  vertical-align: middle;
+}
+
+.c11:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus >circle,
+.c11:focus >ellipse,
+.c11:focus >line,
+.c11:focus >path,
+.c11:focus >polygon,
+.c11:focus >polyline,
+.c11:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c11:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c11:focus:not(:focus-visible) >circle,
+.c11:focus:not(:focus-visible) >ellipse,
+.c11:focus:not(:focus-visible) >line,
+.c11:focus:not(:focus-visible) >path,
+.c11:focus:not(:focus-visible) >polygon,
+.c11:focus:not(:focus-visible) >polyline,
+.c11:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c11:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c5 {
   font-size: 18px;
   line-height: 0;
 }
 
-.c4 >svg {
+.c5 >svg {
   margin: 0 auto;
 }
 
-.c2 {
+.c3 {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -11995,181 +5338,166 @@ exports[`Pagination should render outside grommet wrapper 1`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c1 {
+  .c2 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c1 {
+  .c2 {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c6 {
-    width: 2px;
+  .c2 {
+    column-gap: 2px;
   }
 }
 
 <div
-  class="c0 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
+  class="c0"
 >
-  <nav
-    aria-label="Pagination Navigation"
-    class="c0"
+  <div
+    class="c1 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
   >
-    <ul
+    <nav
+      aria-label="Pagination Navigation"
       class="c1"
     >
-      <li
+      <ul
         class="c2"
       >
-        <button
-          aria-label="Go to previous page"
-          class="c3 c4"
-          type="button"
+        <li
+          class="c3"
         >
-          <svg
-            aria-label="Previous"
-            class="c5"
-            viewBox="0 0 24 24"
+          <button
+            aria-label="Go to previous page"
+            class="c4 c5"
+            type="button"
           >
-            <path
-              d="M17 2 7 12l10 10"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-      </li>
-      <div
-        class="c6"
-      />
-      <li
-        class="c2"
-      >
-        <button
-          aria-label="Go to page 1"
-          class="c7 c4"
-          type="button"
+            <svg
+              aria-label="Previous"
+              class="c6"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M17 2 7 12l10 10"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </li>
+        <li
+          class="c3"
         >
-          1
-        </button>
-      </li>
-      <div
-        class="c6"
-      />
-      <li
-        class="c2"
-      >
-        <span
-          class="c8 c9"
-        >
-          …
-        </span>
-      </li>
-      <div
-        class="c6"
-      />
-      <li
-        class="c2"
-      >
-        <button
-          aria-label="Go to page 9"
-          class="c7 c4"
-          type="button"
-        >
-          9
-        </button>
-      </li>
-      <div
-        class="c6"
-      />
-      <li
-        class="c2"
-      >
-        <button
-          aria-current="page"
-          aria-label="Go to page 10"
-          class="c10 c4"
-          type="button"
-        >
-          10
-        </button>
-      </li>
-      <div
-        class="c6"
-      />
-      <li
-        class="c2"
-      >
-        <button
-          aria-label="Go to page 11"
-          class="c7 c4"
-          type="button"
-        >
-          11
-        </button>
-      </li>
-      <div
-        class="c6"
-      />
-      <li
-        class="c2"
-      >
-        <span
-          class="c8 c9"
-        >
-          …
-        </span>
-      </li>
-      <div
-        class="c6"
-      />
-      <li
-        class="c2"
-      >
-        <button
-          aria-label="Go to page 24"
-          class="c7 c4"
-          type="button"
-        >
-          24
-        </button>
-      </li>
-      <div
-        class="c6"
-      />
-      <li
-        class="c2"
-      >
-        <button
-          aria-label="Go to next page"
-          class="c3 c4"
-          type="button"
-        >
-          <svg
-            aria-label="Next"
-            class="c5"
-            viewBox="0 0 24 24"
+          <button
+            aria-label="Go to page 1"
+            class="c7 c5"
+            type="button"
           >
-            <path
-              d="m7 2 10 10L7 22"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-      </li>
-    </ul>
-  </nav>
+            1
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <span
+            class="c8 c9"
+          >
+            …
+          </span>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 20"
+            class="c7 c5"
+            type="button"
+          >
+            20
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 21"
+            class="c7 c5"
+            type="button"
+          >
+            21
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 22"
+            class="c7 c5"
+            type="button"
+          >
+            22
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 23"
+            class="c7 c5"
+            type="button"
+          >
+            23
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-current="page"
+            aria-label="Go to page 24"
+            class="c10 c5"
+            type="button"
+          >
+            24
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-disabled="true"
+            aria-label="Go to next page"
+            class="c11 c5"
+            disabled=""
+            type="button"
+          >
+            <svg
+              aria-label="Next"
+              class="c12"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m7 2 10 10L7 22"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </li>
+      </ul>
+    </nav>
+  </div>
 </div>
 `;
 
-exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 1`] = `
+exports[`Pagination should disable previous and next controls when numberItems
+  < step 1`] = `
 .c6 {
   display: inline-block;
   flex: 0 0 auto;
@@ -12198,38 +5526,6 @@ exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 
 .c6 *[FILL-RULE],
 .c6 *[fill*='#'],
 .c6 *[FILL*='#'] {
-  fill: inherit;
-  stroke: none;
-}
-
-.c13 {
-  display: inline-block;
-  flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
-  fill: #000000;
-  stroke: #000000;
-}
-
-.c13 g {
-  fill: inherit;
-  stroke: inherit;
-}
-
-.c13 *:not([stroke])[fill='none'] {
-  stroke-width: 0;
-}
-
-.c13 *[stroke*='#'],
-.c13 *[STROKE*='#'] {
-  stroke: inherit;
-  fill: none;
-}
-
-.c13 *[fill-rule],
-.c13 *[FILL-RULE],
-.c13 *[fill*='#'],
-.c13 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -12264,15 +5560,939 @@ exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 
   min-height: 0;
   flex-direction: row;
   padding: 0px;
+  column-gap: 3px;
+}
+
+.c4 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 0;
+  text-align: center;
+  opacity: 0.3;
+  cursor: default;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c4 >svg {
+  display: flex;
+  align-self: center;
+  vertical-align: middle;
+}
+
+.c4:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus >circle,
+.c4:focus >ellipse,
+.c4:focus >line,
+.c4:focus >path,
+.c4:focus >polygon,
+.c4:focus >polyline,
+.c4:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c4:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c4:focus:not(:focus-visible) >circle,
+.c4:focus:not(:focus-visible) >ellipse,
+.c4:focus:not(:focus-visible) >line,
+.c4:focus:not(:focus-visible) >path,
+.c4:focus:not(:focus-visible) >polygon,
+.c4:focus:not(:focus-visible) >polyline,
+.c4:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c4:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
 }
 
 .c7 {
-  flex: 0 0 auto;
-  align-self: stretch;
-  width: 3px;
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  background-color: rgba(221, 221, 221, 0.4);
+  color: #000000;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+  color: #444444;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
 }
 
-.c10 {
+.c7:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c7:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c7:focus >circle,
+.c7:focus >ellipse,
+.c7:focus >line,
+.c7:focus >path,
+.c7:focus >polygon,
+.c7:focus >polyline,
+.c7:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c7:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c7:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c7:focus:not(:focus-visible) >circle,
+.c7:focus:not(:focus-visible) >ellipse,
+.c7:focus:not(:focus-visible) >line,
+.c7:focus:not(:focus-visible) >path,
+.c7:focus:not(:focus-visible) >polygon,
+.c7:focus:not(:focus-visible) >polyline,
+.c7:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c7:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c5 {
+  font-size: 18px;
+  line-height: 0;
+}
+
+.c5 >svg {
+  margin: 0 auto;
+}
+
+.c3 {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  max-width: 100%;
+  height: 36px;
+  min-width: 36px;
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    column-gap: 2px;
+  }
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
+  >
+    <nav
+      aria-label="Pagination Navigation"
+      class="c1"
+    >
+      <ul
+        class="c2"
+      >
+        <li
+          class="c3"
+        >
+          <button
+            aria-disabled="true"
+            aria-label="Go to previous page"
+            class="c4 c5"
+            disabled=""
+            type="button"
+          >
+            <svg
+              aria-label="Previous"
+              class="c6"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M17 2 7 12l10 10"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-current="page"
+            aria-label="Go to page 1"
+            class="c7 c5"
+            type="button"
+          >
+            1
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-disabled="true"
+            aria-label="Go to next page"
+            class="c4 c5"
+            disabled=""
+            type="button"
+          >
+            <svg
+              aria-label="Next"
+              class="c6"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m7 2 10 10L7 22"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</div>
+`;
+
+exports[`Pagination should disable previous and next controls when numberItems
+  === 0 1`] = `
+.c6 {
+  display: inline-block;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #666666;
+  stroke: #666666;
+}
+
+.c6 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c6 *:not([stroke])[fill='none'] {
+  stroke-width: 0;
+}
+
+.c6 *[stroke*='#'],
+.c6 *[STROKE*='#'] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c6 *[fill-rule],
+.c6 *[FILL-RULE],
+.c6 *[fill*='#'],
+.c6 *[FILL*='#'] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  flex: 0 0 auto;
+}
+
+.c2 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin: 0px;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  padding: 0px;
+  column-gap: 3px;
+}
+
+.c4 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 0;
+  text-align: center;
+  opacity: 0.3;
+  cursor: default;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c4 >svg {
+  display: flex;
+  align-self: center;
+  vertical-align: middle;
+}
+
+.c4:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus >circle,
+.c4:focus >ellipse,
+.c4:focus >line,
+.c4:focus >path,
+.c4:focus >polygon,
+.c4:focus >polyline,
+.c4:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c4:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c4:focus:not(:focus-visible) >circle,
+.c4:focus:not(:focus-visible) >ellipse,
+.c4:focus:not(:focus-visible) >line,
+.c4:focus:not(:focus-visible) >path,
+.c4:focus:not(:focus-visible) >polygon,
+.c4:focus:not(:focus-visible) >polyline,
+.c4:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c4:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c5 {
+  font-size: 18px;
+  line-height: 0;
+}
+
+.c5 >svg {
+  margin: 0 auto;
+}
+
+.c3 {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  max-width: 100%;
+  height: 36px;
+  min-width: 36px;
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    column-gap: 2px;
+  }
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
+  >
+    <nav
+      aria-label="Pagination Navigation"
+      class="c1"
+    >
+      <ul
+        class="c2"
+      >
+        <li
+          class="c3"
+        >
+          <button
+            aria-disabled="true"
+            aria-label="Go to previous page"
+            class="c4 c5"
+            disabled=""
+            type="button"
+          >
+            <svg
+              aria-label="Previous"
+              class="c6"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M17 2 7 12l10 10"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to next page"
+            class="c4 c5"
+            disabled=""
+            type="button"
+          >
+            <svg
+              aria-label="Next"
+              class="c6"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m7 2 10 10L7 22"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</div>
+`;
+
+exports[`Pagination should disable previous and next controls when numberItems
+  === step 1`] = `
+.c6 {
+  display: inline-block;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #666666;
+  stroke: #666666;
+}
+
+.c6 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c6 *:not([stroke])[fill='none'] {
+  stroke-width: 0;
+}
+
+.c6 *[stroke*='#'],
+.c6 *[STROKE*='#'] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c6 *[fill-rule],
+.c6 *[FILL-RULE],
+.c6 *[fill*='#'],
+.c6 *[FILL*='#'] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  flex: 0 0 auto;
+}
+
+.c2 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin: 0px;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  padding: 0px;
+  column-gap: 3px;
+}
+
+.c4 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 0;
+  text-align: center;
+  opacity: 0.3;
+  cursor: default;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c4 >svg {
+  display: flex;
+  align-self: center;
+  vertical-align: middle;
+}
+
+.c4:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus >circle,
+.c4:focus >ellipse,
+.c4:focus >line,
+.c4:focus >path,
+.c4:focus >polygon,
+.c4:focus >polyline,
+.c4:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c4:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c4:focus:not(:focus-visible) >circle,
+.c4:focus:not(:focus-visible) >ellipse,
+.c4:focus:not(:focus-visible) >line,
+.c4:focus:not(:focus-visible) >path,
+.c4:focus:not(:focus-visible) >polygon,
+.c4:focus:not(:focus-visible) >polyline,
+.c4:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c4:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c7 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  background-color: rgba(221, 221, 221, 0.4);
+  color: #000000;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+  color: #444444;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c7:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c7:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c7:focus >circle,
+.c7:focus >ellipse,
+.c7:focus >line,
+.c7:focus >path,
+.c7:focus >polygon,
+.c7:focus >polyline,
+.c7:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c7:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c7:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c7:focus:not(:focus-visible) >circle,
+.c7:focus:not(:focus-visible) >ellipse,
+.c7:focus:not(:focus-visible) >line,
+.c7:focus:not(:focus-visible) >path,
+.c7:focus:not(:focus-visible) >polygon,
+.c7:focus:not(:focus-visible) >polyline,
+.c7:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c7:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c5 {
+  font-size: 18px;
+  line-height: 0;
+}
+
+.c5 >svg {
+  margin: 0 auto;
+}
+
+.c3 {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  max-width: 100%;
+  height: 36px;
+  min-width: 36px;
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    column-gap: 2px;
+  }
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
+  >
+    <nav
+      aria-label="Pagination Navigation"
+      class="c1"
+    >
+      <ul
+        class="c2"
+      >
+        <li
+          class="c3"
+        >
+          <button
+            aria-disabled="true"
+            aria-label="Go to previous page"
+            class="c4 c5"
+            disabled=""
+            type="button"
+          >
+            <svg
+              aria-label="Previous"
+              class="c6"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M17 2 7 12l10 10"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-current="page"
+            aria-label="Go to page 1"
+            class="c7 c5"
+            type="button"
+          >
+            1
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-disabled="true"
+            aria-label="Go to next page"
+            class="c4 c5"
+            disabled=""
+            type="button"
+          >
+            <svg
+              aria-label="Next"
+              class="c6"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m7 2 10 10L7 22"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</div>
+`;
+
+exports[`Pagination should disable previous button if on first page 1`] = `
+.c6 {
+  display: inline-block;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #666666;
+  stroke: #666666;
+}
+
+.c6 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c6 *:not([stroke])[fill='none'] {
+  stroke-width: 0;
+}
+
+.c6 *[stroke*='#'],
+.c6 *[STROKE*='#'] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c6 *[fill-rule],
+.c6 *[FILL-RULE],
+.c6 *[fill*='#'],
+.c6 *[FILL*='#'] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c12 {
+  display: inline-block;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #000000;
+  stroke: #000000;
+}
+
+.c12 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c12 *:not([stroke])[fill='none'] {
+  stroke-width: 0;
+}
+
+.c12 *[stroke*='#'],
+.c12 *[STROKE*='#'] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c12 *[fill-rule],
+.c12 *[FILL-RULE],
+.c12 *[fill*='#'],
+.c12 *[FILL*='#'] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  flex: 0 0 auto;
+}
+
+.c2 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin: 0px;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  padding: 0px;
+  column-gap: 3px;
+}
+
+.c9 {
   font-size: 18px;
   line-height: 24px;
 }
@@ -12350,6 +6570,480 @@ exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 
   border: 0;
 }
 
+.c7 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  background-color: rgba(221, 221, 221, 0.4);
+  color: #000000;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+  color: #444444;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c7:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c7:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c7:focus >circle,
+.c7:focus >ellipse,
+.c7:focus >line,
+.c7:focus >path,
+.c7:focus >polygon,
+.c7:focus >polyline,
+.c7:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c7:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c7:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c7:focus:not(:focus-visible) >circle,
+.c7:focus:not(:focus-visible) >ellipse,
+.c7:focus:not(:focus-visible) >line,
+.c7:focus:not(:focus-visible) >path,
+.c7:focus:not(:focus-visible) >polygon,
+.c7:focus:not(:focus-visible) >polyline,
+.c7:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c7:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c8 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  color: #000000;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c8:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c8:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus >circle,
+.c8:focus >ellipse,
+.c8:focus >line,
+.c8:focus >path,
+.c8:focus >polygon,
+.c8:focus >polyline,
+.c8:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c8:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c8:focus:not(:focus-visible) >circle,
+.c8:focus:not(:focus-visible) >ellipse,
+.c8:focus:not(:focus-visible) >line,
+.c8:focus:not(:focus-visible) >path,
+.c8:focus:not(:focus-visible) >polygon,
+.c8:focus:not(:focus-visible) >polyline,
+.c8:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c8:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c11 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 0;
+  color: #000000;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c11 >svg {
+  display: flex;
+  align-self: center;
+  vertical-align: middle;
+}
+
+.c11:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c11:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus >circle,
+.c11:focus >ellipse,
+.c11:focus >line,
+.c11:focus >path,
+.c11:focus >polygon,
+.c11:focus >polyline,
+.c11:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c11:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c11:focus:not(:focus-visible) >circle,
+.c11:focus:not(:focus-visible) >ellipse,
+.c11:focus:not(:focus-visible) >line,
+.c11:focus:not(:focus-visible) >path,
+.c11:focus:not(:focus-visible) >polygon,
+.c11:focus:not(:focus-visible) >polyline,
+.c11:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c11:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c5 {
+  font-size: 18px;
+  line-height: 0;
+}
+
+.c5 >svg {
+  margin: 0 auto;
+}
+
+.c3 {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  max-width: 100%;
+  height: 36px;
+  min-width: 36px;
+}
+
+.c10 {
+  font-weight: bold;
+  font-size: 18px;
+  line-height: 0;
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    column-gap: 2px;
+  }
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
+  >
+    <nav
+      aria-label="Pagination Navigation"
+      class="c1"
+    >
+      <ul
+        class="c2"
+      >
+        <li
+          class="c3"
+        >
+          <button
+            aria-disabled="true"
+            aria-label="Go to previous page"
+            class="c4 c5"
+            disabled=""
+            type="button"
+          >
+            <svg
+              aria-label="Previous"
+              class="c6"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M17 2 7 12l10 10"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-current="page"
+            aria-label="Go to page 1"
+            class="c7 c5"
+            type="button"
+          >
+            1
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 2"
+            class="c8 c5"
+            type="button"
+          >
+            2
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 3"
+            class="c8 c5"
+            type="button"
+          >
+            3
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 4"
+            class="c8 c5"
+            type="button"
+          >
+            4
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 5"
+            class="c8 c5"
+            type="button"
+          >
+            5
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <span
+            class="c9 c10"
+          >
+            …
+          </span>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 24"
+            class="c8 c5"
+            type="button"
+          >
+            24
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to next page"
+            class="c11 c5"
+            type="button"
+          >
+            <svg
+              aria-label="Next"
+              class="c12"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m7 2 10 10L7 22"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</div>
+`;
+
+exports[`Pagination should display next page of results when "next" is
+  selected 1`] = `
+.c6 {
+  display: inline-block;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #000000;
+  stroke: #000000;
+}
+
+.c6 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c6 *:not([stroke])[fill='none'] {
+  stroke-width: 0;
+}
+
+.c6 *[stroke*='#'],
+.c6 *[STROKE*='#'] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c6 *[fill-rule],
+.c6 *[FILL-RULE],
+.c6 *[fill*='#'],
+.c6 *[FILL*='#'] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  flex: 0 0 auto;
+}
+
+.c2 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin: 0px;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  padding: 0px;
+  column-gap: 3px;
+}
+
+.c9 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
 .c8 {
   display: inline-block;
   box-sizing: border-box;
@@ -12423,7 +7117,7 @@ exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 
   border: 0;
 }
 
-.c9 {
+.c7 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -12449,51 +7143,51 @@ exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 
   flex: 1 0 auto;
 }
 
-.c9:hover {
+.c7:hover {
   background-color: rgba(51, 51, 51, 0.06274509803921569);
 }
 
-.c9:focus {
+.c7:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c9:focus >circle,
-.c9:focus >ellipse,
-.c9:focus >line,
-.c9:focus >path,
-.c9:focus >polygon,
-.c9:focus >polyline,
-.c9:focus >rect {
+.c7:focus >circle,
+.c7:focus >ellipse,
+.c7:focus >line,
+.c7:focus >path,
+.c7:focus >polygon,
+.c7:focus >polyline,
+.c7:focus >rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c9:focus ::-moz-focus-inner {
+.c7:focus ::-moz-focus-inner {
   border: 0;
 }
 
-.c9:focus:not(:focus-visible) {
+.c7:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c9:focus:not(:focus-visible) >circle,
-.c9:focus:not(:focus-visible) >ellipse,
-.c9:focus:not(:focus-visible) >line,
-.c9:focus:not(:focus-visible) >path,
-.c9:focus:not(:focus-visible) >polygon,
-.c9:focus:not(:focus-visible) >polyline,
-.c9:focus:not(:focus-visible) >rect {
+.c7:focus:not(:focus-visible) >circle,
+.c7:focus:not(:focus-visible) >ellipse,
+.c7:focus:not(:focus-visible) >line,
+.c7:focus:not(:focus-visible) >path,
+.c7:focus:not(:focus-visible) >polygon,
+.c7:focus:not(:focus-visible) >polyline,
+.c7:focus:not(:focus-visible) >rect {
   outline: none;
   box-shadow: none;
 }
 
-.c9:focus:not(:focus-visible) ::-moz-focus-inner {
+.c7:focus:not(:focus-visible) ::-moz-focus-inner {
   border: 0;
 }
 
-.c12 {
+.c4 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -12519,53 +7213,53 @@ exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 
   flex: 1 0 auto;
 }
 
-.c12 >svg {
+.c4 >svg {
   display: flex;
   align-self: center;
   vertical-align: middle;
 }
 
-.c12:hover {
+.c4:hover {
   background-color: rgba(51, 51, 51, 0.06274509803921569);
 }
 
-.c12:focus {
+.c4:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus >circle,
-.c12:focus >ellipse,
-.c12:focus >line,
-.c12:focus >path,
-.c12:focus >polygon,
-.c12:focus >polyline,
-.c12:focus >rect {
+.c4:focus >circle,
+.c4:focus >ellipse,
+.c4:focus >line,
+.c4:focus >path,
+.c4:focus >polygon,
+.c4:focus >polyline,
+.c4:focus >rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus ::-moz-focus-inner {
+.c4:focus ::-moz-focus-inner {
   border: 0;
 }
 
-.c12:focus:not(:focus-visible) {
+.c4:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible) >circle,
-.c12:focus:not(:focus-visible) >ellipse,
-.c12:focus:not(:focus-visible) >line,
-.c12:focus:not(:focus-visible) >path,
-.c12:focus:not(:focus-visible) >polygon,
-.c12:focus:not(:focus-visible) >polyline,
-.c12:focus:not(:focus-visible) >rect {
+.c4:focus:not(:focus-visible) >circle,
+.c4:focus:not(:focus-visible) >ellipse,
+.c4:focus:not(:focus-visible) >line,
+.c4:focus:not(:focus-visible) >path,
+.c4:focus:not(:focus-visible) >polygon,
+.c4:focus:not(:focus-visible) >polyline,
+.c4:focus:not(:focus-visible) >rect {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible) ::-moz-focus-inner {
+.c4:focus:not(:focus-visible) ::-moz-focus-inner {
   border: 0;
 }
 
@@ -12587,7 +7281,7 @@ exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 
   min-width: 36px;
 }
 
-.c11 {
+.c10 {
   font-weight: bold;
   font-size: 18px;
   line-height: 0;
@@ -12606,8 +7300,8 @@ exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 
 }
 
 @media only screen and (max-width: 768px) {
-  .c7 {
-    width: 2px;
+  .c2 {
+    column-gap: 2px;
   }
 }
 
@@ -12628,10 +7322,8 @@ exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 
           class="c3"
         >
           <button
-            aria-disabled="true"
             aria-label="Go to previous page"
             class="c4 c5"
-            disabled=""
             type="button"
           >
             <svg
@@ -12648,89 +7340,93 @@ exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 
             </svg>
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <button
-            aria-current="page"
             aria-label="Go to page 1"
-            class="c8 c5"
+            class="c7 c5"
             type="button"
           >
             1
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <button
+            aria-current="page"
             aria-label="Go to page 2"
-            class="c9 c5"
+            class="c8 c5"
             type="button"
           >
             2
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <button
             aria-label="Go to page 3"
-            class="c9 c5"
+            class="c7 c5"
             type="button"
           >
             3
           </button>
         </li>
-        <div
-          class="c7"
-        />
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 4"
+            class="c7 c5"
+            type="button"
+          >
+            4
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 5"
+            class="c7 c5"
+            type="button"
+          >
+            5
+          </button>
+        </li>
         <li
           class="c3"
         >
           <span
-            class="c10 c11"
+            class="c9 c10"
           >
             …
           </span>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <button
             aria-label="Go to page 24"
-            class="c9 c5"
+            class="c7 c5"
             type="button"
           >
             24
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <button
             aria-label="Go to next page"
-            class="c12 c5"
+            class="c4 c5"
             type="button"
           >
             <svg
               aria-label="Next"
-              class="c13"
+              class="c6"
               viewBox="0 0 24 24"
             >
               <path
@@ -12748,8 +7444,149 @@ exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 
 </div>
 `;
 
-exports[`Pagination should set page to last page if page prop > total possible
-  pages 1`] = `
+exports[`Pagination should display next page of results when "next" is
+  selected 2`] = `
+<div
+  class="StyledGrommet-sc-19lkkz7-0 drDzQW"
+>
+  <div
+    class="StyledBox-sc-13pk1d4-0 euJJjo Pagination__StyledPaginationContainer-sc-rnlw6m-0"
+  >
+    <nav
+      aria-label="Pagination Navigation"
+      class="StyledBox-sc-13pk1d4-0 euJJjo"
+    >
+      <ul
+        class="StyledBox-sc-13pk1d4-0 gkMlIT"
+      >
+        <li
+          class="StyledPageControl__StyledContainer-sc-1vlfaez-1 bjXWCk"
+        >
+          <button
+            aria-label="Go to previous page"
+            class="StyledButtonKind-sc-1vhfpnt-0 eSmHiu StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jrdXPY"
+            type="button"
+          >
+            <svg
+              aria-label="Previous"
+              class="StyledIcon-sc-ofa7kd-0 itWvUq"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M17 2 7 12l10 10"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </li>
+        <li
+          class="StyledPageControl__StyledContainer-sc-1vlfaez-1 bjXWCk"
+        >
+          <button
+            aria-label="Go to page 1"
+            class="StyledButtonKind-sc-1vhfpnt-0 hsdMMS StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jrdXPY"
+            type="button"
+          >
+            1
+          </button>
+        </li>
+        <li
+          class="StyledPageControl__StyledContainer-sc-1vlfaez-1 bjXWCk"
+        >
+          <button
+            aria-current="page"
+            aria-label="Go to page 2"
+            class="StyledButtonKind-sc-1vhfpnt-0 eYeISA StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jrdXPY"
+            type="button"
+          >
+            2
+          </button>
+        </li>
+        <li
+          class="StyledPageControl__StyledContainer-sc-1vlfaez-1 bjXWCk"
+        >
+          <button
+            aria-label="Go to page 3"
+            class="StyledButtonKind-sc-1vhfpnt-0 hsdMMS StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jrdXPY"
+            type="button"
+          >
+            3
+          </button>
+        </li>
+        <li
+          class="StyledPageControl__StyledContainer-sc-1vlfaez-1 bjXWCk"
+        >
+          <button
+            aria-label="Go to page 4"
+            class="StyledButtonKind-sc-1vhfpnt-0 hsdMMS StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jrdXPY"
+            type="button"
+          >
+            4
+          </button>
+        </li>
+        <li
+          class="StyledPageControl__StyledContainer-sc-1vlfaez-1 bjXWCk"
+        >
+          <button
+            aria-label="Go to page 5"
+            class="StyledButtonKind-sc-1vhfpnt-0 hsdMMS StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jrdXPY"
+            type="button"
+          >
+            5
+          </button>
+        </li>
+        <li
+          class="StyledPageControl__StyledContainer-sc-1vlfaez-1 bjXWCk"
+        >
+          <span
+            class="StyledText-sc-1sadyjn-0 fjinKI StyledPageControl__StyledSeparator-sc-1vlfaez-2 iaZUel"
+          >
+            …
+          </span>
+        </li>
+        <li
+          class="StyledPageControl__StyledContainer-sc-1vlfaez-1 bjXWCk"
+        >
+          <button
+            aria-label="Go to page 24"
+            class="StyledButtonKind-sc-1vhfpnt-0 hsdMMS StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jrdXPY"
+            type="button"
+          >
+            24
+          </button>
+        </li>
+        <li
+          class="StyledPageControl__StyledContainer-sc-1vlfaez-1 bjXWCk"
+        >
+          <button
+            aria-label="Go to next page"
+            class="StyledButtonKind-sc-1vhfpnt-0 eSmHiu StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jrdXPY"
+            type="button"
+          >
+            <svg
+              aria-label="Next"
+              class="StyledIcon-sc-ofa7kd-0 itWvUq"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m7 2 10 10L7 22"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</div>
+`;
+
+exports[`Pagination should display page 'n' of results when "page n" is
+  selected 1`] = `
 .c6 {
   display: inline-block;
   flex: 0 0 auto;
@@ -12778,38 +7615,6 @@ exports[`Pagination should set page to last page if page prop > total possible
 .c6 *[FILL-RULE],
 .c6 *[fill*='#'],
 .c6 *[FILL*='#'] {
-  fill: inherit;
-  stroke: none;
-}
-
-.c13 {
-  display: inline-block;
-  flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
-  fill: #666666;
-  stroke: #666666;
-}
-
-.c13 g {
-  fill: inherit;
-  stroke: inherit;
-}
-
-.c13 *:not([stroke])[fill='none'] {
-  stroke-width: 0;
-}
-
-.c13 *[stroke*='#'],
-.c13 *[STROKE*='#'] {
-  stroke: inherit;
-  fill: none;
-}
-
-.c13 *[fill-rule],
-.c13 *[FILL-RULE],
-.c13 *[fill*='#'],
-.c13 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -12844,12 +7649,479 @@ exports[`Pagination should set page to last page if page prop > total possible
   min-height: 0;
   flex-direction: row;
   padding: 0px;
+  column-gap: 3px;
+}
+
+.c9 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c8 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  background-color: rgba(221, 221, 221, 0.4);
+  color: #000000;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+  color: #444444;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c8:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c8:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus >circle,
+.c8:focus >ellipse,
+.c8:focus >line,
+.c8:focus >path,
+.c8:focus >polygon,
+.c8:focus >polyline,
+.c8:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c8:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c8:focus:not(:focus-visible) >circle,
+.c8:focus:not(:focus-visible) >ellipse,
+.c8:focus:not(:focus-visible) >line,
+.c8:focus:not(:focus-visible) >path,
+.c8:focus:not(:focus-visible) >polygon,
+.c8:focus:not(:focus-visible) >polyline,
+.c8:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c8:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
 }
 
 .c7 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  color: #000000;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c7:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c7:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c7:focus >circle,
+.c7:focus >ellipse,
+.c7:focus >line,
+.c7:focus >path,
+.c7:focus >polygon,
+.c7:focus >polyline,
+.c7:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c7:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c7:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c7:focus:not(:focus-visible) >circle,
+.c7:focus:not(:focus-visible) >ellipse,
+.c7:focus:not(:focus-visible) >line,
+.c7:focus:not(:focus-visible) >path,
+.c7:focus:not(:focus-visible) >polygon,
+.c7:focus:not(:focus-visible) >polyline,
+.c7:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c7:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c4 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 0;
+  color: #000000;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c4 >svg {
+  display: flex;
+  align-self: center;
+  vertical-align: middle;
+}
+
+.c4:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c4:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus >circle,
+.c4:focus >ellipse,
+.c4:focus >line,
+.c4:focus >path,
+.c4:focus >polygon,
+.c4:focus >polyline,
+.c4:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c4:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c4:focus:not(:focus-visible) >circle,
+.c4:focus:not(:focus-visible) >ellipse,
+.c4:focus:not(:focus-visible) >line,
+.c4:focus:not(:focus-visible) >path,
+.c4:focus:not(:focus-visible) >polygon,
+.c4:focus:not(:focus-visible) >polyline,
+.c4:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c4:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c5 {
+  font-size: 18px;
+  line-height: 0;
+}
+
+.c5 >svg {
+  margin: 0 auto;
+}
+
+.c3 {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  max-width: 100%;
+  height: 36px;
+  min-width: 36px;
+}
+
+.c10 {
+  font-weight: bold;
+  font-size: 18px;
+  line-height: 0;
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    column-gap: 2px;
+  }
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
+  >
+    <nav
+      aria-label="Pagination Navigation"
+      class="c1"
+    >
+      <ul
+        class="c2"
+      >
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to previous page"
+            class="c4 c5"
+            type="button"
+          >
+            <svg
+              aria-label="Previous"
+              class="c6"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M17 2 7 12l10 10"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 1"
+            class="c7 c5"
+            type="button"
+          >
+            1
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-current="page"
+            aria-label="Go to page 2"
+            class="c8 c5"
+            type="button"
+          >
+            2
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 3"
+            class="c7 c5"
+            type="button"
+          >
+            3
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 4"
+            class="c7 c5"
+            type="button"
+          >
+            4
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 5"
+            class="c7 c5"
+            type="button"
+          >
+            5
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <span
+            class="c9 c10"
+          >
+            …
+          </span>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 24"
+            class="c7 c5"
+            type="button"
+          >
+            24
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to next page"
+            class="c4 c5"
+            type="button"
+          >
+            <svg
+              aria-label="Next"
+              class="c6"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m7 2 10 10L7 22"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</div>
+`;
+
+exports[`Pagination should display previous page of results when "previous" is
+  selected 1`] = `
+.c6 {
+  display: inline-block;
   flex: 0 0 auto;
-  align-self: stretch;
-  width: 3px;
+  width: 24px;
+  height: 24px;
+  fill: #000000;
+  stroke: #000000;
+}
+
+.c6 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c6 *:not([stroke])[fill='none'] {
+  stroke-width: 0;
+}
+
+.c6 *[stroke*='#'],
+.c6 *[STROKE*='#'] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c6 *[fill-rule],
+.c6 *[FILL-RULE],
+.c6 *[fill*='#'],
+.c6 *[FILL*='#'] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  flex: 0 0 auto;
+}
+
+.c2 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin: 0px;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  padding: 0px;
+  column-gap: 3px;
 }
 
 .c9 {
@@ -12933,6 +8205,721 @@ exports[`Pagination should set page to last page if page prop > total possible
   border: 0;
 }
 
+.c7 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  color: #000000;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c7:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c7:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c7:focus >circle,
+.c7:focus >ellipse,
+.c7:focus >line,
+.c7:focus >path,
+.c7:focus >polygon,
+.c7:focus >polyline,
+.c7:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c7:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c7:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c7:focus:not(:focus-visible) >circle,
+.c7:focus:not(:focus-visible) >ellipse,
+.c7:focus:not(:focus-visible) >line,
+.c7:focus:not(:focus-visible) >path,
+.c7:focus:not(:focus-visible) >polygon,
+.c7:focus:not(:focus-visible) >polyline,
+.c7:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c7:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c8 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  background-color: rgba(221, 221, 221, 0.4);
+  color: #000000;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+  color: #444444;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c8:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c8:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus >circle,
+.c8:focus >ellipse,
+.c8:focus >line,
+.c8:focus >path,
+.c8:focus >polygon,
+.c8:focus >polyline,
+.c8:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c8:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c8:focus:not(:focus-visible) >circle,
+.c8:focus:not(:focus-visible) >ellipse,
+.c8:focus:not(:focus-visible) >line,
+.c8:focus:not(:focus-visible) >path,
+.c8:focus:not(:focus-visible) >polygon,
+.c8:focus:not(:focus-visible) >polyline,
+.c8:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c8:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c5 {
+  font-size: 18px;
+  line-height: 0;
+}
+
+.c5 >svg {
+  margin: 0 auto;
+}
+
+.c3 {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  max-width: 100%;
+  height: 36px;
+  min-width: 36px;
+}
+
+.c10 {
+  font-weight: bold;
+  font-size: 18px;
+  line-height: 0;
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    column-gap: 2px;
+  }
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
+  >
+    <nav
+      aria-label="Pagination Navigation"
+      class="c1"
+    >
+      <ul
+        class="c2"
+      >
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to previous page"
+            class="c4 c5"
+            type="button"
+          >
+            <svg
+              aria-label="Previous"
+              class="c6"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M17 2 7 12l10 10"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 1"
+            class="c7 c5"
+            type="button"
+          >
+            1
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-current="page"
+            aria-label="Go to page 2"
+            class="c8 c5"
+            type="button"
+          >
+            2
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 3"
+            class="c7 c5"
+            type="button"
+          >
+            3
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 4"
+            class="c7 c5"
+            type="button"
+          >
+            4
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 5"
+            class="c7 c5"
+            type="button"
+          >
+            5
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <span
+            class="c9 c10"
+          >
+            …
+          </span>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 24"
+            class="c7 c5"
+            type="button"
+          >
+            24
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to next page"
+            class="c4 c5"
+            type="button"
+          >
+            <svg
+              aria-label="Next"
+              class="c6"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m7 2 10 10L7 22"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</div>
+`;
+
+exports[`Pagination should display previous page of results when "previous" is
+  selected 2`] = `
+<div
+  class="StyledGrommet-sc-19lkkz7-0 drDzQW"
+>
+  <div
+    class="StyledBox-sc-13pk1d4-0 euJJjo Pagination__StyledPaginationContainer-sc-rnlw6m-0"
+  >
+    <nav
+      aria-label="Pagination Navigation"
+      class="StyledBox-sc-13pk1d4-0 euJJjo"
+    >
+      <ul
+        class="StyledBox-sc-13pk1d4-0 gkMlIT"
+      >
+        <li
+          class="StyledPageControl__StyledContainer-sc-1vlfaez-1 bjXWCk"
+        >
+          <button
+            aria-label="Go to previous page"
+            class="StyledButtonKind-sc-1vhfpnt-0 eSmHiu StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jrdXPY"
+            type="button"
+          >
+            <svg
+              aria-label="Previous"
+              class="StyledIcon-sc-ofa7kd-0 itWvUq"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M17 2 7 12l10 10"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </li>
+        <li
+          class="StyledPageControl__StyledContainer-sc-1vlfaez-1 bjXWCk"
+        >
+          <button
+            aria-label="Go to page 1"
+            class="StyledButtonKind-sc-1vhfpnt-0 hsdMMS StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jrdXPY"
+            type="button"
+          >
+            1
+          </button>
+        </li>
+        <li
+          class="StyledPageControl__StyledContainer-sc-1vlfaez-1 bjXWCk"
+        >
+          <button
+            aria-current="page"
+            aria-label="Go to page 2"
+            class="StyledButtonKind-sc-1vhfpnt-0 eYeISA StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jrdXPY"
+            type="button"
+          >
+            2
+          </button>
+        </li>
+        <li
+          class="StyledPageControl__StyledContainer-sc-1vlfaez-1 bjXWCk"
+        >
+          <button
+            aria-label="Go to page 3"
+            class="StyledButtonKind-sc-1vhfpnt-0 hsdMMS StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jrdXPY"
+            type="button"
+          >
+            3
+          </button>
+        </li>
+        <li
+          class="StyledPageControl__StyledContainer-sc-1vlfaez-1 bjXWCk"
+        >
+          <button
+            aria-label="Go to page 4"
+            class="StyledButtonKind-sc-1vhfpnt-0 hsdMMS StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jrdXPY"
+            type="button"
+          >
+            4
+          </button>
+        </li>
+        <li
+          class="StyledPageControl__StyledContainer-sc-1vlfaez-1 bjXWCk"
+        >
+          <button
+            aria-label="Go to page 5"
+            class="StyledButtonKind-sc-1vhfpnt-0 hsdMMS StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jrdXPY"
+            type="button"
+          >
+            5
+          </button>
+        </li>
+        <li
+          class="StyledPageControl__StyledContainer-sc-1vlfaez-1 bjXWCk"
+        >
+          <span
+            class="StyledText-sc-1sadyjn-0 fjinKI StyledPageControl__StyledSeparator-sc-1vlfaez-2 iaZUel"
+          >
+            …
+          </span>
+        </li>
+        <li
+          class="StyledPageControl__StyledContainer-sc-1vlfaez-1 bjXWCk"
+        >
+          <button
+            aria-label="Go to page 24"
+            class="StyledButtonKind-sc-1vhfpnt-0 hsdMMS StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jrdXPY"
+            type="button"
+          >
+            24
+          </button>
+        </li>
+        <li
+          class="StyledPageControl__StyledContainer-sc-1vlfaez-1 bjXWCk"
+        >
+          <button
+            aria-label="Go to next page"
+            class="StyledButtonKind-sc-1vhfpnt-0 eSmHiu StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 jrdXPY"
+            type="button"
+          >
+            <svg
+              aria-label="Next"
+              class="StyledIcon-sc-ofa7kd-0 itWvUq"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m7 2 10 10L7 22"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</div>
+`;
+
+exports[`Pagination should display the correct last page based on items length
+  and step 1`] = `
+.c6 {
+  display: inline-block;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #666666;
+  stroke: #666666;
+}
+
+.c6 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c6 *:not([stroke])[fill='none'] {
+  stroke-width: 0;
+}
+
+.c6 *[stroke*='#'],
+.c6 *[STROKE*='#'] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c6 *[fill-rule],
+.c6 *[FILL-RULE],
+.c6 *[fill*='#'],
+.c6 *[FILL*='#'] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c12 {
+  display: inline-block;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #000000;
+  stroke: #000000;
+}
+
+.c12 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c12 *:not([stroke])[fill='none'] {
+  stroke-width: 0;
+}
+
+.c12 *[stroke*='#'],
+.c12 *[STROKE*='#'] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c12 *[fill-rule],
+.c12 *[FILL-RULE],
+.c12 *[fill*='#'],
+.c12 *[FILL*='#'] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  flex: 0 0 auto;
+}
+
+.c2 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin: 0px;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  padding: 0px;
+  column-gap: 3px;
+}
+
+.c9 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c4 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 0;
+  text-align: center;
+  opacity: 0.3;
+  cursor: default;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c4 >svg {
+  display: flex;
+  align-self: center;
+  vertical-align: middle;
+}
+
+.c4:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus >circle,
+.c4:focus >ellipse,
+.c4:focus >line,
+.c4:focus >path,
+.c4:focus >polygon,
+.c4:focus >polyline,
+.c4:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c4:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c4:focus:not(:focus-visible) >circle,
+.c4:focus:not(:focus-visible) >ellipse,
+.c4:focus:not(:focus-visible) >line,
+.c4:focus:not(:focus-visible) >path,
+.c4:focus:not(:focus-visible) >polygon,
+.c4:focus:not(:focus-visible) >polyline,
+.c4:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c4:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c7 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  background-color: rgba(221, 221, 221, 0.4);
+  color: #000000;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+  color: #444444;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c7:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c7:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c7:focus >circle,
+.c7:focus >ellipse,
+.c7:focus >line,
+.c7:focus >path,
+.c7:focus >polygon,
+.c7:focus >polyline,
+.c7:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c7:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c7:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c7:focus:not(:focus-visible) >circle,
+.c7:focus:not(:focus-visible) >ellipse,
+.c7:focus:not(:focus-visible) >line,
+.c7:focus:not(:focus-visible) >path,
+.c7:focus:not(:focus-visible) >polygon,
+.c7:focus:not(:focus-visible) >polyline,
+.c7:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c7:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
 .c8 {
   display: inline-block;
   box-sizing: border-box;
@@ -13013,15 +9000,12 @@ exports[`Pagination should set page to last page if page prop > total possible
   background: transparent;
   overflow: visible;
   text-transform: none;
-  background-color: rgba(221, 221, 221, 0.4);
-  color: #000000;
   border: none;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-  color: #444444;
+  line-height: 0;
+  color: #000000;
   text-align: center;
   transition-property: color,background-color,border-color,box-shadow;
   transition-duration: 0.1s;
@@ -13030,6 +9014,12 @@ exports[`Pagination should set page to last page if page prop > total possible
   height: 100%;
   max-width: none;
   flex: 1 0 auto;
+}
+
+.c11 >svg {
+  display: flex;
+  align-self: center;
+  vertical-align: middle;
 }
 
 .c11:hover {
@@ -13076,7 +9066,306 @@ exports[`Pagination should set page to last page if page prop > total possible
   border: 0;
 }
 
-.c12 {
+.c5 {
+  font-size: 18px;
+  line-height: 0;
+}
+
+.c5 >svg {
+  margin: 0 auto;
+}
+
+.c3 {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  max-width: 100%;
+  height: 36px;
+  min-width: 36px;
+}
+
+.c10 {
+  font-weight: bold;
+  font-size: 18px;
+  line-height: 0;
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    column-gap: 2px;
+  }
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
+  >
+    <nav
+      aria-label="Pagination Navigation"
+      class="c1"
+    >
+      <ul
+        class="c2"
+      >
+        <li
+          class="c3"
+        >
+          <button
+            aria-disabled="true"
+            aria-label="Go to previous page"
+            class="c4 c5"
+            disabled=""
+            type="button"
+          >
+            <svg
+              aria-label="Previous"
+              class="c6"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M17 2 7 12l10 10"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-current="page"
+            aria-label="Go to page 1"
+            class="c7 c5"
+            type="button"
+          >
+            1
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 2"
+            class="c8 c5"
+            type="button"
+          >
+            2
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 3"
+            class="c8 c5"
+            type="button"
+          >
+            3
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 4"
+            class="c8 c5"
+            type="button"
+          >
+            4
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 5"
+            class="c8 c5"
+            type="button"
+          >
+            5
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <span
+            class="c9 c10"
+          >
+            …
+          </span>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 24"
+            class="c8 c5"
+            type="button"
+          >
+            24
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to next page"
+            class="c11 c5"
+            type="button"
+          >
+            <svg
+              aria-label="Next"
+              class="c12"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m7 2 10 10L7 22"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</div>
+`;
+
+exports[`Pagination should have no items 1`] = `
+<DocumentFragment>
+  .c11 {
+  display: inline-block;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #666666;
+  stroke: #666666;
+}
+
+.c11 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c11 *:not([stroke])[fill='none'] {
+  stroke-width: 0;
+}
+
+.c11 *[stroke*='#'],
+.c11 *[STROKE*='#'] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c11 *[fill-rule],
+.c11 *[FILL-RULE],
+.c11 *[fill*='#'],
+.c11 *[FILL*='#'] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  flex: 0 0 auto;
+  flex-wrap: wrap;
+  gap: 12px 6px;
+}
+
+.c2 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  flex: 1 0 auto;
+}
+
+.c3 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.c5 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 12px 6px;
+}
+
+.c6 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  flex: 0 0 auto;
+}
+
+.c7 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin: 0px;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  padding: 0px;
+  column-gap: 3px;
+}
+
+.c4 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c9 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -13103,49 +9392,2503 @@ exports[`Pagination should set page to last page if page prop > total possible
   flex: 1 0 auto;
 }
 
-.c12 >svg {
+.c9 >svg {
   display: flex;
   align-self: center;
   vertical-align: middle;
 }
 
-.c12:focus {
+.c9:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus >circle,
-.c12:focus >ellipse,
-.c12:focus >line,
-.c12:focus >path,
-.c12:focus >polygon,
-.c12:focus >polyline,
-.c12:focus >rect {
+.c9:focus >circle,
+.c9:focus >ellipse,
+.c9:focus >line,
+.c9:focus >path,
+.c9:focus >polygon,
+.c9:focus >polyline,
+.c9:focus >rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c12:focus ::-moz-focus-inner {
+.c9:focus ::-moz-focus-inner {
   border: 0;
 }
 
-.c12:focus:not(:focus-visible) {
+.c9:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible) >circle,
-.c12:focus:not(:focus-visible) >ellipse,
-.c12:focus:not(:focus-visible) >line,
-.c12:focus:not(:focus-visible) >path,
-.c12:focus:not(:focus-visible) >polygon,
-.c12:focus:not(:focus-visible) >polyline,
-.c12:focus:not(:focus-visible) >rect {
+.c9:focus:not(:focus-visible) >circle,
+.c9:focus:not(:focus-visible) >ellipse,
+.c9:focus:not(:focus-visible) >line,
+.c9:focus:not(:focus-visible) >path,
+.c9:focus:not(:focus-visible) >polygon,
+.c9:focus:not(:focus-visible) >polyline,
+.c9:focus:not(:focus-visible) >rect {
   outline: none;
   box-shadow: none;
 }
 
-.c12:focus:not(:focus-visible) ::-moz-focus-inner {
+.c9:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c10 {
+  font-size: 18px;
+  line-height: 0;
+}
+
+.c10 >svg {
+  margin: 0 auto;
+}
+
+.c8 {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  max-width: 100%;
+  height: 36px;
+  min-width: 36px;
+}
+
+@media only screen and (max-width: 768px) {
+  .c7 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c7 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c7 {
+    column-gap: 2px;
+  }
+}
+
+<div
+    class="c0"
+  >
+    <div
+      class="c1 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
+    >
+      <div
+        class="c2"
+      >
+        <div
+          class="c3"
+        >
+          <span
+            class="c4"
+          >
+            0 items
+          </span>
+        </div>
+      </div>
+      <div
+        class="c5"
+      >
+        <nav
+          aria-label="Pagination Navigation"
+          class="c6"
+        >
+          <ul
+            class="c7"
+          >
+            <li
+              class="c8"
+            >
+              <button
+                aria-disabled="true"
+                aria-label="Go to previous page"
+                class="c9 c10"
+                disabled=""
+                type="button"
+              >
+                <svg
+                  aria-label="Previous"
+                  class="c11"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M17 2 7 12l10 10"
+                    fill="none"
+                    stroke="#000"
+                    stroke-width="2"
+                  />
+                </svg>
+              </button>
+            </li>
+            <li
+              class="c8"
+            >
+              <button
+                aria-label="Go to next page"
+                class="c9 c10"
+                disabled=""
+                type="button"
+              >
+                <svg
+                  aria-label="Next"
+                  class="c11"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="m7 2 10 10L7 22"
+                    fill="none"
+                    stroke="#000"
+                    stroke-width="2"
+                  />
+                </svg>
+              </button>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Pagination should render correct numberEdgePages 1`] = `
+.c6 {
+  display: inline-block;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #000000;
+  stroke: #000000;
+}
+
+.c6 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c6 *:not([stroke])[fill='none'] {
+  stroke-width: 0;
+}
+
+.c6 *[stroke*='#'],
+.c6 *[STROKE*='#'] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c6 *[fill-rule],
+.c6 *[FILL-RULE],
+.c6 *[fill*='#'],
+.c6 *[FILL*='#'] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  flex: 0 0 auto;
+}
+
+.c2 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin: 0px;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  padding: 0px;
+  column-gap: 3px;
+}
+
+.c8 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c4 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 0;
+  color: #000000;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c4 >svg {
+  display: flex;
+  align-self: center;
+  vertical-align: middle;
+}
+
+.c4:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c4:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus >circle,
+.c4:focus >ellipse,
+.c4:focus >line,
+.c4:focus >path,
+.c4:focus >polygon,
+.c4:focus >polyline,
+.c4:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c4:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c4:focus:not(:focus-visible) >circle,
+.c4:focus:not(:focus-visible) >ellipse,
+.c4:focus:not(:focus-visible) >line,
+.c4:focus:not(:focus-visible) >path,
+.c4:focus:not(:focus-visible) >polygon,
+.c4:focus:not(:focus-visible) >polyline,
+.c4:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c4:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c7 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  color: #000000;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c7:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c7:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c7:focus >circle,
+.c7:focus >ellipse,
+.c7:focus >line,
+.c7:focus >path,
+.c7:focus >polygon,
+.c7:focus >polyline,
+.c7:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c7:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c7:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c7:focus:not(:focus-visible) >circle,
+.c7:focus:not(:focus-visible) >ellipse,
+.c7:focus:not(:focus-visible) >line,
+.c7:focus:not(:focus-visible) >path,
+.c7:focus:not(:focus-visible) >polygon,
+.c7:focus:not(:focus-visible) >polyline,
+.c7:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c7:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c10 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  background-color: rgba(221, 221, 221, 0.4);
+  color: #000000;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+  color: #444444;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c10:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c10:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus >circle,
+.c10:focus >ellipse,
+.c10:focus >line,
+.c10:focus >path,
+.c10:focus >polygon,
+.c10:focus >polyline,
+.c10:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c10:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c10:focus:not(:focus-visible) >circle,
+.c10:focus:not(:focus-visible) >ellipse,
+.c10:focus:not(:focus-visible) >line,
+.c10:focus:not(:focus-visible) >path,
+.c10:focus:not(:focus-visible) >polygon,
+.c10:focus:not(:focus-visible) >polyline,
+.c10:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c10:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c5 {
+  font-size: 18px;
+  line-height: 0;
+}
+
+.c5 >svg {
+  margin: 0 auto;
+}
+
+.c3 {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  max-width: 100%;
+  height: 36px;
+  min-width: 36px;
+}
+
+.c9 {
+  font-weight: bold;
+  font-size: 18px;
+  line-height: 0;
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    column-gap: 2px;
+  }
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
+  >
+    <nav
+      aria-label="Pagination Navigation"
+      class="c1"
+    >
+      <ul
+        class="c2"
+      >
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to previous page"
+            class="c4 c5"
+            type="button"
+          >
+            <svg
+              aria-label="Previous"
+              class="c6"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M17 2 7 12l10 10"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 1"
+            class="c7 c5"
+            type="button"
+          >
+            1
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 2"
+            class="c7 c5"
+            type="button"
+          >
+            2
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 3"
+            class="c7 c5"
+            type="button"
+          >
+            3
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <span
+            class="c8 c9"
+          >
+            …
+          </span>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 9"
+            class="c7 c5"
+            type="button"
+          >
+            9
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-current="page"
+            aria-label="Go to page 10"
+            class="c10 c5"
+            type="button"
+          >
+            10
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 11"
+            class="c7 c5"
+            type="button"
+          >
+            11
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <span
+            class="c8 c9"
+          >
+            …
+          </span>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 22"
+            class="c7 c5"
+            type="button"
+          >
+            22
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 23"
+            class="c7 c5"
+            type="button"
+          >
+            23
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 24"
+            class="c7 c5"
+            type="button"
+          >
+            24
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to next page"
+            class="c4 c5"
+            type="button"
+          >
+            <svg
+              aria-label="Next"
+              class="c6"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m7 2 10 10L7 22"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</div>
+`;
+
+exports[`Pagination should render correct numberMiddlePages when even 1`] = `
+.c6 {
+  display: inline-block;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #000000;
+  stroke: #000000;
+}
+
+.c6 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c6 *:not([stroke])[fill='none'] {
+  stroke-width: 0;
+}
+
+.c6 *[stroke*='#'],
+.c6 *[STROKE*='#'] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c6 *[fill-rule],
+.c6 *[FILL-RULE],
+.c6 *[fill*='#'],
+.c6 *[FILL*='#'] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  flex: 0 0 auto;
+}
+
+.c2 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin: 0px;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  padding: 0px;
+  column-gap: 3px;
+}
+
+.c8 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c4 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 0;
+  color: #000000;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c4 >svg {
+  display: flex;
+  align-self: center;
+  vertical-align: middle;
+}
+
+.c4:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c4:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus >circle,
+.c4:focus >ellipse,
+.c4:focus >line,
+.c4:focus >path,
+.c4:focus >polygon,
+.c4:focus >polyline,
+.c4:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c4:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c4:focus:not(:focus-visible) >circle,
+.c4:focus:not(:focus-visible) >ellipse,
+.c4:focus:not(:focus-visible) >line,
+.c4:focus:not(:focus-visible) >path,
+.c4:focus:not(:focus-visible) >polygon,
+.c4:focus:not(:focus-visible) >polyline,
+.c4:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c4:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c7 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  color: #000000;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c7:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c7:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c7:focus >circle,
+.c7:focus >ellipse,
+.c7:focus >line,
+.c7:focus >path,
+.c7:focus >polygon,
+.c7:focus >polyline,
+.c7:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c7:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c7:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c7:focus:not(:focus-visible) >circle,
+.c7:focus:not(:focus-visible) >ellipse,
+.c7:focus:not(:focus-visible) >line,
+.c7:focus:not(:focus-visible) >path,
+.c7:focus:not(:focus-visible) >polygon,
+.c7:focus:not(:focus-visible) >polyline,
+.c7:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c7:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c10 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  background-color: rgba(221, 221, 221, 0.4);
+  color: #000000;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+  color: #444444;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c10:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c10:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus >circle,
+.c10:focus >ellipse,
+.c10:focus >line,
+.c10:focus >path,
+.c10:focus >polygon,
+.c10:focus >polyline,
+.c10:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c10:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c10:focus:not(:focus-visible) >circle,
+.c10:focus:not(:focus-visible) >ellipse,
+.c10:focus:not(:focus-visible) >line,
+.c10:focus:not(:focus-visible) >path,
+.c10:focus:not(:focus-visible) >polygon,
+.c10:focus:not(:focus-visible) >polyline,
+.c10:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c10:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c5 {
+  font-size: 18px;
+  line-height: 0;
+}
+
+.c5 >svg {
+  margin: 0 auto;
+}
+
+.c3 {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  max-width: 100%;
+  height: 36px;
+  min-width: 36px;
+}
+
+.c9 {
+  font-weight: bold;
+  font-size: 18px;
+  line-height: 0;
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    column-gap: 2px;
+  }
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
+  >
+    <nav
+      aria-label="Pagination Navigation"
+      class="c1"
+    >
+      <ul
+        class="c2"
+      >
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to previous page"
+            class="c4 c5"
+            type="button"
+          >
+            <svg
+              aria-label="Previous"
+              class="c6"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M17 2 7 12l10 10"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 1"
+            class="c7 c5"
+            type="button"
+          >
+            1
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <span
+            class="c8 c9"
+          >
+            …
+          </span>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 9"
+            class="c7 c5"
+            type="button"
+          >
+            9
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-current="page"
+            aria-label="Go to page 10"
+            class="c10 c5"
+            type="button"
+          >
+            10
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 11"
+            class="c7 c5"
+            type="button"
+          >
+            11
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 12"
+            class="c7 c5"
+            type="button"
+          >
+            12
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <span
+            class="c8 c9"
+          >
+            …
+          </span>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 24"
+            class="c7 c5"
+            type="button"
+          >
+            24
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to next page"
+            class="c4 c5"
+            type="button"
+          >
+            <svg
+              aria-label="Next"
+              class="c6"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m7 2 10 10L7 22"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</div>
+`;
+
+exports[`Pagination should render correct numberMiddlePages when odd 1`] = `
+.c6 {
+  display: inline-block;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #000000;
+  stroke: #000000;
+}
+
+.c6 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c6 *:not([stroke])[fill='none'] {
+  stroke-width: 0;
+}
+
+.c6 *[stroke*='#'],
+.c6 *[STROKE*='#'] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c6 *[fill-rule],
+.c6 *[FILL-RULE],
+.c6 *[fill*='#'],
+.c6 *[FILL*='#'] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  flex: 0 0 auto;
+}
+
+.c2 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin: 0px;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  padding: 0px;
+  column-gap: 3px;
+}
+
+.c8 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c4 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 0;
+  color: #000000;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c4 >svg {
+  display: flex;
+  align-self: center;
+  vertical-align: middle;
+}
+
+.c4:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c4:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus >circle,
+.c4:focus >ellipse,
+.c4:focus >line,
+.c4:focus >path,
+.c4:focus >polygon,
+.c4:focus >polyline,
+.c4:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c4:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c4:focus:not(:focus-visible) >circle,
+.c4:focus:not(:focus-visible) >ellipse,
+.c4:focus:not(:focus-visible) >line,
+.c4:focus:not(:focus-visible) >path,
+.c4:focus:not(:focus-visible) >polygon,
+.c4:focus:not(:focus-visible) >polyline,
+.c4:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c4:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c7 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  color: #000000;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c7:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c7:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c7:focus >circle,
+.c7:focus >ellipse,
+.c7:focus >line,
+.c7:focus >path,
+.c7:focus >polygon,
+.c7:focus >polyline,
+.c7:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c7:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c7:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c7:focus:not(:focus-visible) >circle,
+.c7:focus:not(:focus-visible) >ellipse,
+.c7:focus:not(:focus-visible) >line,
+.c7:focus:not(:focus-visible) >path,
+.c7:focus:not(:focus-visible) >polygon,
+.c7:focus:not(:focus-visible) >polyline,
+.c7:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c7:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c10 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  background-color: rgba(221, 221, 221, 0.4);
+  color: #000000;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+  color: #444444;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c10:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c10:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus >circle,
+.c10:focus >ellipse,
+.c10:focus >line,
+.c10:focus >path,
+.c10:focus >polygon,
+.c10:focus >polyline,
+.c10:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c10:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c10:focus:not(:focus-visible) >circle,
+.c10:focus:not(:focus-visible) >ellipse,
+.c10:focus:not(:focus-visible) >line,
+.c10:focus:not(:focus-visible) >path,
+.c10:focus:not(:focus-visible) >polygon,
+.c10:focus:not(:focus-visible) >polyline,
+.c10:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c10:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c5 {
+  font-size: 18px;
+  line-height: 0;
+}
+
+.c5 >svg {
+  margin: 0 auto;
+}
+
+.c3 {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  max-width: 100%;
+  height: 36px;
+  min-width: 36px;
+}
+
+.c9 {
+  font-weight: bold;
+  font-size: 18px;
+  line-height: 0;
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    column-gap: 2px;
+  }
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
+  >
+    <nav
+      aria-label="Pagination Navigation"
+      class="c1"
+    >
+      <ul
+        class="c2"
+      >
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to previous page"
+            class="c4 c5"
+            type="button"
+          >
+            <svg
+              aria-label="Previous"
+              class="c6"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M17 2 7 12l10 10"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 1"
+            class="c7 c5"
+            type="button"
+          >
+            1
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <span
+            class="c8 c9"
+          >
+            …
+          </span>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 8"
+            class="c7 c5"
+            type="button"
+          >
+            8
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 9"
+            class="c7 c5"
+            type="button"
+          >
+            9
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-current="page"
+            aria-label="Go to page 10"
+            class="c10 c5"
+            type="button"
+          >
+            10
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 11"
+            class="c7 c5"
+            type="button"
+          >
+            11
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 12"
+            class="c7 c5"
+            type="button"
+          >
+            12
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <span
+            class="c8 c9"
+          >
+            …
+          </span>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 24"
+            class="c7 c5"
+            type="button"
+          >
+            24
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to next page"
+            class="c4 c5"
+            type="button"
+          >
+            <svg
+              aria-label="Next"
+              class="c6"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m7 2 10 10L7 22"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</div>
+`;
+
+exports[`Pagination should render outside grommet wrapper 1`] = `
+.c5 {
+  display: inline-block;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #000000;
+  stroke: #000000;
+}
+
+.c5 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c5 *:not([stroke])[fill='none'] {
+  stroke-width: 0;
+}
+
+.c5 *[stroke*='#'],
+.c5 *[STROKE*='#'] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c5 *[fill-rule],
+.c5 *[FILL-RULE],
+.c5 *[fill*='#'],
+.c5 *[FILL*='#'] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c0 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  flex: 0 0 auto;
+}
+
+.c1 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin: 0px;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  padding: 0px;
+  column-gap: 3px;
+}
+
+.c7 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c3 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 0;
+  color: #000000;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c3 >svg {
+  display: flex;
+  align-self: center;
+  vertical-align: middle;
+}
+
+.c3:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c3:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus >circle,
+.c3:focus >ellipse,
+.c3:focus >line,
+.c3:focus >path,
+.c3:focus >polygon,
+.c3:focus >polyline,
+.c3:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c3:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c3:focus:not(:focus-visible) >circle,
+.c3:focus:not(:focus-visible) >ellipse,
+.c3:focus:not(:focus-visible) >line,
+.c3:focus:not(:focus-visible) >path,
+.c3:focus:not(:focus-visible) >polygon,
+.c3:focus:not(:focus-visible) >polyline,
+.c3:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c3:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c6 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  color: #000000;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c6:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c6:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c6:focus >circle,
+.c6:focus >ellipse,
+.c6:focus >line,
+.c6:focus >path,
+.c6:focus >polygon,
+.c6:focus >polyline,
+.c6:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c6:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c6:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c6:focus:not(:focus-visible) >circle,
+.c6:focus:not(:focus-visible) >ellipse,
+.c6:focus:not(:focus-visible) >line,
+.c6:focus:not(:focus-visible) >path,
+.c6:focus:not(:focus-visible) >polygon,
+.c6:focus:not(:focus-visible) >polyline,
+.c6:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c6:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c9 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  background-color: rgba(221, 221, 221, 0.4);
+  color: #000000;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+  color: #444444;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c9:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c9:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9:focus >circle,
+.c9:focus >ellipse,
+.c9:focus >line,
+.c9:focus >path,
+.c9:focus >polygon,
+.c9:focus >polyline,
+.c9:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c9:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c9:focus:not(:focus-visible) >circle,
+.c9:focus:not(:focus-visible) >ellipse,
+.c9:focus:not(:focus-visible) >line,
+.c9:focus:not(:focus-visible) >path,
+.c9:focus:not(:focus-visible) >polygon,
+.c9:focus:not(:focus-visible) >polyline,
+.c9:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c9:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c4 {
+  font-size: 18px;
+  line-height: 0;
+}
+
+.c4 >svg {
+  margin: 0 auto;
+}
+
+.c2 {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  max-width: 100%;
+  height: 36px;
+  min-width: 36px;
+}
+
+.c8 {
+  font-weight: bold;
+  font-size: 18px;
+  line-height: 0;
+}
+
+@media only screen and (max-width: 768px) {
+  .c1 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c1 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c1 {
+    column-gap: 2px;
+  }
+}
+
+<div
+  class="c0 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
+>
+  <nav
+    aria-label="Pagination Navigation"
+    class="c0"
+  >
+    <ul
+      class="c1"
+    >
+      <li
+        class="c2"
+      >
+        <button
+          aria-label="Go to previous page"
+          class="c3 c4"
+          type="button"
+        >
+          <svg
+            aria-label="Previous"
+            class="c5"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M17 2 7 12l10 10"
+              fill="none"
+              stroke="#000"
+              stroke-width="2"
+            />
+          </svg>
+        </button>
+      </li>
+      <li
+        class="c2"
+      >
+        <button
+          aria-label="Go to page 1"
+          class="c6 c4"
+          type="button"
+        >
+          1
+        </button>
+      </li>
+      <li
+        class="c2"
+      >
+        <span
+          class="c7 c8"
+        >
+          …
+        </span>
+      </li>
+      <li
+        class="c2"
+      >
+        <button
+          aria-label="Go to page 9"
+          class="c6 c4"
+          type="button"
+        >
+          9
+        </button>
+      </li>
+      <li
+        class="c2"
+      >
+        <button
+          aria-current="page"
+          aria-label="Go to page 10"
+          class="c9 c4"
+          type="button"
+        >
+          10
+        </button>
+      </li>
+      <li
+        class="c2"
+      >
+        <button
+          aria-label="Go to page 11"
+          class="c6 c4"
+          type="button"
+        >
+          11
+        </button>
+      </li>
+      <li
+        class="c2"
+      >
+        <span
+          class="c7 c8"
+        >
+          …
+        </span>
+      </li>
+      <li
+        class="c2"
+      >
+        <button
+          aria-label="Go to page 24"
+          class="c6 c4"
+          type="button"
+        >
+          24
+        </button>
+      </li>
+      <li
+        class="c2"
+      >
+        <button
+          aria-label="Go to next page"
+          class="c3 c4"
+          type="button"
+        >
+          <svg
+            aria-label="Next"
+            class="c5"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="m7 2 10 10L7 22"
+              fill="none"
+              stroke="#000"
+              stroke-width="2"
+            />
+          </svg>
+        </button>
+      </li>
+    </ul>
+  </nav>
+</div>
+`;
+
+exports[`Pagination should set numberMiddlePages = 1 if user provides value < 1 1`] = `
+.c6 {
+  display: inline-block;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #666666;
+  stroke: #666666;
+}
+
+.c6 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c6 *:not([stroke])[fill='none'] {
+  stroke-width: 0;
+}
+
+.c6 *[stroke*='#'],
+.c6 *[STROKE*='#'] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c6 *[fill-rule],
+.c6 *[FILL-RULE],
+.c6 *[fill*='#'],
+.c6 *[FILL*='#'] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c12 {
+  display: inline-block;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #000000;
+  stroke: #000000;
+}
+
+.c12 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c12 *:not([stroke])[fill='none'] {
+  stroke-width: 0;
+}
+
+.c12 *[stroke*='#'],
+.c12 *[STROKE*='#'] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c12 *[fill-rule],
+.c12 *[FILL-RULE],
+.c12 *[fill*='#'],
+.c12 *[FILL*='#'] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  flex: 0 0 auto;
+}
+
+.c2 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin: 0px;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  padding: 0px;
+  column-gap: 3px;
+}
+
+.c9 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c4 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 0;
+  text-align: center;
+  opacity: 0.3;
+  cursor: default;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c4 >svg {
+  display: flex;
+  align-self: center;
+  vertical-align: middle;
+}
+
+.c4:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus >circle,
+.c4:focus >ellipse,
+.c4:focus >line,
+.c4:focus >path,
+.c4:focus >polygon,
+.c4:focus >polyline,
+.c4:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c4:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c4:focus:not(:focus-visible) >circle,
+.c4:focus:not(:focus-visible) >ellipse,
+.c4:focus:not(:focus-visible) >line,
+.c4:focus:not(:focus-visible) >path,
+.c4:focus:not(:focus-visible) >polygon,
+.c4:focus:not(:focus-visible) >polyline,
+.c4:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c4:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c7 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  background-color: rgba(221, 221, 221, 0.4);
+  color: #000000;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+  color: #444444;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c7:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c7:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c7:focus >circle,
+.c7:focus >ellipse,
+.c7:focus >line,
+.c7:focus >path,
+.c7:focus >polygon,
+.c7:focus >polyline,
+.c7:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c7:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c7:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c7:focus:not(:focus-visible) >circle,
+.c7:focus:not(:focus-visible) >ellipse,
+.c7:focus:not(:focus-visible) >line,
+.c7:focus:not(:focus-visible) >path,
+.c7:focus:not(:focus-visible) >polygon,
+.c7:focus:not(:focus-visible) >polyline,
+.c7:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c7:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c8 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  color: #000000;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c8:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c8:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus >circle,
+.c8:focus >ellipse,
+.c8:focus >line,
+.c8:focus >path,
+.c8:focus >polygon,
+.c8:focus >polyline,
+.c8:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c8:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c8:focus:not(:focus-visible) >circle,
+.c8:focus:not(:focus-visible) >ellipse,
+.c8:focus:not(:focus-visible) >line,
+.c8:focus:not(:focus-visible) >path,
+.c8:focus:not(:focus-visible) >polygon,
+.c8:focus:not(:focus-visible) >polyline,
+.c8:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c8:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c11 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 0;
+  color: #000000;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c11 >svg {
+  display: flex;
+  align-self: center;
+  vertical-align: middle;
+}
+
+.c11:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c11:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus >circle,
+.c11:focus >ellipse,
+.c11:focus >line,
+.c11:focus >path,
+.c11:focus >polygon,
+.c11:focus >polyline,
+.c11:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c11:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c11:focus:not(:focus-visible) >circle,
+.c11:focus:not(:focus-visible) >ellipse,
+.c11:focus:not(:focus-visible) >line,
+.c11:focus:not(:focus-visible) >path,
+.c11:focus:not(:focus-visible) >polygon,
+.c11:focus:not(:focus-visible) >polyline,
+.c11:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c11:focus:not(:focus-visible) ::-moz-focus-inner {
   border: 0;
 }
 
@@ -13186,8 +11929,565 @@ exports[`Pagination should set page to last page if page prop > total possible
 }
 
 @media only screen and (max-width: 768px) {
-  .c7 {
-    width: 2px;
+  .c2 {
+    column-gap: 2px;
+  }
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
+  >
+    <nav
+      aria-label="Pagination Navigation"
+      class="c1"
+    >
+      <ul
+        class="c2"
+      >
+        <li
+          class="c3"
+        >
+          <button
+            aria-disabled="true"
+            aria-label="Go to previous page"
+            class="c4 c5"
+            disabled=""
+            type="button"
+          >
+            <svg
+              aria-label="Previous"
+              class="c6"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M17 2 7 12l10 10"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-current="page"
+            aria-label="Go to page 1"
+            class="c7 c5"
+            type="button"
+          >
+            1
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 2"
+            class="c8 c5"
+            type="button"
+          >
+            2
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 3"
+            class="c8 c5"
+            type="button"
+          >
+            3
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <span
+            class="c9 c10"
+          >
+            …
+          </span>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to page 24"
+            class="c8 c5"
+            type="button"
+          >
+            24
+          </button>
+        </li>
+        <li
+          class="c3"
+        >
+          <button
+            aria-label="Go to next page"
+            class="c11 c5"
+            type="button"
+          >
+            <svg
+              aria-label="Next"
+              class="c12"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m7 2 10 10L7 22"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</div>
+`;
+
+exports[`Pagination should set page to last page if page prop > total possible
+  pages 1`] = `
+.c6 {
+  display: inline-block;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #000000;
+  stroke: #000000;
+}
+
+.c6 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c6 *:not([stroke])[fill='none'] {
+  stroke-width: 0;
+}
+
+.c6 *[stroke*='#'],
+.c6 *[STROKE*='#'] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c6 *[fill-rule],
+.c6 *[FILL-RULE],
+.c6 *[fill*='#'],
+.c6 *[FILL*='#'] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c12 {
+  display: inline-block;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #666666;
+  stroke: #666666;
+}
+
+.c12 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c12 *:not([stroke])[fill='none'] {
+  stroke-width: 0;
+}
+
+.c12 *[stroke*='#'],
+.c12 *[STROKE*='#'] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c12 *[fill-rule],
+.c12 *[FILL-RULE],
+.c12 *[fill*='#'],
+.c12 *[FILL*='#'] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  flex: 0 0 auto;
+}
+
+.c2 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin: 0px;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  padding: 0px;
+  column-gap: 3px;
+}
+
+.c8 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c4 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 0;
+  color: #000000;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c4 >svg {
+  display: flex;
+  align-self: center;
+  vertical-align: middle;
+}
+
+.c4:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c4:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus >circle,
+.c4:focus >ellipse,
+.c4:focus >line,
+.c4:focus >path,
+.c4:focus >polygon,
+.c4:focus >polyline,
+.c4:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c4:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c4:focus:not(:focus-visible) >circle,
+.c4:focus:not(:focus-visible) >ellipse,
+.c4:focus:not(:focus-visible) >line,
+.c4:focus:not(:focus-visible) >path,
+.c4:focus:not(:focus-visible) >polygon,
+.c4:focus:not(:focus-visible) >polyline,
+.c4:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c4:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c7 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  color: #000000;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c7:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c7:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c7:focus >circle,
+.c7:focus >ellipse,
+.c7:focus >line,
+.c7:focus >path,
+.c7:focus >polygon,
+.c7:focus >polyline,
+.c7:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c7:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c7:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c7:focus:not(:focus-visible) >circle,
+.c7:focus:not(:focus-visible) >ellipse,
+.c7:focus:not(:focus-visible) >line,
+.c7:focus:not(:focus-visible) >path,
+.c7:focus:not(:focus-visible) >polygon,
+.c7:focus:not(:focus-visible) >polyline,
+.c7:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c7:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c10 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  background-color: rgba(221, 221, 221, 0.4);
+  color: #000000;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+  color: #444444;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c10:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c10:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus >circle,
+.c10:focus >ellipse,
+.c10:focus >line,
+.c10:focus >path,
+.c10:focus >polygon,
+.c10:focus >polyline,
+.c10:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c10:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c10:focus:not(:focus-visible) >circle,
+.c10:focus:not(:focus-visible) >ellipse,
+.c10:focus:not(:focus-visible) >line,
+.c10:focus:not(:focus-visible) >path,
+.c10:focus:not(:focus-visible) >polygon,
+.c10:focus:not(:focus-visible) >polyline,
+.c10:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c10:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c11 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 0;
+  text-align: center;
+  opacity: 0.3;
+  cursor: default;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c11 >svg {
+  display: flex;
+  align-self: center;
+  vertical-align: middle;
+}
+
+.c11:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus >circle,
+.c11:focus >ellipse,
+.c11:focus >line,
+.c11:focus >path,
+.c11:focus >polygon,
+.c11:focus >polyline,
+.c11:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c11:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c11:focus:not(:focus-visible) >circle,
+.c11:focus:not(:focus-visible) >ellipse,
+.c11:focus:not(:focus-visible) >line,
+.c11:focus:not(:focus-visible) >path,
+.c11:focus:not(:focus-visible) >polygon,
+.c11:focus:not(:focus-visible) >polyline,
+.c11:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c11:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c5 {
+  font-size: 18px;
+  line-height: 0;
+}
+
+.c5 >svg {
+  margin: 0 auto;
+}
+
+.c3 {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  max-width: 100%;
+  height: 36px;
+  min-width: 36px;
+}
+
+.c9 {
+  font-weight: bold;
+  font-size: 18px;
+  line-height: 0;
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    padding: 0px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    column-gap: 2px;
   }
 }
 
@@ -13226,119 +12526,95 @@ exports[`Pagination should set page to last page if page prop > total possible
             </svg>
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <button
             aria-label="Go to page 1"
-            class="c8 c5"
+            class="c7 c5"
             type="button"
           >
             1
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <span
-            class="c9 c10"
+            class="c8 c9"
           >
             …
           </span>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <button
             aria-label="Go to page 6"
-            class="c8 c5"
+            class="c7 c5"
             type="button"
           >
             6
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <button
             aria-label="Go to page 7"
-            class="c8 c5"
+            class="c7 c5"
             type="button"
           >
             7
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <button
             aria-label="Go to page 8"
-            class="c8 c5"
+            class="c7 c5"
             type="button"
           >
             8
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <button
             aria-label="Go to page 9"
-            class="c8 c5"
+            class="c7 c5"
             type="button"
           >
             9
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <button
             aria-current="page"
             aria-label="Go to page 10"
-            class="c11 c5"
+            class="c10 c5"
             type="button"
           >
             10
           </button>
         </li>
-        <div
-          class="c7"
-        />
         <li
           class="c3"
         >
           <button
             aria-disabled="true"
             aria-label="Go to next page"
-            class="c12 c5"
+            class="c11 c5"
             disabled=""
             type="button"
           >
             <svg
               aria-label="Next"
-              class="c13"
+              class="c12"
               viewBox="0 0 24 24"
             >
               <path


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Using the prop `cssGap`, I avoid using the StyledBoxGap element to add gaps between the elements. 
This was as per the Box component comment: 'an internal prop'.

#### Where should the reviewer start?
[Pagination Component](https://github.com/grommet/grommet/blob/4a970d1eb0a176e072910d251f300d719e52552b/src/js/components/Pagination/Pagination.js)
Is also worth checking if cssGap should be added to the declarations file and docs.

#### What testing has been done on this PR?
- Used npm link to test the components in a test project
- Used Snapshots/Jest to test the output of the components

#### How should this be manually tested?
- Measure Pagination before/after pulling the branch. **Shouldn't have changed.**
- Avoid any extra customization to the component to get a proper measurement

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### What are the relevant issues?
- Fixes https://github.com/grommet/grommet/issues/7375

#### Screenshots (if appropriate)
|![before](https://github.com/user-attachments/assets/852d0a2c-175c-4bd7-9bf2-532b69257d44) *Before*|
|:--:|
|![after](https://github.com/user-attachments/assets/86356c9a-d6fb-4d6c-8a5d-4953a1ebfbe8) *After*|