### PR TITLE
Feat: Added accessibility to change text area size using up and down keys

### DIFF
--- a/src/js/components/TextArea/TextArea.js
+++ b/src/js/components/TextArea/TextArea.js
@@ -39,7 +39,33 @@ const TextArea = forwardRef(
           event.stopPropagation();
           event.nativeEvent.stopImmediatePropagation();
         }}
-        onKeyDown={onKeyDown}
+        onKeyDown={(event) => {
+          if (onKeyDown) {
+            onKeyDown(event);
+          }
+          if (ref?.current && !!ref.current.value === false) {
+            if (rest.resize === true || rest.resize === 'horizontal') {
+              const currentWidth = ref.current.getBoundingClientRect().width;
+              if (event.code === 'ArrowDown') {
+                // eslint-disable-next-line no-param-reassign
+                ref.current.style.width = `${currentWidth - 10}px`;
+              } else if (event.code === 'ArrowUp') {
+                // eslint-disable-next-line no-param-reassign
+                ref.current.style.width = `${currentWidth + 10}px`;
+              }
+            }
+            if (rest.resize === true || rest.resize === 'vertical') {
+              const currentHeight = ref.current.getBoundingClientRect().height;
+              if (event.code === 'ArrowDown') {
+                // eslint-disable-next-line no-param-reassign
+                ref.current.style.height = `${currentHeight - 10}px`;
+              } else if (event.code === 'ArrowUp') {
+                // eslint-disable-next-line no-param-reassign
+                ref.current.style.height = `${currentHeight + 10}px`;
+              }
+            }
+          }
+        }}
       >
         <StyledTextArea
           aria-label={a11yTitle}

--- a/src/js/components/TextArea/TextArea.js
+++ b/src/js/components/TextArea/TextArea.js
@@ -43,25 +43,26 @@ const TextArea = forwardRef(
           if (onKeyDown) {
             onKeyDown(event);
           }
-          if (ref?.current && !!ref.current.value === false) {
+          const textArea = document.activeElement;
+          if (textArea && !!textArea.value === false) {
             if (rest.resize === true || rest.resize === 'horizontal') {
-              const currentWidth = ref.current.getBoundingClientRect().width;
+              const currentWidth = textArea.getBoundingClientRect().width;
               if (event.code === 'ArrowDown') {
                 // eslint-disable-next-line no-param-reassign
-                ref.current.style.width = `${currentWidth - 10}px`;
+                textArea.style.width = `${currentWidth - 10}px`;
               } else if (event.code === 'ArrowUp') {
                 // eslint-disable-next-line no-param-reassign
-                ref.current.style.width = `${currentWidth + 10}px`;
+                textArea.style.width = `${currentWidth + 10}px`;
               }
             }
             if (rest.resize === true || rest.resize === 'vertical') {
-              const currentHeight = ref.current.getBoundingClientRect().height;
+              const currentHeight = textArea.getBoundingClientRect().height;
               if (event.code === 'ArrowDown') {
                 // eslint-disable-next-line no-param-reassign
-                ref.current.style.height = `${currentHeight - 10}px`;
+                textArea.style.height = `${currentHeight - 10}px`;
               } else if (event.code === 'ArrowUp') {
                 // eslint-disable-next-line no-param-reassign
-                ref.current.style.height = `${currentHeight + 10}px`;
+                textArea.style.height = `${currentHeight + 10}px`;
               }
             }
           }

--- a/src/js/components/TextArea/__tests__/TextArea-test.tsx
+++ b/src/js/components/TextArea/__tests__/TextArea-test.tsx
@@ -256,3 +256,141 @@ describe('TextArea', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 });
+
+describe('TextArea resize keyboard controls', () => {
+  beforeEach(() => {
+    // Mock getBoundingClientRect as it is used in the TextArea component and doesn't exist in the test environment
+    Element.prototype.getBoundingClientRect = jest.fn(() => ({
+      width: 100,
+      height: 100,
+      top: 0,
+      left: 0,
+      bottom: 0,
+      right: 0,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    }));
+  });
+
+  test('should resize horizontally with arrow keys when resize="horizontal"', () => {
+    const ref = React.createRef<HTMLTextAreaElement>();
+
+    const { getByRole } = render(
+      <Grommet>
+        <TextArea ref={ref} resize="horizontal" value="" />
+      </Grommet>,
+    );
+
+    const textarea = getByRole('textbox');
+    const initialWidth = textarea.getBoundingClientRect().width;
+
+    fireEvent.keyDown(textarea, { code: 'ArrowUp' });
+    expect(textarea.style.width).toBe(`${initialWidth + 10}px`);
+    expect(textarea.style.height).toBe('');
+
+    fireEvent.keyDown(textarea, { code: 'ArrowDown' });
+    expect(textarea.style.width).toBe(`${initialWidth - 10}px`);
+    expect(textarea.style.height).toBe('');
+  });
+
+  test('should resize vertically with arrow keys when resize="vertical"', () => {
+    const ref = React.createRef<HTMLTextAreaElement>();
+    const { getByRole } = render(
+      <Grommet>
+        <TextArea ref={ref} resize="vertical" value="" />
+      </Grommet>,
+    );
+
+    const textarea = getByRole('textbox');
+    const initialHeight = textarea.getBoundingClientRect().height;
+
+    fireEvent.keyDown(textarea, { code: 'ArrowUp' });
+    expect(textarea.style.height).toBe(`${initialHeight + 10}px`);
+    expect(textarea.style.width).toBe('');
+
+    fireEvent.keyDown(textarea, { code: 'ArrowDown' });
+    expect(textarea.style.height).toBe(`${initialHeight - 10}px`);
+    expect(textarea.style.width).toBe('');
+  });
+
+  test('should resize both dimensions with arrow keys when resize=true', () => {
+    const ref = React.createRef<HTMLTextAreaElement>();
+
+    const { getByRole } = render(
+      <Grommet>
+        <TextArea ref={ref} resize={true} value="" />
+      </Grommet>,
+    );
+
+    const textarea = getByRole('textbox');
+    const initialHeight = textarea.getBoundingClientRect().height;
+    const initialWidth = textarea.getBoundingClientRect().width;
+
+    fireEvent.keyDown(textarea, { code: 'ArrowUp' });
+    expect(textarea.style.width).toBe(`${initialWidth + 10}px`);
+    expect(textarea.style.height).toBe(`${initialHeight + 10}px`);
+
+    fireEvent.keyDown(textarea, { code: 'ArrowDown' });
+    expect(textarea.style.width).toBe(`${initialWidth - 10}px`);
+    expect(textarea.style.height).toBe(`${initialHeight - 10}px`);
+  });
+
+  test('should not resize when resize=false', () => {
+    const ref = React.createRef<HTMLTextAreaElement>();
+
+    const { getByRole } = render(
+      <Grommet>
+        <TextArea ref={ref} resize={false} value="" />
+      </Grommet>,
+    );
+
+    const textarea = getByRole('textbox');
+
+    fireEvent.keyDown(textarea, { code: 'ArrowUp' });
+    expect(textarea.style.width).toBe('');
+    expect(textarea.style.height).toBe('');
+
+    fireEvent.keyDown(textarea, { code: 'ArrowDown' });
+    expect(textarea.style.width).toBe('');
+    expect(textarea.style.height).toBe('');
+  });
+
+  test('should not resize when textarea has value', () => {
+    const ref = React.createRef<HTMLTextAreaElement>();
+
+    const { getByRole } = render(
+      <Grommet>
+        <TextArea ref={ref} resize={true} value="test value" />
+      </Grommet>,
+    );
+
+    const textarea = getByRole('textbox');
+
+    fireEvent.keyDown(textarea, { code: 'ArrowUp' });
+    expect(textarea.style.width).toBe('');
+    expect(textarea.style.height).toBe('');
+
+    fireEvent.keyDown(textarea, { code: 'ArrowDown' });
+    expect(textarea.style.width).toBe('');
+    expect(textarea.style.height).toBe('');
+  });
+
+  test('should not resize when ref is not provided in textarea', () => {
+    const { getByRole } = render(
+      <Grommet>
+        <TextArea resize={true} />
+      </Grommet>,
+    );
+
+    const textarea = getByRole('textbox');
+
+    fireEvent.keyDown(textarea, { code: 'ArrowUp' });
+    expect(textarea.style.width).toBe('');
+    expect(textarea.style.height).toBe('');
+
+    fireEvent.keyDown(textarea, { code: 'ArrowDown' });
+    expect(textarea.style.width).toBe('');
+    expect(textarea.style.height).toBe('');
+  });
+});

--- a/src/js/components/TextArea/__tests__/TextArea-test.tsx
+++ b/src/js/components/TextArea/__tests__/TextArea-test.tsx
@@ -255,142 +255,142 @@ describe('TextArea', () => {
     expect(getByLabelText('item-2')).toBeTruthy();
     expect(container.firstChild).toMatchSnapshot();
   });
-});
 
-describe('TextArea resize keyboard controls', () => {
-  beforeEach(() => {
-    // Mock getBoundingClientRect as it is used in the TextArea component and doesn't exist in the test environment
-    Element.prototype.getBoundingClientRect = jest.fn(() => ({
-      width: 100,
-      height: 100,
-      top: 0,
-      left: 0,
-      bottom: 0,
-      right: 0,
-      x: 0,
-      y: 0,
-      toJSON: () => {},
-    }));
-  });
+  describe('resize keyboard controls', () => {
+    beforeEach(() => {
+      // Mock getBoundingClientRect
+      Element.prototype.getBoundingClientRect = jest.fn(() => ({
+        width: 100,
+        height: 100,
+        top: 0,
+        left: 0,
+        bottom: 0,
+        right: 0,
+        x: 0,
+        y: 0,
+        toJSON: () => {},
+      }));
+    });
 
-  test('should resize horizontally with arrow keys when resize="horizontal"', () => {
-    const ref = React.createRef<HTMLTextAreaElement>();
+    test('should resize horizontally with arrow keys when resize="horizontal"', () => {
+      // Mock document.activeElement
+      Object.defineProperty(document, 'activeElement', {
+        get: jest.fn(),
+        configurable: true,
+      });
 
-    const { getByRole } = render(
-      <Grommet>
-        <TextArea ref={ref} resize="horizontal" value="" />
-      </Grommet>,
-    );
+      const { getByRole } = render(
+        <Grommet>
+          <TextArea resize="horizontal" value="" />
+        </Grommet>,
+      );
 
-    const textarea = getByRole('textbox');
-    const initialWidth = textarea.getBoundingClientRect().width;
+      const textarea = getByRole('textbox');
+      const initialWidth = textarea.getBoundingClientRect().width;
 
-    fireEvent.keyDown(textarea, { code: 'ArrowUp' });
-    expect(textarea.style.width).toBe(`${initialWidth + 10}px`);
-    expect(textarea.style.height).toBe('');
+      // Set the mock to return the textarea
+      jest.spyOn(document, 'activeElement', 'get').mockReturnValue(textarea);
 
-    fireEvent.keyDown(textarea, { code: 'ArrowDown' });
-    expect(textarea.style.width).toBe(`${initialWidth - 10}px`);
-    expect(textarea.style.height).toBe('');
-  });
+      fireEvent.keyDown(textarea, { code: 'ArrowUp' });
+      expect(textarea.style.width).toBe(`${initialWidth + 10}px`);
+      expect(textarea.style.height).toBe('');
 
-  test('should resize vertically with arrow keys when resize="vertical"', () => {
-    const ref = React.createRef<HTMLTextAreaElement>();
-    const { getByRole } = render(
-      <Grommet>
-        <TextArea ref={ref} resize="vertical" value="" />
-      </Grommet>,
-    );
+      fireEvent.keyDown(textarea, { code: 'ArrowDown' });
+      expect(textarea.style.width).toBe(`${initialWidth - 10}px`);
+      expect(textarea.style.height).toBe('');
+    });
 
-    const textarea = getByRole('textbox');
-    const initialHeight = textarea.getBoundingClientRect().height;
+    test('should resize vertically with arrow keys when resize="vertical"', () => {
+      // Mock document.activeElement
+      Object.defineProperty(document, 'activeElement', {
+        get: jest.fn(),
+        configurable: true,
+      });
 
-    fireEvent.keyDown(textarea, { code: 'ArrowUp' });
-    expect(textarea.style.height).toBe(`${initialHeight + 10}px`);
-    expect(textarea.style.width).toBe('');
+      const { getByRole } = render(
+        <Grommet>
+          <TextArea resize="vertical" value="" />
+        </Grommet>,
+      );
 
-    fireEvent.keyDown(textarea, { code: 'ArrowDown' });
-    expect(textarea.style.height).toBe(`${initialHeight - 10}px`);
-    expect(textarea.style.width).toBe('');
-  });
+      const textarea = getByRole('textbox');
+      const initialHeight = textarea.getBoundingClientRect().height;
 
-  test('should resize both dimensions with arrow keys when resize=true', () => {
-    const ref = React.createRef<HTMLTextAreaElement>();
+      // Set the mock to return the textarea
+      jest.spyOn(document, 'activeElement', 'get').mockReturnValue(textarea);
 
-    const { getByRole } = render(
-      <Grommet>
-        <TextArea ref={ref} resize={true} value="" />
-      </Grommet>,
-    );
+      fireEvent.keyDown(textarea, { code: 'ArrowUp' });
+      expect(textarea.style.height).toBe(`${initialHeight + 10}px`);
+      expect(textarea.style.width).toBe('');
 
-    const textarea = getByRole('textbox');
-    const initialHeight = textarea.getBoundingClientRect().height;
-    const initialWidth = textarea.getBoundingClientRect().width;
+      fireEvent.keyDown(textarea, { code: 'ArrowDown' });
+      expect(textarea.style.height).toBe(`${initialHeight - 10}px`);
+      expect(textarea.style.width).toBe('');
+    });
 
-    fireEvent.keyDown(textarea, { code: 'ArrowUp' });
-    expect(textarea.style.width).toBe(`${initialWidth + 10}px`);
-    expect(textarea.style.height).toBe(`${initialHeight + 10}px`);
+    test('should resize both dimensions with arrow keys when resize=true', () => {
+      // Mock document.activeElement
+      Object.defineProperty(document, 'activeElement', {
+        get: jest.fn(),
+        configurable: true,
+      });
 
-    fireEvent.keyDown(textarea, { code: 'ArrowDown' });
-    expect(textarea.style.width).toBe(`${initialWidth - 10}px`);
-    expect(textarea.style.height).toBe(`${initialHeight - 10}px`);
-  });
+      const { getByRole } = render(
+        <Grommet>
+          <TextArea resize={true} value="" />
+        </Grommet>,
+      );
 
-  test('should not resize when resize=false', () => {
-    const ref = React.createRef<HTMLTextAreaElement>();
+      const textarea = getByRole('textbox');
+      const initialHeight = textarea.getBoundingClientRect().height;
+      const initialWidth = textarea.getBoundingClientRect().width;
 
-    const { getByRole } = render(
-      <Grommet>
-        <TextArea ref={ref} resize={false} value="" />
-      </Grommet>,
-    );
+      // Set the mock to return the textarea
+      jest.spyOn(document, 'activeElement', 'get').mockReturnValue(textarea);
 
-    const textarea = getByRole('textbox');
+      fireEvent.keyDown(textarea, { code: 'ArrowUp' });
+      expect(textarea.style.width).toBe(`${initialWidth + 10}px`);
+      expect(textarea.style.height).toBe(`${initialHeight + 10}px`);
 
-    fireEvent.keyDown(textarea, { code: 'ArrowUp' });
-    expect(textarea.style.width).toBe('');
-    expect(textarea.style.height).toBe('');
+      fireEvent.keyDown(textarea, { code: 'ArrowDown' });
+      expect(textarea.style.width).toBe(`${initialWidth - 10}px`);
+      expect(textarea.style.height).toBe(`${initialHeight - 10}px`);
+    });
 
-    fireEvent.keyDown(textarea, { code: 'ArrowDown' });
-    expect(textarea.style.width).toBe('');
-    expect(textarea.style.height).toBe('');
-  });
+    test('should not resize when resize=false', () => {
+      const { getByRole } = render(
+        <Grommet>
+          <TextArea resize={false} value="" />
+        </Grommet>,
+      );
 
-  test('should not resize when textarea has value', () => {
-    const ref = React.createRef<HTMLTextAreaElement>();
+      const textarea = getByRole('textbox');
 
-    const { getByRole } = render(
-      <Grommet>
-        <TextArea ref={ref} resize={true} value="test value" />
-      </Grommet>,
-    );
+      fireEvent.keyDown(textarea, { code: 'ArrowUp' });
+      expect(textarea.style.width).toBe('');
+      expect(textarea.style.height).toBe('');
 
-    const textarea = getByRole('textbox');
+      fireEvent.keyDown(textarea, { code: 'ArrowDown' });
+      expect(textarea.style.width).toBe('');
+      expect(textarea.style.height).toBe('');
+    });
 
-    fireEvent.keyDown(textarea, { code: 'ArrowUp' });
-    expect(textarea.style.width).toBe('');
-    expect(textarea.style.height).toBe('');
+    test('should not resize when textarea has value', () => {
+      const { getByRole } = render(
+        <Grommet>
+          <TextArea resize={true} value="test value" />
+        </Grommet>,
+      );
 
-    fireEvent.keyDown(textarea, { code: 'ArrowDown' });
-    expect(textarea.style.width).toBe('');
-    expect(textarea.style.height).toBe('');
-  });
+      const textarea = getByRole('textbox');
 
-  test('should not resize when ref is not provided in textarea', () => {
-    const { getByRole } = render(
-      <Grommet>
-        <TextArea resize={true} />
-      </Grommet>,
-    );
+      fireEvent.keyDown(textarea, { code: 'ArrowUp' });
+      expect(textarea.style.width).toBe('');
+      expect(textarea.style.height).toBe('');
 
-    const textarea = getByRole('textbox');
-
-    fireEvent.keyDown(textarea, { code: 'ArrowUp' });
-    expect(textarea.style.width).toBe('');
-    expect(textarea.style.height).toBe('');
-
-    fireEvent.keyDown(textarea, { code: 'ArrowDown' });
-    expect(textarea.style.width).toBe('');
-    expect(textarea.style.height).toBe('');
+      fireEvent.keyDown(textarea, { code: 'ArrowDown' });
+      expect(textarea.style.width).toBe('');
+      expect(textarea.style.height).toBe('');
+    });
   });
 });

--- a/src/js/components/TextArea/stories/Simple.js
+++ b/src/js/components/TextArea/stories/Simple.js
@@ -1,9 +1,10 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 
 import { Box, TextArea } from 'grommet';
 
 const Resize = (props) => {
   const [value, setValue] = useState('');
+  const ref = useRef(null);
 
   const onChange = (event) => setValue(event.target.value);
 
@@ -14,6 +15,7 @@ const Resize = (props) => {
       <TextArea
         aria-label="text area"
         value={value}
+        ref={ref}
         onChange={onChange}
         {...props}
       />

--- a/src/js/components/TextArea/stories/Simple.js
+++ b/src/js/components/TextArea/stories/Simple.js
@@ -1,10 +1,9 @@
-import React, { useState, useRef } from 'react';
+import React, { useState } from 'react';
 
 import { Box, TextArea } from 'grommet';
 
 const Resize = (props) => {
   const [value, setValue] = useState('');
-  const ref = useRef(null);
 
   const onChange = (event) => setValue(event.target.value);
 
@@ -15,7 +14,6 @@ const Resize = (props) => {
       <TextArea
         aria-label="text area"
         value={value}
-        ref={ref}
         onChange={onChange}
         {...props}
       />


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Text area can be resized using up and down arrow keys

#### Where should the reviewer start?
`src/js/components/TextArea/TextArea.js`

#### What testing has been done on this PR?
- [x] Modifying text area size when there's no data added
- [x] Trying to modify text area size when `resize` prop passed is false
- [x] Trying to modify text area size when there's content in it
- [x] Modifying text area size when `resize` prop passed is either `horizontal or vertical` 

#### How should this be manually tested?
This can be tested via storybook component

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [x] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)
https://github.com/user-attachments/assets/c1e81641-e2b3-4b4b-ada2-be37d4e7feb9


#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Yes this is backwards compatible, any function passed for `onKeyDown` prop will be executed along with this change
