### PR TITLE
Add theme.global.radius and theme.global.breakpoint[size].radius

### DIFF
--- a/src/js/components/Box/__tests__/Box-test.tsx
+++ b/src/js/components/Box/__tests__/Box-test.tsx
@@ -96,4 +96,28 @@ describe('Box', () => {
     expect(getByLabelText('test-2')).toBeTruthy();
     expect(container).toMatchSnapshot();
   });
+
+  test('custom theme radius', () => {
+    const customTheme = {
+      global: {
+        radius: {
+          small: '4px',
+          medium: '7px',
+        },
+      },
+    };
+    const { getByText, asFragment } = render(
+      <Grommet theme={customTheme}>
+        <Box round="small">Small rounding</Box>
+        <Box round="medium">Medium rounding</Box>
+      </Grommet>,
+    );
+    expect(asFragment()).toMatchSnapshot();
+    const small = getByText('Small rounding');
+    const medium = getByText('Medium rounding');
+    let style = window.getComputedStyle(small);
+    expect(style.borderRadius).toBe('4px');
+    style = window.getComputedStyle(medium);
+    expect(style.borderRadius).toBe('7px');
+  });
 });

--- a/src/js/components/Box/__tests__/__snapshots__/Box-test.tsx.snap
+++ b/src/js/components/Box/__tests__/__snapshots__/Box-test.tsx.snap
@@ -87,6 +87,67 @@ exports[`Box as string 1`] = `
 </div>
 `;
 
+exports[`Box custom theme radius 1`] = `
+<DocumentFragment>
+  .c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  border-radius: 4px;
+}
+
+.c2 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  border-radius: 7px;
+}
+
+@media only screen and (max-width: 768px) {
+  .c1 {
+    border-radius: 4px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    border-radius: 7px;
+  }
+}
+
+<div
+    class="c0"
+  >
+    <div
+      class="c1"
+    >
+      Small rounding
+    </div>
+    <div
+      class="c2"
+    >
+      Medium rounding
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`Box default 1`] = `
 .c0 {
   font-size: 18px;

--- a/src/js/components/Layer/StyledLayer.js
+++ b/src/js/components/Layer/StyledLayer.js
@@ -618,7 +618,9 @@ const POSITIONS = {
 const roundStyle = (data, theme, position, margin) => {
   const styles = [];
   const size = data === true ? 'medium' : data;
-  const round = theme.global.edgeSize[size] || size;
+  // fallback to edgeSize for backwards compatibility
+  const round =
+    theme.global[theme.global.radius ? 'radius' : 'edgeSize'][size] || size;
   // if user provides CSS string such as '50px 12px', apply that always
   const customCSS = round.split(' ').length > 1;
 

--- a/src/js/components/Meter/StyledMeter.js
+++ b/src/js/components/Meter/StyledMeter.js
@@ -2,8 +2,12 @@ import styled, { css } from 'styled-components';
 
 import { genericStyles, styledComponentsConfig } from '../../utils';
 
+// fallback to edgeSize for backwards compatibility
 const roundStyle = css`
-  border-radius: ${(props) => props.theme.global.edgeSize[props.round.size]};
+  border-radius: ${(props) =>
+    props.theme.global[props.theme.global.radius ? 'radius' : 'edgeSize'][
+      props.round.size
+    ]};
 `;
 
 // overflow: hidden is needed for ie11

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -314,18 +314,21 @@ export interface ThemeType {
         value?: number;
         borderSize?: BreakpointBorderSize;
         edgeSize?: BreakpointEdgeSize;
+        radius?: BreakpointEdgeSize;
         size?: BreakpointSize;
       };
       medium?: {
         value?: number;
         borderSize?: BreakpointBorderSize;
         edgeSize?: BreakpointEdgeSize;
+        radius?: BreakpointEdgeSize;
         size?: BreakpointSize;
       };
       large?: {
         value?: number;
         borderSize?: BreakpointBorderSize;
         edgeSize?: BreakpointEdgeSize;
+        radius?: BreakpointEdgeSize;
         size?: BreakpointSize;
       };
       [x: string]:
@@ -333,6 +336,7 @@ export interface ThemeType {
             value?: number;
             borderSize?: BreakpointBorderSize;
             edgeSize?: BreakpointEdgeSize;
+            radius?: BreakpointEdgeSize;
             size?: BreakpointSize;
           }
         | undefined;
@@ -460,6 +464,7 @@ export interface ThemeType {
       medium?: number;
       weak?: number;
     };
+    radius?: BreakpointEdgeSize;
     selected?: {
       background?: BackgroundType;
       color?: ColorType;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -188,6 +188,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
             large: `${baseSpacing}px`, // 24
             xlarge: `${baseSpacing * 2}px`, // 48
           },
+          // radius: {},
           size: {
             xxsmall: `${baseSpacing}px`, // 24
             xsmall: `${baseSpacing * 2}px`, // 48
@@ -328,6 +329,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         medium: 0.4,
         weak: 0.1,
       },
+      // radius: {},
       selected: {
         background: 'selected',
         color: 'white',

--- a/src/js/utils/responsive.js
+++ b/src/js/utils/responsive.js
@@ -32,6 +32,7 @@ export const getBreakpointStyle = (theme, breakpointSize) => {
     (breakpointSize && theme.global.breakpoints[breakpointSize]) || {};
   if (!breakpoint.edgeSize) breakpoint.edgeSize = theme.global.edgeSize;
   if (!breakpoint.borderSize) breakpoint.borderSize = theme.global.borderSize;
+  if (!breakpoint.radius) breakpoint.radius = theme.global.radius;
   if (!breakpoint.size) breakpoint.size = theme.global.size;
   return breakpoint;
 };

--- a/src/js/utils/styles.js
+++ b/src/js/utils/styles.js
@@ -700,17 +700,20 @@ const ROUND_MAP = {
 
 export const roundStyle = (data, responsive, theme) => {
   const breakpoint = getBreakpointStyle(theme, theme.box.responsiveBreakpoint);
+  // fallback to edgeSize for backwards compatibility
+  const radius = theme.global.radius ? 'radius' : 'edgeSize';
+
   const styles = [];
   if (typeof data === 'object') {
     const size =
       ROUND_MAP[data.size] ||
-      theme.global.edgeSize[data.size || 'medium'] ||
+      theme.global[radius][data.size || 'medium'] ||
       data.size;
     const responsiveSize =
       responsive &&
       breakpoint &&
-      breakpoint.edgeSize[data.size] &&
-      (breakpoint.edgeSize[data.size] || data.size);
+      breakpoint[radius]?.[data.size] &&
+      (breakpoint[radius][data.size] || data.size);
     if (data.corner === 'top') {
       styles.push(css`
         border-top-left-radius: ${size};
@@ -807,10 +810,10 @@ export const roundStyle = (data, responsive, theme) => {
   } else {
     const size = data === true ? 'medium' : data;
     styles.push(css`
-      border-radius: ${ROUND_MAP[size] || theme.global.edgeSize[size] || size};
+      border-radius: ${ROUND_MAP[size] || theme.global[radius][size] || size};
     `);
     const responsiveSize =
-      responsive && breakpoint && breakpoint.edgeSize[size];
+      responsive && breakpoint && breakpoint[radius]?.[size];
     if (responsiveSize) {
       styles.push(
         breakpointStyle(

--- a/src/js/utils/styles.js
+++ b/src/js/utils/styles.js
@@ -810,7 +810,7 @@ export const roundStyle = (data, responsive, theme) => {
   } else {
     const size = data === true ? 'medium' : data;
     styles.push(css`
-      border-radius: ${ROUND_MAP[size] || theme.global[radius][size] || size};
+      border-radius: ${ROUND_MAP[size] || theme.global[radius]?.[size] || size};
     `);
     const responsiveSize =
       responsive && breakpoint && breakpoint[radius]?.[size];


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Adds `theme.global.radius` and `theme.global.breakpoint[size].radius` to allow for radius values to be styled independently from "edgeSize" (which controls gap, margin, pad).

Adjusts logic to fallback to "edgeSize" if theme.global.radius is not provided.

#### Where should the reviewer start?
Add theme.global.radius and theme.global.breakpoint[size].radius

#### What testing has been done on this PR?
Locally by modifying base theme.

#### How should this be manually tested?
```
theme: {
   global: {
      breakpoint: {
        small: {
            radius: {
              small: '2px',
            },
         },
      },
     radius: {
         small: '38px',
     },
}
```
#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [x] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [x] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Yes.

#### Should this PR be mentioned in the release notes?
Yes.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.