### PR TITLE
fix: check onClickItem or onOrder is defined before preventing event in List component

### DIFF
--- a/src/js/components/List/List.js
+++ b/src/js/components/List/List.js
@@ -305,28 +305,30 @@ const List = React.forwardRef(
         <Keyboard
           onEnter={onSelectOption}
           onSpace={(event) => {
-            event.preventDefault();
+            if (onClickItem || onOrder) {
+              event.preventDefault();
+            }
             onSelectOption(event);
           }}
           onUp={(event) => {
-            event.preventDefault();
-            if ((onClickItem || onOrder) && active) {
-              const min = onOrder ? 1 : 0;
-              updateActive(Math.max(active - 1, min));
+            if (onClickItem || onOrder) {
+              event.preventDefault();
+              if (active) {
+                const min = onOrder ? 1 : 0;
+                updateActive(Math.max(active - 1, min));
+              }
             }
           }}
           onDown={(event) => {
-            event.preventDefault();
-            if (
-              (onClickItem || onOrder) &&
-              orderableData &&
-              orderableData.length
-            ) {
-              const min = onOrder ? 1 : 0;
-              const max = onOrder
-                ? orderableData.length * 2 - 2
-                : data.length - 1;
-              updateActive(active >= min ? Math.min(active + 1, max) : min);
+            if (onClickItem || onOrder) {
+              event.preventDefault();
+              if (orderableData && orderableData.length) {
+                const min = onOrder ? 1 : 0;
+                const max = onOrder
+                  ? orderableData.length * 2 - 2
+                  : data.length - 1;
+                updateActive(active >= min ? Math.min(active + 1, max) : min);
+              }
             }
           }}
           onKeyDown={onKeyDown}


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
_Prevents_ `event.preventDefault();` from running in `List` component events if `onClickItem` or `onOrder` isn't defined.

#### Where should the reviewer start?
- [List](https://github.com/grommet/grommet/blob/07811588d21e0be78dc89e5ec1a574e5c1b04ae5/src/js/components/List/List.js) component and the issues provided below. 

#### What testing has been done on this PR?
- Used npm link to test the components in a test project
- Used Snapshots/Jest to test the output of the components

#### What are the relevant issues?
- Fixes https://github.com/grommet/grommet/issues/7414
- Fixes https://github.com/grommet/grommet/issues/7362

#### Is this change backwards compatible or is it a breaking change?
- Shouldn't
