### PR TITLE
remove git().silent because it is deprecated

### DIFF
--- a/tools/release-stable.js
+++ b/tools/release-stable.js
@@ -10,7 +10,6 @@ const localDist = path.resolve('dist');
 if (process.env.CI) {
   del(localFolder).then(() => {
     git()
-      .silent(false)
       .clone(repoURL, localFolder)
       .then(() => git(localFolder).checkout('stable'))
       .then(() => del([`${localFolder}/**/*`]))


### PR DESCRIPTION
#### What does this PR do?
Remove git silent because it is deprecated

<img width="783" alt="Screenshot 2024-12-19 at 9 50 50 AM" src="https://github.com/user-attachments/assets/16821836-eb65-4d7f-955b-1a068c5bd43f" />

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
backwards compatible