### PR TITLE
Select, SelectMultiple -- Add extend to listbox

### DIFF
--- a/src/js/components/Select/StyledSelect.js
+++ b/src/js/components/Select/StyledSelect.js
@@ -33,6 +33,14 @@ export const OptionsContainer = styled.div.withConfig(styledComponentsConfig)`
   scroll-behavior: smooth;
   overflow: auto;
   outline: none;
+  ${(props) => {
+    if (props.selectMultiple)
+      return (
+        props.theme.selectMultiple.listbox &&
+        props.theme.selectMultiple.listbox.extend
+      );
+    return props.theme.select.listbox && props.theme.select.listbox.extend;
+  }};
 `;
 
 export const HiddenInput = styled.input.withConfig(styledComponentsConfig)`

--- a/src/js/components/Select/__tests__/Select-test.js
+++ b/src/js/components/Select/__tests__/Select-test.js
@@ -1815,6 +1815,39 @@ describe('Select', () => {
     expectPortal('test-clear-selection__drop').toMatchSnapshot();
   });
 
+  test('renders custom listbox styling', () => {
+    jest.useFakeTimers();
+    const customTheme = {
+      select: {
+        listbox: {
+          extend: `padding: 24px;`,
+        },
+      },
+    };
+
+    const { getByPlaceholderText, getByRole } = render(
+      <Grommet theme={customTheme}>
+        <Select
+          data-testid="test-select-style-open"
+          id="test-listbox"
+          options={['morning', 'afternoon', 'evening']}
+          placeholder="Select time"
+          value="afternoon"
+        />
+      </Grommet>,
+    );
+
+    fireEvent.click(getByPlaceholderText('Select time'));
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+
+    expectPortal('test-listbox__drop').toMatchSnapshot();
+    const listbox = getByRole('listbox');
+    const styles = window.getComputedStyle(listbox);
+    expect(styles.padding).toBe('24px');
+  });
+
   window.scrollTo.mockRestore();
   window.HTMLElement.prototype.scrollIntoView.mockRestore();
 });

--- a/src/js/components/Select/__tests__/__snapshots__/Select-multiple-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-multiple-test.js.snap
@@ -2451,7 +2451,7 @@ exports[`Select Controlled multiple onChange without labelKey 4`] = `
   >
     <div
       aria-multiselectable="true"
-      class="StyledSelect__OptionsContainer-sc-znp66n-1 oteVR"
+      class="StyledSelect__OptionsContainer-sc-znp66n-1 hjcpqT"
       role="listbox"
       tabindex="-1"
     >
@@ -2524,7 +2524,7 @@ exports[`Select Controlled multiple onChange without labelKey 6`] = `
   >
     <div
       aria-multiselectable="true"
-      class="StyledSelect__OptionsContainer-sc-znp66n-1 oteVR"
+      class="StyledSelect__OptionsContainer-sc-znp66n-1 hjcpqT"
       role="listbox"
       tabindex="-1"
     >
@@ -3336,7 +3336,7 @@ exports[`Select Controlled multiple onChange without valueKey 4`] = `
   >
     <div
       aria-multiselectable="true"
-      class="StyledSelect__OptionsContainer-sc-znp66n-1 oteVR"
+      class="StyledSelect__OptionsContainer-sc-znp66n-1 hjcpqT"
       role="listbox"
       tabindex="-1"
     >
@@ -3409,7 +3409,7 @@ exports[`Select Controlled multiple onChange without valueKey 6`] = `
   >
     <div
       aria-multiselectable="true"
-      class="StyledSelect__OptionsContainer-sc-znp66n-1 oteVR"
+      class="StyledSelect__OptionsContainer-sc-znp66n-1 hjcpqT"
       role="listbox"
       tabindex="-1"
     >
@@ -4223,7 +4223,7 @@ exports[`Select Controlled multiple onChange without valueKey or labelKey 4`] = 
   >
     <div
       aria-multiselectable="true"
-      class="StyledSelect__OptionsContainer-sc-znp66n-1 oteVR"
+      class="StyledSelect__OptionsContainer-sc-znp66n-1 hjcpqT"
       role="listbox"
       tabindex="-1"
     >
@@ -4294,7 +4294,7 @@ exports[`Select Controlled multiple onChange without valueKey or labelKey 6`] = 
   >
     <div
       aria-multiselectable="true"
-      class="StyledSelect__OptionsContainer-sc-znp66n-1 oteVR"
+      class="StyledSelect__OptionsContainer-sc-znp66n-1 hjcpqT"
       role="listbox"
       tabindex="-1"
     >

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -12012,7 +12012,7 @@ exports[`Select prop: onOpen 4`] = `
 
 exports[`Select prop: onOpen 5`] = `
 <div
-  class="StyledSelect__OptionsContainer-sc-znp66n-1 oteVR"
+  class="StyledSelect__OptionsContainer-sc-znp66n-1 hjcpqT"
   role="listbox"
   tabindex="-1"
 >
@@ -12949,6 +12949,286 @@ exports[`Select renders custom icon 1`] = `
     </div>
   </button>
 </div>
+`;
+
+exports[`Select renders custom listbox styling 1`] = `
+.c0 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  overflow: auto;
+  box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.20);
+}
+
+.c2 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.c7 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: flex-start;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  padding: 12px;
+}
+
+.c11 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  height: 0px;
+  flex: 0 0 auto;
+}
+
+.c1 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  border-radius: 0px;
+  position: fixed;
+  z-index: 20;
+  outline: none;
+  background-color: #FFFFFF;
+  color: #444444;
+  opacity: 0;
+  transform-origin: top left;
+  animation: kPQHBD 0.1s forwards;
+  animation-delay: 0.01s;
+}
+
+.c8 {
+  margin: 0px;
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c5 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c5:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c5:focus:not(:focus-visible) >circle,
+.c5:focus:not(:focus-visible) >ellipse,
+.c5:focus:not(:focus-visible) >line,
+.c5:focus:not(:focus-visible) >path,
+.c5:focus:not(:focus-visible) >polygon,
+.c5:focus:not(:focus-visible) >polyline,
+.c5:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c5:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c9 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c9:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c9:focus:not(:focus-visible) >circle,
+.c9:focus:not(:focus-visible) >ellipse,
+.c9:focus:not(:focus-visible) >line,
+.c9:focus:not(:focus-visible) >path,
+.c9:focus:not(:focus-visible) >polygon,
+.c9:focus:not(:focus-visible) >polyline,
+.c9:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c9:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c3 {
+  max-height: inherit;
+}
+
+.c4 {
+  position: relative;
+  scroll-behavior: smooth;
+  overflow: auto;
+  outline: none;
+  padding: 24px;
+}
+
+.c6 {
+  display: block;
+  width: 100%;
+}
+
+.c10 {
+  background-color: #7D4CDB;
+  color: #FFFFFF;
+  display: block;
+  width: 100%;
+}
+
+@media only screen and (max-width: 768px) {
+
+}
+
+@media only screen and (max-width: 768px) {
+  .c7 {
+    padding: 6px;
+  }
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c1 {
+    display: flex;
+    align-items: stretch;
+  }
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c3 {
+    width: 100%;
+  }
+}
+
+<div
+  class="c0 c1"
+  data-g-portal-id="0"
+  id="test-listbox__drop"
+  style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
+  tabindex="-1"
+>
+  <div
+    class="c2 c3"
+    id="test-listbox__select-drop"
+  >
+    <div
+      class="c4"
+      role="listbox"
+      tabindex="-1"
+    >
+      <button
+        aria-posinset="1"
+        aria-selected="false"
+        aria-setsize="3"
+        class="c5 c6"
+        role="option"
+        tabindex="-1"
+        type="button"
+      >
+        <div
+          class="c7"
+        >
+          <span
+            class="c8"
+          >
+            morning
+          </span>
+        </div>
+      </button>
+      <button
+        aria-posinset="2"
+        aria-selected="true"
+        aria-setsize="3"
+        class="c9 c10"
+        role="option"
+        tabindex="0"
+        type="button"
+      >
+        <div
+          class="c7"
+        >
+          <span
+            class="c8"
+          >
+            afternoon
+          </span>
+        </div>
+      </button>
+      <button
+        aria-posinset="3"
+        aria-selected="false"
+        aria-setsize="3"
+        class="c5 c6"
+        role="option"
+        tabindex="-1"
+        type="button"
+      >
+        <div
+          class="c7"
+        >
+          <span
+            class="c8"
+          >
+            evening
+          </span>
+        </div>
+      </button>
+      <div
+        class="c11"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Select renders custom listbox styling 2`] = `
+"@media only screen and (max-width: 768px) {
+  .eLuJRp {
+    margin-left: 6px;
+    margin-right: 6px;
+  }
+}"
 `;
 
 exports[`Select renders custom up and down icons 1`] = `

--- a/src/js/components/SelectMultiple/SelectMultipleContainer.js
+++ b/src/js/components/SelectMultiple/SelectMultipleContainer.js
@@ -435,7 +435,7 @@ const SelectMultipleContainer = forwardRef(
               aria-multiselectable
               onMouseMove={() => setKeyboardNavigation(false)}
               aria-activedescendant={optionsRef?.current?.children[activeIndex]}
-              selectMultiple
+              selectMultiple // internal prop
             >
               <InfiniteScroll
                 items={options}

--- a/src/js/components/SelectMultiple/SelectMultipleContainer.js
+++ b/src/js/components/SelectMultiple/SelectMultipleContainer.js
@@ -435,6 +435,7 @@ const SelectMultipleContainer = forwardRef(
               aria-multiselectable
               onMouseMove={() => setKeyboardNavigation(false)}
               aria-activedescendant={optionsRef?.current?.children[activeIndex]}
+              selectMultiple
             >
               <InfiniteScroll
                 items={options}

--- a/src/js/components/SelectMultiple/__tests__/SelectMultiple-test.tsx
+++ b/src/js/components/SelectMultiple/__tests__/SelectMultiple-test.tsx
@@ -585,4 +585,38 @@ describe('SelectMultiple with portal', () => {
 
     expectPortal('test-select__drop').toMatchSnapshot();
   });
+
+  test('renders custom listbox styling', () => {
+    jest.useFakeTimers();
+    const customTheme = {
+      selectMultiple: {
+        listbox: {
+          extend: `padding: 24px;`,
+        },
+      },
+    };
+
+    const { getByRole } = render(
+      <Grommet theme={customTheme}>
+        <SelectMultiple
+          data-testid="test-select-style-open"
+          id="test-listbox"
+          options={['morning', 'afternoon', 'evening']}
+          placeholder="Select time"
+          value={[]}
+        />
+      </Grommet>,
+    );
+
+    // open SelectMultiple
+    fireEvent.click(getByRole('button', { name: /Select time. 0 selected/i }));
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+
+    expectPortal('test-listbox__drop').toMatchSnapshot();
+    const listbox = getByRole('listbox');
+    const styles = window.getComputedStyle(listbox);
+    expect(styles.padding).toBe('24px');
+  });
 });

--- a/src/js/components/SelectMultiple/__tests__/__snapshots__/SelectMultiple-test.tsx.snap
+++ b/src/js/components/SelectMultiple/__tests__/__snapshots__/SelectMultiple-test.tsx.snap
@@ -6196,6 +6196,471 @@ exports[`SelectMultiple with portal limit 2`] = `
 }"
 `;
 
+exports[`SelectMultiple with portal renders custom listbox styling 1`] = `
+.c2 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.c0 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  overflow: auto;
+  box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.20);
+}
+
+.c4 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  min-height: 48px;
+  flex: 0 0 auto;
+  width: 100%;
+  justify-content: space-between;
+  padding: 6px;
+}
+
+.c12 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-right: 12px;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.c15 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: center;
+  border: solid 2px rgba(0, 0, 0, 0.15);
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  height: 24px;
+  width: 24px;
+  justify-content: center;
+  border-radius: 4px;
+}
+
+.c16 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-self: center;
+  align-items: flex-start;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  width: 100%;
+}
+
+.c17 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  height: 0px;
+  flex: 0 0 auto;
+}
+
+.c6 {
+  flex: 0 0 auto;
+  align-self: stretch;
+  width: 12px;
+}
+
+.c1 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  border-radius: 0px;
+  position: fixed;
+  z-index: 20;
+  outline: none;
+  background-color: #FFFFFF;
+  color: #444444;
+  opacity: 0;
+  transform-origin: top left;
+  animation: kPQHBD 0.1s forwards;
+  animation-delay: 0.01s;
+}
+
+.c5 {
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.c9 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c9:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c9:focus:not(:focus-visible) >circle,
+.c9:focus:not(:focus-visible) >ellipse,
+.c9:focus:not(:focus-visible) >line,
+.c9:focus:not(:focus-visible) >path,
+.c9:focus:not(:focus-visible) >polygon,
+.c9:focus:not(:focus-visible) >polyline,
+.c9:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c9:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c7 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: 2px solid #7D4CDB;
+  border-radius: 18px;
+  color: #444444;
+  padding: 4px 22px;
+  font-size: 18px;
+  line-height: 24px;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+}
+
+.c7:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c7:focus >circle,
+.c7:focus >ellipse,
+.c7:focus >line,
+.c7:focus >path,
+.c7:focus >polygon,
+.c7:focus >polyline,
+.c7:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c7:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c7:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c7:focus:not(:focus-visible) >circle,
+.c7:focus:not(:focus-visible) >ellipse,
+.c7:focus:not(:focus-visible) >line,
+.c7:focus:not(:focus-visible) >path,
+.c7:focus:not(:focus-visible) >polygon,
+.c7:focus:not(:focus-visible) >polyline,
+.c7:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c7:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c3 {
+  max-height: inherit;
+}
+
+.c8 {
+  position: relative;
+  scroll-behavior: smooth;
+  overflow: auto;
+  outline: none;
+  padding: 24px;
+}
+
+.c10 {
+  display: block;
+  width: 100%;
+}
+
+.c11 {
+  display: flex;
+  flex-direction: row;
+  user-select: none;
+  -webkit-user-select: none;
+  width: fit-content;
+  padding: 6px;
+  cursor: pointer;
+}
+
+.c11:hover input:not([disabled])+div,
+.c11:hover input:not([disabled])+span {
+  border-color: #000000;
+}
+
+.c14 {
+  opacity: 0;
+  -moz-appearance: none;
+  width: 0;
+  height: 0;
+  margin: 0;
+  cursor: pointer;
+}
+
+.c14:checked+span>span {
+  left: calc( 48px - 24px );
+  background: #7D4CDB;
+}
+
+.c13 {
+  flex-shrink: 0;
+}
+
+@media only screen and (max-width: 768px) {
+
+}
+
+@media only screen and (max-width: 768px) {
+  .c4 {
+    padding: 3px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c12 {
+    margin-right: 6px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c15 {
+    border: solid 2px rgba(0, 0, 0, 0.15);
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c6 {
+    width: 6px;
+  }
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c1 {
+    display: flex;
+    align-items: stretch;
+  }
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+  .c3 {
+    width: 100%;
+  }
+}
+
+<div
+  class="c0 c1"
+  data-g-portal-id="0"
+  id="test-listbox__drop"
+  style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
+  tabindex="-1"
+>
+  <div
+    aria-label="Select dropdown"
+    class="c2 c3"
+    id="test-listbox__select-drop"
+  >
+    <div
+      class="c4"
+    >
+      <span
+        class="c5"
+      >
+        0 selected
+      </span>
+      <div
+        class="c6"
+      />
+      <button
+        aria-label="Select all 3 options"
+        class="c7"
+        type="button"
+      >
+        Select All
+      </button>
+    </div>
+    <div
+      aria-multiselectable="true"
+      class="c8"
+      role="listbox"
+      tabindex="0"
+    >
+      <button
+        aria-label="morning not selected"
+        aria-posinset="1"
+        aria-selected="false"
+        aria-setsize="3"
+        class="c9 c10"
+        id="option0"
+        role="option"
+        tabindex="-1"
+        type="button"
+      >
+        <label
+          class="c11"
+          style="pointer-events: none;"
+        >
+          <div
+            class="c12 c13"
+          >
+            <input
+              class="c14"
+              inert=""
+              tabindex="-1"
+              type="checkbox"
+            />
+            <div
+              class="c15 "
+            />
+          </div>
+          <div
+            class="c16"
+          >
+            morning
+          </div>
+        </label>
+      </button>
+      <button
+        aria-label="afternoon not selected"
+        aria-posinset="2"
+        aria-selected="false"
+        aria-setsize="3"
+        class="c9 c10"
+        id="option1"
+        role="option"
+        tabindex="-1"
+        type="button"
+      >
+        <label
+          class="c11"
+          style="pointer-events: none;"
+        >
+          <div
+            class="c12 c13"
+          >
+            <input
+              class="c14"
+              inert=""
+              tabindex="-1"
+              type="checkbox"
+            />
+            <div
+              class="c15 "
+            />
+          </div>
+          <div
+            class="c16"
+          >
+            afternoon
+          </div>
+        </label>
+      </button>
+      <button
+        aria-label="evening not selected"
+        aria-posinset="3"
+        aria-selected="false"
+        aria-setsize="3"
+        class="c9 c10"
+        id="option2"
+        role="option"
+        tabindex="-1"
+        type="button"
+      >
+        <label
+          class="c11"
+          style="pointer-events: none;"
+        >
+          <div
+            class="c12 c13"
+          >
+            <input
+              class="c14"
+              inert=""
+              tabindex="-1"
+              type="checkbox"
+            />
+            <div
+              class="c15 "
+            />
+          </div>
+          <div
+            class="c16"
+          >
+            evening
+          </div>
+        </label>
+      </button>
+      <div
+        class="c17"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`SelectMultiple with portal renders custom listbox styling 2`] = `
+"@media only screen and (max-width: 768px) {
+  .fTAuUd {
+    margin-left: 6px;
+    margin-right: 6px;
+  }
+}"
+`;
+
 exports[`SelectMultiple with portal select all and clear 1`] = `
 .c2 {
   display: flex;

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -1672,6 +1672,9 @@ export interface ThemeType {
       up?: React.ReactNode | Icon;
       margin?: MarginType;
     };
+    listbox?: {
+      extend?: ExtendType;
+    };
     options?: {
       container?: PropsOf<typeof Box>;
       text?: PropsOf<typeof Text>;
@@ -1682,6 +1685,9 @@ export interface ThemeType {
   };
   selectMultiple?: {
     maxInline?: number;
+    listbox?: {
+      extend?: ExtendType;
+    };
   };
   skeleton?: BoxProps & { colors?: SkeletonColorsType; extend?: ExtendType };
   skipLinks?: {

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1864,6 +1864,9 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         down: FormDown,
         // up: undefined
       },
+      // listbox: {
+      //   extend: undefined,
+      // },
       options: {
         container: {
           align: 'start',
@@ -1878,6 +1881,9 @@ export const generate = (baseSpacing = 24, scale = 6) => {
     },
     selectMultiple: {
       maxInline: 5,
+      // listbox: {
+      //   extend: () => undefined,
+      // },
     },
     skeleton: {
       border: false,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

This PR adds an extend to the theme for the "listbox" container directly surrounding the options. Open to naming suggestions, but things like "option.container" etc were already taken and apply to different things. "Listbox" is because this is the container with role="listbox".

Had to pass through `selectMultiple` as a prop on OptionsContainer so that the extend could differentiate between desired styling for Select vs SelectMultiple

#### Where should the reviewer start?
src/js/components/Select/StyledSelect.js

#### What testing has been done on this PR?
Locally. Also added jest tests.

#### How should this be manually tested?

```
theme: {
   select: {
      listbox: {
          extend: `padding: 24px;`,
      },
   },
  selectMultiple: {
      listbox: {
          extend: `padding: 12px;`,
      },
   },
}
```

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Yes.

#### Should this PR be mentioned in the release notes?
Yes.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.