### PR TITLE
Update grommet-icons dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@emotion/is-prop-valid": "^1.3.1",
-    "grommet-icons": "^4.12.2",
+    "grommet-icons": "^4.12.3",
     "hoist-non-react-statics": "^3.3.2",
     "markdown-to-jsx": "7.4.4",
     "prop-types": "^15.8.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11381,14 +11381,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"grommet-icons@npm:^4.12.2":
-  version: 4.12.2
-  resolution: "grommet-icons@npm:4.12.2"
+"grommet-icons@npm:^4.12.3":
+  version: 4.12.3
+  resolution: "grommet-icons@npm:4.12.3"
   peerDependencies:
     react: ^16.6.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.6.0 || ^17.0.0 || ^18.0.0
     styled-components: ">= 5.x"
-  checksum: 10c0/8de2f3212adda21aa9b1ff1c19422067bea74df807d71d8138eb508bec209e50796b4ff60c5c4c57e02695cee75bacb0a74a563df3c65e9abdc31ebd543b8f6a
+  checksum: 10c0/ccc48ba741dab1681b7c7cde1c227e1ed766c2269fde3abed5b619208d7bcaeb6e7bf61280d188ad4df50f4cc8288fe9a18ab4815323b988cfb371071a8a793d
   languageName: node
   linkType: hard
 
@@ -11465,7 +11465,7 @@ __metadata:
     eslint-plugin-react-hooks: "npm:5.0.0"
     eslint-plugin-testing-library: "npm:^6.4.0"
     fs-extra: "npm:^11.3.0"
-    grommet-icons: "npm:^4.12.2"
+    grommet-icons: "npm:^4.12.3"
     grommet-theme-hpe: "npm:^5.7.0"
     hoist-non-react-statics: "npm:^3.3.2"
     jest: "npm:^29.7.0"


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Updates grommet-icons dependency.

#### Where should the reviewer start?

#### What testing has been done on this PR?

Tested locally with "rem" based text theme, Notification close icon applies padding as expected.
<img width="1370" alt="Screenshot 2025-01-31 at 2 39 50 PM" src="https://github.com/user-attachments/assets/93ae3506-ffb4-4dc7-9e49-a63858f5986f" />
<img width="1004" alt="Screenshot 2025-01-31 at 2 39 43 PM" src="https://github.com/user-attachments/assets/c0b9bea6-dc57-4283-9890-81a7d1266ede" />


#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
