### PR TITLE
Fix keyboard navigation for Select with clear and search (#7341)

### DIFF
--- a/src/js/components/Select/__tests__/Select-test.js
+++ b/src/js/components/Select/__tests__/Select-test.js
@@ -1709,6 +1709,128 @@ describe('Select', () => {
     expect(getAllByRole('option')[0]).toHaveFocus();
   });
 
+  test('allows keyboard navigation with search and top clear', () => {
+    jest.useFakeTimers();
+    const onSearch = jest.fn();
+    const downKeyOn = (element) =>
+      fireEvent.keyDown(element, {
+        key: 'Down',
+        keyCode: 40,
+        which: 40,
+      });
+    const upKeyOn = (element) =>
+      fireEvent.keyDown(element, {
+        key: 'Up',
+        keyCode: 38,
+        which: 38,
+      });
+
+    const { getAllByRole, getByLabelText, getByPlaceholderText } = render(
+      <Grommet>
+        <Select
+          clear={{ position: 'top' }}
+          id="test-select"
+          options={['one', 'two']}
+          onSearch={onSearch}
+          searchPlaceholder="test search"
+          placeholder="test select"
+          // Preselect option to make clear immediately available
+          value="one"
+        />
+      </Grommet>,
+    );
+
+    downKeyOn(getByPlaceholderText('test select'));
+    // Wait for auto-focus behaviour
+    act(() => jest.advanceTimersByTime(100));
+
+    const search = getByPlaceholderText('test search');
+    const selectDrop = document.getElementById('test-select__select-drop');
+    const clear = getByLabelText(/Clear selection/);
+
+    expect(search).toHaveFocus();
+    downKeyOn(selectDrop);
+    expect(clear).toHaveFocus();
+    downKeyOn(selectDrop);
+    expect(getAllByRole('option')[0]).toHaveFocus();
+    downKeyOn(selectDrop);
+    expect(getAllByRole('option')[1]).toHaveFocus();
+    downKeyOn(selectDrop);
+    // Focus should stay on the last selectable option
+    expect(getAllByRole('option')[1]).toHaveFocus();
+
+    upKeyOn(selectDrop);
+    expect(getAllByRole('option')[0]).toHaveFocus();
+    upKeyOn(selectDrop);
+    expect(clear).toHaveFocus();
+    upKeyOn(selectDrop);
+    expect(search).toHaveFocus();
+    upKeyOn(selectDrop);
+    // Focus should stay on the search input
+    expect(search).toHaveFocus();
+  });
+
+  test('allows keyboard navigation with search and bottom clear', () => {
+    jest.useFakeTimers();
+    const onSearch = jest.fn();
+    const downKeyOn = (element) =>
+      fireEvent.keyDown(element, {
+        key: 'Down',
+        keyCode: 40,
+        which: 40,
+      });
+    const upKeyOn = (element) =>
+      fireEvent.keyDown(element, {
+        key: 'Up',
+        keyCode: 38,
+        which: 38,
+      });
+
+    const { getAllByRole, getByLabelText, getByPlaceholderText } = render(
+      <Grommet>
+        <Select
+          clear={{ position: 'bottom' }}
+          id="test-select"
+          options={['one', 'two']}
+          onSearch={onSearch}
+          searchPlaceholder="test search"
+          placeholder="test select"
+          // Preselect option to make clear immediately available
+          value="one"
+        />
+      </Grommet>,
+    );
+
+    downKeyOn(getByPlaceholderText('test select'));
+    // Wait for auto-focus behaviour
+    act(() => jest.advanceTimersByTime(100));
+
+    const search = getByPlaceholderText('test search');
+    const selectDrop = document.getElementById('test-select__select-drop');
+    const clear = getByLabelText(/Clear selection/);
+
+    expect(search).toHaveFocus();
+    downKeyOn(selectDrop);
+    expect(getAllByRole('option')[0]).toHaveFocus();
+    downKeyOn(selectDrop);
+    expect(getAllByRole('option')[1]).toHaveFocus();
+    downKeyOn(selectDrop);
+    expect(clear).toHaveFocus();
+    downKeyOn(selectDrop);
+    // Focus should stay on clear
+    expect(clear).toHaveFocus();
+
+    upKeyOn(selectDrop);
+    expect(getAllByRole('option')[1]).toHaveFocus();
+    upKeyOn(selectDrop);
+    expect(getAllByRole('option')[0]).toHaveFocus();
+    upKeyOn(selectDrop);
+    expect(search).toHaveFocus();
+    upKeyOn(selectDrop);
+    // Focus should stay on the search input
+    expect(search).toHaveFocus();
+  });
+
   test('focusIndicator is true by default when plain is false', () => {
     const { container } = render(
       <Grommet>


### PR DESCRIPTION
#### What does this PR do?

It addresses incomplete keyboard navigation support for Select when both `clear` and `onSearch` are configured.

#### Where should the reviewer start?

Noteworthy changes are concentrated in `SelectContainer`.

#### What testing has been done on this PR?

I've added two additional test cases that emulate vertical navigation through constituents of the Select dropdown configured with both `clear` and `onSearch`.

#### How should this be manually tested?

Modifying the "Search" story for Select to add `clear` for tinkering is an expedient option. I did this myself as I was trying to find fringe cases that would break my proposed changes.

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

At first I had a trivial fix in mind, but it wasn't until I started trying to break it that I discovered Select configurations involving disabled options introduced some complications.

#### What are the relevant issues?

#7341

#### Screenshots (if appropriate)

`onSearch` + `clear` bottom position + disabled boundary options:

![](https://github.com/user-attachments/assets/fc6dc3f3-50f0-4a94-801d-6b6fe5e195cc)

`onSearch` + `clear` top position + disabled boundary options:

![](https://github.com/user-attachments/assets/5e69a504-6888-45f2-8bde-8ccab5c78d7f)

`clear` top position:

![](https://github.com/user-attachments/assets/acc15cae-3abc-4d02-a5fa-b82eedcc6271)

`clear` bottom position:

![](https://github.com/user-attachments/assets/f3529e15-b583-4747-af7d-414da557e41e)

`clear` mouse over focus:

![](https://github.com/user-attachments/assets/b000c3c8-a983-4ef8-8d51-edf97b3b3175)

#### Do the grommet docs need to be updated?

Maintainers to decide.

#### Should this PR be mentioned in the release notes?

Maintainers to decide.

#### Is this change backwards compatible or is it a breaking change?

It shouldn't be a breaking change.