### PR TITLE
List - Fixed accessibility violations with `onOrder`

### DIFF
--- a/src/js/components/DataTableColumns/__tests__/DataTableColumns-test.tsx
+++ b/src/js/components/DataTableColumns/__tests__/DataTableColumns-test.tsx
@@ -214,7 +214,7 @@ describe('DataTableColumns', () => {
 
     screen.getByRole('button', { name: '2 Name move up' });
 
-    const list = screen.getByRole('listbox');
+    const list = screen.getByRole('list');
     const listItems = within(list).getAllByRole('listitem');
 
     const dragElement = listItems[2];

--- a/src/js/components/DataTableColumns/__tests__/__snapshots__/DataTableColumns-test.tsx.snap
+++ b/src/js/components/DataTableColumns/__tests__/__snapshots__/DataTableColumns-test.tsx.snap
@@ -417,7 +417,7 @@ exports[`DataTableColumns pinned 1`] = `
       aria-labelledby="test-data--order-columns-tab"
       class="c2"
       id="test-data--order-columns"
-      role="listbox"
+      role="list"
       tabindex="0"
     >
       <li
@@ -2570,7 +2570,7 @@ exports[`DataTableColumns renders 3`] = `
       aria-labelledby="test-data--order-columns-tab"
       class="c0"
       id="test-data--order-columns"
-      role="listbox"
+      role="list"
       tabindex="0"
     >
       <li

--- a/src/js/components/List/List.js
+++ b/src/js/components/List/List.js
@@ -234,7 +234,7 @@ const List = React.forwardRef(
     const sendAnalytics = useAnalytics();
 
     const ariaProps = {
-      role: onClickItem || onOrder ? 'listbox' : 'list',
+      role: onClickItem ? 'listbox' : 'list',
     };
 
     if (active >= 0) {

--- a/src/js/components/List/__tests__/List-test.tsx
+++ b/src/js/components/List/__tests__/List-test.tsx
@@ -1047,7 +1047,7 @@ describe('List pinned', () => {
 
     expect(asFragment()).toMatchSnapshot();
 
-    const list = screen.getByRole('listbox');
+    const list = screen.getByRole('list');
     const listItems = within(list).getAllByRole('listitem');
     const middleItem = screen.getByRole('button', {
       name: '3 San Francisco move up',

--- a/src/js/components/List/__tests__/__snapshots__/List-test.tsx.snap
+++ b/src/js/components/List/__tests__/__snapshots__/List-test.tsx.snap
@@ -1362,7 +1362,7 @@ exports[`List disabled Disabled items should be allowed to be re-ordered 1`] = `
   >
     <ul
       class="c1"
-      role="listbox"
+      role="list"
       tabindex="0"
     >
       <li
@@ -2023,7 +2023,7 @@ exports[`List disabled Disabled items should be allowed to be re-ordered 2`] = `
     <ul
       aria-activedescendant="BoiseMoveUp"
       class="c1"
-      role="listbox"
+      role="list"
       tabindex="0"
     >
       <li
@@ -12816,7 +12816,7 @@ exports[`List itemKey function 1`] = `
   >
     <ul
       class="c1"
-      role="listbox"
+      role="list"
       tabindex="0"
     >
       <li
@@ -13753,7 +13753,7 @@ exports[`List onOrder Keyboard move down 1`] = `
 >
   <ul
     class="c1"
-    role="listbox"
+    role="list"
     tabindex="0"
   >
     <li
@@ -13907,7 +13907,7 @@ exports[`List onOrder Keyboard move down 2`] = `
   <ul
     aria-activedescendant="alphaMoveDown"
     class="List__StyledList-sc-130gdqg-0 cYeNGw"
-    role="listbox"
+    role="list"
     tabindex="0"
   >
     <li
@@ -14061,7 +14061,7 @@ exports[`List onOrder Keyboard move down 3`] = `
   <ul
     aria-activedescendant="alphaMoveUp"
     class="List__StyledList-sc-130gdqg-0 cYeNGw"
-    role="listbox"
+    role="list"
     tabindex="0"
   >
     <li
@@ -14477,7 +14477,7 @@ exports[`List onOrder Keyboard move up 1`] = `
 >
   <ul
     class="c1"
-    role="listbox"
+    role="list"
     tabindex="0"
   >
     <li
@@ -14631,7 +14631,7 @@ exports[`List onOrder Keyboard move up 2`] = `
   <ul
     aria-activedescendant="betaMoveUp"
     class="List__StyledList-sc-130gdqg-0 cYeNGw"
-    role="listbox"
+    role="list"
     tabindex="0"
   >
     <li
@@ -14785,7 +14785,7 @@ exports[`List onOrder Keyboard move up 3`] = `
   <ul
     aria-activedescendant="betaMoveDown"
     class="List__StyledList-sc-130gdqg-0 cYeNGw"
-    role="listbox"
+    role="list"
     tabindex="0"
   >
     <li
@@ -15201,7 +15201,7 @@ exports[`List onOrder Mouse move down 1`] = `
 >
   <ul
     class="c1"
-    role="listbox"
+    role="list"
     tabindex="0"
   >
     <li
@@ -15354,7 +15354,7 @@ exports[`List onOrder Mouse move down 2`] = `
 >
   <ul
     class="List__StyledList-sc-130gdqg-0 cYeNGw"
-    role="listbox"
+    role="list"
     tabindex="0"
   >
     <li
@@ -15848,7 +15848,7 @@ exports[`List onOrder with action Render 1`] = `
   >
     <ul
       class="c1"
-      role="listbox"
+      role="list"
       tabindex="0"
     >
       <li
@@ -16286,7 +16286,7 @@ exports[`List onOrder with no-index Keyboard move down 1`] = `
 >
   <ul
     class="c1"
-    role="listbox"
+    role="list"
     tabindex="0"
   >
     <li
@@ -16424,7 +16424,7 @@ exports[`List onOrder with no-index Keyboard move down 2`] = `
   <ul
     aria-activedescendant="alphaMoveDown"
     class="List__StyledList-sc-130gdqg-0 cYeNGw"
-    role="listbox"
+    role="list"
     tabindex="0"
   >
     <li
@@ -16562,7 +16562,7 @@ exports[`List onOrder with no-index Keyboard move down 3`] = `
   <ul
     aria-activedescendant="alphaMoveUp"
     class="List__StyledList-sc-130gdqg-0 cYeNGw"
-    role="listbox"
+    role="list"
     tabindex="0"
   >
     <li
@@ -16957,7 +16957,7 @@ exports[`List onOrder with no-index Keyboard move up 1`] = `
 >
   <ul
     class="c1"
-    role="listbox"
+    role="list"
     tabindex="0"
   >
     <li
@@ -17095,7 +17095,7 @@ exports[`List onOrder with no-index Keyboard move up 2`] = `
   <ul
     aria-activedescendant="betaMoveUp"
     class="List__StyledList-sc-130gdqg-0 cYeNGw"
-    role="listbox"
+    role="list"
     tabindex="0"
   >
     <li
@@ -17233,7 +17233,7 @@ exports[`List onOrder with no-index Keyboard move up 3`] = `
   <ul
     aria-activedescendant="betaMoveDown"
     class="List__StyledList-sc-130gdqg-0 cYeNGw"
-    role="listbox"
+    role="list"
     tabindex="0"
   >
     <li
@@ -17628,7 +17628,7 @@ exports[`List onOrder with no-index Mouse move down 1`] = `
 >
   <ul
     class="c1"
-    role="listbox"
+    role="list"
     tabindex="0"
   >
     <li
@@ -17765,7 +17765,7 @@ exports[`List onOrder with no-index Mouse move down 2`] = `
 >
   <ul
     class="List__StyledList-sc-130gdqg-0 cYeNGw"
-    role="listbox"
+    role="list"
     tabindex="0"
   >
     <li
@@ -18408,7 +18408,7 @@ exports[`List pinned Pinned items should not be allowed to be re-ordered 1`] = `
   >
     <ul
       class="c1"
-      role="listbox"
+      role="list"
       tabindex="0"
     >
       <li
@@ -19095,7 +19095,7 @@ exports[`List pinned Pinned items should not be allowed to be re-ordered 2`] = `
     <ul
       aria-activedescendant="Los GatosMoveUp"
       class="c1"
-      role="listbox"
+      role="list"
       tabindex="0"
     >
       <li
@@ -20649,7 +20649,7 @@ exports[`List pinned should apply pinned object styling to items when data are o
   >
     <ul
       class="c1"
-      role="listbox"
+      role="list"
       tabindex="0"
     >
       <li
@@ -21295,7 +21295,7 @@ exports[`List pinned should apply pinned object styling to items when data are s
   >
     <ul
       class="c1"
-      role="listbox"
+      role="list"
       tabindex="0"
     >
       <li


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Resolves the following accessibility issues with the List `onOrder` prop

![image](https://github.com/user-attachments/assets/fd79b246-42e7-407f-a1dc-c0a91cad863f)

#### Where should the reviewer start?

#### What testing has been done on this PR?
Tested with existing List onOrder story and tested with voiceover

#### How should this be manually tested?
Check the accessibility tab on the List/onOrder story

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes https://github.com/grommet/grommet/issues/7425

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible