### PR TITLE
Enhance button theme with elevation

### DIFF
--- a/src/js/components/Box/StyledBox.js
+++ b/src/js/components/Box/StyledBox.js
@@ -7,6 +7,7 @@ import {
   borderStyle,
   breakpointStyle,
   edgeStyle,
+  elevationStyle,
   fillStyle,
   focusStyle,
   genericStyles,
@@ -74,13 +75,6 @@ const directionStyle = (direction, theme) => {
   }
   return styles;
 };
-
-const elevationStyle = (elevation) => css`
-  box-shadow: ${(props) =>
-    props.theme.global.elevation[props.theme.dark ? 'dark' : 'light'][
-      elevation
-    ]};
-`;
 
 const FLEX_MAP = {
   [true]: '1 1',

--- a/src/js/components/Button/StyledButton.js
+++ b/src/js/components/Button/StyledButton.js
@@ -11,7 +11,7 @@ import {
   getHoverIndicatorStyle,
   normalizeColor,
 } from '../../utils';
-import { styledComponentsConfig } from '../../utils/styles';
+import { elevationStyle, styledComponentsConfig } from '../../utils/styles';
 
 const radiusStyle = (props) => {
   // border.radius shouldn't impact an only-icon rendering.
@@ -60,6 +60,8 @@ const basicStyle = (props) => css`
       props.theme,
     )};
   border-radius: ${radiusStyle(props)};
+  ${props.theme.button.elevation &&
+  elevationStyle(props.theme.button.elevation)}
   color: ${normalizeColor(props.theme.button.color || 'text', props.theme)};
   padding: ${padStyle(props)};
   ${fontStyle(props)}
@@ -77,6 +79,8 @@ const primaryStyle = (props) => css`
     props.theme.button.color,
   )}
   border-radius: ${radiusStyle(props)};
+  ${props.theme.button.primary?.elevation &&
+  elevationStyle(props.theme.button.primary?.elevation)}
   ${props.theme.button.primary && props.theme.button.primary.extend}
 `;
 

--- a/src/js/components/Button/__tests__/Button-kind-test.js
+++ b/src/js/components/Button/__tests__/Button-kind-test.js
@@ -911,4 +911,49 @@ describe('Button kind', () => {
 
     expect(asFragment()).toMatchSnapshot();
   });
+
+  test('should render elevation', () => {
+    const DEFAULT_ELEVATION = 'inset 3px 0 red';
+    const PRIMARY_ELEVATION = 'inset 5px 0 blue';
+
+    const theme = {
+      global: {
+        elevation: {
+          light: {
+            'test-elevation': DEFAULT_ELEVATION,
+            'test-elevation-primary': PRIMARY_ELEVATION,
+          },
+          dark: {
+            'test-elevation': DEFAULT_ELEVATION,
+            'test-elevation-primary': PRIMARY_ELEVATION,
+          },
+        },
+      },
+      button: {
+        default: {
+          elevation: 'test-elevation',
+        },
+        primary: {
+          elevation: 'test-elevation-primary',
+        },
+        hover: {
+          elevation: 'large',
+          primary: {
+            elevation: 'medium',
+          },
+        },
+      },
+    };
+
+    const { asFragment } = render(
+      <Grommet theme={theme}>
+        <Button label="Default" />
+        <Button label="Primary" primary />
+        {/* should not render elevation on plain button */}
+        <Button>Plain</Button>
+      </Grommet>,
+    );
+
+    expect(asFragment()).toMatchSnapshot();
+  });
 });

--- a/src/js/components/Button/__tests__/Button-test.tsx
+++ b/src/js/components/Button/__tests__/Button-test.tsx
@@ -10,6 +10,7 @@ import '@testing-library/jest-dom';
 
 import { Add, Next } from 'grommet-icons';
 import { Grommet, Button, Text } from '../..';
+import { ThemeType } from '../../../themes';
 
 describe('Button', () => {
   test('should have no accessibility violations', async () => {
@@ -622,6 +623,42 @@ describe('Button', () => {
 
     style = window.getComputedStyle(childPadButton);
     expect(style.padding).toBe('0px');
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  test('should render elevation', () => {
+    const DEFAULT_ELEVATION = 'inset 3px 0 red';
+    const PRIMARY_ELEVATION = 'inset 5px 0 blue';
+    const theme: ThemeType = {
+      global: {
+        elevation: {
+          light: {
+            'test-elevation': DEFAULT_ELEVATION,
+            'test-elevation-primary': PRIMARY_ELEVATION,
+          },
+          dark: {
+            'test-elevation': DEFAULT_ELEVATION,
+            'test-elevation-primary': PRIMARY_ELEVATION,
+          },
+        },
+      },
+      button: {
+        elevation: 'test-elevation',
+        primary: {
+          elevation: 'test-elevation-primary',
+        },
+      },
+    };
+
+    const { asFragment } = render(
+      <Grommet theme={theme}>
+        <Button label="Default" />
+        <Button label="Primary" primary />
+        {/* should not render elevation on plain button */}
+        <Button>Plain</Button>
+      </Grommet>,
+    );
 
     expect(asFragment()).toMatchSnapshot();
   });

--- a/src/js/components/Button/__tests__/__snapshots__/Button-kind-test.js.snap
+++ b/src/js/components/Button/__tests__/__snapshots__/Button-kind-test.js.snap
@@ -5590,6 +5590,236 @@ exports[`Button kind should apply styling according to theme size definitions 1`
 </div>
 `;
 
+exports[`Button kind should render elevation 1`] = `
+<DocumentFragment>
+  .c1 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 18px;
+  padding: 4px 22px;
+  font-size: 18px;
+  line-height: 24px;
+  box-shadow: inset 3px 0 red;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+}
+
+.c1:hover {
+  box-shadow: 0px 8px 16px rgba(0, 0, 0, 0.20);
+}
+
+.c1:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c1:focus >circle,
+.c1:focus >ellipse,
+.c1:focus >line,
+.c1:focus >path,
+.c1:focus >polygon,
+.c1:focus >polyline,
+.c1:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c1:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c1:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c1:focus:not(:focus-visible) >circle,
+.c1:focus:not(:focus-visible) >ellipse,
+.c1:focus:not(:focus-visible) >line,
+.c1:focus:not(:focus-visible) >path,
+.c1:focus:not(:focus-visible) >polygon,
+.c1:focus:not(:focus-visible) >polyline,
+.c1:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c1:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c2 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 18px;
+  padding: 4px 22px;
+  font-size: 18px;
+  line-height: 24px;
+  box-shadow: inset 5px 0 blue;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+}
+
+.c2:hover {
+  box-shadow: 0px 8px 16px rgba(0, 0, 0, 0.20);
+}
+
+.c2:hover {
+  box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.20);
+}
+
+.c2:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c2:focus >circle,
+.c2:focus >ellipse,
+.c2:focus >line,
+.c2:focus >path,
+.c2:focus >polygon,
+.c2:focus >polyline,
+.c2:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c2:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c2:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c2:focus:not(:focus-visible) >circle,
+.c2:focus:not(:focus-visible) >ellipse,
+.c2:focus:not(:focus-visible) >line,
+.c2:focus:not(:focus-visible) >path,
+.c2:focus:not(:focus-visible) >polygon,
+.c2:focus:not(:focus-visible) >polyline,
+.c2:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c2:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c3 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  color: inherit;
+}
+
+.c3:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus >circle,
+.c3:focus >ellipse,
+.c3:focus >line,
+.c3:focus >path,
+.c3:focus >polygon,
+.c3:focus >polyline,
+.c3:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c3:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c3:focus:not(:focus-visible) >circle,
+.c3:focus:not(:focus-visible) >ellipse,
+.c3:focus:not(:focus-visible) >line,
+.c3:focus:not(:focus-visible) >path,
+.c3:focus:not(:focus-visible) >polygon,
+.c3:focus:not(:focus-visible) >polyline,
+.c3:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c3:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+<div
+    class="c0"
+  >
+    <button
+      class="c1"
+      type="button"
+    >
+      Default
+    </button>
+    <button
+      class="c2"
+      type="button"
+    >
+      Primary
+    </button>
+    <button
+      class="c3"
+      type="button"
+    >
+      Plain
+    </button>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`Button kind should render pad 1`] = `
 <DocumentFragment>
   .c3 {

--- a/src/js/components/Button/__tests__/__snapshots__/Button-test.tsx.snap
+++ b/src/js/components/Button/__tests__/__snapshots__/Button-test.tsx.snap
@@ -3708,6 +3708,236 @@ exports[`Button reverse icon label 1`] = `
 </div>
 `;
 
+exports[`Button should render elevation 1`] = `
+<DocumentFragment>
+  .c1 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: 2px solid #7D4CDB;
+  border-radius: 18px;
+  box-shadow: inset 3px 0 red;
+  color: #444444;
+  padding: 4px 22px;
+  font-size: 18px;
+  line-height: 24px;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+}
+
+.c1:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c1:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c1:focus >circle,
+.c1:focus >ellipse,
+.c1:focus >line,
+.c1:focus >path,
+.c1:focus >polygon,
+.c1:focus >polyline,
+.c1:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c1:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c1:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c1:focus:not(:focus-visible) >circle,
+.c1:focus:not(:focus-visible) >ellipse,
+.c1:focus:not(:focus-visible) >line,
+.c1:focus:not(:focus-visible) >path,
+.c1:focus:not(:focus-visible) >polygon,
+.c1:focus:not(:focus-visible) >polyline,
+.c1:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c1:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c2 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: 2px solid #7D4CDB;
+  border-radius: 18px;
+  box-shadow: inset 3px 0 red;
+  color: #444444;
+  padding: 4px 22px;
+  font-size: 18px;
+  line-height: 24px;
+  background-color: #7D4CDB;
+  color: #f8f8f8;
+  border-radius: 18px;
+  box-shadow: inset 5px 0 blue;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+}
+
+.c2:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c2:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c2:focus >circle,
+.c2:focus >ellipse,
+.c2:focus >line,
+.c2:focus >path,
+.c2:focus >polygon,
+.c2:focus >polyline,
+.c2:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c2:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c2:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c2:focus:not(:focus-visible) >circle,
+.c2:focus:not(:focus-visible) >ellipse,
+.c2:focus:not(:focus-visible) >line,
+.c2:focus:not(:focus-visible) >path,
+.c2:focus:not(:focus-visible) >polygon,
+.c2:focus:not(:focus-visible) >polyline,
+.c2:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c2:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c3 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c3:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus >circle,
+.c3:focus >ellipse,
+.c3:focus >line,
+.c3:focus >path,
+.c3:focus >polygon,
+.c3:focus >polyline,
+.c3:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c3:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c3:focus:not(:focus-visible) >circle,
+.c3:focus:not(:focus-visible) >ellipse,
+.c3:focus:not(:focus-visible) >line,
+.c3:focus:not(:focus-visible) >path,
+.c3:focus:not(:focus-visible) >polygon,
+.c3:focus:not(:focus-visible) >polyline,
+.c3:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c3:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+<div
+    class="c0"
+  >
+    <button
+      class="c1"
+      type="button"
+    >
+      Default
+    </button>
+    <button
+      class="c2"
+      type="button"
+    >
+      Primary
+    </button>
+    <button
+      class="c3"
+      type="button"
+    >
+      Plain
+    </button>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`Button should render pad 1`] = `
 <DocumentFragment>
   .c3 {

--- a/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.tsx.snap
+++ b/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.tsx.snap
@@ -2484,7 +2484,7 @@ exports[`DateInput controlled format inline 2`] = `
     </div>
   </div>
   <button
-    class="StyledButton-sc-323bzc-0 dGPAnB"
+    class="StyledButton-sc-323bzc-0 btMUUh"
     type="button"
   >
     first

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-controlled.tsx.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-controlled.tsx.snap
@@ -218,7 +218,7 @@ exports[`Form controlled controlled 2`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 VObaP"
+      class="StyledButton-sc-323bzc-0 hocFoX"
       type="submit"
     >
       Submit
@@ -252,7 +252,7 @@ exports[`Form controlled controlled 3`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 VObaP"
+      class="StyledButton-sc-323bzc-0 hocFoX"
       type="submit"
     >
       Submit
@@ -704,7 +704,7 @@ exports[`Form controlled controlled Array of Form Fields 2`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 VObaP"
+      class="StyledButton-sc-323bzc-0 hocFoX"
       type="submit"
     >
       Submit
@@ -845,7 +845,7 @@ exports[`Form controlled controlled Array of Form Fields 3`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 VObaP"
+      class="StyledButton-sc-323bzc-0 hocFoX"
       type="submit"
     >
       Submit
@@ -1267,7 +1267,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate 2`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 VObaP"
+      class="StyledButton-sc-323bzc-0 hocFoX"
       type="submit"
     >
       Submit
@@ -1662,7 +1662,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate custom error
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 VObaP"
+      class="StyledButton-sc-323bzc-0 hocFoX"
       type="submit"
     >
       Submit
@@ -1910,7 +1910,7 @@ exports[`Form controlled controlled FormField deprecated 2`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 VObaP"
+      class="StyledButton-sc-323bzc-0 hocFoX"
       type="submit"
     >
       Submit
@@ -1950,7 +1950,7 @@ exports[`Form controlled controlled FormField deprecated 3`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 VObaP"
+      class="StyledButton-sc-323bzc-0 hocFoX"
       type="submit"
     >
       Submit
@@ -2177,7 +2177,7 @@ exports[`Form controlled controlled input 2`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 VObaP"
+      class="StyledButton-sc-323bzc-0 hocFoX"
       type="submit"
     >
       Submit
@@ -2211,7 +2211,7 @@ exports[`Form controlled controlled input 3`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 VObaP"
+      class="StyledButton-sc-323bzc-0 hocFoX"
       type="submit"
     >
       Submit
@@ -2438,7 +2438,7 @@ exports[`Form controlled controlled input lazy 2`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 VObaP"
+      class="StyledButton-sc-323bzc-0 hocFoX"
       type="submit"
     >
       Submit
@@ -2472,7 +2472,7 @@ exports[`Form controlled controlled input lazy 3`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 VObaP"
+      class="StyledButton-sc-323bzc-0 hocFoX"
       type="submit"
     >
       Submit
@@ -2699,7 +2699,7 @@ exports[`Form controlled controlled lazy 2`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 VObaP"
+      class="StyledButton-sc-323bzc-0 hocFoX"
       type="submit"
     >
       Submit
@@ -2733,7 +2733,7 @@ exports[`Form controlled controlled lazy 3`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 VObaP"
+      class="StyledButton-sc-323bzc-0 hocFoX"
       type="submit"
     >
       Submit
@@ -3180,7 +3180,7 @@ exports[`Form controlled controlled onValidate 2`] = `
       </span>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 VObaP"
+      class="StyledButton-sc-323bzc-0 hocFoX"
       type="submit"
     >
       Submit
@@ -3434,7 +3434,7 @@ exports[`Form controlled controlled onValidate custom error 2`] = `
       </span>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 VObaP"
+      class="StyledButton-sc-323bzc-0 hocFoX"
       type="submit"
     >
       Submit
@@ -3684,7 +3684,7 @@ exports[`Form controlled controlled onValidate custom info 2`] = `
       </span>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 VObaP"
+      class="StyledButton-sc-323bzc-0 hocFoX"
       type="submit"
     >
       Submit
@@ -4453,7 +4453,7 @@ exports[`Form controlled dynamicly removed fields using blur validation
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 VObaP"
+      class="StyledButton-sc-323bzc-0 hocFoX"
       type="submit"
     >
       Submit
@@ -4515,7 +4515,7 @@ exports[`Form controlled dynamicly removed fields using blur validation
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 VObaP"
+      class="StyledButton-sc-323bzc-0 hocFoX"
       type="submit"
     >
       Submit

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.tsx.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.tsx.snap
@@ -1174,7 +1174,7 @@ exports[`Form uncontrolled dynamically removed fields should be removed from for
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 VObaP"
+      class="StyledButton-sc-323bzc-0 hocFoX"
       type="submit"
     >
       Submit
@@ -1716,7 +1716,7 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 VObaP"
+      class="StyledButton-sc-323bzc-0 hocFoX"
       type="submit"
     >
       Submit
@@ -1777,7 +1777,7 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 VObaP"
+      class="StyledButton-sc-323bzc-0 hocFoX"
       type="submit"
     >
       Submit
@@ -3135,7 +3135,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 VObaP"
+      class="StyledButton-sc-323bzc-0 hocFoX"
       type="reset"
     >
       Reset
@@ -3360,7 +3360,7 @@ exports[`Form uncontrolled uncontrolled 2`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 VObaP"
+      class="StyledButton-sc-323bzc-0 hocFoX"
       type="submit"
     >
       Submit
@@ -3393,7 +3393,7 @@ exports[`Form uncontrolled uncontrolled 3`] = `
       </div>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 VObaP"
+      class="StyledButton-sc-323bzc-0 hocFoX"
       type="submit"
     >
       Submit
@@ -3645,7 +3645,7 @@ exports[`Form uncontrolled uncontrolled onValidate 2`] = `
       </span>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 VObaP"
+      class="StyledButton-sc-323bzc-0 hocFoX"
       type="submit"
     >
       Submit
@@ -3897,7 +3897,7 @@ exports[`Form uncontrolled uncontrolled onValidate custom error 2`] = `
       </span>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 VObaP"
+      class="StyledButton-sc-323bzc-0 hocFoX"
       type="submit"
     >
       Submit
@@ -4145,7 +4145,7 @@ exports[`Form uncontrolled uncontrolled onValidate custom info 2`] = `
       </span>
     </div>
     <button
-      class="StyledButton-sc-323bzc-0 VObaP"
+      class="StyledButton-sc-323bzc-0 hocFoX"
       type="submit"
     >
       Submit

--- a/src/js/components/Tip/__tests__/__snapshots__/Tip-test.tsx.snap
+++ b/src/js/components/Tip/__tests__/__snapshots__/Tip-test.tsx.snap
@@ -198,7 +198,7 @@ exports[`Tip focus and blur events on the Tip's child 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 drDzQW"
 >
   <button
-    class="StyledButton-sc-323bzc-0 dGPAnB"
+    class="StyledButton-sc-323bzc-0 btMUUh"
     type="button"
   >
     Test Events

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -150,6 +150,7 @@ interface ButtonKindType {
     | boolean;
   color?: ColorType;
   direction?: DirectionType;
+  elevation?: ElevationType;
   font?: {
     size?: string;
     weight?: number | string;
@@ -188,6 +189,7 @@ interface ButtonType {
     radius?: string;
   };
   color?: ColorType;
+  elevation?: ElevationType;
   extend?: ExtendType;
   minWidth?: string;
   maxWidth?: string;
@@ -381,6 +383,7 @@ export interface ThemeType {
         medium?: string;
         large?: string;
         xlarge?: string;
+        [x: string]: string;
       };
       dark?: {
         none?: string;
@@ -389,6 +392,7 @@ export interface ThemeType {
         medium?: string;
         large?: string;
         xlarge?: string;
+        [x: string]: string;
       };
     };
     focus?: {

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -496,12 +496,14 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         width: `${borderWidth}px`,
         radius: `${baseSpacing * 0.75}px`,
       },
-      // color: { dark: undefined, light: undefined }
+      // color: { dark: undefined, light: undefined },
+      // elevation: undefined,
       // default: {
       //   background: undefined,
       //   border: undefined,
       //   color: undefined,
       //   direction: undefined,
+      //   elevation: undefined,
       //   font: {
       //     size: undefined,
       //     weight: undefined,
@@ -523,6 +525,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       //   border: undefined,
       //   color: undefined,
       //   direction: undefined,
+      //   elevation: undefined,
       //   icon: undefined,
       //   padding: {
       //     vertical: undefined,
@@ -540,6 +543,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       //   border: undefined,
       //   color: undefined,
       //   direction: undefined,
+      //   elevation: undefined,
       //   icon: undefined,
       //   padding: {
       //     vertical: undefined,
@@ -553,6 +557,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       //   border: undefined,
       //   color: undefined,
       //   direction: undefined,
+      //   elevation: undefined,
       //   icon: undefined,
       //   padding: {
       //     vertical: undefined,

--- a/src/js/utils/styles.js
+++ b/src/js/utils/styles.js
@@ -581,6 +581,13 @@ export const plainInputStyle = css`
   border: none;
 `;
 
+export const elevationStyle = (elevation) => css`
+  box-shadow: ${(props) =>
+    props.theme.global.elevation[props.theme.dark ? 'dark' : 'light'][
+      elevation
+    ]};
+`;
+
 // CSS for this sub-object in the theme
 export const kindPartStyles = (obj, theme, colorValue) => {
   const styles = [];
@@ -648,6 +655,9 @@ export const kindPartStyles = (obj, theme, colorValue) => {
         ? theme.global.opacity.medium
         : theme.global.opacity[obj.opacity] || obj.opacity;
     styles.push(`opacity: ${opacity};`);
+  }
+  if (obj.elevation) {
+    styles.push(elevationStyle(obj.elevation));
   }
   if (obj.extend) styles.push(obj.extend);
   return styles;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR enhances Button theme to allow for `elevation` of a Button to be themed. This enhancement is specific to enabling the styling of the "bookend" within a "selected option" in a Select. Use of box-shadow to implement this styling is to avoid having to recalculate padding when this bookend is rendered (which would be necessary if implemented as a border).

Additionally, this will allow us to introduce a new elevation within grommet-theme-hpe called `inset-selected` (or something similar) which can be applied in the theme to `button.selected.option` as well as used by teams if they are composing custom Select option render via children or custom List items where one item might need to be indicated as "selected" (see screenshots and code examples below).

NOTE: With List, there is an `unfocusStyle` that applies to the List container onClick of an item and therefore is removing the box-shadow bookend. I'm not sure if this unfocusStyle is behaving exactly as we'd expect (see screen capture below), but I think addressing any changes should be handled separately from this PR.

#### Where should the reviewer start?
src/js/utils/styles.js

#### What testing has been done on this PR?
Locally on:
1. modified grommet theme (StyledButton)

<img width="270" alt="Screenshot 2024-10-31 at 9 49 17 AM" src="https://github.com/user-attachments/assets/9407344e-d899-4f63-a846-b2da8ff39d07">

```
const customGrommet = deepMerge(grommet, {
  button: {
    elevation: 'small',
    primary: {
      elevation: 'medium',
    },
  },
});
```

2. modified hpe theme (StyledButtonKind) -- just for testing, not planned style change

<img width="274" alt="Screenshot 2024-10-31 at 10 01 08 AM" src="https://github.com/user-attachments/assets/92bb3af9-7bbd-4f04-8601-7f26fd8baa0e">

```
const customTheme = deepMerge(hpe, {
  global: {
    colors: {
      'background-selected-weak': {
        light: '#CBFAEB',
        dark: '#093A2F',
      },
      'border-selected': {
        light: '#01A982',
        dark: '#01A982',
      },
    },
    elevation: {
      light: {
        'inset-selected': 'inset 3px 0 #01A982',
      },
      dark: {
        'inset-selected': 'inset 3px 0 #01A982',
      },
    },
  },
  button: {
    primary: {
      elevation: 'medium',
    },
    hover: {
      primary: {
        elevation: 'medium',
      },
    },
    // This might apply outside of just option button
    // such as within a list item (inbox experience)
    selected: {
      option: {
        background: 'background-selected-weak',
        color: 'text-strong',
        elevation: 'inset-selected',
        font: {
          weight: 500,
        },
      },
    },
  },
});
```

3. Select with standard options

<img width="359" alt="Screenshot 2024-10-31 at 9 49 49 AM" src="https://github.com/user-attachments/assets/c12a433e-453a-4ea7-80f3-b2d492d8348a">

4. Select with custom options render

<img width="314" alt="Screenshot 2024-10-31 at 9 50 16 AM" src="https://github.com/user-attachments/assets/8ccd430c-2fd3-4216-85fa-db1321541dd8">

```
<Select
        id="select"
        name="select"
        placeholder="Select"
        value={value}
        options={options}
        onChange={({ option }) => setValue(option)}
      >
        {(option, index, options, { selected }) => (
          <Box
            key={index}
            background={selected ? 'background-selected-weak' : undefined}
            elevation={selected ? 'inset-selected' : undefined}
            pad={{ horizontal: 'small', vertical: 'xsmall' }}
          >
            <Text
              color={selected ? 'text-onSelectedWeak' : undefined}
              weight={selected ? 500 : undefined}
            >
              {option}
            </Text>
            <Text size="small">This is an additional description</Text>
          </Box>
        )}
      </Select>
```

7. List with onClickItem

<img width="438" alt="Screenshot 2024-10-31 at 9 52 09 AM" src="https://github.com/user-attachments/assets/cece3d74-b505-4da0-8f95-87a10c40a292">

```
<List
        aria-label="onClickItem list"
        data={data.slice(0, 10)}
        onClickItem={(e) => console.log('click') || setSelected(e.item.entry)}
        itemProps={{
          [data.map((datum) => datum.entry).indexOf(selected)]: {
            background: 'background-selected-weak',
            elevation: 'inset-selected',
          },
        }}
      >
        {(datum) => (
          <Box>
            <Text weight={500}>{datum.entry}</Text>
            <Text size="small">This is additional descriptive text.</Text>
          </Box>
        )}
      </List>
```

See above to re: List focus style issue to be looked at in separate PR -- when I click on the List item the inset box-shadow is being removed, when I click outside of the list (List container no longer is in focus), the box-shadow shows again.

https://github.com/user-attachments/assets/a329f0c1-826d-4107-8603-2326711ebe8d


#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [x] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #7404 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Yes.

#### Should this PR be mentioned in the release notes?
Yes.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.