### PR TITLE
Fix nested interactive issue for SelectMultiple

### DIFF
--- a/src/js/components/CheckBox/CheckBox.js
+++ b/src/js/components/CheckBox/CheckBox.js
@@ -32,6 +32,7 @@ const CheckBox = forwardRef(
       'aria-label': ariaLabel,
       checked: checkedProp,
       children,
+      containerProps, // internal only for now, used by SelectMultiple
       defaultChecked = false,
       disabled,
       fill,
@@ -222,6 +223,7 @@ const CheckBox = forwardRef(
         onMouseOut={(event) => onMouseOut?.(event)}
         {...passThemeFlag}
         {...themeableProps}
+        {...containerProps}
       >
         {first}
         {second}

--- a/src/js/components/Data/__tests__/__snapshots__/Data-test.tsx.snap
+++ b/src/js/components/Data/__tests__/__snapshots__/Data-test.tsx.snap
@@ -4192,6 +4192,7 @@ exports[`Data should render property label and return property value to view whe
                               autocomplete="off"
                               class="c13 c14"
                               id="data-selectMultiple__input"
+                              inert=""
                               name="selectMultiple"
                               placeholder="2 selected of 9"
                               readonly=""
@@ -4220,6 +4221,7 @@ exports[`Data should render property label and return property value to view whe
                         <input
                           class="c17"
                           id="data-selectMultiple__input"
+                          inert=""
                           name="selectMultiple"
                           readonly=""
                           type="text"
@@ -4265,6 +4267,7 @@ exports[`Data should render property label and return property value to view whe
                               autocomplete="off"
                               class="c13 c14"
                               id="data-selectMultipleSimple__input"
+                              inert=""
                               name="selectMultipleSimple"
                               placeholder="1 selected of 9"
                               readonly=""
@@ -4293,6 +4296,7 @@ exports[`Data should render property label and return property value to view whe
                         <input
                           class="c17"
                           id="data-selectMultipleSimple__input"
+                          inert=""
                           name="selectMultipleSimple"
                           readonly=""
                           type="text"

--- a/src/js/components/Data/__tests__/__snapshots__/Data-test.tsx.snap
+++ b/src/js/components/Data/__tests__/__snapshots__/Data-test.tsx.snap
@@ -4321,6 +4321,7 @@ exports[`Data should render property label and return property value to view whe
                         >
                           <label
                             class="c20"
+                            style="pointer-events: none;"
                           >
                             <div
                               class="c21 c22"
@@ -4328,6 +4329,7 @@ exports[`Data should render property label and return property value to view whe
                               <input
                                 checked=""
                                 class="c23"
+                                inert=""
                                 tabindex="-1"
                                 type="checkbox"
                               />

--- a/src/js/components/SelectMultiple/SelectMultiple.js
+++ b/src/js/components/SelectMultiple/SelectMultiple.js
@@ -475,6 +475,7 @@ const SelectMultiple = forwardRef(
                         defaultCursor={disabled === true || undefined}
                         focusIndicator={false}
                         id={id ? `${id}__input` : undefined}
+                        inert="" // revisit for React 19
                         name={name}
                         width="100%"
                         {...rest}
@@ -508,6 +509,7 @@ const SelectMultiple = forwardRef(
                       type="text"
                       name={name}
                       id={id ? `${id}__input` : undefined}
+                      inert="" // revisit for React 19
                       value={inputValue}
                       ref={inputRef}
                       readOnly
@@ -519,6 +521,7 @@ const SelectMultiple = forwardRef(
                       a11yTitle={ariaLabel || a11yTitle}
                       disabled={disabled}
                       id={id}
+                      inert="" // revisit for React 19
                       name={name}
                       ref={inputRef}
                       placeholder={placeholder || 'Select'}
@@ -557,6 +560,7 @@ const SelectMultiple = forwardRef(
                         type="text"
                         name={name}
                         id={id ? `${id}__input` : undefined}
+                        inert="" // revisit for React 19
                         value={inputValue}
                         ref={inputRef}
                         readOnly
@@ -567,6 +571,7 @@ const SelectMultiple = forwardRef(
                       a11yTitle={ariaLabel || a11yTitle}
                       disabled={disabled}
                       id={id}
+                      inert="" // revisit for React 19
                       name={name}
                       ref={inputRef}
                       placeholder={placeholder}

--- a/src/js/components/SelectMultiple/SelectMultipleContainer.js
+++ b/src/js/components/SelectMultiple/SelectMultipleContainer.js
@@ -490,7 +490,7 @@ const SelectMultipleContainer = forwardRef(
                         tabIndex="-1"
                         checked={optionSelected}
                         disabled={optionDisabled}
-                        inert=""
+                        inert="" // revisit for React 19
                         containerProps={{
                           // in Firefox when we have inert set, the checkbox
                           // click event gets swallowed by the checkbox.
@@ -546,7 +546,7 @@ const SelectMultipleContainer = forwardRef(
                           tabIndex="-1"
                           checked={optionSelected}
                           disabled={optionDisabled}
-                          inert=""
+                          inert="" // revisit for React 19
                           containerProps={{
                             // in Firefox when we have inert set, the checkbox
                             // click event gets swallowed by the checkbox.

--- a/src/js/components/SelectMultiple/SelectMultipleContainer.js
+++ b/src/js/components/SelectMultiple/SelectMultipleContainer.js
@@ -490,6 +490,16 @@ const SelectMultipleContainer = forwardRef(
                         tabIndex="-1"
                         checked={optionSelected}
                         disabled={optionDisabled}
+                        inert=""
+                        containerProps={{
+                          // in Firefox when we have inert set, the checkbox
+                          // click event gets swallowed by the checkbox.
+                          // We need the click event to go the the button
+                          // around the checkbox so we use pointerEvents =
+                          // none. For code clarity we decided an inline
+                          // style made sense here.
+                          style: { pointerEvents: 'none' },
+                        }}
                       />
                     );
                   }
@@ -536,6 +546,16 @@ const SelectMultipleContainer = forwardRef(
                           tabIndex="-1"
                           checked={optionSelected}
                           disabled={optionDisabled}
+                          inert=""
+                          containerProps={{
+                            // in Firefox when we have inert set, the checkbox
+                            // click event gets swallowed by the checkbox.
+                            // We need the click event to go the the button
+                            // around the checkbox so we use pointerEvents =
+                            // none. For code clarity we decided an inline
+                            // style made sense here.
+                            style: { pointerEvents: 'none' },
+                          }}
                         />
                       );
                     }

--- a/src/js/components/SelectMultiple/SelectMultipleValue.js
+++ b/src/js/components/SelectMultiple/SelectMultipleValue.js
@@ -167,7 +167,7 @@ const SelectMultipleValue = ({
                 pad="xsmall"
                 tabIndex="-1"
                 checked={optionSelected}
-                inert=""
+                inert="" // revisit for React 19
                 containerProps={{
                   // in Firefox when we have inert set, the checkbox
                   // click event gets swallowed by the checkbox.

--- a/src/js/components/SelectMultiple/SelectMultipleValue.js
+++ b/src/js/components/SelectMultiple/SelectMultipleValue.js
@@ -167,6 +167,16 @@ const SelectMultipleValue = ({
                 pad="xsmall"
                 tabIndex="-1"
                 checked={optionSelected}
+                inert=""
+                containerProps={{
+                  // in Firefox when we have inert set, the checkbox
+                  // click event gets swallowed by the checkbox.
+                  // We need the click event to go the the button
+                  // around the checkbox so we use pointerEvents =
+                  // none. For code clarity we decided an inline
+                  // style made sense here.
+                  style: { pointerEvents: 'none' },
+                }}
               />
             )}
           </SelectOption>

--- a/src/js/components/SelectMultiple/__tests__/__snapshots__/SelectMultiple-test.tsx.snap
+++ b/src/js/components/SelectMultiple/__tests__/__snapshots__/SelectMultiple-test.tsx.snap
@@ -3514,6 +3514,7 @@ exports[`SelectMultiple showSelectionInline 1`] = `
         >
           <label
             class="c14"
+            style="pointer-events: none;"
           >
             <div
               class="c15 c16"
@@ -3521,6 +3522,7 @@ exports[`SelectMultiple showSelectionInline 1`] = `
               <input
                 checked=""
                 class="c17"
+                inert=""
                 tabindex="-1"
                 type="checkbox"
               />
@@ -3559,6 +3561,7 @@ exports[`SelectMultiple showSelectionInline 1`] = `
         >
           <label
             class="c14"
+            style="pointer-events: none;"
           >
             <div
               class="c15 c16"
@@ -3566,6 +3569,7 @@ exports[`SelectMultiple showSelectionInline 1`] = `
               <input
                 checked=""
                 class="c17"
+                inert=""
                 tabindex="-1"
                 type="checkbox"
               />
@@ -3604,6 +3608,7 @@ exports[`SelectMultiple showSelectionInline 1`] = `
         >
           <label
             class="c14"
+            style="pointer-events: none;"
           >
             <div
               class="c15 c16"
@@ -3611,6 +3616,7 @@ exports[`SelectMultiple showSelectionInline 1`] = `
               <input
                 checked=""
                 class="c17"
+                inert=""
                 tabindex="-1"
                 type="checkbox"
               />
@@ -4670,6 +4676,7 @@ exports[`SelectMultiple showSelectionInline with disabled options 1`] = `
           <label
             class="c14"
             disabled=""
+            style="pointer-events: none;"
           >
             <div
               class="c15 c16"
@@ -4679,6 +4686,7 @@ exports[`SelectMultiple showSelectionInline with disabled options 1`] = `
                 checked=""
                 class="c17"
                 disabled=""
+                inert=""
                 tabindex="-1"
                 type="checkbox"
               />
@@ -5167,6 +5175,7 @@ exports[`SelectMultiple valueKey and labelKey 1`] = `
         >
           <label
             class="c14"
+            style="pointer-events: none;"
           >
             <div
               class="c15 c16"
@@ -5174,6 +5183,7 @@ exports[`SelectMultiple valueKey and labelKey 1`] = `
               <input
                 checked=""
                 class="c17"
+                inert=""
                 tabindex="-1"
                 type="checkbox"
               />

--- a/src/js/components/SelectMultiple/__tests__/__snapshots__/SelectMultiple-test.tsx.snap
+++ b/src/js/components/SelectMultiple/__tests__/__snapshots__/SelectMultiple-test.tsx.snap
@@ -235,6 +235,7 @@ exports[`SelectMultiple children 1`] = `
             <input
               autocomplete="off"
               class="c7 c8"
+              inert=""
               readonly=""
               tabindex="-1"
               type="text"
@@ -499,6 +500,7 @@ exports[`SelectMultiple defaultValue 1`] = `
             <input
               autocomplete="off"
               class="c7 c8"
+              inert=""
               readonly=""
               tabindex="-1"
               type="text"
@@ -767,6 +769,7 @@ exports[`SelectMultiple disabled 1`] = `
             <input
               autocomplete="off"
               class="c7 c8"
+              inert=""
               readonly=""
               tabindex="-1"
               type="text"
@@ -1059,6 +1062,7 @@ exports[`SelectMultiple keyboard interactions 1`] = `
             <input
               autocomplete="off"
               class="c7 c8"
+              inert=""
               readonly=""
               tabindex="-1"
               type="text"
@@ -1324,6 +1328,7 @@ exports[`SelectMultiple null value 1`] = `
               <input
                 autocomplete="off"
                 class="c7 c8"
+                inert=""
                 readonly=""
                 tabindex="-1"
                 type="text"
@@ -1589,6 +1594,7 @@ exports[`SelectMultiple placeholder 1`] = `
             <input
               autocomplete="off"
               class="c7 c8"
+              inert=""
               placeholder="placeholder text"
               readonly=""
               tabindex="-1"
@@ -1841,6 +1847,7 @@ exports[`SelectMultiple renders selectMultiple outside grommet wrapper 1`] = `
           <input
             autocomplete="off"
             class="c6 c7"
+            inert=""
             readonly=""
             tabindex="-1"
             type="text"
@@ -2136,6 +2143,7 @@ exports[`SelectMultiple should display custom messages 1`] = `
                 autocomplete="off"
                 class="c7 c8"
                 data-g-tabindex="-1"
+                inert=""
                 placeholder="Select"
                 readonly=""
                 tabindex="-1"
@@ -2434,6 +2442,7 @@ exports[`SelectMultiple should display custom messages 2`] = `
                 autocomplete="off"
                 class="c7 c8"
                 data-g-tabindex="-1"
+                inert=""
                 placeholder="Select"
                 readonly=""
                 tabindex="-1"
@@ -2732,6 +2741,7 @@ exports[`SelectMultiple should display custom messages 3`] = `
                 autocomplete="off"
                 class="c7 c8"
                 data-g-tabindex="-1"
+                inert=""
                 placeholder="Select"
                 readonly=""
                 tabindex="-1"
@@ -2999,6 +3009,7 @@ exports[`SelectMultiple should not have accessibility violations 1`] = `
               aria-label="test"
               autocomplete="off"
               class="c7 c8"
+              inert=""
               readonly=""
               tabindex="-1"
               type="text"
@@ -3452,6 +3463,7 @@ exports[`SelectMultiple showSelectionInline 1`] = `
             <input
               autocomplete="off"
               class="c7 c8"
+              inert=""
               placeholder="3 selected of 3"
               readonly=""
               tabindex="-1"
@@ -3478,6 +3490,7 @@ exports[`SelectMultiple showSelectionInline 1`] = `
         </div>
         <input
           class="c11"
+          inert=""
           readonly=""
           type="text"
         />
@@ -3974,6 +3987,7 @@ exports[`SelectMultiple showSelectionInline with children 1`] = `
             <input
               autocomplete="off"
               class="c7 c8"
+              inert=""
               placeholder="3 selected of 3"
               readonly=""
               tabindex="-1"
@@ -4000,6 +4014,7 @@ exports[`SelectMultiple showSelectionInline with children 1`] = `
         </div>
         <input
           class="c11"
+          inert=""
           readonly=""
           type="text"
         />
@@ -4175,6 +4190,7 @@ exports[`SelectMultiple showSelectionInline with children 2`] = `
             <input
               autocomplete="off"
               class="c1 c2"
+              inert=""
               placeholder="Select"
               readonly=""
               tabindex="-1"
@@ -4601,6 +4617,7 @@ exports[`SelectMultiple showSelectionInline with disabled options 1`] = `
             <input
               autocomplete="off"
               class="c7 c8"
+              inert=""
               placeholder="1 selected of 3"
               readonly=""
               tabindex="-1"
@@ -4627,6 +4644,7 @@ exports[`SelectMultiple showSelectionInline with disabled options 1`] = `
         </div>
         <input
           class="c11"
+          inert=""
           readonly=""
           type="text"
         />
@@ -5098,6 +5116,7 @@ exports[`SelectMultiple valueKey and labelKey 1`] = `
             <input
               autocomplete="off"
               class="c7 c8"
+              inert=""
               placeholder="1 selected of 2"
               readonly=""
               tabindex="-1"
@@ -5124,6 +5143,7 @@ exports[`SelectMultiple valueKey and labelKey 1`] = `
         </div>
         <input
           class="c11"
+          inert=""
           readonly=""
           type="text"
         />
@@ -5425,6 +5445,7 @@ exports[`SelectMultiple with portal disabled option 1`] = `
           autocomplete="off"
           class="c5 c6"
           id="test-select__drop__input"
+          inert=""
           readonly=""
           tabindex="-1"
           type="text"
@@ -5743,6 +5764,7 @@ exports[`SelectMultiple with portal empty options 1`] = `
           autocomplete="off"
           class="c5 c6"
           id="test-select__drop__input"
+          inert=""
           readonly=""
           tabindex="-1"
           type="text"
@@ -6073,6 +6095,7 @@ exports[`SelectMultiple with portal limit 1`] = `
           autocomplete="off"
           class="c5 c6"
           id="test-select__drop__input"
+          inert=""
           readonly=""
           tabindex="-1"
           type="text"
@@ -6403,6 +6426,7 @@ exports[`SelectMultiple with portal select all and clear 1`] = `
           autocomplete="off"
           class="c5 c6"
           id="test-select__drop__input"
+          inert=""
           readonly=""
           tabindex="-1"
           type="text"
@@ -6516,6 +6540,7 @@ exports[`SelectMultiple with portal select all and clear 3`] = `
           autocomplete="off"
           class="StyledTextInput-sc-1x30a0s-0 hbKDLO StyledSelect__SelectTextInput-sc-znp66n-4 xDoY"
           id="test-select__drop__input"
+          inert=""
           readonly=""
           tabindex="-1"
           type="text"


### PR DESCRIPTION
#### What does this PR do?
Follow on to https://github.com/grommet/grommet/pull/7420, fixes the nested interactive issue for SelectMultiple

In addition to adding `inert` to the inputs within the drop button we also needed to add `inert` to the CheckBoxes because they are nested within a Button element. I also added `pointerEvents: 'none'` to the CheckBoxes to prevent an issue in FireFox where the click event was swallowed by the CheckBox instead of triggering the click event on the Button.

To add the `pointerEvents: 'none'` style onto the StyledCheckBoxContainer I needed to add containerProps onto CheckBox, for now leaving this as an internal only prop.

Normally we avoid inline styles but in this case it was the solution that felt like it was the most readable and least intrusive to the CheckBox component.

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?
Check that SelectMultiple Storybook stories no longer have an error in the accessibility tab for nested interactive elements

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible