### PR TITLE
Added focus indicator to RadioButton

### DIFF
--- a/src/js/components/FormField/FormField.js
+++ b/src/js/components/FormField/FormField.js
@@ -38,6 +38,7 @@ const grommetInputNames = [
   'TextArea',
   'DateInput',
   'FileInput',
+  'RadioButton',
   'RadioButtonGroup',
   'RangeInput',
   'RangeSelector',
@@ -47,6 +48,7 @@ const grommetInputNames = [
 const grommetInputPadNames = [
   'CheckBox',
   'CheckBoxGroup',
+  'RadioButton',
   'RadioButtonGroup',
   'RangeInput',
   'RangeSelector',

--- a/src/js/components/RadioButton/RadioButton.js
+++ b/src/js/components/RadioButton/RadioButton.js
@@ -1,6 +1,6 @@
 import React, { forwardRef, useState } from 'react';
 
-import { normalizeColor, removeUndefined } from '../../utils';
+import { normalizeColor, removeUndefined, useKeyboard } from '../../utils';
 
 import {
   StyledRadioButton,
@@ -20,8 +20,8 @@ const RadioButton = forwardRef(
       checked,
       children,
       disabled,
-      focus,
-      focusIndicator,
+      focus: focusProp,
+      focusIndicator = true,
       id,
       label,
       name,
@@ -32,6 +32,8 @@ const RadioButton = forwardRef(
   ) => {
     const { theme, passThemeFlag } = useThemeValue();
     const [hover, setHover] = useState();
+    const [focus, setFocus] = useState(focusProp);
+    const usingKeyboard = useKeyboard();
     const normalizedLabel =
       typeof label === 'string' ? (
         <StyledRadioButtonLabel {...passThemeFlag}>
@@ -71,6 +73,12 @@ const RadioButton = forwardRef(
         }}
         focus={focus}
         focusIndicator={focusIndicator}
+        onFocus={() => {
+          setFocus(true);
+        }}
+        onBlur={() => {
+          setFocus(false);
+        }}
         onMouseEnter={() => setHover(true)}
         onMouseLeave={() => setHover(false)}
         {...passThemeFlag}
@@ -99,7 +107,7 @@ const RadioButton = forwardRef(
             children({ checked, focus: focus && focusIndicator, hover })
           ) : (
             <StyledRadioButtonBox
-              focus={focus && focusIndicator}
+              focus={focus && focusIndicator && usingKeyboard}
               align="center"
               justify="center"
               width={theme.radioButton.size}

--- a/src/js/components/RadioButton/RadioButton.js
+++ b/src/js/components/RadioButton/RadioButton.js
@@ -73,12 +73,8 @@ const RadioButton = forwardRef(
         }}
         focus={focus}
         focusIndicator={focusIndicator}
-        onFocus={() => {
-          setFocus(true);
-        }}
-        onBlur={() => {
-          setFocus(false);
-        }}
+        onFocus={() => setFocus(true)}
+        onBlur={() => setFocus(false)}
         onMouseEnter={() => setHover(true)}
         onMouseLeave={() => setHover(false)}
         {...passThemeFlag}

--- a/src/js/components/RadioButton/stories/Children.js
+++ b/src/js/components/RadioButton/stories/Children.js
@@ -2,9 +2,16 @@ import React from 'react';
 
 import { Box, Button, RadioButton } from 'grommet';
 import { Ascend } from 'grommet-icons';
+import styled from 'styled-components';
+import { focusStyle, useKeyboard } from 'grommet/utils';
+
+const StyledRadioChild = styled(Box)`
+  ${(props) => props.focus && props.keyboard && focusStyle()}
+`;
 
 export const Children = () => {
   const [selected, setSelected] = React.useState();
+  const usingKeyboard = useKeyboard();
 
   return (
     <Box align="center" pad="large" gap="large">
@@ -14,8 +21,10 @@ export const Children = () => {
         checked={selected === 'option 1'}
         onChange={(event) => setSelected(event.target.value)}
       >
-        {({ checked }) => (
-          <Ascend color={checked ? 'brand' : 'status-unknown'} />
+        {({ checked, focus }) => (
+          <StyledRadioChild focus={focus} keyboard={usingKeyboard}>
+            <Ascend color={checked ? 'brand' : 'status-unknown'} />
+          </StyledRadioChild>
         )}
       </RadioButton>
 

--- a/src/js/components/RadioButtonGroup/stories/Children.js
+++ b/src/js/components/RadioButtonGroup/stories/Children.js
@@ -2,9 +2,16 @@ import React, { useState } from 'react';
 
 import { Box, RadioButtonGroup } from 'grommet';
 import { Ascend, Descend } from 'grommet-icons';
+import styled from 'styled-components';
+import { focusStyle, useKeyboard } from 'grommet/utils';
+
+const StyledRadioChild = styled(Box)`
+  ${(props) => props.focus && props.keyboard && focusStyle()}
+`;
 
 export const Children = () => {
   const [value, setValue] = useState();
+  const usingKeyboard = useKeyboard();
 
   return (
     <Box align="center" pad="large">
@@ -24,9 +31,14 @@ export const Children = () => {
           else if (focus) background = 'light-4';
           else background = 'light-2';
           return (
-            <Box background={background} pad="xsmall">
+            <StyledRadioChild
+              focus={focus}
+              keyboard={usingKeyboard}
+              background={background}
+              pad="xsmall"
+            >
               <Icon />
-            </Box>
+            </StyledRadioChild>
           );
         }}
       </RadioButtonGroup>


### PR DESCRIPTION
#### What does this PR do?
Added focus indicator to the radio button component.
I also changed the RadioButton/Children story to show how focus indicator could be implemented with custom children.

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes https://github.com/grommet/grommet/issues/6328

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible