### PR TITLE
Remove unused date/random mocks in the Accordion tests

### DIFF
--- a/src/js/components/Accordion/__tests__/Accordion-test.tsx
+++ b/src/js/components/Accordion/__tests__/Accordion-test.tsx
@@ -19,18 +19,6 @@ const customTheme = {
 };
 
 describe('Accordion', () => {
-  beforeEach(() => {
-    // Mocked values so we get consistent snapshots. I chose
-    // consecutive numbers for the mocked values.
-    jest.spyOn(Date, 'now').mockImplementation(() => 12345678);
-    jest.spyOn(global.Math, 'random').mockReturnValue(0.123456789);
-  });
-
-  afterEach(() => {
-    jest.spyOn(Date, 'now').mockRestore();
-    jest.spyOn(global.Math, 'random').mockRestore();
-  });
-
   test('should have no accessibility violations', async () => {
     const { container, asFragment } = render(
       <Grommet>


### PR DESCRIPTION
Remove unnecessary date.now and random mocks in the Accordion tests
#### What does this PR do?
Remove unnecessary date.now and random mocks in the Accordion tests
With the addition of the useId() polyfill, Accordion no longer needs the mocks for Date.now() and random().

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
