### PR TITLE
fix pagination accessibility stories

### DIFF
--- a/src/js/components/Pagination/stories/CustomThemed/Custom.tsx
+++ b/src/js/components/Pagination/stories/CustomThemed/Custom.tsx
@@ -52,7 +52,10 @@ export const Custom = () => (
         <Text margin={{ bottom: 'small' }}>
           Custom Theme via theme.pagination.button
         </Text>
-        <Pagination numberItems={237} />
+        <Pagination
+          aria-label="Pagination with custom button theme"
+          numberItems={237}
+        />
       </Box>
       <Box
         align="start"
@@ -62,7 +65,10 @@ export const Custom = () => (
         <Text margin={{ bottom: 'small' }}>
           Custom Theme via theme.pagination.button
         </Text>
-        <Pagination numberItems={237} />
+        <Pagination
+          aria-label="Pagination with custom button theme and black background"
+          numberItems={237}
+        />
       </Box>
     </Box>
   </Grommet>

--- a/src/js/components/Pagination/stories/NumberEdgePages.js
+++ b/src/js/components/Pagination/stories/NumberEdgePages.js
@@ -8,11 +8,21 @@ export const NumberEdgePages = () => (
   <Box pad="small" gap="medium">
     <Box>
       <Text>numberEdgePages = 2 (number of pages on start/end)</Text>
-      <Pagination numberItems={237} page={10} numberEdgePages={2} />
+      <Pagination
+        aria-label="Pagination with 2 pages at the start and end"
+        numberItems={237}
+        page={10}
+        numberEdgePages={2}
+      />
     </Box>
     <Box>
       <Text>numberEdgePages = 0</Text>
-      <Pagination numberItems={237} page={10} numberEdgePages={0} />
+      <Pagination
+        aria-label="Pagination with no pages at the start and end"
+        numberItems={237}
+        page={10}
+        numberEdgePages={0}
+      />
     </Box>
   </Box>
   // </Grommet>

--- a/src/js/components/Pagination/stories/NumberMiddlePages.js
+++ b/src/js/components/Pagination/stories/NumberMiddlePages.js
@@ -8,11 +8,21 @@ export const NumberMiddlePages = () => (
   <Box pad="small" gap="medium">
     <Box>
       <Text>numberMiddlePages = 4 (number of pages in the middle)</Text>
-      <Pagination numberItems={237} page={10} numberMiddlePages={4} />
+      <Pagination
+        aria-label="Pagination with 4 pages in the middle"
+        numberItems={237}
+        page={10}
+        numberMiddlePages={4}
+      />
     </Box>
     <Box>
       <Text>numberMiddlePages = 5 (number of pages in the middle)</Text>
-      <Pagination numberItems={237} page={10} numberMiddlePages={5} />
+      <Pagination
+        aria-label="Pagination with 5 pages in the middle"
+        numberItems={237}
+        page={10}
+        numberMiddlePages={5}
+      />
     </Box>
   </Box>
   // </Grommet>

--- a/src/js/components/Pagination/stories/Simple.js
+++ b/src/js/components/Pagination/stories/Simple.js
@@ -8,7 +8,10 @@ export const Simple = () => (
   <Box align="start" pad="small" gap="medium">
     <Box>
       <Text>Default</Text>
-      <Pagination numberItems={237} />
+      <Pagination
+        aria-label="Pagination with default settings"
+        numberItems={237}
+      />
     </Box>
     <Box>
       <Text>Box Props</Text>
@@ -18,6 +21,7 @@ export const Simple = () => (
         background="brand"
         pad="medium"
         margin="small"
+        aria-label="Pagination with custom background and spacing"
       />
     </Box>
   </Box>

--- a/src/js/components/Pagination/stories/Size.js
+++ b/src/js/components/Pagination/stories/Size.js
@@ -7,11 +7,23 @@ export const Size = () => (
   // <Grommet theme={...}>
   <Box align="start" pad="small" gap="medium">
     <Text>Small</Text>
-    <Pagination numberItems={237} size="small" />
+    <Pagination
+      aria-label="Pagination with small size"
+      numberItems={237}
+      size="small"
+    />
     <Text>Medium (Default)</Text>
-    <Pagination numberItems={237} size="medium" />
+    <Pagination
+      aria-label="Pagination with medium size"
+      numberItems={237}
+      size="medium"
+    />
     <Text>Large</Text>
-    <Pagination numberItems={237} size="large" />
+    <Pagination
+      aria-label="Pagination with large size"
+      numberItems={237}
+      size="large"
+    />
   </Box>
   // </Grommet>
 );

--- a/src/js/components/Pagination/stories/Steps.js
+++ b/src/js/components/Pagination/stories/Steps.js
@@ -8,15 +8,29 @@ export const Steps = () => (
   <Box align="start" pad="small" gap="xlarge">
     <Box fill="horizontal">
       <Text>Pagination with stepOptions</Text>
-      <Pagination numberItems={237} stepOptions />
+      <Pagination
+        aria-label="Pagination with step options to change items per page"
+        numberItems={237}
+        stepOptions
+      />
     </Box>
     <Box fill="horizontal">
       <Text>Pagination with stepOptions and summary</Text>
-      <Pagination numberItems={237} stepOptions summary />
+      <Pagination
+        aria-label="Pagination with step options and summary of items per page"
+        numberItems={237}
+        stepOptions
+        summary
+      />
     </Box>
     <Box fill="horizontal">
       <Text>Pagination with custom step sizes</Text>
-      <Pagination numberItems={237} stepOptions={[10, 20, 30, 1000]} summary />
+      <Pagination
+        aria-label="Pagination with custom step sizes and summary"
+        numberItems={237}
+        stepOptions={[10, 20, 30, 1000]}
+        summary
+      />
     </Box>
   </Box>
   // </Grommet>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
adds an `aria-label` to the pagination
#### Where should the reviewer start?
pagination/stories
#### What testing has been done on this PR?
yes storybook
#### How should this be manually tested?
storybook
#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
The landmark must have a unique aria-label, aria-labelledby, or title to make landmarks distinguishable
#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
yes