### PR TITLE
Add extend to formfield container based on child input kind

### DIFF
--- a/src/js/components/Data/__tests__/__snapshots__/Data-test.tsx.snap
+++ b/src/js/components/Data/__tests__/__snapshots__/Data-test.tsx.snap
@@ -4166,7 +4166,7 @@ exports[`Data should render property label and return property value to view whe
                   SelectMultiple Name
                 </label>
                 <div
-                  class="c7 FormField__FormFieldContentBox-sc-m9hood-1"
+                  class="c7 "
                 >
                   <div
                     class="c8 "
@@ -4241,7 +4241,7 @@ exports[`Data should render property label and return property value to view whe
                   SelectMultiple Simple Name
                 </label>
                 <div
-                  class="c7 FormField__FormFieldContentBox-sc-m9hood-1"
+                  class="c7 "
                 >
                   <div
                     class="c8 "
@@ -4370,7 +4370,7 @@ exports[`Data should render property label and return property value to view whe
                   CheckBoxGroup Name
                 </label>
                 <div
-                  class="c27 FormField__FormFieldContentBox-sc-m9hood-1"
+                  class="c27 "
                 >
                   <div
                     class="c28 StyledCheckBoxGroup-sc-2nhc5d-0"

--- a/src/js/components/DataFilter/__tests__/__snapshots__/DataFilter-test.tsx.snap
+++ b/src/js/components/DataFilter/__tests__/__snapshots__/DataFilter-test.tsx.snap
@@ -728,7 +728,7 @@ exports[`DataFilter children 1`] = `
                 name
               </label>
               <div
-                class="c7 FormField__FormFieldContentBox-sc-m9hood-1"
+                class="c7 "
               >
                 <div
                   class="c8"
@@ -1061,7 +1061,7 @@ exports[`DataFilter options 1`] = `
                 name
               </label>
               <div
-                class="c7 FormField__FormFieldContentBox-sc-m9hood-1"
+                class="c7 "
               >
                 <div
                   class="c8 StyledCheckBoxGroup-sc-2nhc5d-0"
@@ -1141,7 +1141,7 @@ exports[`DataFilter options 1`] = `
                 Enabled
               </label>
               <div
-                class="c7 FormField__FormFieldContentBox-sc-m9hood-1"
+                class="c7 "
               >
                 <div
                   class="c8 StyledCheckBoxGroup-sc-2nhc5d-0"
@@ -1200,7 +1200,7 @@ exports[`DataFilter options 1`] = `
                 Type
               </label>
               <div
-                class="c7 FormField__FormFieldContentBox-sc-m9hood-1"
+                class="c7 "
               >
                 <div
                   class="c8 StyledCheckBoxGroup-sc-2nhc5d-0"
@@ -1598,7 +1598,7 @@ exports[`DataFilter range Data 1`] = `
                 Rating
               </label>
               <div
-                class="c7 FormField__FormFieldContentBox-sc-m9hood-1"
+                class="c7 "
               >
                 <div
                   class="c8"
@@ -2023,7 +2023,7 @@ exports[`DataFilter range prop 1`] = `
                 rating
               </label>
               <div
-                class="c7 FormField__FormFieldContentBox-sc-m9hood-1"
+                class="c7 "
               >
                 <div
                   class="c8"
@@ -2541,7 +2541,7 @@ exports[`DataFilter renders 1`] = `
                 name
               </label>
               <div
-                class="c7 FormField__FormFieldContentBox-sc-m9hood-1"
+                class="c7 "
               >
                 <div
                   class="c8 StyledCheckBoxGroup-sc-2nhc5d-0"
@@ -2621,7 +2621,7 @@ exports[`DataFilter renders 1`] = `
                 enabled
               </label>
               <div
-                class="c7 FormField__FormFieldContentBox-sc-m9hood-1"
+                class="c7 "
               >
                 <div
                   class="c8 StyledCheckBoxGroup-sc-2nhc5d-0"
@@ -2680,7 +2680,7 @@ exports[`DataFilter renders 1`] = `
                 rating
               </label>
               <div
-                class="c7 FormField__FormFieldContentBox-sc-m9hood-1"
+                class="c7 "
               >
                 <div
                   class="c15"

--- a/src/js/components/DataFilters/__tests__/__snapshots__/DataFilters-test.tsx.snap
+++ b/src/js/components/DataFilters/__tests__/__snapshots__/DataFilters-test.tsx.snap
@@ -332,7 +332,7 @@ exports[`DataFilters clear 1`] = `
                 name
               </label>
               <div
-                class="c7 FormField__FormFieldContentBox-sc-m9hood-1"
+                class="c7 "
               >
                 <div
                   class="c8 StyledCheckBoxGroup-sc-2nhc5d-0"
@@ -1714,7 +1714,7 @@ exports[`DataFilters layer 2`] = `
                   name
                 </label>
                 <div
-                  class="c15 FormField__FormFieldContentBox-sc-m9hood-1"
+                  class="c15 "
                 >
                   <div
                     class="c16 StyledCheckBoxGroup-sc-2nhc5d-0"
@@ -2123,7 +2123,7 @@ exports[`DataFilters properties array 1`] = `
                 name
               </label>
               <div
-                class="c7 FormField__FormFieldContentBox-sc-m9hood-1"
+                class="c7 "
               >
                 <div
                   class="c8 StyledCheckBoxGroup-sc-2nhc5d-0"
@@ -2493,7 +2493,7 @@ exports[`DataFilters properties object 1`] = `
                 name
               </label>
               <div
-                class="c7 FormField__FormFieldContentBox-sc-m9hood-1"
+                class="c7 "
               >
                 <div
                   class="c8 StyledCheckBoxGroup-sc-2nhc5d-0"
@@ -2863,7 +2863,7 @@ exports[`DataFilters renders 1`] = `
                 name
               </label>
               <div
-                class="c7 FormField__FormFieldContentBox-sc-m9hood-1"
+                class="c7 "
               >
                 <div
                   class="c8 StyledCheckBoxGroup-sc-2nhc5d-0"
@@ -3316,7 +3316,7 @@ exports[`DataFilters should display all filter options regardless of result set 
                   name
                 </label>
                 <div
-                  class="c7 FormField__FormFieldContentBox-sc-m9hood-1"
+                  class="c7 "
                 >
                   <div
                     class="c8 StyledCheckBoxGroup-sc-2nhc5d-0"
@@ -3375,7 +3375,7 @@ exports[`DataFilters should display all filter options regardless of result set 
                   color
                 </label>
                 <div
-                  class="c7 FormField__FormFieldContentBox-sc-m9hood-1"
+                  class="c7 "
                 >
                   <div
                     class="c8 StyledCheckBoxGroup-sc-2nhc5d-0"
@@ -4208,7 +4208,7 @@ exports[`DataFilters sub objects 1`] = `
                 City
               </label>
               <div
-                class="c7 FormField__FormFieldContentBox-sc-m9hood-1"
+                class="c7 "
               >
                 <div
                   class="c8 StyledCheckBoxGroup-sc-2nhc5d-0"
@@ -4279,7 +4279,7 @@ exports[`DataFilters sub objects 1`] = `
                 Latitude
               </label>
               <div
-                class="c7 FormField__FormFieldContentBox-sc-m9hood-1"
+                class="c7 "
               >
                 <div
                   class="c17"

--- a/src/js/components/DataSearch/__tests__/__snapshots__/DataSearch-test.tsx.snap
+++ b/src/js/components/DataSearch/__tests__/__snapshots__/DataSearch-test.tsx.snap
@@ -647,7 +647,7 @@ exports[`DataSearch renders 1`] = `
                 Search
               </label>
               <div
-                class="c7 FormField__FormFieldContentBox-sc-m9hood-1"
+                class="c7 "
               >
                 <div
                   class="c8"

--- a/src/js/components/DataSort/__tests__/__snapshots__/DataSort-test.tsx.snap
+++ b/src/js/components/DataSort/__tests__/__snapshots__/DataSort-test.tsx.snap
@@ -863,7 +863,7 @@ exports[`DataSort renders 1`] = `
                 Sort by
               </label>
               <div
-                class="c7 FormField__FormFieldContentBox-sc-m9hood-1"
+                class="c7 "
               >
                 <button
                   aria-expanded="false"
@@ -926,7 +926,7 @@ exports[`DataSort renders 1`] = `
                 Sort direction
               </label>
               <div
-                class="c16 FormField__FormFieldContentBox-sc-m9hood-1"
+                class="c16 "
               >
                 <div
                   class="c17"
@@ -1357,7 +1357,7 @@ exports[`DataSort sort when data array is empty 1`] = `
           Sort by
         </label>
         <div
-          class="c5 FormField__FormFieldContentBox-sc-m9hood-1"
+          class="c5 "
         >
           <button
             aria-expanded="false"
@@ -1420,7 +1420,7 @@ exports[`DataSort sort when data array is empty 1`] = `
           Sort direction
         </label>
         <div
-          class="c14 FormField__FormFieldContentBox-sc-m9hood-1"
+          class="c14 "
         >
           <div
             class="c15"

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-controlled.tsx.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-controlled.tsx.snap
@@ -168,7 +168,7 @@ exports[`Form controlled controlled 1`] = `
       class="c1 "
     >
       <div
-        class="c2 FormField__FormFieldContentBox-sc-m9hood-1"
+        class="c2 "
       >
         <div
           class="c3"
@@ -202,7 +202,7 @@ exports[`Form controlled controlled 2`] = `
       class="StyledBox-sc-13pk1d4-0 ipOUDz FormField__FormFieldBox-sc-m9hood-0 ikMUUn"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1"
+        class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1 dTkVKT"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kihEXm"
@@ -236,7 +236,7 @@ exports[`Form controlled controlled 3`] = `
       class="StyledBox-sc-13pk1d4-0 ipOUDz FormField__FormFieldBox-sc-m9hood-0 ikMUUn"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1"
+        class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1 dTkVKT"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kihEXm"
@@ -443,7 +443,7 @@ exports[`Form controlled controlled Array of Form Fields 1`] = `
         class="c2 "
       >
         <div
-          class="c3 FormField__FormFieldContentBox-sc-m9hood-1"
+          class="c3 "
         >
           <div
             class="c4"
@@ -462,7 +462,7 @@ exports[`Form controlled controlled Array of Form Fields 1`] = `
         class="c2 "
       >
         <div
-          class="c3 FormField__FormFieldContentBox-sc-m9hood-1"
+          class="c3 "
         >
           <div
             class="c4"
@@ -485,7 +485,7 @@ exports[`Form controlled controlled Array of Form Fields 1`] = `
         class="c2 "
       >
         <div
-          class="c3 FormField__FormFieldContentBox-sc-m9hood-1"
+          class="c3 "
         >
           <div
             class="c4"
@@ -504,7 +504,7 @@ exports[`Form controlled controlled Array of Form Fields 1`] = `
         class="c2 "
       >
         <div
-          class="c3 FormField__FormFieldContentBox-sc-m9hood-1"
+          class="c3 "
         >
           <div
             class="c4"
@@ -527,7 +527,7 @@ exports[`Form controlled controlled Array of Form Fields 1`] = `
         class="c2 "
       >
         <div
-          class="c3 FormField__FormFieldContentBox-sc-m9hood-1"
+          class="c3 "
         >
           <div
             class="c4"
@@ -546,7 +546,7 @@ exports[`Form controlled controlled Array of Form Fields 1`] = `
         class="c2 "
       >
         <div
-          class="c3 FormField__FormFieldContentBox-sc-m9hood-1"
+          class="c3 "
         >
           <div
             class="c4"
@@ -584,7 +584,7 @@ exports[`Form controlled controlled Array of Form Fields 2`] = `
         class="StyledBox-sc-13pk1d4-0 ipOUDz FormField__FormFieldBox-sc-m9hood-0 ikMUUn"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1"
+          class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1 dTkVKT"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kihEXm"
@@ -603,7 +603,7 @@ exports[`Form controlled controlled Array of Form Fields 2`] = `
         class="StyledBox-sc-13pk1d4-0 ipOUDz FormField__FormFieldBox-sc-m9hood-0 ikMUUn"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1"
+          class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1 dTkVKT"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kihEXm"
@@ -626,7 +626,7 @@ exports[`Form controlled controlled Array of Form Fields 2`] = `
         class="StyledBox-sc-13pk1d4-0 ipOUDz FormField__FormFieldBox-sc-m9hood-0 ikMUUn"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1"
+          class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1 dTkVKT"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kihEXm"
@@ -645,7 +645,7 @@ exports[`Form controlled controlled Array of Form Fields 2`] = `
         class="StyledBox-sc-13pk1d4-0 ipOUDz FormField__FormFieldBox-sc-m9hood-0 ikMUUn"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1"
+          class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1 dTkVKT"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kihEXm"
@@ -668,7 +668,7 @@ exports[`Form controlled controlled Array of Form Fields 2`] = `
         class="StyledBox-sc-13pk1d4-0 ipOUDz FormField__FormFieldBox-sc-m9hood-0 ikMUUn"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1"
+          class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1 dTkVKT"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kihEXm"
@@ -687,7 +687,7 @@ exports[`Form controlled controlled Array of Form Fields 2`] = `
         class="StyledBox-sc-13pk1d4-0 ipOUDz FormField__FormFieldBox-sc-m9hood-0 ikMUUn"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1"
+          class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1 dTkVKT"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kihEXm"
@@ -725,7 +725,7 @@ exports[`Form controlled controlled Array of Form Fields 3`] = `
         class="StyledBox-sc-13pk1d4-0 ipOUDz FormField__FormFieldBox-sc-m9hood-0 ikMUUn"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1"
+          class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1 dTkVKT"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kihEXm"
@@ -744,7 +744,7 @@ exports[`Form controlled controlled Array of Form Fields 3`] = `
         class="StyledBox-sc-13pk1d4-0 ipOUDz FormField__FormFieldBox-sc-m9hood-0 ikMUUn"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1"
+          class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1 dTkVKT"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kihEXm"
@@ -767,7 +767,7 @@ exports[`Form controlled controlled Array of Form Fields 3`] = `
         class="StyledBox-sc-13pk1d4-0 ipOUDz FormField__FormFieldBox-sc-m9hood-0 ikMUUn"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1"
+          class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1 dTkVKT"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kihEXm"
@@ -786,7 +786,7 @@ exports[`Form controlled controlled Array of Form Fields 3`] = `
         class="StyledBox-sc-13pk1d4-0 ipOUDz FormField__FormFieldBox-sc-m9hood-0 ikMUUn"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1"
+          class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1 dTkVKT"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kihEXm"
@@ -809,7 +809,7 @@ exports[`Form controlled controlled Array of Form Fields 3`] = `
         class="StyledBox-sc-13pk1d4-0 ipOUDz FormField__FormFieldBox-sc-m9hood-0 ikMUUn"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1"
+          class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1 dTkVKT"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kihEXm"
@@ -828,7 +828,7 @@ exports[`Form controlled controlled Array of Form Fields 3`] = `
         class="StyledBox-sc-13pk1d4-0 ipOUDz FormField__FormFieldBox-sc-m9hood-0 ikMUUn"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1"
+          class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1 dTkVKT"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kihEXm"
@@ -1036,7 +1036,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate 1`] = `
         class="c2 "
       >
         <div
-          class="c3 FormField__FormFieldContentBox-sc-m9hood-1"
+          class="c3 "
         >
           <div
             class="c4"
@@ -1055,7 +1055,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate 1`] = `
         class="c2 "
       >
         <div
-          class="c3 FormField__FormFieldContentBox-sc-m9hood-1"
+          class="c3 "
         >
           <div
             class="c4"
@@ -1078,7 +1078,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate 1`] = `
         class="c2 "
       >
         <div
-          class="c3 FormField__FormFieldContentBox-sc-m9hood-1"
+          class="c3 "
         >
           <div
             class="c4"
@@ -1097,7 +1097,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate 1`] = `
         class="c2 "
       >
         <div
-          class="c3 FormField__FormFieldContentBox-sc-m9hood-1"
+          class="c3 "
         >
           <div
             class="c4"
@@ -1135,7 +1135,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate 2`] = `
         class="StyledBox-sc-13pk1d4-0 ipOUDz FormField__FormFieldBox-sc-m9hood-0 ikMUUn"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 dRCTHV FormField__FormFieldContentBox-sc-m9hood-1"
+          class="StyledBox-sc-13pk1d4-0 dRCTHV FormField__FormFieldContentBox-sc-m9hood-1 dTkVKT"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kihEXm"
@@ -1181,7 +1181,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate 2`] = `
         class="StyledBox-sc-13pk1d4-0 ipOUDz FormField__FormFieldBox-sc-m9hood-0 ikMUUn"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1"
+          class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1 dTkVKT"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kihEXm"
@@ -1204,7 +1204,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate 2`] = `
         class="StyledBox-sc-13pk1d4-0 ipOUDz FormField__FormFieldBox-sc-m9hood-0 ikMUUn"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 dRCTHV FormField__FormFieldContentBox-sc-m9hood-1"
+          class="StyledBox-sc-13pk1d4-0 dRCTHV FormField__FormFieldContentBox-sc-m9hood-1 dTkVKT"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kihEXm"
@@ -1250,7 +1250,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate 2`] = `
         class="StyledBox-sc-13pk1d4-0 ipOUDz FormField__FormFieldBox-sc-m9hood-0 ikMUUn"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1"
+          class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1 dTkVKT"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kihEXm"
@@ -1458,7 +1458,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate custom error
         class="c2 "
       >
         <div
-          class="c3 FormField__FormFieldContentBox-sc-m9hood-1"
+          class="c3 "
         >
           <div
             class="c4"
@@ -1477,7 +1477,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate custom error
         class="c2 "
       >
         <div
-          class="c3 FormField__FormFieldContentBox-sc-m9hood-1"
+          class="c3 "
         >
           <div
             class="c4"
@@ -1500,7 +1500,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate custom error
         class="c2 "
       >
         <div
-          class="c3 FormField__FormFieldContentBox-sc-m9hood-1"
+          class="c3 "
         >
           <div
             class="c4"
@@ -1519,7 +1519,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate custom error
         class="c2 "
       >
         <div
-          class="c3 FormField__FormFieldContentBox-sc-m9hood-1"
+          class="c3 "
         >
           <div
             class="c4"
@@ -1557,7 +1557,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate custom error
         class="StyledBox-sc-13pk1d4-0 ipOUDz FormField__FormFieldBox-sc-m9hood-0 ikMUUn"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1"
+          class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1 dTkVKT"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kihEXm"
@@ -1576,7 +1576,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate custom error
         class="StyledBox-sc-13pk1d4-0 ipOUDz FormField__FormFieldBox-sc-m9hood-0 ikMUUn"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1"
+          class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1 dTkVKT"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kihEXm"
@@ -1599,7 +1599,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate custom error
         class="StyledBox-sc-13pk1d4-0 ipOUDz FormField__FormFieldBox-sc-m9hood-0 ikMUUn"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 dRCTHV FormField__FormFieldContentBox-sc-m9hood-1"
+          class="StyledBox-sc-13pk1d4-0 dRCTHV FormField__FormFieldContentBox-sc-m9hood-1 dTkVKT"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kihEXm"
@@ -1645,7 +1645,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate custom error
         class="StyledBox-sc-13pk1d4-0 ipOUDz FormField__FormFieldBox-sc-m9hood-0 ikMUUn"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1"
+          class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1 dTkVKT"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kihEXm"
@@ -1854,7 +1854,7 @@ exports[`Form controlled controlled FormField deprecated 1`] = `
         test
       </label>
       <div
-        class="c3 FormField__FormFieldContentBox-sc-m9hood-1"
+        class="c3 "
       >
         <div
           class="c4"
@@ -1894,7 +1894,7 @@ exports[`Form controlled controlled FormField deprecated 2`] = `
         test
       </label>
       <div
-        class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1"
+        class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1 dTkVKT"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kihEXm"
@@ -1934,7 +1934,7 @@ exports[`Form controlled controlled FormField deprecated 3`] = `
         test
       </label>
       <div
-        class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1"
+        class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1 dTkVKT"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kihEXm"
@@ -2127,7 +2127,7 @@ exports[`Form controlled controlled input 1`] = `
       class="c1 "
     >
       <div
-        class="c2 FormField__FormFieldContentBox-sc-m9hood-1"
+        class="c2 "
       >
         <div
           class="c3"
@@ -2161,7 +2161,7 @@ exports[`Form controlled controlled input 2`] = `
       class="StyledBox-sc-13pk1d4-0 ipOUDz FormField__FormFieldBox-sc-m9hood-0 ikMUUn"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1"
+        class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1 dTkVKT"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kihEXm"
@@ -2195,7 +2195,7 @@ exports[`Form controlled controlled input 3`] = `
       class="StyledBox-sc-13pk1d4-0 ipOUDz FormField__FormFieldBox-sc-m9hood-0 ikMUUn"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1"
+        class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1 dTkVKT"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kihEXm"
@@ -2388,7 +2388,7 @@ exports[`Form controlled controlled input lazy 1`] = `
       class="c1 "
     >
       <div
-        class="c2 FormField__FormFieldContentBox-sc-m9hood-1"
+        class="c2 "
       >
         <div
           class="c3"
@@ -2422,7 +2422,7 @@ exports[`Form controlled controlled input lazy 2`] = `
       class="StyledBox-sc-13pk1d4-0 ipOUDz FormField__FormFieldBox-sc-m9hood-0 ikMUUn"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1"
+        class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1 dTkVKT"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kihEXm"
@@ -2456,7 +2456,7 @@ exports[`Form controlled controlled input lazy 3`] = `
       class="StyledBox-sc-13pk1d4-0 ipOUDz FormField__FormFieldBox-sc-m9hood-0 ikMUUn"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1"
+        class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1 dTkVKT"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kihEXm"
@@ -2649,7 +2649,7 @@ exports[`Form controlled controlled lazy 1`] = `
       class="c1 "
     >
       <div
-        class="c2 FormField__FormFieldContentBox-sc-m9hood-1"
+        class="c2 "
       >
         <div
           class="c3"
@@ -2683,7 +2683,7 @@ exports[`Form controlled controlled lazy 2`] = `
       class="StyledBox-sc-13pk1d4-0 ipOUDz FormField__FormFieldBox-sc-m9hood-0 ikMUUn"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1"
+        class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1 dTkVKT"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kihEXm"
@@ -2717,7 +2717,7 @@ exports[`Form controlled controlled lazy 3`] = `
       class="StyledBox-sc-13pk1d4-0 ipOUDz FormField__FormFieldBox-sc-m9hood-0 ikMUUn"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1"
+        class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1 dTkVKT"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kihEXm"
@@ -2910,7 +2910,7 @@ exports[`Form controlled controlled onChange touched 1`] = `
       class="c1 "
     >
       <div
-        class="c2 FormField__FormFieldContentBox-sc-m9hood-1"
+        class="c2 "
       >
         <div
           class="c3"
@@ -3103,7 +3103,7 @@ exports[`Form controlled controlled onValidate 1`] = `
       class="c1 "
     >
       <div
-        class="c2 FormField__FormFieldContentBox-sc-m9hood-1"
+        class="c2 "
       >
         <div
           class="c3"
@@ -3137,7 +3137,7 @@ exports[`Form controlled controlled onValidate 2`] = `
       class="StyledBox-sc-13pk1d4-0 ipOUDz FormField__FormFieldBox-sc-m9hood-0 ikMUUn"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 dRCTHV FormField__FormFieldContentBox-sc-m9hood-1"
+        class="StyledBox-sc-13pk1d4-0 dRCTHV FormField__FormFieldContentBox-sc-m9hood-1 dTkVKT"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kihEXm"
@@ -3357,7 +3357,7 @@ exports[`Form controlled controlled onValidate custom error 1`] = `
       class="c1 "
     >
       <div
-        class="c2 FormField__FormFieldContentBox-sc-m9hood-1"
+        class="c2 "
       >
         <div
           class="c3"
@@ -3391,7 +3391,7 @@ exports[`Form controlled controlled onValidate custom error 2`] = `
       class="StyledBox-sc-13pk1d4-0 ipOUDz FormField__FormFieldBox-sc-m9hood-0 ikMUUn"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 dRCTHV FormField__FormFieldContentBox-sc-m9hood-1"
+        class="StyledBox-sc-13pk1d4-0 dRCTHV FormField__FormFieldContentBox-sc-m9hood-1 dTkVKT"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kihEXm"
@@ -3611,7 +3611,7 @@ exports[`Form controlled controlled onValidate custom info 1`] = `
       class="c1 "
     >
       <div
-        class="c2 FormField__FormFieldContentBox-sc-m9hood-1"
+        class="c2 "
       >
         <div
           class="c3"
@@ -3645,7 +3645,7 @@ exports[`Form controlled controlled onValidate custom info 2`] = `
       class="StyledBox-sc-13pk1d4-0 ipOUDz FormField__FormFieldBox-sc-m9hood-0 ikMUUn"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1"
+        class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1 dTkVKT"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kihEXm"
@@ -3852,7 +3852,7 @@ exports[`Form controlled custom theme 1`] = `
         custom theme label
       </label>
       <div
-        class="c3 FormField__FormFieldContentBox-sc-m9hood-1"
+        class="c3 "
       >
         <div
           class="c4"
@@ -4198,7 +4198,7 @@ exports[`Form controlled dynamicly removed fields using blur validation
       class="c1 "
     >
       <div
-        class="c2 FormField__FormFieldContentBox-sc-m9hood-1"
+        class="c2 "
       >
         <div
           class="c3"
@@ -4217,7 +4217,7 @@ exports[`Form controlled dynamicly removed fields using blur validation
       class="c1 "
     >
       <div
-        class="c5 FormField__FormFieldContentBox-sc-m9hood-1"
+        class="c5 "
       >
         <label
           class="c6"
@@ -4260,7 +4260,7 @@ exports[`Form controlled dynamicly removed fields using blur validation
       class="StyledBox-sc-13pk1d4-0 ipOUDz FormField__FormFieldBox-sc-m9hood-0 ikMUUn"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1"
+        class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1 dTkVKT"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kihEXm"
@@ -4279,7 +4279,7 @@ exports[`Form controlled dynamicly removed fields using blur validation
       class="StyledBox-sc-13pk1d4-0 ipOUDz FormField__FormFieldBox-sc-m9hood-0 ikMUUn"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 itXtYk FormField__FormFieldContentBox-sc-m9hood-1"
+        class="StyledBox-sc-13pk1d4-0 itXtYk FormField__FormFieldContentBox-sc-m9hood-1 dTkVKT"
       >
         <label
           class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fmiiKd"
@@ -4454,7 +4454,7 @@ exports[`Form controlled dynamicly removed fields using blur validation
       class="c0 "
     >
       <div
-        class="c1 FormField__FormFieldContentBox-sc-m9hood-1"
+        class="c1 "
       >
         <div
           class="c2"
@@ -4489,7 +4489,7 @@ exports[`Form controlled dynamicly removed fields using blur validation
       class="StyledBox-sc-13pk1d4-0 ipOUDz FormField__FormFieldBox-sc-m9hood-0 ikMUUn"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1"
+        class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1 dTkVKT"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kihEXm"
@@ -4508,7 +4508,7 @@ exports[`Form controlled dynamicly removed fields using blur validation
       class="StyledBox-sc-13pk1d4-0 ipOUDz FormField__FormFieldBox-sc-m9hood-0 ikMUUn"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 itXtYk FormField__FormFieldContentBox-sc-m9hood-1 hppbSa"
+        class="StyledBox-sc-13pk1d4-0 itXtYk FormField__FormFieldContentBox-sc-m9hood-1 bNNaVg"
       >
         <label
           class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fNAqFP"

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.tsx.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.tsx.snap
@@ -128,7 +128,7 @@ exports[`Form accessibility Box with TextInput in Form should
       class="c1 "
     >
       <div
-        class="c2 FormField__FormFieldContentBox-sc-m9hood-1"
+        class="c2 "
       >
         <div
           class="c3"
@@ -279,7 +279,7 @@ exports[`Form accessibility CheckBox in Form should have no accessibility violat
       class="c1 "
     >
       <div
-        class="c2 FormField__FormFieldContentBox-sc-m9hood-1"
+        class="c2 "
       >
         <label
           class="c3"
@@ -406,7 +406,7 @@ exports[`Form accessibility FormField with an explicit TextInput child
       class="c1 "
     >
       <div
-        class="c2 FormField__FormFieldContentBox-sc-m9hood-1"
+        class="c2 "
       >
         <div
           class="c3"
@@ -637,7 +637,7 @@ exports[`Form accessibility Select in Form should have no accessibility violatio
       class="c1 "
     >
       <div
-        class="c2 FormField__FormFieldContentBox-sc-m9hood-1"
+        class="c2 "
       >
         <button
           aria-expanded="false"
@@ -793,7 +793,7 @@ exports[`Form accessibility TextInput in Form should have
       class="c1 "
     >
       <div
-        class="c2 FormField__FormFieldContentBox-sc-m9hood-1"
+        class="c2 "
       >
         <div
           class="c3"
@@ -1073,7 +1073,7 @@ exports[`Form uncontrolled dynamically removed fields should be removed from for
       class="c1 "
     >
       <div
-        class="c2 FormField__FormFieldContentBox-sc-m9hood-1"
+        class="c2 "
       >
         <div
           class="c3"
@@ -1091,7 +1091,7 @@ exports[`Form uncontrolled dynamically removed fields should be removed from for
       class="c1 "
     >
       <div
-        class="c5 FormField__FormFieldContentBox-sc-m9hood-1"
+        class="c5 "
       >
         <label
           class="c6"
@@ -1133,7 +1133,7 @@ exports[`Form uncontrolled dynamically removed fields should be removed from for
       class="StyledBox-sc-13pk1d4-0 ipOUDz FormField__FormFieldBox-sc-m9hood-0 ikMUUn"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1"
+        class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1 dTkVKT"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kihEXm"
@@ -1151,7 +1151,7 @@ exports[`Form uncontrolled dynamically removed fields should be removed from for
       class="StyledBox-sc-13pk1d4-0 ipOUDz FormField__FormFieldBox-sc-m9hood-0 ikMUUn"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 itXtYk FormField__FormFieldContentBox-sc-m9hood-1"
+        class="StyledBox-sc-13pk1d4-0 itXtYk FormField__FormFieldContentBox-sc-m9hood-1 dTkVKT"
       >
         <label
           class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fmiiKd"
@@ -1448,7 +1448,7 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation
       class="c1 "
     >
       <div
-        class="c2 FormField__FormFieldContentBox-sc-m9hood-1"
+        class="c2 "
       >
         <div
           class="c3"
@@ -1466,7 +1466,7 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation
       class="c1 "
     >
       <div
-        class="c5 FormField__FormFieldContentBox-sc-m9hood-1"
+        class="c5 "
       >
         <label
           class="c6"
@@ -1509,7 +1509,7 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation
       class="StyledBox-sc-13pk1d4-0 ipOUDz FormField__FormFieldBox-sc-m9hood-0 ikMUUn"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1"
+        class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1 dTkVKT"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kihEXm"
@@ -1527,7 +1527,7 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation
       class="StyledBox-sc-13pk1d4-0 ipOUDz FormField__FormFieldBox-sc-m9hood-0 ikMUUn"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 itXtYk FormField__FormFieldContentBox-sc-m9hood-1"
+        class="StyledBox-sc-13pk1d4-0 itXtYk FormField__FormFieldContentBox-sc-m9hood-1 dTkVKT"
       >
         <label
           class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fmiiKd"
@@ -1702,7 +1702,7 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation
       class="c0 "
     >
       <div
-        class="c1 FormField__FormFieldContentBox-sc-m9hood-1"
+        class="c1 "
       >
         <div
           class="c2"
@@ -1736,7 +1736,7 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation
       class="StyledBox-sc-13pk1d4-0 ipOUDz FormField__FormFieldBox-sc-m9hood-0 ikMUUn"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1"
+        class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1 dTkVKT"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kihEXm"
@@ -1754,7 +1754,7 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation
       class="StyledBox-sc-13pk1d4-0 ipOUDz FormField__FormFieldBox-sc-m9hood-0 ikMUUn"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 itXtYk FormField__FormFieldContentBox-sc-m9hood-1 hppbSa"
+        class="StyledBox-sc-13pk1d4-0 itXtYk FormField__FormFieldContentBox-sc-m9hood-1 bNNaVg"
       >
         <label
           class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fNAqFP"
@@ -1917,7 +1917,7 @@ exports[`Form uncontrolled errors 1`] = `
       class="c1 "
     >
       <div
-        class="c2 FormField__FormFieldContentBox-sc-m9hood-1"
+        class="c2 "
       >
         <div
           class="c3"
@@ -2050,7 +2050,7 @@ exports[`Form uncontrolled infos 1`] = `
       class="c1 "
     >
       <div
-        class="c2 FormField__FormFieldContentBox-sc-m9hood-1"
+        class="c2 "
       >
         <div
           class="c3"
@@ -2709,7 +2709,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 1`] =
         Select Size
       </label>
       <div
-        class="c3 FormField__FormFieldContentBox-sc-m9hood-1"
+        class="c3 "
       >
         <button
           aria-expanded="false"
@@ -2773,7 +2773,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 1`] =
         CheckBox
       </label>
       <div
-        class="c12 FormField__FormFieldContentBox-sc-m9hood-1"
+        class="c12 "
       >
         <label
           class="c13"
@@ -2819,7 +2819,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 1`] =
         RadioButtonGroup
       </label>
       <div
-        class="c12 FormField__FormFieldContentBox-sc-m9hood-1"
+        class="c12 "
       >
         <div
           class="c19"
@@ -2947,7 +2947,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
         Select Size
       </label>
       <div
-        class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1"
+        class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1 dTkVKT"
       >
         <button
           aria-expanded="false"
@@ -3011,7 +3011,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
         CheckBox
       </label>
       <div
-        class="StyledBox-sc-13pk1d4-0 itXtYk FormField__FormFieldContentBox-sc-m9hood-1"
+        class="StyledBox-sc-13pk1d4-0 itXtYk FormField__FormFieldContentBox-sc-m9hood-1 dTkVKT"
       >
         <label
           class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 fmiiKd"
@@ -3046,7 +3046,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
         RadioButtonGroup
       </label>
       <div
-        class="StyledBox-sc-13pk1d4-0 itXtYk FormField__FormFieldContentBox-sc-m9hood-1"
+        class="StyledBox-sc-13pk1d4-0 itXtYk FormField__FormFieldContentBox-sc-m9hood-1 dTkVKT"
       >
         <div
           class="StyledBox-sc-13pk1d4-0 iIwYtW"
@@ -3315,7 +3315,7 @@ exports[`Form uncontrolled uncontrolled 1`] = `
       class="c1 "
     >
       <div
-        class="c2 FormField__FormFieldContentBox-sc-m9hood-1"
+        class="c2 "
       >
         <div
           class="c3"
@@ -3348,7 +3348,7 @@ exports[`Form uncontrolled uncontrolled 2`] = `
       class="StyledBox-sc-13pk1d4-0 ipOUDz FormField__FormFieldBox-sc-m9hood-0 ikMUUn"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1"
+        class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1 dTkVKT"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kihEXm"
@@ -3381,7 +3381,7 @@ exports[`Form uncontrolled uncontrolled 3`] = `
       class="StyledBox-sc-13pk1d4-0 ipOUDz FormField__FormFieldBox-sc-m9hood-0 ikMUUn"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1"
+        class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1 dTkVKT"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kihEXm"
@@ -3573,7 +3573,7 @@ exports[`Form uncontrolled uncontrolled onValidate 1`] = `
       class="c1 "
     >
       <div
-        class="c2 FormField__FormFieldContentBox-sc-m9hood-1"
+        class="c2 "
       >
         <div
           class="c3"
@@ -3606,7 +3606,7 @@ exports[`Form uncontrolled uncontrolled onValidate 2`] = `
       class="StyledBox-sc-13pk1d4-0 ipOUDz FormField__FormFieldBox-sc-m9hood-0 ikMUUn"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 dRCTHV FormField__FormFieldContentBox-sc-m9hood-1"
+        class="StyledBox-sc-13pk1d4-0 dRCTHV FormField__FormFieldContentBox-sc-m9hood-1 dTkVKT"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kihEXm"
@@ -3825,7 +3825,7 @@ exports[`Form uncontrolled uncontrolled onValidate custom error 1`] = `
       class="c1 "
     >
       <div
-        class="c2 FormField__FormFieldContentBox-sc-m9hood-1"
+        class="c2 "
       >
         <div
           class="c3"
@@ -3858,7 +3858,7 @@ exports[`Form uncontrolled uncontrolled onValidate custom error 2`] = `
       class="StyledBox-sc-13pk1d4-0 ipOUDz FormField__FormFieldBox-sc-m9hood-0 ikMUUn"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 dRCTHV FormField__FormFieldContentBox-sc-m9hood-1"
+        class="StyledBox-sc-13pk1d4-0 dRCTHV FormField__FormFieldContentBox-sc-m9hood-1 dTkVKT"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kihEXm"
@@ -4077,7 +4077,7 @@ exports[`Form uncontrolled uncontrolled onValidate custom info 1`] = `
       class="c1 "
     >
       <div
-        class="c2 FormField__FormFieldContentBox-sc-m9hood-1"
+        class="c2 "
       >
         <div
           class="c3"
@@ -4110,7 +4110,7 @@ exports[`Form uncontrolled uncontrolled onValidate custom info 2`] = `
       class="StyledBox-sc-13pk1d4-0 ipOUDz FormField__FormFieldBox-sc-m9hood-0 ikMUUn"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1"
+        class="StyledBox-sc-13pk1d4-0 jkOlet FormField__FormFieldContentBox-sc-m9hood-1 dTkVKT"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kihEXm"
@@ -4325,7 +4325,7 @@ exports[`Form uncontrolled update 1`] = `
       class="c1 "
     >
       <div
-        class="c2 FormField__FormFieldContentBox-sc-m9hood-1"
+        class="c2 "
       >
         <div
           class="c3"
@@ -4343,7 +4343,7 @@ exports[`Form uncontrolled update 1`] = `
       class="c1 "
     >
       <div
-        class="c2 FormField__FormFieldContentBox-sc-m9hood-1"
+        class="c2 "
       >
         <div
           class="c3"
@@ -4606,7 +4606,7 @@ exports[`Form uncontrolled with field 1`] = `
       class="c1 "
     >
       <div
-        class="c2 FormField__FormFieldContentBox-sc-m9hood-1"
+        class="c2 "
       >
         <div
           class="c3"

--- a/src/js/components/FormField/FormField.js
+++ b/src/js/components/FormField/FormField.js
@@ -349,7 +349,8 @@ const FormField = forwardRef(
     Children.forEach(children, (child) => {
       if (child && child.type) {
         childName = child.type.displayName;
-        if (childName?.length > 1)
+        // camelCase component name to match theme object key
+        if (childName?.length > 0)
           childName = childName.charAt(0).toLowerCase() + childName.slice(1);
       }
     });

--- a/src/js/components/FormField/FormField.js
+++ b/src/js/components/FormField/FormField.js
@@ -68,6 +68,15 @@ const FormFieldBox = styled(Box)`
 
 const FormFieldContentBox = styled(Box)`
   ${(props) => props.focus && focusStyle({ justBorder: true })}
+  ${(props) =>
+    props.theme.formField &&
+    props.theme.formField[props?.componentName]?.container?.extend}
+`;
+
+const StyledContentsBox = styled(Box)`
+  ${(props) =>
+    props.theme.formField &&
+    props.theme.formField[props?.componentName]?.container?.extend}
 `;
 
 const StyledMessageContainer = styled(Box)`
@@ -336,11 +345,26 @@ const FormField = forwardRef(
       isFileInputComponent = true;
     }
 
+    let childName;
+    Children.forEach(children, (child) => {
+      if (child && child.type) {
+        childName = child.type.displayName;
+        if (childName?.length > 1)
+          childName = childName.charAt(0).toLowerCase() + childName.slice(1);
+      }
+    });
+
     if (!themeBorder) {
       contents = (
-        <Box {...themeContentProps} {...contentProps}>
+        <StyledContentsBox
+          disabledProp={disabled}
+          error={error}
+          componentName={childName}
+          {...themeContentProps}
+          {...contentProps}
+        >
           {contents}
-        </Box>
+        </StyledContentsBox>
       );
     }
 
@@ -435,6 +459,9 @@ const FormField = forwardRef(
           : {};
       contents = (
         <FormFieldContentBox
+          disabledProp={disabled}
+          error={error}
+          componentName={childName}
           {...themeContentProps}
           {...innerProps}
           {...contentProps}

--- a/src/js/components/FormField/__tests__/FormField-test.tsx
+++ b/src/js/components/FormField/__tests__/FormField-test.tsx
@@ -4,7 +4,7 @@ import 'jest-axe/extend-expect';
 import 'jest-styled-components';
 import React from 'react';
 import 'regenerator-runtime/runtime';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import { Alert, New, StatusInfo } from 'grommet-icons';
 import { FormField } from '..';
@@ -627,6 +627,29 @@ describe('FormField', () => {
         <FormField label="Label">
           <TextInput />
           {false && <Text>foobar</Text>}
+        </FormField>
+      </Grommet>,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test('Custom theme TextInput FormField container', () => {
+    const { container } = render(
+      <Grommet
+        theme={{
+          formField: {
+            textInput: {
+              container: {
+                extend: (props: any) => css`
+                  color: ${props['href'] ? 'green' : 'red'};
+                `,
+              },
+            },
+          },
+        }}
+      >
+        <FormField disabled label="Label">
+          <TextInput />
         </FormField>
       </Grommet>,
     );

--- a/src/js/components/FormField/__tests__/FormField-test.tsx
+++ b/src/js/components/FormField/__tests__/FormField-test.tsx
@@ -641,7 +641,7 @@ describe('FormField', () => {
             textInput: {
               container: {
                 extend: (props: any) => css`
-                  color: ${props['href'] ? 'green' : 'red'};
+                  color: ${props['disabledProp'] ? 'green' : 'red'};
                 `,
               },
             },

--- a/src/js/components/FormField/__tests__/__snapshots__/FormField-test.tsx.snap
+++ b/src/js/components/FormField/__tests__/__snapshots__/FormField-test.tsx.snap
@@ -1,5 +1,139 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`FormField Custom theme TextInput FormField container 1`] = `
+.c1 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-bottom: 12px;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.c3 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  background-color: rgba(204, 204, 204, 0.4);
+  color: #444444;
+  border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.c2 {
+  margin-left: 12px;
+  margin-right: 12px;
+  margin-top: 6px;
+  margin-bottom: 6px;
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c6 {
+  box-sizing: border-box;
+  font-size: inherit;
+  font-family: inherit;
+  border: none;
+  -webkit-appearance: none;
+  background: transparent;
+  color: inherit;
+  width: 100%;
+  padding: 11px;
+  font-weight: 600;
+  margin: 0;
+  border: 1px solid rgba(0, 0, 0, 0.33);
+  border-radius: 4px;
+  outline: none;
+  border: none;
+}
+
+.c6::-webkit-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c6::-moz-placeholder {
+  color: #AAAAAA;
+}
+
+.c6:-ms-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c6 ::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+.c6::-moz-focus-inner {
+  border: none;
+  outline: none;
+}
+
+.c6:-moz-placeholder,
+.c6::-moz-placeholder {
+  opacity: 1;
+}
+
+.c5 {
+  position: relative;
+  width: 100%;
+}
+
+.c4 {
+  color: red;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+@media only screen and (max-width: 768px) {
+  .c1 {
+    margin-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c3 {
+    border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  }
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1 "
+  >
+    <label
+      class="c2"
+    >
+      Label
+    </label>
+    <div
+      class="c3 c4"
+    >
+      <div
+        class="c5"
+      >
+        <input
+          autocomplete="off"
+          class="c6"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`FormField Field with null as child 1`] = `
 .c1 {
   display: flex;

--- a/src/js/components/FormField/__tests__/__snapshots__/FormField-test.tsx.snap
+++ b/src/js/components/FormField/__tests__/__snapshots__/FormField-test.tsx.snap
@@ -113,7 +113,7 @@ exports[`FormField Field with null as child 1`] = `
       Label
     </label>
     <div
-      class="c3 FormField__FormFieldContentBox-sc-m9hood-1"
+      class="c3 "
     >
       <div
         class="c4"
@@ -178,7 +178,7 @@ exports[`FormField abut 1`] = `
     class="c1 "
   >
     <div
-      class="c2 FormField__FormFieldContentBox-sc-m9hood-1"
+      class="c2 "
     />
   </div>
 </div>
@@ -234,7 +234,7 @@ exports[`FormField abut with margin 1`] = `
     class="c1 "
   >
     <div
-      class="c2 FormField__FormFieldContentBox-sc-m9hood-1"
+      class="c2 "
     />
   </div>
 </div>
@@ -403,7 +403,7 @@ exports[`FormField checkbox pad is defined in formfield 1`] = `
         label
       </label>
       <div
-        class="c3 FormField__FormFieldContentBox-sc-m9hood-1"
+        class="c3 "
       >
         <label
           class="c4"
@@ -554,7 +554,7 @@ exports[`FormField contentProps 1`] = `
         label
       </label>
       <div
-        class="c3 FormField__FormFieldContentBox-sc-m9hood-1"
+        class="c3 "
       >
         <div
           class="c4"
@@ -768,7 +768,7 @@ exports[`FormField custom error and info icon and container 1`] = `
         label
       </label>
       <div
-        class="c3 FormField__FormFieldContentBox-sc-m9hood-1"
+        class="c3 "
       >
         <div
           class="c4"
@@ -781,7 +781,7 @@ exports[`FormField custom error and info icon and container 1`] = `
         </div>
       </div>
       <div
-        class="c6 FormField__StyledMessageContainer-sc-m9hood-2"
+        class="c6 FormField__StyledMessageContainer-sc-m9hood-3"
       >
         <div
           class="c7"
@@ -806,7 +806,7 @@ exports[`FormField custom error and info icon and container 1`] = `
         </span>
       </div>
       <div
-        class="c10 FormField__StyledMessageContainer-sc-m9hood-2"
+        class="c10 FormField__StyledMessageContainer-sc-m9hood-3"
       >
         <div
           class="c7"
@@ -889,7 +889,7 @@ exports[`FormField custom formfield 1`] = `
     class="c1 c2"
   >
     <div
-      class="c3 FormField__FormFieldContentBox-sc-m9hood-1"
+      class="c3 "
     />
   </div>
 </div>
@@ -1018,7 +1018,7 @@ exports[`FormField custom input margin 1`] = `
         label
       </label>
       <div
-        class="c3 FormField__FormFieldContentBox-sc-m9hood-1"
+        class="c3 "
       >
         <div
           class="c4"
@@ -1147,7 +1147,7 @@ exports[`FormField custom label 1`] = `
         label
       </label>
       <div
-        class="c3 FormField__FormFieldContentBox-sc-m9hood-1"
+        class="c3 "
       >
         <div
           class="c4"
@@ -1262,14 +1262,14 @@ exports[`FormField default 1`] = `
     class="c1 "
   >
     <div
-      class="c2 FormField__FormFieldContentBox-sc-m9hood-1"
+      class="c2 "
     />
   </div>
   <div
     class="c1 "
   >
     <div
-      class="c2 FormField__FormFieldContentBox-sc-m9hood-1"
+      class="c2 "
     >
       <div
         class="c3"
@@ -1321,7 +1321,7 @@ exports[`FormField default outside grommet wrapper 1`] = `
   class="c0 "
 >
   <div
-    class="c1 FormField__FormFieldContentBox-sc-m9hood-1"
+    class="c1 "
   />
 </div>
 `;
@@ -1429,7 +1429,7 @@ exports[`FormField disabled 1`] = `
     class="c1 "
   >
     <div
-      class="c2 FormField__FormFieldContentBox-sc-m9hood-1"
+      class="c2 "
     />
   </div>
    
@@ -1438,7 +1438,7 @@ exports[`FormField disabled 1`] = `
       class="c1 "
     >
       <div
-        class="c2 FormField__FormFieldContentBox-sc-m9hood-1"
+        class="c2 "
       >
         <div
           class="c3"
@@ -1593,7 +1593,7 @@ exports[`FormField disabled with custom label for help and info 1`] = `
         Text to help the user know what is possible
       </span>
       <div
-        class="c4 FormField__FormFieldContentBox-sc-m9hood-1"
+        class="c4 "
       >
         <div
           class="c5"
@@ -1667,7 +1667,7 @@ exports[`FormField empty margin 1`] = `
     class="c1 "
   >
     <div
-      class="c2 FormField__FormFieldContentBox-sc-m9hood-1"
+      class="c2 "
     />
   </div>
 </div>
@@ -1733,7 +1733,7 @@ exports[`FormField error 1`] = `
     class="c1 "
   >
     <div
-      class="c2 FormField__FormFieldContentBox-sc-m9hood-1"
+      class="c2 "
     />
     <span
       class="c3"
@@ -1806,7 +1806,7 @@ exports[`FormField help 1`] = `
       test help
     </span>
     <div
-      class="c3 FormField__FormFieldContentBox-sc-m9hood-1"
+      class="c3 "
     />
   </div>
 </div>
@@ -1862,7 +1862,7 @@ exports[`FormField htmlFor 1`] = `
     class="c1 "
   >
     <div
-      class="c2 FormField__FormFieldContentBox-sc-m9hood-1"
+      class="c2 "
     />
   </div>
 </div>
@@ -1928,7 +1928,7 @@ exports[`FormField info 1`] = `
     class="c1 "
   >
     <div
-      class="c2 FormField__FormFieldContentBox-sc-m9hood-1"
+      class="c2 "
     />
     <span
       class="c3"
@@ -2026,7 +2026,7 @@ exports[`FormField info and help label colors 1`] = `
       Text to help the user know what is possible
     </span>
     <div
-      class="c4 FormField__FormFieldContentBox-sc-m9hood-1"
+      class="c4 "
     />
     <span
       class="c5"
@@ -2101,7 +2101,7 @@ exports[`FormField label 1`] = `
       test label
     </label>
     <div
-      class="c3 FormField__FormFieldContentBox-sc-m9hood-1"
+      class="c3 "
     />
   </div>
 </div>
@@ -2157,7 +2157,7 @@ exports[`FormField margin 1`] = `
     class="c1 "
   >
     <div
-      class="c2 FormField__FormFieldContentBox-sc-m9hood-1"
+      class="c2 "
     />
   </div>
 </div>
@@ -2278,7 +2278,7 @@ exports[`FormField max and threshold validation 1`] = `
         label
       </label>
       <div
-        class="c3 FormField__FormFieldContentBox-sc-m9hood-1"
+        class="c3 "
       >
         <div
           class="c4"
@@ -2354,7 +2354,7 @@ exports[`FormField pad 1`] = `
     class="c1 "
   >
     <div
-      class="c2 FormField__FormFieldContentBox-sc-m9hood-1"
+      class="c2 "
     />
   </div>
 </div>
@@ -2474,7 +2474,7 @@ exports[`FormField pad with border undefined 1`] = `
         label
       </label>
       <div
-        class="c3"
+        class="c3 FormField__StyledContentsBox-sc-m9hood-2"
       >
         <div
           class="c4"
@@ -2589,7 +2589,7 @@ exports[`FormField required 1`] = `
     class="c1 "
   >
     <div
-      class="c2 FormField__FormFieldContentBox-sc-m9hood-1"
+      class="c2 "
     />
   </div>
    
@@ -2598,7 +2598,7 @@ exports[`FormField required 1`] = `
       class="c1 "
     >
       <div
-        class="c2 FormField__FormFieldContentBox-sc-m9hood-1"
+        class="c2 "
       >
         <div
           class="c3"
@@ -2664,7 +2664,7 @@ exports[`FormField should have no accessibility violations 1`] = `
     class="c1 "
   >
     <div
-      class="c2 FormField__FormFieldContentBox-sc-m9hood-1"
+      class="c2 "
     />
   </div>
 </div>
@@ -2784,7 +2784,7 @@ exports[`FormField should not render asterisk when required.indicator === false 
         label
       </label>
       <div
-        class="c3 FormField__FormFieldContentBox-sc-m9hood-1"
+        class="c3 "
       >
         <div
           class="c4"
@@ -2947,7 +2947,7 @@ exports[`FormField should render asterisk when requiredIndicator === true 1`] = 
         </span>
       </label>
       <div
-        class="c6 FormField__FormFieldContentBox-sc-m9hood-1"
+        class="c6 "
       >
         <div
           class="c7"
@@ -3122,7 +3122,7 @@ exports[`FormField should render custom indicator when requiredIndicator is
         </svg>
       </label>
       <div
-        class="c4 FormField__FormFieldContentBox-sc-m9hood-1"
+        class="c4 "
       >
         <div
           class="c5"

--- a/src/js/components/FormField/__tests__/__snapshots__/FormField-test.tsx.snap
+++ b/src/js/components/FormField/__tests__/__snapshots__/FormField-test.tsx.snap
@@ -82,7 +82,7 @@ exports[`FormField Custom theme TextInput FormField container 1`] = `
 }
 
 .c4 {
-  color: red;
+  color: green;
 }
 
 .c0 {

--- a/src/js/components/StarRating/__tests__/__snapshots__/StarRating-tests.tsx.snap
+++ b/src/js/components/StarRating/__tests__/__snapshots__/StarRating-tests.tsx.snap
@@ -1392,7 +1392,7 @@ exports[`StarRating value for rating 1`] = `
         test-starRating
       </label>
       <div
-        class="c3 FormField__FormFieldContentBox-sc-m9hood-1"
+        class="c3 "
       >
         <div
           class="c4"

--- a/src/js/components/ThumbsRating/__tests__/__snapshots__/ThumbsRating.tsx.snap
+++ b/src/js/components/ThumbsRating/__tests__/__snapshots__/ThumbsRating.tsx.snap
@@ -774,7 +774,7 @@ exports[`ThumbsRating value for thumbs 1`] = `
         test-starRating
       </label>
       <div
-        class="c3 FormField__FormFieldContentBox-sc-m9hood-1"
+        class="c3 "
       >
         <div
           class="c4"

--- a/src/js/components/Toolbar/__tests__/__snapshots__/Toolbar-test.js.snap
+++ b/src/js/components/Toolbar/__tests__/__snapshots__/Toolbar-test.js.snap
@@ -473,7 +473,7 @@ exports[`DataFilters renders 1`] = `
                   name
                 </label>
                 <div
-                  class="c13 FormField__FormFieldContentBox-sc-m9hood-1"
+                  class="c13 "
                 >
                   <div
                     class="c3 StyledCheckBoxGroup-sc-2nhc5d-0"
@@ -995,7 +995,7 @@ exports[`DataFilters renders outside grommet wrapper 1`] = `
                 name
               </label>
               <div
-                class="c12 FormField__FormFieldContentBox-sc-m9hood-1"
+                class="c12 "
               >
                 <div
                   class="c2 StyledCheckBoxGroup-sc-2nhc5d-0"

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -916,7 +916,6 @@ export interface ThemeType {
     round?: RoundType;
   };
   formField?: {
-    // TODO add TS type
     border?: BorderType & {
       error?: {
         color?: ColorType;
@@ -927,6 +926,9 @@ export interface ThemeType {
       pad?: PadType;
     };
     checkBox?: {
+      container?: {
+        extend?: ExtendType;
+      };
       pad?: PadType;
     };
     disabled?: {
@@ -981,6 +983,71 @@ export interface ThemeType {
         margin?: MarginType;
         size?: string;
         color?: ColorType;
+      };
+    };
+    checkBoxGroup?: {
+      container?: {
+        extend?: ExtendType;
+      };
+    };
+    textArea?: {
+      container?: {
+        extend?: ExtendType;
+      };
+    };
+    textInput?: {
+      container?: {
+        extend?: ExtendType;
+      };
+    };
+    select?: {
+      container?: {
+        extend?: ExtendType;
+      };
+    };
+    maskedInput?: {
+      container?: {
+        extend?: ExtendType;
+      };
+    };
+    selectMultiple?: {
+      container?: {
+        extend?: ExtendType;
+      };
+    };
+    dateInput?: {
+      container?: {
+        extend?: ExtendType;
+      };
+    };
+    fileInput?: {
+      container?: {
+        extend?: ExtendType;
+      };
+    };
+    radioButton?: {
+      container?: {
+        extend?: ExtendType;
+      };
+    };
+    radioButtonGroup?: {
+      container?: {
+        extend?: ExtendType;
+      };
+    };
+    rangeSelector?: {
+      container?: {
+        extend?: ExtendType;
+      };
+    };
+    starRating?: {
+      container?: {
+        extend?: ExtendType;
+      };
+    };
+    thumbsRating?: {
+      container?: {
+        extend?: ExtendType;
       };
     };
   };

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -282,6 +282,12 @@ type DigitalTexts =
   | 'xxlarge'
   | string;
 
+type ContainerExtend = {
+  container?: {
+    extend?: ExtendType;
+  };
+};
+
 export interface ThemeType {
   global?: {
     active?: {
@@ -925,12 +931,6 @@ export interface ThemeType {
       margin?: MarginType;
       pad?: PadType;
     };
-    checkBox?: {
-      container?: {
-        extend?: ExtendType;
-      };
-      pad?: PadType;
-    };
     disabled?: {
       background?: BackgroundType;
       border?: {
@@ -985,71 +985,20 @@ export interface ThemeType {
         color?: ColorType;
       };
     };
-    checkBoxGroup?: {
-      container?: {
-        extend?: ExtendType;
-      };
-    };
-    textArea?: {
-      container?: {
-        extend?: ExtendType;
-      };
-    };
-    textInput?: {
-      container?: {
-        extend?: ExtendType;
-      };
-    };
-    select?: {
-      container?: {
-        extend?: ExtendType;
-      };
-    };
-    maskedInput?: {
-      container?: {
-        extend?: ExtendType;
-      };
-    };
-    selectMultiple?: {
-      container?: {
-        extend?: ExtendType;
-      };
-    };
-    dateInput?: {
-      container?: {
-        extend?: ExtendType;
-      };
-    };
-    fileInput?: {
-      container?: {
-        extend?: ExtendType;
-      };
-    };
-    radioButton?: {
-      container?: {
-        extend?: ExtendType;
-      };
-    };
-    radioButtonGroup?: {
-      container?: {
-        extend?: ExtendType;
-      };
-    };
-    rangeSelector?: {
-      container?: {
-        extend?: ExtendType;
-      };
-    };
-    starRating?: {
-      container?: {
-        extend?: ExtendType;
-      };
-    };
-    thumbsRating?: {
-      container?: {
-        extend?: ExtendType;
-      };
-    };
+    checkBox?: ContainerExtend & { pad?: PadType };
+    checkBoxGroup?: ContainerExtend;
+    textArea?: ContainerExtend;
+    textInput?: ContainerExtend;
+    select?: ContainerExtend;
+    maskedInput?: ContainerExtend;
+    selectMultiple?: ContainerExtend;
+    dateInput?: ContainerExtend;
+    fileInput?: ContainerExtend;
+    radioButton?: ContainerExtend;
+    radioButtonGroup?: ContainerExtend;
+    rangeSelector?: ContainerExtend;
+    starRating?: ContainerExtend;
+    thumbsRating?: ContainerExtend;
   };
   grommet?: {
     extend?: ExtendType;

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -916,6 +916,7 @@ export interface ThemeType {
     round?: RoundType;
   };
   formField?: {
+    // TODO add TS type
     border?: BorderType & {
       error?: {
         color?: ColorType;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1006,6 +1006,11 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       // extend: undefined,
     },
     formField: {
+      // [inputname]: {
+      //  container: {
+      //    extend: undefined,
+      //   }
+      // }
       border: {
         color: 'border',
         error: {


### PR DESCRIPTION
#### What does this PR do?
Adds an extend to the FormField container to style it differently based on the kind of child element (TextInput, TextArea, etc.).

Marking as a draft because I need to add the TS types and a jest test

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes https://github.com/grommet/grommet/issues/7495

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Yes
#### Should this PR be mentioned in the release notes?
Yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible