### PR TITLE
Fix unFocusStyle for twoColor focus

### DIFF
--- a/src/js/utils/styles.js
+++ b/src/js/utils/styles.js
@@ -292,6 +292,7 @@ const unfocusStyles = (props, { forceOutline, justBorder } = {}) => {
       global: { focus },
     },
   } = props;
+  let compoundFocusStyle = '';
   if (!focus || (forceOutline && !focus.outline)) {
     const color = normalizeColor('focus', props.theme);
     if (color) return `outline: none;`;
@@ -299,31 +300,48 @@ const unfocusStyles = (props, { forceOutline, justBorder } = {}) => {
   }
   if (focus.outline && (!focus.border || !justBorder)) {
     if (typeof focus.outline === 'object') {
-      return `
+      const outlineStyle = `
         outline-offset: 0px;
         outline: none;
       `;
+      compoundFocusStyle += outlineStyle;
+      if (!focus.twoColor)
+        return `
+        outline-offset: 0px;
+        outline: none;
+      `;
+    } else {
+      const outlineStyle = `outline: none;`;
+      compoundFocusStyle += outlineStyle;
+      if (!focus.twoColor) return outlineStyle;
     }
-    return `outline: none;`;
   }
   if (focus.shadow && (!focus.border || !justBorder)) {
     if (typeof focus.shadow === 'object') {
-      return `
+      const shadowStyle = `
         outline: none;
         box-shadow: none;
       `;
+      compoundFocusStyle += shadowStyle;
+      if (!focus.twoColor) return shadowStyle;
+    } else {
+      const shadowStyle = `
+        outline: none;
+        box-shadow: none;
+      `;
+      compoundFocusStyle += shadowStyle;
+      if (!focus.twoColor) return shadowStyle;
     }
-    return `
-      outline: none;
-      box-shadow: none;
-    `;
   }
   if (focus.border) {
-    return `
+    const borderStyle = `
       outline: none;
       border-color: none;
     `;
+    compoundFocusStyle += borderStyle;
+    if (!focus.twoColor) return borderStyle;
   }
+  if (focus.twoColor && compoundFocusStyle.length) return compoundFocusStyle;
   return ''; // defensive
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
In https://github.com/grommet/grommet/pull/7479, the twoColor focus strategy was added to focusStyles but the mirrored adjustments were not made in unfocusStyles. This adds the necessary code to ensure focus styles are removed appropriately in the case of twoColor focus approach.

#### Where should the reviewer start?

#### What testing has been done on this PR?

Locally

BEFORE (part of the two color focus still remained when interacting with mouse)


https://github.com/user-attachments/assets/ac7fd563-d22c-41c9-a40c-645968fb30bf

AFTER (focus does not appear when interacting with mouse)


https://github.com/user-attachments/assets/f7f53a9d-e481-492d-be0a-9589c79af4dc


twoColor focus still appears when interacting with keyboard

<img width="1367" alt="Screenshot 2025-01-29 at 12 14 28 PM" src="https://github.com/user-attachments/assets/bb209655-7413-48f6-9f97-25224d4ac3e5" />


#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
