### PR TITLE
update status colors to meet wcag

### DIFF
--- a/src/js/components/Box/__tests__/__snapshots__/Box-style-test.tsx.snap
+++ b/src/js/components/Box/__tests__/__snapshots__/Box-style-test.tsx.snap
@@ -299,7 +299,7 @@ exports[`Box background 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background-color: #FF4040;
+  background-color: #EB0000;
   color: #f8f8f8;
   min-width: 0;
   min-height: 0;

--- a/src/js/components/Button/__tests__/__snapshots__/Button-kind-test.js.snap
+++ b/src/js/components/Button/__tests__/__snapshots__/Button-kind-test.js.snap
@@ -157,8 +157,8 @@ exports[`Button kind badge should apply background 1`] = `
   box-sizing: border-box;
   max-width: 100%;
   align-items: center;
-  background-color: #00C781;
-  color: #444444;
+  background-color: #009E67;
+  color: #f8f8f8;
   min-width: 0;
   min-height: 0;
   flex-direction: column;
@@ -185,7 +185,7 @@ exports[`Button kind badge should apply background 1`] = `
 .c6 {
   font-size: 14px;
   line-height: 20px;
-  color: #000000;
+  color: #FFFFFF;
   font-weight: normal;
 }
 

--- a/src/js/components/Button/__tests__/__snapshots__/Button-test.tsx.snap
+++ b/src/js/components/Button/__tests__/__snapshots__/Button-test.tsx.snap
@@ -370,8 +370,8 @@ exports[`Button badge should apply background 1`] = `
   box-sizing: border-box;
   max-width: 100%;
   align-items: center;
-  background-color: #00C781;
-  color: #444444;
+  background-color: #009E67;
+  color: #f8f8f8;
   min-width: 0;
   min-height: 0;
   flex-direction: column;
@@ -398,7 +398,7 @@ exports[`Button badge should apply background 1`] = `
 .c6 {
   font-size: 14px;
   line-height: 20px;
-  color: #000000;
+  color: #FFFFFF;
   font-weight: normal;
 }
 

--- a/src/js/components/Chart/__tests__/__snapshots__/Chart-test.tsx.snap
+++ b/src/js/components/Chart/__tests__/__snapshots__/Chart-test.tsx.snap
@@ -3037,7 +3037,7 @@ exports[`Chart value style 1`] = `
       stroke-linejoin="miter"
     >
       <g
-        fill="#00C781"
+        fill="#009E67"
         opacity="0.8"
         stroke="none"
       >
@@ -3084,7 +3084,7 @@ exports[`Chart value style 1`] = `
       <g
         fill="none"
         opacity="0.8"
-        stroke="#00C781"
+        stroke="#009E67"
         stroke-width="12"
       >
         <title>

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-controlled.tsx.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-controlled.tsx.snap
@@ -1135,7 +1135,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate 2`] = `
         class="StyledBox-sc-13pk1d4-0 jhVljw FormField__FormFieldBox-sc-m9hood-0 hvnrHE"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 diHhzW FormField__FormFieldContentBox-sc-m9hood-1"
+          class="StyledBox-sc-13pk1d4-0 ekFCqu FormField__FormFieldContentBox-sc-m9hood-1"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 fayRfZ"
@@ -1156,7 +1156,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate 2`] = `
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
-  color: #FF4040;
+  color: #EB0000;
 }
 
 @media only screen and (max-width: 768px) {
@@ -1204,7 +1204,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate 2`] = `
         class="StyledBox-sc-13pk1d4-0 jhVljw FormField__FormFieldBox-sc-m9hood-0 hvnrHE"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 diHhzW FormField__FormFieldContentBox-sc-m9hood-1"
+          class="StyledBox-sc-13pk1d4-0 ekFCqu FormField__FormFieldContentBox-sc-m9hood-1"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 fayRfZ"
@@ -1225,7 +1225,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate 2`] = `
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
-  color: #FF4040;
+  color: #EB0000;
 }
 
 @media only screen and (max-width: 768px) {
@@ -1599,7 +1599,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate custom error
         class="StyledBox-sc-13pk1d4-0 jhVljw FormField__FormFieldBox-sc-m9hood-0 hvnrHE"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 diHhzW FormField__FormFieldContentBox-sc-m9hood-1"
+          class="StyledBox-sc-13pk1d4-0 ekFCqu FormField__FormFieldContentBox-sc-m9hood-1"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 fayRfZ"
@@ -1620,7 +1620,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate custom error
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
-  color: #FF4040;
+  color: #EB0000;
 }
 
 @media only screen and (max-width: 768px) {
@@ -3137,7 +3137,7 @@ exports[`Form controlled controlled onValidate 2`] = `
       class="StyledBox-sc-13pk1d4-0 jhVljw FormField__FormFieldBox-sc-m9hood-0 hvnrHE"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 diHhzW FormField__FormFieldContentBox-sc-m9hood-1"
+        class="StyledBox-sc-13pk1d4-0 ekFCqu FormField__FormFieldContentBox-sc-m9hood-1"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 fayRfZ"
@@ -3158,7 +3158,7 @@ exports[`Form controlled controlled onValidate 2`] = `
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
-  color: #FF4040;
+  color: #EB0000;
 }
 
 @media only screen and (max-width: 768px) {
@@ -3391,7 +3391,7 @@ exports[`Form controlled controlled onValidate custom error 2`] = `
       class="StyledBox-sc-13pk1d4-0 jhVljw FormField__FormFieldBox-sc-m9hood-0 hvnrHE"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 diHhzW FormField__FormFieldContentBox-sc-m9hood-1"
+        class="StyledBox-sc-13pk1d4-0 ekFCqu FormField__FormFieldContentBox-sc-m9hood-1"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 fayRfZ"
@@ -3412,7 +3412,7 @@ exports[`Form controlled controlled onValidate custom error 2`] = `
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
-  color: #FF4040;
+  color: #EB0000;
 }
 
 @media only screen and (max-width: 768px) {

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.tsx.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.tsx.snap
@@ -1832,7 +1832,7 @@ exports[`Form uncontrolled errors 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  border-bottom: solid 1px #FF4040;
+  border-bottom: solid 1px #EB0000;
   min-width: 0;
   min-height: 0;
   flex-direction: column;
@@ -1845,7 +1845,7 @@ exports[`Form uncontrolled errors 1`] = `
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
-  color: #FF4040;
+  color: #EB0000;
 }
 
 .c4 {
@@ -1905,7 +1905,7 @@ exports[`Form uncontrolled errors 1`] = `
 
 @media only screen and (max-width: 768px) {
   .c2 {
-    border-bottom: solid 1px #FF4040;
+    border-bottom: solid 1px #EB0000;
   }
 }
 
@@ -2080,7 +2080,7 @@ exports[`Form uncontrolled regexp validation 1`] = `
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
-  color: #FF4040;
+  color: #EB0000;
 }
 
 @media only screen and (max-width: 768px) {
@@ -2111,7 +2111,7 @@ exports[`Form uncontrolled regexp validation with status 1`] = `
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
-  color: #FF4040;
+  color: #EB0000;
 }
 
 @media only screen and (max-width: 768px) {
@@ -2161,7 +2161,7 @@ exports[`Form uncontrolled required validation 1`] = `
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
-  color: #FF4040;
+  color: #EB0000;
 }
 
 @media only screen and (max-width: 768px) {
@@ -3606,7 +3606,7 @@ exports[`Form uncontrolled uncontrolled onValidate 2`] = `
       class="StyledBox-sc-13pk1d4-0 jhVljw FormField__FormFieldBox-sc-m9hood-0 hvnrHE"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 diHhzW FormField__FormFieldContentBox-sc-m9hood-1"
+        class="StyledBox-sc-13pk1d4-0 ekFCqu FormField__FormFieldContentBox-sc-m9hood-1"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 fayRfZ"
@@ -3626,7 +3626,7 @@ exports[`Form uncontrolled uncontrolled onValidate 2`] = `
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
-  color: #FF4040;
+  color: #EB0000;
 }
 
 @media only screen and (max-width: 768px) {
@@ -3858,7 +3858,7 @@ exports[`Form uncontrolled uncontrolled onValidate custom error 2`] = `
       class="StyledBox-sc-13pk1d4-0 jhVljw FormField__FormFieldBox-sc-m9hood-0 hvnrHE"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 diHhzW FormField__FormFieldContentBox-sc-m9hood-1"
+        class="StyledBox-sc-13pk1d4-0 ekFCqu FormField__FormFieldContentBox-sc-m9hood-1"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 fayRfZ"
@@ -3878,7 +3878,7 @@ exports[`Form uncontrolled uncontrolled onValidate custom error 2`] = `
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
-  color: #FF4040;
+  color: #EB0000;
 }
 
 @media only screen and (max-width: 768px) {
@@ -4375,7 +4375,7 @@ exports[`Form uncontrolled validate 1`] = `
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
-  color: #FF4040;
+  color: #EB0000;
 }
 
 @media only screen and (max-width: 768px) {
@@ -4438,7 +4438,7 @@ exports[`Form uncontrolled validate 3`] = `
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
-  color: #FF4040;
+  color: #EB0000;
 }
 
 @media only screen and (max-width: 768px) {

--- a/src/js/components/FormField/__tests__/__snapshots__/FormField-test.tsx.snap
+++ b/src/js/components/FormField/__tests__/__snapshots__/FormField-test.tsx.snap
@@ -670,7 +670,7 @@ exports[`FormField custom error and info icon and container 1`] = `
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
-  color: #FF4040;
+  color: #EB0000;
 }
 
 .c11 {
@@ -1660,7 +1660,7 @@ exports[`FormField error 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  border-bottom: solid 1px #FF4040;
+  border-bottom: solid 1px #EB0000;
   min-width: 0;
   min-height: 0;
   flex-direction: column;
@@ -1673,7 +1673,7 @@ exports[`FormField error 1`] = `
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
-  color: #FF4040;
+  color: #EB0000;
 }
 
 .c0 {
@@ -1694,7 +1694,7 @@ exports[`FormField error 1`] = `
 
 @media only screen and (max-width: 768px) {
   .c2 {
-    border-bottom: solid 1px #FF4040;
+    border-bottom: solid 1px #EB0000;
   }
 }
 

--- a/src/js/components/Grommet/__tests__/__snapshots__/Grommet-test.js.snap
+++ b/src/js/components/Grommet/__tests__/__snapshots__/Grommet-test.js.snap
@@ -124,9 +124,9 @@ exports[`Grommet cssVars 1`] = `
   --neutral-4: #A2423D;
   --status-critical: #EB0000;
   --status-error: #B30000;
-  --status-warning: #FFAA15;
+  --status-warning: #C27B00;
   --status-ok: #009E67;
-  --status-unknown: #CCCCCC;
+  --status-unknown: #919191;
   --status-disabled: #CCCCCC;
 }
 

--- a/src/js/components/Grommet/__tests__/__snapshots__/Grommet-test.js.snap
+++ b/src/js/components/Grommet/__tests__/__snapshots__/Grommet-test.js.snap
@@ -122,10 +122,10 @@ exports[`Grommet cssVars 1`] = `
   --neutral-2: #3D138D;
   --neutral-3: #00739D;
   --neutral-4: #A2423D;
-  --status-critical: #FF4040;
+  --status-critical: #EB0000;
   --status-error: #B30000;
   --status-warning: #FFAA15;
-  --status-ok: #00C781;
+  --status-ok: #009E67;
   --status-unknown: #CCCCCC;
   --status-disabled: #CCCCCC;
 }

--- a/src/js/components/Notification/__tests__/__snapshots__/Notification-test.tsx.snap
+++ b/src/js/components/Notification/__tests__/__snapshots__/Notification-test.tsx.snap
@@ -191,8 +191,8 @@ exports[`Notification global 1`] = `
   flex: 0 0 auto;
   width: 24px;
   height: 24px;
-  fill: #CCCCCC;
-  stroke: #CCCCCC;
+  fill: #919191;
+  stroke: #919191;
 }
 
 .c4 g {
@@ -222,7 +222,7 @@ exports[`Notification global 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background-color: rgba(204, 204, 204, 0.1);
+  background-color: rgba(145, 145, 145, 0.1);
   min-width: 0;
   min-height: 0;
   flex-direction: row;
@@ -386,8 +386,8 @@ exports[`Notification multi actions 1`] = `
   flex: 0 0 auto;
   width: 24px;
   height: 24px;
-  fill: #CCCCCC;
-  stroke: #CCCCCC;
+  fill: #919191;
+  stroke: #919191;
 }
 
 .c4 g {
@@ -417,7 +417,7 @@ exports[`Notification multi actions 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background-color: rgba(204, 204, 204, 0.1);
+  background-color: rgba(145, 145, 145, 0.1);
   min-width: 0;
   min-height: 0;
   flex-direction: row;
@@ -605,8 +605,8 @@ exports[`Notification position bottom 1`] = `
   flex: 0 0 auto;
   width: 24px;
   height: 24px;
-  fill: #CCCCCC;
-  stroke: #CCCCCC;
+  fill: #919191;
+  stroke: #919191;
 }
 
 .c5 g {
@@ -831,7 +831,7 @@ exports[`Notification position bottom 1`] = `
 
 exports[`Notification position bottom 2`] = `
 "@media only screen and (max-width: 768px) {
-  .kBcinS {
+  .fPdQ {
     border-radius: 3px;
   }
 }
@@ -860,8 +860,8 @@ exports[`Notification position bottom-left 1`] = `
   flex: 0 0 auto;
   width: 24px;
   height: 24px;
-  fill: #CCCCCC;
-  stroke: #CCCCCC;
+  fill: #919191;
+  stroke: #919191;
 }
 
 .c5 g {
@@ -1086,7 +1086,7 @@ exports[`Notification position bottom-left 1`] = `
 
 exports[`Notification position bottom-left 2`] = `
 "@media only screen and (max-width: 768px) {
-  .kBcinS {
+  .fPdQ {
     border-radius: 3px;
   }
 }
@@ -1115,8 +1115,8 @@ exports[`Notification position bottom-right 1`] = `
   flex: 0 0 auto;
   width: 24px;
   height: 24px;
-  fill: #CCCCCC;
-  stroke: #CCCCCC;
+  fill: #919191;
+  stroke: #919191;
 }
 
 .c5 g {
@@ -1341,7 +1341,7 @@ exports[`Notification position bottom-right 1`] = `
 
 exports[`Notification position bottom-right 2`] = `
 "@media only screen and (max-width: 768px) {
-  .kBcinS {
+  .fPdQ {
     border-radius: 3px;
   }
 }
@@ -1370,8 +1370,8 @@ exports[`Notification position center 1`] = `
   flex: 0 0 auto;
   width: 24px;
   height: 24px;
-  fill: #CCCCCC;
-  stroke: #CCCCCC;
+  fill: #919191;
+  stroke: #919191;
 }
 
 .c5 g {
@@ -1596,7 +1596,7 @@ exports[`Notification position center 1`] = `
 
 exports[`Notification position center 2`] = `
 "@media only screen and (max-width: 768px) {
-  .kBcinS {
+  .fPdQ {
     border-radius: 3px;
   }
 }
@@ -1625,8 +1625,8 @@ exports[`Notification position end 1`] = `
   flex: 0 0 auto;
   width: 24px;
   height: 24px;
-  fill: #CCCCCC;
-  stroke: #CCCCCC;
+  fill: #919191;
+  stroke: #919191;
 }
 
 .c5 g {
@@ -1851,7 +1851,7 @@ exports[`Notification position end 1`] = `
 
 exports[`Notification position end 2`] = `
 "@media only screen and (max-width: 768px) {
-  .kBcinS {
+  .fPdQ {
     border-radius: 3px;
   }
 }
@@ -1880,8 +1880,8 @@ exports[`Notification position left 1`] = `
   flex: 0 0 auto;
   width: 24px;
   height: 24px;
-  fill: #CCCCCC;
-  stroke: #CCCCCC;
+  fill: #919191;
+  stroke: #919191;
 }
 
 .c5 g {
@@ -2106,7 +2106,7 @@ exports[`Notification position left 1`] = `
 
 exports[`Notification position left 2`] = `
 "@media only screen and (max-width: 768px) {
-  .kBcinS {
+  .fPdQ {
     border-radius: 3px;
   }
 }
@@ -2135,8 +2135,8 @@ exports[`Notification position right 1`] = `
   flex: 0 0 auto;
   width: 24px;
   height: 24px;
-  fill: #CCCCCC;
-  stroke: #CCCCCC;
+  fill: #919191;
+  stroke: #919191;
 }
 
 .c5 g {
@@ -2361,7 +2361,7 @@ exports[`Notification position right 1`] = `
 
 exports[`Notification position right 2`] = `
 "@media only screen and (max-width: 768px) {
-  .kBcinS {
+  .fPdQ {
     border-radius: 3px;
   }
 }
@@ -2390,8 +2390,8 @@ exports[`Notification position start 1`] = `
   flex: 0 0 auto;
   width: 24px;
   height: 24px;
-  fill: #CCCCCC;
-  stroke: #CCCCCC;
+  fill: #919191;
+  stroke: #919191;
 }
 
 .c5 g {
@@ -2616,7 +2616,7 @@ exports[`Notification position start 1`] = `
 
 exports[`Notification position start 2`] = `
 "@media only screen and (max-width: 768px) {
-  .kBcinS {
+  .fPdQ {
     border-radius: 3px;
   }
 }
@@ -2645,8 +2645,8 @@ exports[`Notification position top 1`] = `
   flex: 0 0 auto;
   width: 24px;
   height: 24px;
-  fill: #CCCCCC;
-  stroke: #CCCCCC;
+  fill: #919191;
+  stroke: #919191;
 }
 
 .c5 g {
@@ -2871,7 +2871,7 @@ exports[`Notification position top 1`] = `
 
 exports[`Notification position top 2`] = `
 "@media only screen and (max-width: 768px) {
-  .kBcinS {
+  .fPdQ {
     border-radius: 3px;
   }
 }
@@ -2900,8 +2900,8 @@ exports[`Notification position top-left 1`] = `
   flex: 0 0 auto;
   width: 24px;
   height: 24px;
-  fill: #CCCCCC;
-  stroke: #CCCCCC;
+  fill: #919191;
+  stroke: #919191;
 }
 
 .c5 g {
@@ -3126,7 +3126,7 @@ exports[`Notification position top-left 1`] = `
 
 exports[`Notification position top-left 2`] = `
 "@media only screen and (max-width: 768px) {
-  .kBcinS {
+  .fPdQ {
     border-radius: 3px;
   }
 }
@@ -3155,8 +3155,8 @@ exports[`Notification position top-right 1`] = `
   flex: 0 0 auto;
   width: 24px;
   height: 24px;
-  fill: #CCCCCC;
-  stroke: #CCCCCC;
+  fill: #919191;
+  stroke: #919191;
 }
 
 .c5 g {
@@ -3381,7 +3381,7 @@ exports[`Notification position top-right 1`] = `
 
 exports[`Notification position top-right 2`] = `
 "@media only screen and (max-width: 768px) {
-  .kBcinS {
+  .fPdQ {
     border-radius: 3px;
   }
 }
@@ -3411,8 +3411,8 @@ exports[`Notification should have no accessibility violations 1`] = `
   flex: 0 0 auto;
   width: 24px;
   height: 24px;
-  fill: #CCCCCC;
-  stroke: #CCCCCC;
+  fill: #919191;
+  stroke: #919191;
 }
 
 .c4 g {
@@ -3442,7 +3442,7 @@ exports[`Notification should have no accessibility violations 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background-color: rgba(204, 204, 204, 0.1);
+  background-color: rgba(145, 145, 145, 0.1);
   min-width: 0;
   min-height: 0;
   flex-direction: row;
@@ -3640,7 +3640,7 @@ exports[`Notification should render custom icon 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background-color: rgba(204, 204, 204, 0.1);
+  background-color: rgba(145, 145, 145, 0.1);
   min-width: 0;
   min-height: 0;
   flex-direction: row;
@@ -3791,8 +3791,8 @@ exports[`Notification should render custom template inside notification 1`] = `
   flex: 0 0 auto;
   width: 24px;
   height: 24px;
-  fill: #CCCCCC;
-  stroke: #CCCCCC;
+  fill: #919191;
+  stroke: #919191;
 }
 
 .c4 g {
@@ -3822,7 +3822,7 @@ exports[`Notification should render custom template inside notification 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background-color: rgba(204, 204, 204, 0.1);
+  background-color: rgba(145, 145, 145, 0.1);
   min-width: 0;
   min-height: 0;
   flex-direction: row;
@@ -3966,8 +3966,8 @@ exports[`Notification should render outside grommet wrapper 1`] = `
   flex: 0 0 auto;
   width: 24px;
   height: 24px;
-  fill: #CCCCCC;
-  stroke: #CCCCCC;
+  fill: #919191;
+  stroke: #919191;
 }
 
 .c3 g {
@@ -3997,7 +3997,7 @@ exports[`Notification should render outside grommet wrapper 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background-color: rgba(204, 204, 204, 0.1);
+  background-color: rgba(145, 145, 145, 0.1);
   min-width: 0;
   min-height: 0;
   flex-direction: row;
@@ -4471,7 +4471,7 @@ exports[`Notification should render the default icon if no icon is passed 1`] = 
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background-color: rgba(204, 204, 204, 0.1);
+  background-color: rgba(145, 145, 145, 0.1);
   min-width: 0;
   min-height: 0;
   flex-direction: row;
@@ -4656,8 +4656,8 @@ exports[`Notification status 1`] = `
   flex: 0 0 auto;
   width: 24px;
   height: 24px;
-  fill: #FFAA15;
-  stroke: #FFAA15;
+  fill: #C27B00;
+  stroke: #C27B00;
 }
 
 .c11 g {
@@ -4764,7 +4764,7 @@ exports[`Notification status 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background-color: rgba(255, 170, 21, 0.1);
+  background-color: rgba(194, 123, 0, 0.1);
   min-width: 0;
   min-height: 0;
   flex-direction: row;

--- a/src/js/components/Notification/__tests__/__snapshots__/Notification-test.tsx.snap
+++ b/src/js/components/Notification/__tests__/__snapshots__/Notification-test.tsx.snap
@@ -7,8 +7,8 @@ exports[`Notification custom theme 1`] = `
   flex: 0 0 auto;
   width: 24px;
   height: 24px;
-  fill: #FF4040;
-  stroke: #FF4040;
+  fill: #EB0000;
+  stroke: #EB0000;
 }
 
 .c4 g {
@@ -4138,8 +4138,8 @@ exports[`Notification should render status and kind specific message and title c
   flex: 0 0 auto;
   width: 24px;
   height: 24px;
-  fill: #00C781;
-  stroke: #00C781;
+  fill: #009E67;
+  stroke: #009E67;
 }
 
 .c4 g {
@@ -4169,7 +4169,7 @@ exports[`Notification should render status and kind specific message and title c
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background-color: rgba(0, 199, 129, 0.1);
+  background-color: rgba(0, 158, 103, 0.1);
   min-width: 0;
   min-height: 0;
   flex-direction: row;
@@ -4214,7 +4214,7 @@ exports[`Notification should render status and kind specific message and title c
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background-color: rgba(0, 199, 129, 0.1);
+  background-color: rgba(0, 158, 103, 0.1);
   min-width: 0;
   min-height: 0;
   flex-direction: row;
@@ -4624,8 +4624,8 @@ exports[`Notification status 1`] = `
   flex: 0 0 auto;
   width: 24px;
   height: 24px;
-  fill: #00C781;
-  stroke: #00C781;
+  fill: #009E67;
+  stroke: #009E67;
 }
 
 .c4 g {
@@ -4688,8 +4688,8 @@ exports[`Notification status 1`] = `
   flex: 0 0 auto;
   width: 24px;
   height: 24px;
-  fill: #FF4040;
-  stroke: #FF4040;
+  fill: #EB0000;
+  stroke: #EB0000;
 }
 
 .c13 g {
@@ -4719,7 +4719,7 @@ exports[`Notification status 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background-color: rgba(0, 199, 129, 0.1);
+  background-color: rgba(0, 158, 103, 0.1);
   min-width: 0;
   min-height: 0;
   flex-direction: row;
@@ -4775,7 +4775,7 @@ exports[`Notification status 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background-color: rgba(255, 64, 64, 0.1);
+  background-color: rgba(235, 0, 0, 0.1);
   min-width: 0;
   min-height: 0;
   flex-direction: row;

--- a/src/js/components/Text/__tests__/__snapshots__/Text-test.tsx.snap
+++ b/src/js/components/Text/__tests__/__snapshots__/Text-test.tsx.snap
@@ -68,7 +68,7 @@ exports[`renders color 1`] = `
 .c1 {
   font-size: 18px;
   line-height: 24px;
-  color: #FF4040;
+  color: #EB0000;
 }
 
 <div

--- a/src/js/themes/__tests__/__snapshots__/theme-test.js.snap
+++ b/src/js/themes/__tests__/__snapshots__/theme-test.js.snap
@@ -1094,7 +1094,18 @@ exports[`Grommet default theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background-color: #FFAA15;
+  background-color: #919191;
+  color: #444444;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.c21 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  background-color: #C27B00;
   color: #444444;
   min-width: 0;
   min-height: 0;
@@ -1327,7 +1338,7 @@ exports[`Grommet default theme 1`] = `
     </span>
   </div>
   <div
-    class="c18"
+    class="c20"
   >
     <span
       class="c2"
@@ -1336,7 +1347,7 @@ exports[`Grommet default theme 1`] = `
     </span>
   </div>
   <div
-    class="c20"
+    class="c21"
   >
     <span
       class="c2"

--- a/src/js/themes/__tests__/__snapshots__/theme-test.js.snap
+++ b/src/js/themes/__tests__/__snapshots__/theme-test.js.snap
@@ -1061,7 +1061,7 @@ exports[`Grommet default theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background-color: #FF4040;
+  background-color: #EB0000;
   color: #f8f8f8;
   min-width: 0;
   min-height: 0;
@@ -1083,8 +1083,8 @@ exports[`Grommet default theme 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  background-color: #00C781;
-  color: #444444;
+  background-color: #009E67;
+  color: #f8f8f8;
   min-width: 0;
   min-height: 0;
   flex-direction: column;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -29,10 +29,10 @@ const brandColor = '#7D4CDB';
 const accentColors = ['#6FFFB0', '#FD6FFF', '#81FCED', '#FFCA58'];
 const neutralColors = ['#00873D', '#3D138D', '#00739D', '#A2423D'];
 const statusColors = {
-  critical: '#FF4040',
+  critical: '#EB0000',
   error: '#B30000',
   warning: '#FFAA15',
-  ok: '#00C781',
+  ok: '#009E67',
   unknown: '#CCCCCC',
   disabled: '#CCCCCC',
 };

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -31,9 +31,9 @@ const neutralColors = ['#00873D', '#3D138D', '#00739D', '#A2423D'];
 const statusColors = {
   critical: '#EB0000',
   error: '#B30000',
-  warning: '#FFAA15',
+  warning: '#C27B00',
   ok: '#009E67',
-  unknown: '#CCCCCC',
+  unknown: '#919191',
   disabled: '#CCCCCC',
 };
 const darkColors = [


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR updates the `status` colors in our base theme.

| Color name | Previous value | Recommended value | Rationale |
|----|----|----|--|
| `status-ok` | `#00C781` | `#009E67` | Previous value had a contrast ratio of `2.02:1`. New value has `3.06:1`  and `5.5:1` in dark mode|
| `status-warning` | `#FFAA15` | `#C27B00` | Previous value had a contrast ratio of `1.77:1`. New value has `3.07:1` and `5.67:1` in dark mode |
| `status-unknown` | `#CCCCCC` | `#919191` | Previous value had a contrast ratio of `1.53:1`. New value has `3.01:1` and `5.84:1` in dark mode|
| `status-critical` | `#FF4040` | `#EB0000`* | No change proposed to this color in this Issue, as previous value had a passing contrast ratio of `3.06:1`. However, this color is proposed to be changed to meet 4,5:1 on white background in [Form error ticket](https://github.com/grommet/grommet/issues/7440). This new value meets `3.15:1` in Notifications, and `4.36:1` in dark mode |
#### Where should the reviewer start?
base theme
#### What testing has been done on this PR?
locally 
#### How should this be manually tested?
locally 
#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
our colors were failing wcag 
#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
yes
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
