### PR TITLE
Add no array index as a key comments

### DIFF
--- a/src/js/components/Menu/Menu.js
+++ b/src/js/components/Menu/Menu.js
@@ -322,6 +322,8 @@ const Menu = forwardRef((props, ref) => {
 
     // if we have a child, turn on plain, and hoverIndicator
     return (
+      // lint isn't flagging this but we shouldn't use index as a key
+      // see no-array-index-key lint rule
       <Box key={index} flex={false} role="none">
         <Button
           ref={(r) => {

--- a/src/js/components/Select/SelectContainer.js
+++ b/src/js/components/Select/SelectContainer.js
@@ -451,6 +451,8 @@ const SelectContainer = forwardRef(
                   // if we have a child, turn on plain, and hoverIndicator
                   return (
                     <SelectOption
+                      // lint isn't flagging this but we shouldn't use index
+                      // as a key see no-array-index-key lint rule
                       key={index}
                       // merge optionRef and activeRef
                       ref={(node) => {

--- a/src/js/components/SelectMultiple/SelectMultipleContainer.js
+++ b/src/js/components/SelectMultiple/SelectMultipleContainer.js
@@ -574,6 +574,8 @@ const SelectMultipleContainer = forwardRef(
                           optionLabel,
                         },
                       })}
+                      // lint isn't flagging this but we shouldn't use index
+                      // as a key see no-array-index-key lint rule
                       key={index}
                       // merge optionRef and activeRef
                       ref={(node) => {


### PR DESCRIPTION
#### What does this PR do?
In [this eslint upgrade PR](https://github.com/grommet/grommet/pull/7508) I removed comments that were disabling a lint rule in places where the rule wasn't being triggered. There were a few places I removed `eslint-disable-next-line react/no-array-index-key`. This PR adds comments to those places so we don't lose track of them even through they are not triggering eslint. See https://github.com/grommet/grommet/pull/7508/files#r1956535695 for more details.

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
