### PR TITLE
add `theme.formfield.disabled.help` & `theme.formfield.disabled.info`

### DIFF
--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-controlled.tsx.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-controlled.tsx.snap
@@ -3666,7 +3666,6 @@ exports[`Form controlled controlled onValidate custom info 2`] = `
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
-  color: #666666;
 }
 
 @media only screen and (max-width: 768px) {

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.tsx.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.tsx.snap
@@ -1978,7 +1978,6 @@ exports[`Form uncontrolled infos 1`] = `
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
-  color: #666666;
 }
 
 .c4 {
@@ -2134,7 +2133,6 @@ exports[`Form uncontrolled regexp validation with status 1`] = `
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
-  color: #666666;
 }
 
 @media only screen and (max-width: 768px) {
@@ -4130,7 +4128,6 @@ exports[`Form uncontrolled uncontrolled onValidate custom info 2`] = `
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
-  color: #666666;
 }
 
 @media only screen and (max-width: 768px) {
@@ -4476,7 +4473,6 @@ exports[`Form uncontrolled validate 4`] = `
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
-  color: #666666;
 }
 
 @media only screen and (max-width: 768px) {

--- a/src/js/components/FormField/FormField.js
+++ b/src/js/components/FormField/FormField.js
@@ -393,6 +393,16 @@ const FormField = forwardRef(
           : labelStyle.color;
     }
 
+    const themeHelpProps = {
+      ...formFieldTheme.help,
+      color: disabled && formFieldTheme?.disabled?.help?.color,
+    };
+
+    const themeInfoProps = {
+      ...formFieldTheme.info,
+      color: disabled && formFieldTheme?.disabled?.info?.color,
+    };
+
     let abut;
     let abutMargin;
     let outerStyle = style;
@@ -571,12 +581,12 @@ const FormField = forwardRef(
                 {showRequiredIndicator ? requiredIndicator : undefined}
               </Text>
             )}
-            <Message message={help} {...formFieldTheme.help} />
+            <Message message={help} {...themeHelpProps} />
           </>
         ) : undefined}
         {contents}
         <Message type="error" message={error} {...formFieldTheme.error} />
-        <Message type="info" message={info} {...formFieldTheme.info} />
+        <Message type="info" message={info} {...themeInfoProps} />
       </FormFieldBox>
     );
   },

--- a/src/js/components/FormField/__tests__/FormField-test.tsx
+++ b/src/js/components/FormField/__tests__/FormField-test.tsx
@@ -186,6 +186,29 @@ describe('FormField', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  test('info and help label colors', () => {
+    const { container } = render(
+      <Grommet
+        theme={{
+          formField: {
+            disabled: { label: { color: 'teal' } },
+            help: { color: 'blue' },
+            info: { color: 'green' },
+          },
+        }}
+      >
+        <FormField
+          label="Label"
+          disabled
+          help="Text to help the user know what is possible"
+          info="Additional contextual information"
+        />
+      </Grommet>,
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
   test('custom formfield', () => {
     const { container } = render(
       <Grommet>

--- a/src/js/components/FormField/__tests__/__snapshots__/FormField-test.tsx.snap
+++ b/src/js/components/FormField/__tests__/__snapshots__/FormField-test.tsx.snap
@@ -673,16 +673,6 @@ exports[`FormField custom error and info icon and container 1`] = `
   color: #EB0000;
 }
 
-.c11 {
-  margin-left: 12px;
-  margin-right: 12px;
-  margin-top: 6px;
-  margin-bottom: 6px;
-  font-size: 18px;
-  line-height: 24px;
-  color: #666666;
-}
-
 .c5 {
   box-sizing: border-box;
   font-size: inherit;
@@ -825,7 +815,7 @@ exports[`FormField custom error and info icon and container 1`] = `
           </svg>
         </div>
         <span
-          class="c11"
+          class="c2"
         >
           Here is a little added info on FormField.
         </span>
@@ -1741,7 +1731,6 @@ exports[`FormField help 1`] = `
   margin-inline-start: 12px;
   font-size: 18px;
   line-height: 24px;
-  color: #555555;
 }
 
 .c0 {
@@ -1868,7 +1857,6 @@ exports[`FormField info 1`] = `
   margin-bottom: 6px;
   font-size: 18px;
   line-height: 24px;
-  color: #666666;
 }
 
 .c0 {
@@ -1906,6 +1894,104 @@ exports[`FormField info 1`] = `
       class="c3"
     >
       test info
+    </span>
+  </div>
+</div>
+`;
+
+exports[`FormField info and help label colors 1`] = `
+.c1 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-bottom: 12px;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.c4 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  background-color: rgba(204, 204, 204, 0.4);
+  color: #444444;
+  border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.c2 {
+  margin-left: 12px;
+  margin-right: 12px;
+  margin-top: 6px;
+  margin-bottom: 6px;
+  font-size: 18px;
+  line-height: 24px;
+  color: teal;
+}
+
+.c3 {
+  margin-inline-start: 12px;
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c5 {
+  margin-left: 12px;
+  margin-right: 12px;
+  margin-top: 6px;
+  margin-bottom: 6px;
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+@media only screen and (max-width: 768px) {
+  .c1 {
+    margin-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c4 {
+    border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  }
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1 "
+  >
+    <label
+      class="c2"
+    >
+      Label
+    </label>
+    <span
+      class="c3"
+    >
+      Text to help the user know what is possible
+    </span>
+    <div
+      class="c4 FormField__FormFieldContentBox-sc-m9hood-1"
+    />
+    <span
+      class="c5"
+    >
+      Additional contextual information
     </span>
   </div>
 </div>

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -45,6 +45,7 @@ import {
 import { HeadingProps } from '../components/Heading';
 import { ParagraphProps } from '../components/Paragraph';
 import { SkeletonProps } from '../components/Skeleton/index';
+import { info } from 'console';
 
 export declare const base: DeepReadonly<ThemeType>;
 export declare const generate: (
@@ -926,6 +927,12 @@ export interface ThemeType {
         color?: ColorType;
       };
       label?: {
+        color?: ColorType;
+      };
+      help?: {
+        color?: ColorType;
+      };
+      info?: {
         color?: ColorType;
       };
     };

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1030,6 +1030,12 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         // label: {
         //   color: undefined,
         // },
+        // help: {
+        //   color: undefined,
+        // },
+        // info: {
+        //   color: undefined,
+        // },
       },
       // focus: {
       //   background: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR enhances the theme in order to provide a custom color to the `info` and `help` labels
#### Where should the reviewer start?
FormField.js
#### What testing has been done on this PR?
storybook & wrote a test 
#### How should this be manually tested?
storybook 

````
      <FormField
        label="Label"
        disabled
        htmlFor="text-input"
        help="Text to help the user know what is possible"
        error="Text to call attention to an issue with this field"
        info="Additional contextual information"
      >
        <TextInput
          id="text-input"
          placeholder="placeholder"
          value="Value"
          onChange={() => {}}
        />
      </FormField>
```
#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
needed for DS 
#### What are the relevant issues?
closes #7478 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
yes
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible