### PR TITLE
fix: requirement indicator below label

### DIFF
--- a/src/js/components/FormField/FormField.js
+++ b/src/js/components/FormField/FormField.js
@@ -506,6 +506,10 @@ const FormField = forwardRef(
     if (typeof required === 'object' && required.indicator === false)
       showRequiredIndicator = false;
 
+    if (showRequiredIndicator) {
+      labelStyle.style = { display: 'flex' };
+    }
+
     return (
       <FormFieldBox
         ref={formFieldRef}

--- a/src/js/components/FormField/__tests__/__snapshots__/FormField-test.tsx.snap
+++ b/src/js/components/FormField/__tests__/__snapshots__/FormField-test.tsx.snap
@@ -2806,6 +2806,7 @@ exports[`FormField should render asterisk when requiredIndicator === true 1`] = 
     >
       <label
         class="c2"
+        style="display: flex;"
       >
         label
         <span
@@ -2980,6 +2981,7 @@ exports[`FormField should render custom indicator when requiredIndicator is
     >
       <label
         class="c2"
+        style="display: flex;"
       >
         label
         <svg


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
- Adds flex (row) for labels in [FormField](https://github.com/grommet/grommet/blob/a3a17c16ce36c49eedc1ea9e8e61b75cfbb83cb9/src/js/components/FormField/FormField.js) in case the value is required. 

#### Where should the reviewer start?
- This [code sandbox](https://codesandbox.io/p/sandbox/grommet-v2-template-forked-d87lgp?file=%2Findex.js%3A34%2C34&workspaceId=724eced4-5631-43d4-a90e-1f99ee73f924) shows a possible issue when the label is `display: block` type element.
- Check the file change for [FormField](https://github.com/grommet/grommet/blob/a3a17c16ce36c49eedc1ea9e8e61b75cfbb83cb9/src/js/components/FormField/FormField.js) 

#### What testing has been done on this PR?
- Ran Jest
- Tested in a mocked test project 

#### Any background context you want to provide?
- The required indicator being a span will go always go below a block type component. 
- Maybe also align with `baseline` could be an improvement.

#### What are the relevant issues?
- Fixes https://github.com/grommet/grommet/issues/7303

#### Screenshots (if appropriate)
![image](https://github.com/user-attachments/assets/706a728f-e926-4780-837d-b27e9e3401ca)

#### Is this change backwards compatible or is it a breaking change?
I'm not sure if this should actually be "fixed". I'm creating the PR because is a simple change.
That said, adding a flex could break previous implementations of this label in FormField. 
Another solution is adding a prop that will remove the required indicator visually and this enables the developer to add them by themselves in the element.
