### PR TITLE
Polyfill useId rather than random id

### DIFF
--- a/src/js/components/Accordion/__tests__/__snapshots__/Accordion-test.tsx.snap
+++ b/src/js/components/Accordion/__tests__/__snapshots__/Accordion-test.tsx.snap
@@ -218,7 +218,7 @@ exports[`Accordion AccordionPanel 1`] = `
         <button
           aria-expanded="false"
           class="c3"
-          id="grommet-accordion-button-12345678.12345679"
+          id=":r1:"
           type="button"
         >
           <div
@@ -252,7 +252,7 @@ exports[`Accordion AccordionPanel 1`] = `
           </div>
         </button>
         <div
-          aria-labelledby="grommet-accordion-button-12345678.12345679"
+          aria-labelledby=":r1:"
           class="c9"
           role="region"
         >
@@ -268,7 +268,7 @@ exports[`Accordion AccordionPanel 1`] = `
         <button
           aria-expanded="false"
           class="c3"
-          id="grommet-accordion-button-12345678.12345679"
+          id=":r2:"
           type="button"
         >
           <div
@@ -302,7 +302,7 @@ exports[`Accordion AccordionPanel 1`] = `
           </div>
         </button>
         <div
-          aria-labelledby="grommet-accordion-button-12345678.12345679"
+          aria-labelledby=":r2:"
           class="c9"
           role="region"
         >
@@ -535,7 +535,7 @@ exports[`Accordion accordion border 1`] = `
         <button
           aria-expanded="false"
           class="c3"
-          id="grommet-accordion-button-12345678.12345679"
+          id=":re:"
           type="button"
         >
           <div
@@ -569,7 +569,7 @@ exports[`Accordion accordion border 1`] = `
           </div>
         </button>
         <div
-          aria-labelledby="grommet-accordion-button-12345678.12345679"
+          aria-labelledby=":re:"
           class="c1"
           role="region"
         >
@@ -802,7 +802,7 @@ exports[`Accordion backward compatibility of hover.color = undefined 1`] = `
         <button
           aria-expanded="false"
           class="c3"
-          id="grommet-accordion-button-12345678.12345679"
+          id=":ri:"
           style="z-index: 1;"
           type="button"
         >
@@ -837,7 +837,7 @@ exports[`Accordion backward compatibility of hover.color = undefined 1`] = `
           </div>
         </button>
         <div
-          aria-labelledby="grommet-accordion-button-12345678.12345679"
+          aria-labelledby=":ri:"
           class="c9"
           role="region"
         >
@@ -1075,7 +1075,7 @@ exports[`Accordion blur styles 1`] = `
         <button
           aria-expanded="false"
           class="c3"
-          id="grommet-accordion-button-12345678.12345679"
+          id=":ro:"
           style="z-index: 1;"
           type="button"
         >
@@ -1110,7 +1110,7 @@ exports[`Accordion blur styles 1`] = `
           </div>
         </button>
         <div
-          aria-labelledby="grommet-accordion-button-12345678.12345679"
+          aria-labelledby=":ro:"
           class="c9"
           role="region"
         >
@@ -1337,7 +1337,7 @@ exports[`Accordion change active index 1`] = `
         <button
           aria-expanded="false"
           class="c3"
-          id="grommet-accordion-button-12345678.12345679"
+          id=":rf:"
           type="button"
         >
           <div
@@ -1371,7 +1371,7 @@ exports[`Accordion change active index 1`] = `
           </div>
         </button>
         <div
-          aria-labelledby="grommet-accordion-button-12345678.12345679"
+          aria-labelledby=":rf:"
           class="c9"
           role="region"
         />
@@ -1382,7 +1382,7 @@ exports[`Accordion change active index 1`] = `
         <button
           aria-expanded="true"
           class="c3"
-          id="grommet-accordion-button-12345678.12345679"
+          id=":rg:"
           type="button"
         >
           <div
@@ -1416,7 +1416,7 @@ exports[`Accordion change active index 1`] = `
           </div>
         </button>
         <div
-          aria-labelledby="grommet-accordion-button-12345678.12345679"
+          aria-labelledby=":rg:"
           class="c9"
           role="region"
         >
@@ -1714,7 +1714,7 @@ exports[`Accordion change active index 2`] = `
         <button
           aria-expanded="false"
           class="c3"
-          id="grommet-accordion-button-12345678.12345679"
+          id=":rf:"
           style="z-index: 1;"
           type="button"
         >
@@ -1749,7 +1749,7 @@ exports[`Accordion change active index 2`] = `
           </div>
         </button>
         <div
-          aria-labelledby="grommet-accordion-button-12345678.12345679"
+          aria-labelledby=":rf:"
           class="c9"
           role="region"
         />
@@ -1760,7 +1760,7 @@ exports[`Accordion change active index 2`] = `
         <button
           aria-expanded="true"
           class="c10"
-          id="grommet-accordion-button-12345678.12345679"
+          id=":rg:"
           type="button"
         >
           <div
@@ -1794,7 +1794,7 @@ exports[`Accordion change active index 2`] = `
           </div>
         </button>
         <div
-          aria-labelledby="grommet-accordion-button-12345678.12345679"
+          aria-labelledby=":rg:"
           class="c9"
           role="region"
         >
@@ -2024,7 +2024,7 @@ exports[`Accordion change to second Panel 1`] = `
         <button
           aria-expanded="false"
           class="c3"
-          id="grommet-accordion-button-12345678.12345679"
+          id=":r7:"
           type="button"
         >
           <div
@@ -2058,7 +2058,7 @@ exports[`Accordion change to second Panel 1`] = `
           </div>
         </button>
         <div
-          aria-labelledby="grommet-accordion-button-12345678.12345679"
+          aria-labelledby=":r7:"
           class="c9"
           role="region"
         >
@@ -2074,7 +2074,7 @@ exports[`Accordion change to second Panel 1`] = `
         <button
           aria-expanded="false"
           class="c3"
-          id="grommet-accordion-button-12345678.12345679"
+          id=":r8:"
           type="button"
         >
           <div
@@ -2108,7 +2108,7 @@ exports[`Accordion change to second Panel 1`] = `
           </div>
         </button>
         <div
-          aria-labelledby="grommet-accordion-button-12345678.12345679"
+          aria-labelledby=":r8:"
           class="c9"
           role="region"
         >
@@ -2421,7 +2421,7 @@ exports[`Accordion change to second Panel 2`] = `
         <button
           aria-expanded="false"
           class="c3"
-          id="grommet-accordion-button-12345678.12345679"
+          id=":r7:"
           type="button"
         >
           <div
@@ -2455,7 +2455,7 @@ exports[`Accordion change to second Panel 2`] = `
           </div>
         </button>
         <div
-          aria-labelledby="grommet-accordion-button-12345678.12345679"
+          aria-labelledby=":r7:"
           class="c9"
           role="region"
         >
@@ -2471,7 +2471,7 @@ exports[`Accordion change to second Panel 2`] = `
         <button
           aria-expanded="true"
           class="c11"
-          id="grommet-accordion-button-12345678.12345679"
+          id=":r8:"
           style="z-index: 1;"
           type="button"
         >
@@ -2506,7 +2506,7 @@ exports[`Accordion change to second Panel 2`] = `
           </div>
         </button>
         <div
-          aria-labelledby="grommet-accordion-button-12345678.12345679"
+          aria-labelledby=":r8:"
           class="c9"
           role="region"
           style=""
@@ -2738,7 +2738,7 @@ exports[`Accordion change to second Panel without onActive 1`] = `
         <button
           aria-expanded="false"
           class="c3"
-          id="grommet-accordion-button-12345678.12345679"
+          id=":r9:"
           type="button"
         >
           <div
@@ -2772,7 +2772,7 @@ exports[`Accordion change to second Panel without onActive 1`] = `
           </div>
         </button>
         <div
-          aria-labelledby="grommet-accordion-button-12345678.12345679"
+          aria-labelledby=":r9:"
           class="c9"
           role="region"
         />
@@ -2783,7 +2783,7 @@ exports[`Accordion change to second Panel without onActive 1`] = `
         <button
           aria-expanded="false"
           class="c3"
-          id="grommet-accordion-button-12345678.12345679"
+          id=":ra:"
           type="button"
         >
           <div
@@ -2817,7 +2817,7 @@ exports[`Accordion change to second Panel without onActive 1`] = `
           </div>
         </button>
         <div
-          aria-labelledby="grommet-accordion-button-12345678.12345679"
+          aria-labelledby=":ra:"
           class="c9"
           role="region"
         />
@@ -3113,7 +3113,7 @@ exports[`Accordion change to second Panel without onActive 2`] = `
         <button
           aria-expanded="false"
           class="c3"
-          id="grommet-accordion-button-12345678.12345679"
+          id=":r9:"
           type="button"
         >
           <div
@@ -3147,7 +3147,7 @@ exports[`Accordion change to second Panel without onActive 2`] = `
           </div>
         </button>
         <div
-          aria-labelledby="grommet-accordion-button-12345678.12345679"
+          aria-labelledby=":r9:"
           class="c9"
           role="region"
         />
@@ -3158,7 +3158,7 @@ exports[`Accordion change to second Panel without onActive 2`] = `
         <button
           aria-expanded="true"
           class="c10"
-          id="grommet-accordion-button-12345678.12345679"
+          id=":ra:"
           style="z-index: 1;"
           type="button"
         >
@@ -3193,7 +3193,7 @@ exports[`Accordion change to second Panel without onActive 2`] = `
           </div>
         </button>
         <div
-          aria-labelledby="grommet-accordion-button-12345678.12345679"
+          aria-labelledby=":ra:"
           class="c9"
           role="region"
         >
@@ -3321,7 +3321,7 @@ exports[`Accordion complex header 1`] = `
         <button
           aria-expanded="false"
           class="c3"
-          id="grommet-accordion-button-12345678.12345679"
+          id=":r5:"
           type="button"
         >
           <div>
@@ -3329,7 +3329,7 @@ exports[`Accordion complex header 1`] = `
           </div>
         </button>
         <div
-          aria-labelledby="grommet-accordion-button-12345678.12345679"
+          aria-labelledby=":r5:"
           class="c4"
           role="region"
         />
@@ -3340,7 +3340,7 @@ exports[`Accordion complex header 1`] = `
         <button
           aria-expanded="true"
           class="c3"
-          id="grommet-accordion-button-12345678.12345679"
+          id=":r6:"
           type="button"
         >
           <div>
@@ -3348,7 +3348,7 @@ exports[`Accordion complex header 1`] = `
           </div>
         </button>
         <div
-          aria-labelledby="grommet-accordion-button-12345678.12345679"
+          aria-labelledby=":r6:"
           class="c4"
           role="region"
         >
@@ -3558,7 +3558,7 @@ exports[`Accordion complex title 1`] = `
           <button
             aria-expanded="false"
             class="c4"
-            id="grommet-accordion-button-12345678.12345679"
+            id=":r3:"
             type="button"
           >
             <div
@@ -3586,7 +3586,7 @@ exports[`Accordion complex title 1`] = `
             </div>
           </button>
           <div
-            aria-labelledby="grommet-accordion-button-12345678.12345679"
+            aria-labelledby=":r3:"
             class="c8"
             role="region"
           >
@@ -3602,7 +3602,7 @@ exports[`Accordion complex title 1`] = `
           <button
             aria-expanded="false"
             class="c4"
-            id="grommet-accordion-button-12345678.12345679"
+            id=":r4:"
             type="button"
           >
             <div
@@ -3630,7 +3630,7 @@ exports[`Accordion complex title 1`] = `
             </div>
           </button>
           <div
-            aria-labelledby="grommet-accordion-button-12345678.12345679"
+            aria-labelledby=":r4:"
             class="c8"
             role="region"
           >
@@ -3869,7 +3869,7 @@ exports[`Accordion custom accordion 1`] = `
         <button
           aria-expanded="false"
           class="c3"
-          id="grommet-accordion-button-12345678.12345679"
+          id=":rd:"
           type="button"
         >
           <div
@@ -3903,7 +3903,7 @@ exports[`Accordion custom accordion 1`] = `
           </div>
         </button>
         <div
-          aria-labelledby="grommet-accordion-button-12345678.12345679"
+          aria-labelledby=":rd:"
           class="c9"
           role="region"
         >
@@ -4146,7 +4146,7 @@ exports[`Accordion custom accordion 2`] = `
         <button
           aria-expanded="false"
           class="c3"
-          id="grommet-accordion-button-12345678.12345679"
+          id=":rd:"
           type="button"
         >
           <div
@@ -4180,7 +4180,7 @@ exports[`Accordion custom accordion 2`] = `
           </div>
         </button>
         <div
-          aria-labelledby="grommet-accordion-button-12345678.12345679"
+          aria-labelledby=":rd:"
           class="c9"
           role="region"
         >
@@ -4418,7 +4418,7 @@ exports[`Accordion focus and hover styles 1`] = `
         <button
           aria-expanded="true"
           class="c3"
-          id="grommet-accordion-button-12345678.12345679"
+          id=":rh:"
           style="z-index: 1;"
           type="button"
         >
@@ -4453,7 +4453,7 @@ exports[`Accordion focus and hover styles 1`] = `
           </div>
         </button>
         <div
-          aria-labelledby="grommet-accordion-button-12345678.12345679"
+          aria-labelledby=":rh:"
           class="c9"
           role="region"
           style=""
@@ -4685,7 +4685,7 @@ exports[`Accordion multiple panels 1`] = `
         <button
           aria-expanded="false"
           class="c3"
-          id="grommet-accordion-button-12345678.12345679"
+          id=":rb:"
           type="button"
         >
           <div
@@ -4719,7 +4719,7 @@ exports[`Accordion multiple panels 1`] = `
           </div>
         </button>
         <div
-          aria-labelledby="grommet-accordion-button-12345678.12345679"
+          aria-labelledby=":rb:"
           class="c9"
           role="region"
         />
@@ -4730,7 +4730,7 @@ exports[`Accordion multiple panels 1`] = `
         <button
           aria-expanded="false"
           class="c3"
-          id="grommet-accordion-button-12345678.12345679"
+          id=":rc:"
           type="button"
         >
           <div
@@ -4764,7 +4764,7 @@ exports[`Accordion multiple panels 1`] = `
           </div>
         </button>
         <div
-          aria-labelledby="grommet-accordion-button-12345678.12345679"
+          aria-labelledby=":rc:"
           class="c9"
           role="region"
         />
@@ -5060,7 +5060,7 @@ exports[`Accordion multiple panels 2`] = `
         <button
           aria-expanded="false"
           class="c3"
-          id="grommet-accordion-button-12345678.12345679"
+          id=":rb:"
           type="button"
         >
           <div
@@ -5094,7 +5094,7 @@ exports[`Accordion multiple panels 2`] = `
           </div>
         </button>
         <div
-          aria-labelledby="grommet-accordion-button-12345678.12345679"
+          aria-labelledby=":rb:"
           class="c9"
           role="region"
         />
@@ -5105,7 +5105,7 @@ exports[`Accordion multiple panels 2`] = `
         <button
           aria-expanded="true"
           class="c10"
-          id="grommet-accordion-button-12345678.12345679"
+          id=":rc:"
           style="z-index: 1;"
           type="button"
         >
@@ -5140,7 +5140,7 @@ exports[`Accordion multiple panels 2`] = `
           </div>
         </button>
         <div
-          aria-labelledby="grommet-accordion-button-12345678.12345679"
+          aria-labelledby=":rc:"
           class="c9"
           role="region"
         >
@@ -5438,7 +5438,7 @@ exports[`Accordion multiple panels 3`] = `
         <button
           aria-expanded="true"
           class="c3"
-          id="grommet-accordion-button-12345678.12345679"
+          id=":rb:"
           style="z-index: 1;"
           type="button"
         >
@@ -5473,7 +5473,7 @@ exports[`Accordion multiple panels 3`] = `
           </div>
         </button>
         <div
-          aria-labelledby="grommet-accordion-button-12345678.12345679"
+          aria-labelledby=":rb:"
           class="c9"
           role="region"
         >
@@ -5486,7 +5486,7 @@ exports[`Accordion multiple panels 3`] = `
         <button
           aria-expanded="true"
           class="c10"
-          id="grommet-accordion-button-12345678.12345679"
+          id=":rc:"
           style=""
           type="button"
         >
@@ -5521,7 +5521,7 @@ exports[`Accordion multiple panels 3`] = `
           </div>
         </button>
         <div
-          aria-labelledby="grommet-accordion-button-12345678.12345679"
+          aria-labelledby=":rc:"
           class="c9"
           role="region"
         >
@@ -5819,7 +5819,7 @@ exports[`Accordion multiple panels 4`] = `
         <button
           aria-expanded="true"
           class="c3"
-          id="grommet-accordion-button-12345678.12345679"
+          id=":rb:"
           style=""
           type="button"
         >
@@ -5854,7 +5854,7 @@ exports[`Accordion multiple panels 4`] = `
           </div>
         </button>
         <div
-          aria-labelledby="grommet-accordion-button-12345678.12345679"
+          aria-labelledby=":rb:"
           class="c9"
           role="region"
         >
@@ -5867,7 +5867,7 @@ exports[`Accordion multiple panels 4`] = `
         <button
           aria-expanded="false"
           class="c10"
-          id="grommet-accordion-button-12345678.12345679"
+          id=":rc:"
           style="z-index: 1;"
           type="button"
         >
@@ -5902,7 +5902,7 @@ exports[`Accordion multiple panels 4`] = `
           </div>
         </button>
         <div
-          aria-labelledby="grommet-accordion-button-12345678.12345679"
+          aria-labelledby=":rc:"
           class="c9"
           role="region"
         />
@@ -6198,7 +6198,7 @@ exports[`Accordion multiple panels 5`] = `
         <button
           aria-expanded="false"
           class="c3"
-          id="grommet-accordion-button-12345678.12345679"
+          id=":rb:"
           style="z-index: 1;"
           type="button"
         >
@@ -6233,7 +6233,7 @@ exports[`Accordion multiple panels 5`] = `
           </div>
         </button>
         <div
-          aria-labelledby="grommet-accordion-button-12345678.12345679"
+          aria-labelledby=":rb:"
           class="c9"
           role="region"
         />
@@ -6244,7 +6244,7 @@ exports[`Accordion multiple panels 5`] = `
         <button
           aria-expanded="false"
           class="c10"
-          id="grommet-accordion-button-12345678.12345679"
+          id=":rc:"
           style=""
           type="button"
         >
@@ -6279,7 +6279,7 @@ exports[`Accordion multiple panels 5`] = `
           </div>
         </button>
         <div
-          aria-labelledby="grommet-accordion-button-12345678.12345679"
+          aria-labelledby=":rc:"
           class="c9"
           role="region"
         />
@@ -6555,7 +6555,7 @@ exports[`Accordion should apply level prop to headings 1`] = `
         <button
           aria-expanded="false"
           class="c3"
-          id="grommet-accordion-button-12345678.12345679"
+          id=":rp:"
           type="button"
         >
           <div
@@ -6589,7 +6589,7 @@ exports[`Accordion should apply level prop to headings 1`] = `
           </div>
         </button>
         <div
-          aria-labelledby="grommet-accordion-button-12345678.12345679"
+          aria-labelledby=":rp:"
           class="c9"
           role="region"
         >
@@ -6605,7 +6605,7 @@ exports[`Accordion should apply level prop to headings 1`] = `
         <button
           aria-expanded="false"
           class="c3"
-          id="grommet-accordion-button-12345678.12345679"
+          id=":rq:"
           type="button"
         >
           <div
@@ -6639,7 +6639,7 @@ exports[`Accordion should apply level prop to headings 1`] = `
           </div>
         </button>
         <div
-          aria-labelledby="grommet-accordion-button-12345678.12345679"
+          aria-labelledby=":rq:"
           class="c9"
           role="region"
         >
@@ -6838,7 +6838,7 @@ exports[`Accordion should have no accessibility violations 1`] = `
         <button
           aria-expanded="false"
           class="c3"
-          id="grommet-accordion-button-12345678.12345679"
+          id=":r0:"
           type="button"
         >
           <div
@@ -6863,7 +6863,7 @@ exports[`Accordion should have no accessibility violations 1`] = `
           </div>
         </button>
         <div
-          aria-labelledby="grommet-accordion-button-12345678.12345679"
+          aria-labelledby=":r0:"
           class="c7"
           role="region"
         >
@@ -7101,7 +7101,7 @@ exports[`Accordion theme hover of hover.heading.color 1`] = `
         <button
           aria-expanded="false"
           class="c3"
-          id="grommet-accordion-button-12345678.12345679"
+          id=":rj:"
           style="z-index: 1;"
           type="button"
         >
@@ -7136,7 +7136,7 @@ exports[`Accordion theme hover of hover.heading.color 1`] = `
           </div>
         </button>
         <div
-          aria-labelledby="grommet-accordion-button-12345678.12345679"
+          aria-labelledby=":rj:"
           class="c9"
           role="region"
         >
@@ -7363,7 +7363,7 @@ exports[`Accordion wrapped panel 1`] = `
         <button
           aria-expanded="false"
           class="c3"
-          id="grommet-accordion-button-12345678.12345679"
+          id=":rm:"
           type="button"
         >
           <div
@@ -7397,7 +7397,7 @@ exports[`Accordion wrapped panel 1`] = `
           </div>
         </button>
         <div
-          aria-labelledby="grommet-accordion-button-12345678.12345679"
+          aria-labelledby=":rm:"
           class="c9"
           role="region"
         />
@@ -7408,7 +7408,7 @@ exports[`Accordion wrapped panel 1`] = `
         <button
           aria-expanded="false"
           class="c3"
-          id="grommet-accordion-button-12345678.12345679"
+          id=":rn:"
           type="button"
         >
           <div
@@ -7442,7 +7442,7 @@ exports[`Accordion wrapped panel 1`] = `
           </div>
         </button>
         <div
-          aria-labelledby="grommet-accordion-button-12345678.12345679"
+          aria-labelledby=":rn:"
           class="c9"
           role="region"
         />
@@ -7738,7 +7738,7 @@ exports[`Accordion wrapped panel 2`] = `
         <button
           aria-expanded="true"
           class="c3"
-          id="grommet-accordion-button-12345678.12345679"
+          id=":rm:"
           style="z-index: 1;"
           type="button"
         >
@@ -7773,7 +7773,7 @@ exports[`Accordion wrapped panel 2`] = `
           </div>
         </button>
         <div
-          aria-labelledby="grommet-accordion-button-12345678.12345679"
+          aria-labelledby=":rm:"
           class="c9"
           role="region"
         >
@@ -7786,7 +7786,7 @@ exports[`Accordion wrapped panel 2`] = `
         <button
           aria-expanded="false"
           class="c10"
-          id="grommet-accordion-button-12345678.12345679"
+          id=":rn:"
           type="button"
         >
           <div
@@ -7820,7 +7820,7 @@ exports[`Accordion wrapped panel 2`] = `
           </div>
         </button>
         <div
-          aria-labelledby="grommet-accordion-button-12345678.12345679"
+          aria-labelledby=":rn:"
           class="c9"
           role="region"
         />

--- a/src/js/components/AccordionPanel/AccordionPanel.js
+++ b/src/js/components/AccordionPanel/AccordionPanel.js
@@ -1,6 +1,6 @@
 import React, { forwardRef, useContext, useMemo, useState } from 'react';
 
-import { normalizeColor, parseMetricToNum } from '../../utils';
+import { normalizeColor, parseMetricToNum, useId } from '../../utils';
 import { Box } from '../Box';
 import { Button } from '../Button';
 import { Collapsible } from '../Collapsible';
@@ -9,13 +9,6 @@ import { Heading } from '../Heading';
 import { AccordionContext } from '../Accordion/AccordionContext';
 import { AccordionPanelPropTypes } from './propTypes';
 import { useThemeValue } from '../../utils/useThemeValue';
-
-// Ideally we should use `useId` from react but this is only available
-// in React 18 and we want to keep compatibility with React 17 and 16.
-function getUID() {
-  const timestamp = Date.now() + Math.random();
-  return `grommet-accordion-button-${timestamp}`;
-}
 
 const AccordionPanel = forwardRef(
   (
@@ -33,7 +26,7 @@ const AccordionPanel = forwardRef(
     },
     ref,
   ) => {
-    const panelButtonId = id ? `grommet_accordion_button_${id}` : getUID();
+    const panelButtonId = useId();
     const { theme } = useThemeValue();
     const { active, animate, level, onPanelChange } =
       useContext(AccordionContext);

--- a/src/js/utils/index.js
+++ b/src/js/utils/index.js
@@ -15,3 +15,4 @@ export * from './readOnly';
 export * from './refs';
 export * from './responsive';
 export * from './use-keyboard';
+export * from './useId';

--- a/src/js/utils/useId.js
+++ b/src/js/utils/useId.js
@@ -5,7 +5,7 @@ let currentId = 0;
 const getId = () => {
   // eslint-disable-next-line no-plusplus
   const id = currentId++;
-  return `:${id.toString(32)}:`;
+  return `:r${id.toString(32)}:`;
 };
 
 const useIdGrommet = () => {

--- a/src/js/utils/useId.js
+++ b/src/js/utils/useId.js
@@ -1,0 +1,19 @@
+import { useId as useIdReact, useState } from 'react';
+
+let currentId = 0;
+
+const getId = () => {
+  // eslint-disable-next-line no-plusplus
+  const id = currentId++;
+  return `:${id.toString(32)}:`;
+};
+
+const useIdGrommet = () => {
+  const [id] = useState(getId);
+  return id;
+};
+
+// Polyfill React 18's useId for compatibility with React 16 and 17
+const useId = useIdReact ?? useIdGrommet;
+
+export { useId };


### PR DESCRIPTION
UPDATE: Tested with React 17.

#### What does this PR do?
The change we made to avoid React 18's `useId` #7351 has the downside that it makes test snapshots involving Accordions change randomly due to the randomly generated button ids. It also has a downside in that the id for an Accordion button changes every render.

This change instead creates a polyfill for React 18's `useId` which works much like their `useId` and stays consistent for tests and renders. If React 18 is being used, it will simply use the React `useId` implementation instead.
  
#### Where should the reviewer start?
utils/useId.js

#### What testing has been done on this PR?
Basic testing with storybook and simulating React 18 being available. It could use a little more testing with the actual React 17 or 16.

#### How should this be manually tested?
Storybook accordion stories.

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible although it can change existing snapshots.