### PR TITLE
Add theme.select.clear.hover

### DIFF
--- a/src/js/components/Select/ClearButton.js
+++ b/src/js/components/Select/ClearButton.js
@@ -1,0 +1,36 @@
+import React, { forwardRef } from 'react';
+
+import { Box } from '../Box';
+import { StyledClearButton, StyledClearButtonText } from './StyledSelect';
+import { useThemeValue } from '../../utils/useThemeValue';
+
+const ClearButton = forwardRef(
+  ({ clear, onClear, name, theme, ...rest }, ref) => {
+    const { label, position } = clear;
+    const align = position !== 'bottom' ? 'start' : 'center';
+    const buttonLabel = label || `Clear ${name || 'selection'}`;
+    const { passThemeFlag } = useThemeValue();
+    return (
+      <StyledClearButton
+        a11yTitle={`${buttonLabel}. Or, press ${
+          position === 'bottom' ? 'shift tab' : 'down arrow'
+        } to move to select options`}
+        fill="horizontal"
+        ref={ref}
+        onClick={onClear}
+        focusIndicator={false}
+        theme={theme}
+        {...passThemeFlag}
+        {...rest}
+      >
+        <Box {...theme.select.clear.container} align={align}>
+          <StyledClearButtonText {...theme.select.clear.text} theme={theme}>
+            {buttonLabel}
+          </StyledClearButtonText>
+        </Box>
+      </StyledClearButton>
+    );
+  },
+);
+
+export { ClearButton };

--- a/src/js/components/Select/SelectContainer.js
+++ b/src/js/components/Select/SelectContainer.js
@@ -6,15 +6,9 @@ import React, {
   useState,
 } from 'react';
 
-import styled from 'styled-components';
-import {
-  setFocusWithoutScroll,
-  getHoverIndicatorStyle,
-  containsFocus,
-} from '../../utils';
+import { setFocusWithoutScroll, containsFocus } from '../../utils';
 
 import { Box } from '../Box';
-import { Button } from '../Button';
 import { InfiniteScroll } from '../InfiniteScroll';
 import { Keyboard } from '../Keyboard';
 import { Text } from '../Text';
@@ -27,40 +21,8 @@ import {
 } from './StyledSelect';
 import { applyKey, useDisabled, getOptionLabel, getOptionValue } from './utils';
 import { EmptySearchOption } from './EmptySearchOption';
+import { ClearButton } from './ClearButton';
 import { useThemeValue } from '../../utils/useThemeValue';
-
-// ensure ClearButton receives visual indication of keyboard
-const StyledButton = styled(Button)`
-  &:focus {
-    ${(props) => getHoverIndicatorStyle('background', props.theme)}
-  }
-`;
-
-const ClearButton = forwardRef(
-  ({ clear, onClear, name, theme, ...rest }, ref) => {
-    const { label, position } = clear;
-    const align = position !== 'bottom' ? 'start' : 'center';
-    const buttonLabel = label || `Clear ${name || 'selection'}`;
-    const { passThemeFlag } = useThemeValue();
-    return (
-      <StyledButton
-        a11yTitle={`${buttonLabel}. Or, press ${
-          position === 'bottom' ? 'shift tab' : 'down arrow'
-        } to move to select options`}
-        fill="horizontal"
-        ref={ref}
-        onClick={onClear}
-        focusIndicator={false}
-        {...passThemeFlag}
-        {...rest}
-      >
-        <Box {...theme.select.clear.container} align={align}>
-          <Text {...theme.select.clear.text}>{buttonLabel}</Text>
-        </Box>
-      </StyledButton>
-    );
-  },
-);
 
 const SelectContainer = forwardRef(
   (

--- a/src/js/components/Select/StyledSelect.js
+++ b/src/js/components/Select/StyledSelect.js
@@ -1,15 +1,17 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import { Box } from '../Box';
 import { Button } from '../Button';
 import { DropButton } from '../DropButton';
 import { TextInput } from '../TextInput';
+import { Text } from '../Text';
 import {
   getHoverIndicatorStyle,
   selectedStyle,
   controlBorderStyle,
   sizeStyle,
   styledComponentsConfig,
+  normalizeColor,
 } from '../../utils';
 
 export const StyledContainer = styled(Box)`
@@ -74,4 +76,28 @@ export const StyledSelectDropButton = styled(DropButton)`
   ${(props) => !props.plainSelect && controlBorderStyle};
   ${(props) => props.theme.select?.control?.extend};
   ${(props) => props.open && props.theme.select?.control?.open};
+`;
+
+// ensure ClearButton receives visual indication of keyboard
+export const StyledClearButton = styled(Button)`
+  &:focus {
+    ${(props) => getHoverIndicatorStyle('background', props.theme)}
+  }
+  &:hover {
+    ${(props) =>
+      props.theme.select.clear?.hover?.background &&
+      css`
+        background: ${normalizeColor(
+          props.theme.select.clear.hover.background,
+          props.theme,
+        )};
+      `}
+  }
+`;
+
+export const StyledClearButtonText = styled(Text)`
+  &:hover {
+    ${({ theme }) =>
+      theme.select.clear?.hover?.text && theme.select.clear.hover.text}
+  }
 `;

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -579,7 +579,7 @@ exports[`Select Clear option renders - bottom 1`] = `
         class="c14"
       >
         <span
-          class="c15"
+          class="c15 "
         >
           Clear selection
         </span>
@@ -1315,7 +1315,7 @@ exports[`Select Clear option renders- top 1`] = `
         class="c6"
       >
         <span
-          class="c7"
+          class="c7 "
         >
           Clear selection
         </span>
@@ -4143,7 +4143,7 @@ exports[`Select default value clear 1`] = `
         class="c6"
       >
         <span
-          class="c7"
+          class="c7 "
         >
           Clear selection
         </span>

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -1451,6 +1451,10 @@ export interface ThemeType {
     clear?: {
       container?: BoxProps;
       text?: TextProps;
+      hover?: {
+        background?: BackgroundType;
+        text?: TextProps;
+      };
     };
     container?: {
       extend?: ExtendType;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1690,6 +1690,10 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         text: {
           color: 'text-weak',
         }, // any text props
+        // hover: {
+        //   background: undefined,
+        //   text: {}, // any text props
+        // },
       },
       container: {
         // extend: undefined,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
- Adds theming to the clear button in select. Both Background and Text. 
- To keep the component brief, extracted the ClearButton to its own component file.
- Added new types in declarations file.

#### Where should the reviewer start?
- The newly created [ClearButton](https://github.com/grommet/grommet/blob/e9054b038cbb3c71f1d1da57017556079d36fc1f/src/js/components/Select/ClearButton.js) file.

#### What testing has been done on this PR?
- Used Storybook test the components

#### How should this be manually tested?
- Add theming for the Clear Button for hover state.
- Run Storybook

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
#### What are the relevant issues?
- https://github.com/grommet/grommet/issues/7342

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
- Yes https://github.com/grommet/grommet-site/pull/527

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
