### PR TITLE
Make remove buttons disabled when the input is disabled

### DIFF
--- a/src/js/components/FileInput/FileInput.js
+++ b/src/js/components/FileInput/FileInput.js
@@ -398,6 +398,7 @@ const FileInput = forwardRef(
                   })}
                   icon={<RemoveIcon />}
                   hoverIndicator
+                  disabled={disabled}
                   onClick={(event) => {
                     if (confirmRemove) {
                       event.persist(); // necessary for when React < v17
@@ -493,6 +494,7 @@ const FileInput = forwardRef(
                     })} ${file.name}`}
                     icon={<RemoveIcon />}
                     hoverIndicator
+                    disabled={disabled}
                     onClick={(event) => {
                       if (confirmRemove) {
                         event.persist(); // necessary for when React < v17


### PR DESCRIPTION

#### What does this PR do?
Makes the X remove file(s) buttons (which are right next to the browse buttons) disabled when the fileinput is disabled. The way they are rendered they don't prevent their click handlers even though they appear disabled.

The browser buttons get appropriately disabled already.

Note this is not the individual X icons next to file names when you have multiple files in the input. Those already get properly disabled.


#### Where should the reviewer start?
FileInput.js

#### What testing has been done on this PR?
storybook and custom example

#### How should this be manually tested?
Create a custom example that allows you to disable the FileInput after adding files to it then attempt to click the X button after the input is disabled. See the related issue.
 
#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Fixes #7511 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Yes

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible