### PR TITLE
fix the scroll tab story for accessibility

### DIFF
--- a/src/js/components/Tabs/stories/Scrollable.js
+++ b/src/js/components/Tabs/stories/Scrollable.js
@@ -15,6 +15,7 @@ const ScrollableTabs = () => (
           pad="xlarge"
           align="center"
           background="light-2"
+          tabIndex={0}
         >
           <Heading>Title</Heading>
           <Paragraph>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR fixes the scroll tabs story that was giving an accessibility error
#### Where should the reviewer start?
scrollable.js
#### What testing has been done on this PR?
storybook
#### How should this be manually tested?
storybook
#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
```
Serious
Element should have focusable content
Serious
Element should be focusable
```
#### What are the relevant issues?
fixes #7434 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
backwards compatible