### PR TITLE
Enhance Notification theme for status/kind-specific `message` and `title` colors

### DIFF
--- a/src/js/components/Notification/Notification.js
+++ b/src/js/components/Notification/Notification.js
@@ -46,6 +46,16 @@ const adaptThemeStyle = (value, theme) => {
   return [textStyle, closeButtonStyle];
 };
 
+const getTextColor = (part, status, kind, theme) => {
+  let color;
+  if (theme.notification?.[status]?.[kind]?.[part]?.color)
+    color = theme.notification?.[status]?.[kind]?.[part]?.color;
+  else if (theme.notification?.[status]?.[part]?.color)
+    color = theme.notification?.[status]?.[part]?.color;
+  else color = theme.notification?.[part]?.color;
+  return color;
+};
+
 const NotificationAnchor = styled(Anchor)`
   white-space: nowrap;
 `;
@@ -141,6 +151,9 @@ const Notification = ({
   let actions;
   let message = messageProp;
 
+  const messageColor = getTextColor('message', status, kind, theme);
+  const titleColor = getTextColor('title', status, kind, theme);
+
   if (actionsProp)
     actions = actionsProp.map((action) => (
       <Fragment key={action.label}>
@@ -159,7 +172,7 @@ const Notification = ({
   if (message || actions)
     message =
       typeof message === 'string' ? (
-        <Message {...theme.notification.message}>
+        <Message {...theme.notification.message} color={messageColor}>
           <Text margin={{ right: 'xsmall' }}>{message}</Text>
           {/* include actions with message so it wraps with message */}
           {actions}
@@ -191,7 +204,11 @@ const Notification = ({
         </Box>
         <Box {...theme.notification.textContainer}>
           <TextWrapper>
-            {title && <Text {...theme.notification.title}>{title}</Text>}
+            {title && (
+              <Text {...theme.notification.title} color={titleColor}>
+                {title}
+              </Text>
+            )}
             {message && title && direction === 'row' && <>&nbsp;</>}
             {message}
           </TextWrapper>

--- a/src/js/components/Notification/__tests__/Notification-test.tsx
+++ b/src/js/components/Notification/__tests__/Notification-test.tsx
@@ -339,4 +339,64 @@ describe('Notification', () => {
     );
     expect(asFragment()).toMatchSnapshot();
   });
+
+  test('should render status and kind specific message and title colors', () => {
+    const theme: ThemeType = {
+      notification: {
+        title: {
+          color: 'blue',
+        },
+        message: {
+          color: 'red',
+        },
+        normal: {
+          message: {
+            color: 'blue',
+          },
+          title: {
+            color: 'red',
+          },
+          global: {
+            title: {
+              color: 'green',
+            },
+            message: {
+              color: 'purple',
+            },
+          },
+          toast: {
+            title: {
+              color: 'skyblue',
+            },
+            message: {
+              color: 'green',
+            },
+          },
+        },
+      },
+    };
+
+    const { asFragment } = render(
+      <Grommet theme={theme}>
+        <Notification
+          status="normal"
+          title="Status Title"
+          message="This is an example of message text"
+        />
+        <Notification
+          status="normal"
+          title="Status Title"
+          message="This is an example of message text"
+          global
+        />
+        <Notification
+          status="normal"
+          title="Status Title"
+          message="This is an example of message text"
+          toast
+        />
+      </Grommet>,
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
 });

--- a/src/js/components/Notification/__tests__/__snapshots__/Notification-test.tsx.snap
+++ b/src/js/components/Notification/__tests__/__snapshots__/Notification-test.tsx.snap
@@ -4307,6 +4307,308 @@ exports[`Notification should render outside grommet wrapper 1`] = `
 </DocumentFragment>
 `;
 
+exports[`Notification should render status and kind specific message and title colors 1`] = `
+<DocumentFragment>
+  .c4 {
+  display: inline-block;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #00C781;
+  stroke: #00C781;
+}
+
+.c4 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c4 *:not([stroke])[fill='none'] {
+  stroke-width: 0;
+}
+
+.c4 *[stroke*='#'],
+.c4 *[STROKE*='#'] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c4 *[fill-rule],
+.c4 *[FILL-RULE],
+.c4 *[fill*='#'],
+.c4 *[FILL*='#'] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c1 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  background-color: rgba(0, 199, 129, 0.1);
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  border-radius: 6px;
+}
+
+.c2 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  flex: 1 1;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c3 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  flex: 0 0 auto;
+  padding-right: 12px;
+}
+
+.c5 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.c9 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  background-color: rgba(0, 199, 129, 0.1);
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  border-radius: 0px;
+}
+
+.c10 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  flex: 1 1;
+  padding-left: 48px;
+  padding-right: 48px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c6 {
+  font-size: 18px;
+  line-height: 24px;
+  color: red;
+  font-weight: bold;
+}
+
+.c8 {
+  margin-right: 6px;
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c11 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c12 {
+  font-size: 18px;
+  line-height: 24px;
+  color: green;
+  font-weight: bold;
+}
+
+.c13 {
+  margin: 0px;
+  font-size: 18px;
+  line-height: 24px;
+  color: purple;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c7 {
+  margin: 0px;
+  font-size: 18px;
+  line-height: 24px;
+  max-width: 432px;
+  color: blue;
+}
+
+@media only screen and (max-width: 768px) {
+  .c1 {
+    border-radius: 3px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    padding-left: 6px;
+    padding-right: 6px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    padding-top: 3px;
+    padding-bottom: 3px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c3 {
+    padding-right: 6px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c9 {
+    border-radius: 0px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c10 {
+    padding-left: 24px;
+    padding-right: 24px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c10 {
+    padding-top: 3px;
+    padding-bottom: 3px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+
+}
+
+<div
+    class="c0"
+  >
+    <div
+      class="c1"
+    >
+      <div
+        class="c2"
+      >
+        <div
+          class="c3"
+        >
+          <svg
+            aria-label="Status is okay"
+            class="c4"
+            viewBox="0 0 12 12"
+          >
+            <circle
+              cx="6"
+              cy="6"
+              fill-rule="evenodd"
+              r="5"
+              stroke="#000"
+            />
+          </svg>
+        </div>
+        <div
+          class="c5"
+        >
+          <span
+            class="c6"
+          >
+            Status Title
+          </span>
+          <p
+            class="c7"
+          >
+            <span
+              class="c8"
+            >
+              This is an example of message text
+            </span>
+          </p>
+        </div>
+      </div>
+    </div>
+    <div
+      class="c9"
+    >
+      <div
+        class="c10"
+      >
+        <div
+          class="c3"
+        >
+          <svg
+            aria-label="Status is okay"
+            class="c4"
+            viewBox="0 0 12 12"
+          >
+            <circle
+              cx="6"
+              cy="6"
+              fill-rule="evenodd"
+              r="5"
+              stroke="#000"
+            />
+          </svg>
+        </div>
+        <div
+          class="c5"
+        >
+          <span
+            class="c11"
+          >
+            <span
+              class="c12"
+            >
+              Status Title
+            </span>
+             
+            <span
+              class="c13"
+            >
+              <span
+                class="c8"
+              >
+                This is an example of message text
+              </span>
+            </span>
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`Notification should render the default icon if no icon is passed 1`] = `
 <DocumentFragment>
   .c4 {

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -1172,66 +1172,174 @@ export interface ThemeType {
       icon?: React.ReactNode | Icon;
       background?: BackgroundType;
       color?: ColorType;
+      message?: {
+        color?: ColorType;
+      };
+      title?: {
+        color?: ColorType;
+      };
       global?: {
         background?: BackgroundType;
+        message?: {
+          color?: ColorType;
+        };
+        title?: {
+          color?: ColorType;
+        };
       };
       toast?: {
         background?: BackgroundType;
+        message?: {
+          color?: ColorType;
+        };
+        title?: {
+          color?: ColorType;
+        };
       };
     };
     warning?: {
       icon?: React.ReactNode | Icon;
       background?: BackgroundType;
       color?: ColorType;
+      message?: {
+        color?: ColorType;
+      };
+      title?: {
+        color?: ColorType;
+      };
       global?: {
         background?: BackgroundType;
+        message?: {
+          color?: ColorType;
+        };
+        title?: {
+          color?: ColorType;
+        };
       };
       toast?: {
         background?: BackgroundType;
+        message?: {
+          color?: ColorType;
+        };
+        title?: {
+          color?: ColorType;
+        };
       };
     };
     normal?: {
       icon?: React.ReactNode | Icon;
       background?: BackgroundType;
       color?: ColorType;
+      message?: {
+        color?: ColorType;
+      };
+      title?: {
+        color?: ColorType;
+      };
       global?: {
         background?: BackgroundType;
+        message?: {
+          color?: ColorType;
+        };
+        title?: {
+          color?: ColorType;
+        };
       };
       toast?: {
         background?: BackgroundType;
+        message?: {
+          color?: ColorType;
+        };
+        title?: {
+          color?: ColorType;
+        };
       };
     };
     info?: {
       icon?: React.ReactNode | Icon;
       background?: BackgroundType;
       color?: ColorType;
+      message?: {
+        color?: ColorType;
+      };
+      title?: {
+        color?: ColorType;
+      };
       global?: {
         background?: BackgroundType;
+        message?: {
+          color?: ColorType;
+        };
+        title?: {
+          color?: ColorType;
+        };
       };
       toast?: {
         background?: BackgroundType;
+        message?: {
+          color?: ColorType;
+        };
+        title?: {
+          color?: ColorType;
+        };
       };
     };
     unknown?: {
       icon?: React.ReactNode | Icon;
       background?: BackgroundType;
       color?: ColorType;
+      message?: {
+        color?: ColorType;
+      };
+      title?: {
+        color?: ColorType;
+      };
       global?: {
         background?: BackgroundType;
+        message?: {
+          color?: ColorType;
+        };
+        title?: {
+          color?: ColorType;
+        };
       };
       toast?: {
         background?: BackgroundType;
+        message?: {
+          color?: ColorType;
+        };
+        title?: {
+          color?: ColorType;
+        };
       };
     };
     undefined?: {
       icon?: React.ReactNode | Icon;
       background?: BackgroundType;
       color?: ColorType;
+      message?: {
+        color?: ColorType;
+      };
+      title?: {
+        color?: ColorType;
+      };
       global?: {
         background?: BackgroundType;
+        message?: {
+          color?: ColorType;
+        };
+        title?: {
+          color?: ColorType;
+        };
       };
       toast?: {
         background?: BackgroundType;
+        message?: {
+          color?: ColorType;
+        };
+        title?: {
+          color?: ColorType;
+        };
       };
     };
   };

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1274,9 +1274,21 @@ export const generate = (baseSpacing = 24, scale = 6) => {
           opacity: 'weak',
         },
         color: 'status-critical',
+        // message: {
+        //   color: undefined,
+        // },
+        // title: {
+        //   color: undefined,
+        // },
         // global: {},
         toast: {
           background: 'background-front',
+          // message: {
+          //   color: undefined,
+          // },
+          // title: {
+          //   color: undefined,
+          // },
         },
       },
       warning: {
@@ -1286,9 +1298,21 @@ export const generate = (baseSpacing = 24, scale = 6) => {
           opacity: 'weak',
         },
         color: 'status-warning',
+        // message: {
+        //   color: undefined,
+        // },
+        // title: {
+        //   color: undefined,
+        // },
         // global: {},
         toast: {
           background: 'background-front',
+          // message: {
+          //   color: undefined,
+          // },
+          // title: {
+          //   color: undefined,
+          // },
         },
       },
       normal: {
@@ -1298,18 +1322,42 @@ export const generate = (baseSpacing = 24, scale = 6) => {
           opacity: 'weak',
         },
         color: 'status-ok',
+        // message: {
+        //   color: undefined,
+        // },
+        // title: {
+        //   color: undefined,
+        // },
         // global: {},
         toast: {
           background: 'background-front',
+          // message: {
+          //   color: undefined,
+          // },
+          // title: {
+          //   color: undefined,
+          // },
         },
       },
       info: {
         icon: CircleInformation,
         background: 'background-contrast',
         color: 'text-strong',
+        // message: {
+        //   color: undefined,
+        // },
+        // title: {
+        //   color: undefined,
+        // },
         // global: {},
         toast: {
           background: 'background-front',
+          // message: {
+          //   color: undefined,
+          // },
+          // title: {
+          //   color: undefined,
+          // },
         },
       },
       unknown: {
@@ -1319,9 +1367,21 @@ export const generate = (baseSpacing = 24, scale = 6) => {
           opacity: 'weak',
         },
         color: 'status-unknown',
+        // message: {
+        //   color: undefined,
+        // },
+        // title: {
+        //   color: undefined,
+        // },
         // global: {},
         toast: {
           background: 'background-front',
+          // message: {
+          //   color: undefined,
+          // },
+          // title: {
+          //   color: undefined,
+          // },
         },
       },
       // deprecate "undefined" in v3
@@ -1330,6 +1390,12 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         icon: StatusUnknownSmall,
         // background: undefined,
         color: 'status-unknown',
+        // message: {
+        //   color: undefined,
+        // },
+        // title: {
+        //   color: undefined,
+        // },
         // global: {},
         // toast: {},
       },


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Enhances Notification theme to allow status/kind-specific `message` and `title` colors. This will us to leverage our token color system where there will be specific `on` colors for text colors on status backgrounds. We won't need to leverage all of these combinations (the background/text colors for our global and inline notifications are the same-- only toast differs), but introducing them for consistency.

#### Where should the reviewer start?
src/js/components/Notification/Notification.js

#### What testing has been done on this PR?
Locally, adjusted preview.js with the following:

```
import React, { useState, useEffect } from 'react';
import Root from 'react-shadow';
import { StyleSheetManager } from 'styled-components';
import { hpe } from 'grommet-theme-hpe';
import isChromatic from 'chromatic/isChromatic';
import { Grommet, grommet, hacktoberfest2022, Box, Text } from '../src/js';
import { deepMerge } from '../src/js/utils';

const CUSTOM_THEMED = 'Custom Themed';

const customTheme = deepMerge(hpe, {
  notification: {
    title: {
      color: 'blue',
    },
    message: {
      color: 'red',
    },
    normal: {
      message: {
        color: 'blue',
      },
      title: {
        color: 'red',
      },
      global: {
        title: {
          color: 'green',
        },
        message: {
          color: 'purple',
        },
      },
      toast: {
        title: {
          color: 'skyblue',
        },
        message: {
          color: 'green',
        },
      },
    },
  },
});

const THEMES = {
  hpe: customTheme,
  grommet,
  hacktoberfest2022,
  base: {},
};

export const decorators = [
  (Story, context) => {
    const [rootRef, setRootRef] = useState(null);
    const [state, setState] = useState('grommet');
    const [root, setRoot] = useState('document');
    const full = context.allArgs?.full || 'min';
    const dir = context.allArgs?.dir;
    const options = context.allArgs?.options;

    useEffect(() => {
      setState(context.globals.theme);
    }, [context.globals.theme]);
    useEffect(() => {
      setRoot(context.globals.root);
    }, [context.globals.root]);

    /**
     * This demonstrates that custom themed stories are driven off the "base"
     * theme. Custom themed stories will live under a "CustomThemed" directory.
     */
    if (context.kind.split('/')[2] === CUSTOM_THEMED && state !== 'base') {
      // if we are running the story in chromatic we want the chromatic snapshot
      // to be taken in the base theme for custom theme stories
      if (isChromatic()) {
        return (
          <Grommet theme={THEMES.base}>
            <Story state={THEMES.base} />
          </Grommet>
        );
      }
      return (
        <Box align="center" pad="large">
          <Text size="large">
            {`Custom themed stories are only displayed in the
                "base" theme mode. To enable, select "base" from the
                Theme menu above.`}
          </Text>
          <div hidden>
            <Story state={THEMES[state]} />
          </div>
        </Box>
      );
    }

    if (root === 'shadow') {
      return (
        // eslint-disable-next-line react/jsx-pascal-case
        <Root.div ref={setRootRef}>
          {rootRef && (
            <StyleSheetManager target={rootRef.shadowRoot}>
              <Grommet
                theme={THEMES[state]}
                full={full}
                dir={dir}
                options={options}
                containerTarget={rootRef.shadowRoot}
              >
                <Story state={THEMES[state]} />
              </Grommet>
            </StyleSheetManager>
          )}
        </Root.div>
      );
    }

    return (
      <Grommet theme={THEMES[state]} full={full} dir={dir} options={options}>
        <Story state={THEMES[state]} />
      </Grommet>
    );
  },
];

export const parameters = {
  layout: 'fullscreen',
  options: {
    storySort: (first, second) => {
      /**
       * The story sort algorithm will only ever compare two stories
       * a single time. This means that every story will only ever be either
       * the "first" parameter OR the "second" parameter, but not both.
       * So, the checks for custom themed stories need to happen on both inputs
       * of this function.
       *
       * A return value of 1 results in sorting the "first" story AFTER the
       * "second" story.
       *
       * A return value of 0 results in sorting the "first" story BEFORE the
       * secondary story.
       */
      const isFirstCustom = first[1].kind.split('/')[2] === CUSTOM_THEMED;
      const isSecondCustom = second[1].kind.split('/')[2] === CUSTOM_THEMED;
      if (isFirstCustom) return 1;
      if (isSecondCustom) return 0;
      return first[1].kind === second[1].kind
        ? 0
        : first[1].id.localeCompare(second[1].id, undefined, { numeric: true });
    },
  },
};

export const globalTypes = {
  theme: {
    defaultValue: 'grommet',
    toolbar: {
      title: 'Theme',
      items: [
        { title: 'base', value: 'base' },
        { title: 'grommet', value: 'grommet' },
        { title: 'hpe', value: 'hpe' },
        { title: 'hacktoberfest2022', value: 'hacktoberfest2022' },
      ],
    },
  },
  root: {
    defaultValue: 'document',
    toolbar: {
      title: 'Root',
      items: ['document', 'shadow'],
    },
  },
};
```

<img width="1328" alt="Screenshot 2024-10-31 at 2 06 35 PM" src="https://github.com/user-attachments/assets/61bf05c6-5b69-4804-a7d8-f51c864afd52">

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [x] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #7410 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Yes.

For each status and each kind
- [ ] `theme.notification.[status].[kind].message.color
- [ ] `theme.notification.[status].[kind].title.color

#### Should this PR be mentioned in the release notes?
Yes.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.