### PR TITLE
Add `theme.menu.container`

### DIFF
--- a/src/js/components/Menu/Menu.js
+++ b/src/js/components/Menu/Menu.js
@@ -387,7 +387,7 @@ const Menu = forwardRef((props, ref) => {
             />
           </Box>
         )}
-        <Box {...theme.menu.group?.container}>
+        <Box {...theme.menu.container} {...theme.menu.group?.container}>
           {group.map((item) => {
             // item index needs to be its index in the entire menu as if
             // it were a flat array

--- a/src/js/components/Menu/Menu.js
+++ b/src/js/components/Menu/Menu.js
@@ -365,7 +365,8 @@ const Menu = forwardRef((props, ref) => {
   };
 
   let menuContent;
-  if (itemCount && Array.isArray(items[0])) {
+  const grouped = itemCount && Array.isArray(items[0]);
+  if (grouped) {
     let index = 0;
     menuContent = items.map((group, groupIndex) => (
       <Box
@@ -444,7 +445,12 @@ const Menu = forwardRef((props, ref) => {
               align.top !== 'bottom'
                 ? controlMirror
                 : undefined}
-              <Box overflow="auto" role="menu" a11yTitle={a11y}>
+              <Box
+                overflow="auto"
+                role="menu"
+                a11yTitle={a11y}
+                {...(!grouped ? theme.menu.container : {})}
+              >
                 {menuContent}
               </Box>
               {/*

--- a/src/js/components/Menu/__tests__/Menu-test.js
+++ b/src/js/components/Menu/__tests__/Menu-test.js
@@ -21,6 +21,10 @@ const customTheme = {
       },
       elevation: 'xlarge',
     },
+    container: {
+      pad: 'xsmall',
+      gap: 'xsmall',
+    },
     icons: {
       color: '#F08080',
     },
@@ -628,6 +632,26 @@ describe('Menu', () => {
             [{ label: 'Item 1' }, { label: 'Item 2' }],
             [{ label: 'Item 3' }],
           ]}
+        />
+      </Grommet>,
+    );
+    fireEvent.keyDown(screen.getByText('Test Menu'), {
+      key: 'Down',
+      keyCode: 40,
+      which: 40,
+    });
+
+    expectPortal('test-menu__drop').toMatchSnapshot();
+  });
+
+  test('should apply theme.menu.container', () => {
+    window.scrollTo = jest.fn();
+    render(
+      <Grommet theme={customTheme}>
+        <Menu
+          id="test-menu"
+          label="Test Menu"
+          items={[{ label: 'Item 1' }, { label: 'Item 2' }]}
         />
       </Grommet>,
     );

--- a/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
+++ b/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
@@ -4560,6 +4560,237 @@ exports[`Menu shift + tab through menu until it closes 1`] = `
 </div>
 `;
 
+exports[`Menu should apply theme.menu.container 1`] = `
+.c0 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  overflow: auto;
+  box-shadow: 0px 12px 24px rgba(0, 0, 0, 0.20);
+}
+
+.c2 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.c4 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  padding: 6px;
+  overflow: auto;
+}
+
+.c5 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  flex: 0 0 auto;
+}
+
+.c7 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  padding: 12px;
+}
+
+.c8 {
+  flex: 0 0 auto;
+  align-self: stretch;
+  height: 6px;
+}
+
+.c1 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  border-radius: 0px;
+  position: fixed;
+  z-index: 20;
+  outline: none;
+  background-color: #FFFFFF;
+  color: #444444;
+  opacity: 0;
+  transform-origin: top left;
+  animation: kPQHBD 0.1s forwards;
+  animation-delay: 0.01s;
+}
+
+.c6 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c6:hover {
+  background-color: rgba(221, 221, 221, 0.4);
+  color: #000000;
+}
+
+.c6:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c6:focus:not(:focus-visible) >circle,
+.c6:focus:not(:focus-visible) >ellipse,
+.c6:focus:not(:focus-visible) >line,
+.c6:focus:not(:focus-visible) >path,
+.c6:focus:not(:focus-visible) >polygon,
+.c6:focus:not(:focus-visible) >polyline,
+.c6:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c6:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c3 {
+  max-height: inherit;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+@media only screen and (max-width: 768px) {
+
+}
+
+@media only screen and (max-width: 768px) {
+  .c4 {
+    padding: 3px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c7 {
+    padding: 6px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+
+}
+
+@media only screen and (max-width: 768px) {
+  .c8 {
+    height: 3px;
+  }
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c1 {
+    display: flex;
+    align-items: stretch;
+  }
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c3 {
+    width: 100%;
+  }
+}
+
+<div
+  class="c0 c1"
+  data-g-portal-id="0"
+  id="test-menu__drop"
+  style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
+  tabindex="-1"
+>
+  <div
+    class="c2 c3"
+    tabindex="-1"
+  >
+    <div
+      class="c4"
+      role="menu"
+    >
+      <div
+        class="c5"
+        role="none"
+      >
+        <button
+          class="c6"
+          role="menuitem"
+          type="button"
+        >
+          <div
+            class="c7"
+          >
+            Item 1
+          </div>
+        </button>
+      </div>
+      <div
+        class="c8"
+      />
+      <div
+        class="c5"
+        role="none"
+      >
+        <button
+          class="c6"
+          role="menuitem"
+          type="button"
+        >
+          <div
+            class="c7"
+          >
+            Item 2
+          </div>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Menu should apply theme.menu.container 2`] = `
+"@media only screen and (max-width: 768px) {
+  .kQRZEu {
+    padding: 6px;
+  }
+}"
+`;
+
 exports[`Menu should apply themed drop props 1`] = `
 .c2 {
   display: flex;
@@ -4694,9 +4925,17 @@ exports[`Menu should apply themed drop props 1`] = `
 }
 
 @media only screen and (max-width: 768px) {
+
+}
+
+@media only screen and (max-width: 768px) {
   .c4 {
     width: 6px;
   }
+}
+
+@media only screen and (max-width: 768px) {
+
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {

--- a/src/js/components/Menu/stories/CustomThemed/Themed.tsx
+++ b/src/js/components/Menu/stories/CustomThemed/Themed.tsx
@@ -61,6 +61,10 @@ const customBreakpoints: ThemeType = {
   },
   menu: {
     background: 'light-3',
+    container: {
+      pad: 'xsmall',
+      gap: 'xsmall',
+    },
     icons: {
       down: FormDown,
       up: FormUp,

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -1211,6 +1211,7 @@ export interface ThemeType {
         };
     drop?: DropType;
     extend?: ExtendType;
+    container?: BoxProps;
     group?: {
       container?: BoxProps;
       separator?: {

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1237,6 +1237,9 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         },
         // any drop props
       },
+      // container: {
+      //   // any box props
+      // },
       group: {
         container: {
           pad: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

This PR adds `theme.menu.container` which styles the Box directly surrounding the menu items. If menu groups are provided, then `theme.menu.group.container` will override theme.menu.container where appropriate.

#### Where should the reviewer start?
src/js/components/Menu/Menu.js

#### What testing has been done on this PR?
Adjusted Custom Themed menu storybook.

Added jest test.

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Yes.

#### Should this PR be mentioned in the release notes?
Yes.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.