### PR TITLE
Fix #7531: Add focus-visible indicator to SelectMultiple options

### DIFF
--- a/src/js/components/Data/__tests__/__snapshots__/Data-test.tsx.snap
+++ b/src/js/components/Data/__tests__/__snapshots__/Data-test.tsx.snap
@@ -4052,6 +4052,14 @@ exports[`Data should render property label and return property value to view whe
   width: 100%;
 }
 
+.c19:focus-visible {
+  outline: 2px solid #2684ff;
+  outline-offset: -2px;
+  box-shadow: 0 0 0 2px #2684ff;
+  z-index: 1;
+  position: relative;
+}
+
 .c14 {
   cursor: pointer;
 }

--- a/src/js/components/DataSort/__tests__/__snapshots__/DataSort-test.tsx.snap
+++ b/src/js/components/DataSort/__tests__/__snapshots__/DataSort-test.tsx.snap
@@ -293,6 +293,14 @@ exports[`DataSort properties 1`] = `
   width: 100%;
 }
 
+.c2:focus-visible {
+  outline: 2px solid #2684ff;
+  outline-offset: -2px;
+  box-shadow: 0 0 0 2px #2684ff;
+  z-index: 1;
+  position: relative;
+}
+
 @media only screen and (max-width: 768px) {
 
 }

--- a/src/js/components/Select/StyledSelect.js
+++ b/src/js/components/Select/StyledSelect.js
@@ -69,6 +69,19 @@ export const SelectOption = styled(Button)`
         props.theme,
       )}
   }
+
+  // Add distinct focus indicator to ensure accessibility for keyboard
+  // navigation
+  // The outline and box-shadow are added to clearly highlight the option
+  // when focused
+  &:focus-visible {
+    outline: 2px solid #2684ff;
+    outline-offset: -2px;
+    box-shadow: 0 0 0 2px #2684ff;
+    z-index: 1;
+    position: relative;
+  }
+
   display: block;
   width: 100%;
   ${(props) => props[`aria-disabled`] && `cursor: default`};

--- a/src/js/components/Select/__tests__/__snapshots__/Select-multiple-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-multiple-test.js.snap
@@ -922,9 +922,25 @@ exports[`Select Controlled multiple onChange toggle with valueKey reduce 2`] = `
   width: 100%;
 }
 
+.c6:focus-visible {
+  outline: 2px solid #2684ff;
+  outline-offset: -2px;
+  box-shadow: 0 0 0 2px #2684ff;
+  z-index: 1;
+  position: relative;
+}
+
 .c10 {
   display: block;
   width: 100%;
+}
+
+.c10:focus-visible {
+  outline: 2px solid #2684ff;
+  outline-offset: -2px;
+  box-shadow: 0 0 0 2px #2684ff;
+  z-index: 1;
+  position: relative;
 }
 
 @media only screen and (max-width: 768px) {
@@ -1398,6 +1414,14 @@ exports[`Select Controlled multiple onChange with valueKey reduce 2`] = `
   width: 100%;
 }
 
+.c6:focus-visible {
+  outline: 2px solid #2684ff;
+  outline-offset: -2px;
+  box-shadow: 0 0 0 2px #2684ff;
+  z-index: 1;
+  position: relative;
+}
+
 @media only screen and (max-width: 768px) {
 
 }
@@ -1867,6 +1891,14 @@ exports[`Select Controlled multiple onChange with valueKey string 2`] = `
 .c6 {
   display: block;
   width: 100%;
+}
+
+.c6:focus-visible {
+  outline: 2px solid #2684ff;
+  outline-offset: -2px;
+  box-shadow: 0 0 0 2px #2684ff;
+  z-index: 1;
+  position: relative;
 }
 
 @media only screen and (max-width: 768px) {
@@ -2342,6 +2374,14 @@ exports[`Select Controlled multiple onChange without labelKey 2`] = `
   width: 100%;
 }
 
+.c6:focus-visible {
+  outline: 2px solid #2684ff;
+  outline-offset: -2px;
+  box-shadow: 0 0 0 2px #2684ff;
+  z-index: 1;
+  position: relative;
+}
+
 @media only screen and (max-width: 768px) {
 
 }
@@ -2459,7 +2499,7 @@ exports[`Select Controlled multiple onChange without labelKey 4`] = `
         aria-posinset="1"
         aria-selected="true"
         aria-setsize="2"
-        class="StyledButton-sc-323bzc-0 hBoYZH StyledSelect__SelectOption-sc-znp66n-3 cEPbDl"
+        class="StyledButton-sc-323bzc-0 hBoYZH StyledSelect__SelectOption-sc-znp66n-3 iwKylE"
         role="option"
         tabindex="0"
         type="button"
@@ -2478,7 +2518,7 @@ exports[`Select Controlled multiple onChange without labelKey 4`] = `
         aria-posinset="2"
         aria-selected="false"
         aria-setsize="2"
-        class="StyledButton-sc-323bzc-0 eKvjSA StyledSelect__SelectOption-sc-znp66n-3 iqnnfQ"
+        class="StyledButton-sc-323bzc-0 eKvjSA StyledSelect__SelectOption-sc-znp66n-3 bXFxDh"
         role="option"
         tabindex="-1"
         type="button"
@@ -2532,7 +2572,7 @@ exports[`Select Controlled multiple onChange without labelKey 6`] = `
         aria-posinset="1"
         aria-selected="true"
         aria-setsize="2"
-        class="StyledButton-sc-323bzc-0 hBoYZH StyledSelect__SelectOption-sc-znp66n-3 cEPbDl"
+        class="StyledButton-sc-323bzc-0 hBoYZH StyledSelect__SelectOption-sc-znp66n-3 iwKylE"
         role="option"
         tabindex="0"
         type="button"
@@ -2551,7 +2591,7 @@ exports[`Select Controlled multiple onChange without labelKey 6`] = `
         aria-posinset="2"
         aria-selected="true"
         aria-setsize="2"
-        class="StyledButton-sc-323bzc-0 hBoYZH StyledSelect__SelectOption-sc-znp66n-3 cEPbDl"
+        class="StyledButton-sc-323bzc-0 hBoYZH StyledSelect__SelectOption-sc-znp66n-3 iwKylE"
         role="option"
         tabindex="0"
         type="button"
@@ -3227,6 +3267,14 @@ exports[`Select Controlled multiple onChange without valueKey 2`] = `
   width: 100%;
 }
 
+.c6:focus-visible {
+  outline: 2px solid #2684ff;
+  outline-offset: -2px;
+  box-shadow: 0 0 0 2px #2684ff;
+  z-index: 1;
+  position: relative;
+}
+
 @media only screen and (max-width: 768px) {
 
 }
@@ -3344,7 +3392,7 @@ exports[`Select Controlled multiple onChange without valueKey 4`] = `
         aria-posinset="1"
         aria-selected="true"
         aria-setsize="2"
-        class="StyledButton-sc-323bzc-0 hBoYZH StyledSelect__SelectOption-sc-znp66n-3 cEPbDl"
+        class="StyledButton-sc-323bzc-0 hBoYZH StyledSelect__SelectOption-sc-znp66n-3 iwKylE"
         role="option"
         tabindex="0"
         type="button"
@@ -3363,7 +3411,7 @@ exports[`Select Controlled multiple onChange without valueKey 4`] = `
         aria-posinset="2"
         aria-selected="false"
         aria-setsize="2"
-        class="StyledButton-sc-323bzc-0 eKvjSA StyledSelect__SelectOption-sc-znp66n-3 iqnnfQ"
+        class="StyledButton-sc-323bzc-0 eKvjSA StyledSelect__SelectOption-sc-znp66n-3 bXFxDh"
         role="option"
         tabindex="-1"
         type="button"
@@ -3417,7 +3465,7 @@ exports[`Select Controlled multiple onChange without valueKey 6`] = `
         aria-posinset="1"
         aria-selected="true"
         aria-setsize="2"
-        class="StyledButton-sc-323bzc-0 hBoYZH StyledSelect__SelectOption-sc-znp66n-3 cEPbDl"
+        class="StyledButton-sc-323bzc-0 hBoYZH StyledSelect__SelectOption-sc-znp66n-3 iwKylE"
         role="option"
         tabindex="0"
         type="button"
@@ -3436,7 +3484,7 @@ exports[`Select Controlled multiple onChange without valueKey 6`] = `
         aria-posinset="2"
         aria-selected="true"
         aria-setsize="2"
-        class="StyledButton-sc-323bzc-0 hBoYZH StyledSelect__SelectOption-sc-znp66n-3 cEPbDl"
+        class="StyledButton-sc-323bzc-0 hBoYZH StyledSelect__SelectOption-sc-znp66n-3 iwKylE"
         role="option"
         tabindex="0"
         type="button"
@@ -4114,6 +4162,14 @@ exports[`Select Controlled multiple onChange without valueKey or labelKey 2`] = 
   width: 100%;
 }
 
+.c6:focus-visible {
+  outline: 2px solid #2684ff;
+  outline-offset: -2px;
+  box-shadow: 0 0 0 2px #2684ff;
+  z-index: 1;
+  position: relative;
+}
+
 @media only screen and (max-width: 768px) {
 
 }
@@ -4230,7 +4286,7 @@ exports[`Select Controlled multiple onChange without valueKey or labelKey 4`] = 
       <button
         aria-posinset="1"
         aria-setsize="2"
-        class="StyledButton-sc-323bzc-0 eKvjSA StyledSelect__SelectOption-sc-znp66n-3 iqnnfQ"
+        class="StyledButton-sc-323bzc-0 eKvjSA StyledSelect__SelectOption-sc-znp66n-3 bXFxDh"
         role="option"
         tabindex="-1"
         type="button"
@@ -4248,7 +4304,7 @@ exports[`Select Controlled multiple onChange without valueKey or labelKey 4`] = 
       <button
         aria-posinset="2"
         aria-setsize="2"
-        class="StyledButton-sc-323bzc-0 eKvjSA StyledSelect__SelectOption-sc-znp66n-3 iqnnfQ"
+        class="StyledButton-sc-323bzc-0 eKvjSA StyledSelect__SelectOption-sc-znp66n-3 bXFxDh"
         role="option"
         tabindex="-1"
         type="button"
@@ -4301,7 +4357,7 @@ exports[`Select Controlled multiple onChange without valueKey or labelKey 6`] = 
       <button
         aria-posinset="1"
         aria-setsize="2"
-        class="StyledButton-sc-323bzc-0 eKvjSA StyledSelect__SelectOption-sc-znp66n-3 iqnnfQ"
+        class="StyledButton-sc-323bzc-0 eKvjSA StyledSelect__SelectOption-sc-znp66n-3 bXFxDh"
         role="option"
         tabindex="-1"
         type="button"
@@ -4319,7 +4375,7 @@ exports[`Select Controlled multiple onChange without valueKey or labelKey 6`] = 
       <button
         aria-posinset="2"
         aria-setsize="2"
-        class="StyledButton-sc-323bzc-0 eKvjSA StyledSelect__SelectOption-sc-znp66n-3 iqnnfQ"
+        class="StyledButton-sc-323bzc-0 eKvjSA StyledSelect__SelectOption-sc-znp66n-3 bXFxDh"
         role="option"
         tabindex="-1"
         type="button"
@@ -5053,6 +5109,14 @@ exports[`Select Controlled multiple values 3`] = `
   width: 100%;
 }
 
+.c6:focus-visible {
+  outline: 2px solid #2684ff;
+  outline-offset: -2px;
+  box-shadow: 0 0 0 2px #2684ff;
+  z-index: 1;
+  position: relative;
+}
+
 @media only screen and (max-width: 768px) {
 
 }
@@ -5522,6 +5586,14 @@ exports[`Select Controlled multiple with empty results 2`] = `
 .c6 {
   display: block;
   width: 100%;
+}
+
+.c6:focus-visible {
+  outline: 2px solid #2684ff;
+  outline-offset: -2px;
+  box-shadow: 0 0 0 2px #2684ff;
+  z-index: 1;
+  position: relative;
 }
 
 @media only screen and (max-width: 768px) {

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -472,11 +472,27 @@ exports[`Select Clear option renders - bottom 1`] = `
   width: 100%;
 }
 
+.c10:focus-visible {
+  outline: 2px solid #2684ff;
+  outline-offset: -2px;
+  box-shadow: 0 0 0 2px #2684ff;
+  z-index: 1;
+  position: relative;
+}
+
 .c6 {
   background-color: #7D4CDB;
   color: #FFFFFF;
   display: block;
   width: 100%;
+}
+
+.c6:focus-visible {
+  outline: 2px solid #2684ff;
+  outline-offset: -2px;
+  box-shadow: 0 0 0 2px #2684ff;
+  z-index: 1;
+  position: relative;
 }
 
 .c13:focus {
@@ -721,6 +737,14 @@ exports[`Select Clear option renders correct label when wrapped in FormField 1`]
   width: 100%;
 }
 
+.c6:focus-visible {
+  outline: 2px solid #2684ff;
+  outline-offset: -2px;
+  box-shadow: 0 0 0 2px #2684ff;
+  z-index: 1;
+  position: relative;
+}
+
 @media only screen and (max-width: 768px) {
 
 }
@@ -943,6 +967,14 @@ exports[`Select Clear option renders custom label 1`] = `
 .c6 {
   display: block;
   width: 100%;
+}
+
+.c6:focus-visible {
+  outline: 2px solid #2684ff;
+  outline-offset: -2px;
+  box-shadow: 0 0 0 2px #2684ff;
+  z-index: 1;
+  position: relative;
 }
 
 @media only screen and (max-width: 768px) {
@@ -1255,11 +1287,27 @@ exports[`Select Clear option renders- top 1`] = `
   width: 100%;
 }
 
+.c14:focus-visible {
+  outline: 2px solid #2684ff;
+  outline-offset: -2px;
+  box-shadow: 0 0 0 2px #2684ff;
+  z-index: 1;
+  position: relative;
+}
+
 .c10 {
   background-color: #7D4CDB;
   color: #FFFFFF;
   display: block;
   width: 100%;
+}
+
+.c10:focus-visible {
+  outline: 2px solid #2684ff;
+  outline-offset: -2px;
+  box-shadow: 0 0 0 2px #2684ff;
+  z-index: 1;
+  position: relative;
 }
 
 .c5:focus {
@@ -2327,6 +2375,14 @@ exports[`Select applies custom global.hover theme to options 2`] = `
   color: #7D4CDB;
 }
 
+.c1:focus-visible {
+  outline: 2px solid #2684ff;
+  outline-offset: -2px;
+  box-shadow: 0 0 0 2px #2684ff;
+  z-index: 1;
+  position: relative;
+}
+
 @media only screen and (max-width: 768px) {
 
 }
@@ -3275,6 +3331,14 @@ exports[`Select complex options and children 3`] = `
   width: 100%;
 }
 
+.c6:focus-visible {
+  outline: 2px solid #2684ff;
+  outline-offset: -2px;
+  box-shadow: 0 0 0 2px #2684ff;
+  z-index: 1;
+  position: relative;
+}
+
 @media only screen and (max-width: 768px) {
 
 }
@@ -4092,11 +4156,27 @@ exports[`Select default value clear 1`] = `
   width: 100%;
 }
 
+.c10:focus-visible {
+  outline: 2px solid #2684ff;
+  outline-offset: -2px;
+  box-shadow: 0 0 0 2px #2684ff;
+  z-index: 1;
+  position: relative;
+}
+
 .c14 {
   background-color: #7D4CDB;
   color: #FFFFFF;
   display: block;
   width: 100%;
+}
+
+.c14:focus-visible {
+  outline: 2px solid #2684ff;
+  outline-offset: -2px;
+  box-shadow: 0 0 0 2px #2684ff;
+  z-index: 1;
+  position: relative;
 }
 
 .c5:focus {
@@ -5203,9 +5283,25 @@ exports[`Select disabled key 2`] = `
   cursor: default;
 }
 
+.c6:focus-visible {
+  outline: 2px solid #2684ff;
+  outline-offset: -2px;
+  box-shadow: 0 0 0 2px #2684ff;
+  z-index: 1;
+  position: relative;
+}
+
 .c10 {
   display: block;
   width: 100%;
+}
+
+.c10:focus-visible {
+  outline: 2px solid #2684ff;
+  outline-offset: -2px;
+  box-shadow: 0 0 0 2px #2684ff;
+  z-index: 1;
+  position: relative;
 }
 
 @media only screen and (max-width: 768px) {
@@ -5466,9 +5562,25 @@ exports[`Select disabled option value 1`] = `
   cursor: default;
 }
 
+.c6:focus-visible {
+  outline: 2px solid #2684ff;
+  outline-offset: -2px;
+  box-shadow: 0 0 0 2px #2684ff;
+  z-index: 1;
+  position: relative;
+}
+
 .c10 {
   display: block;
   width: 100%;
+}
+
+.c10:focus-visible {
+  outline: 2px solid #2684ff;
+  outline-offset: -2px;
+  box-shadow: 0 0 0 2px #2684ff;
+  z-index: 1;
+  position: relative;
 }
 
 @media only screen and (max-width: 768px) {
@@ -6052,6 +6164,14 @@ exports[`Select large drop container height 1`] = `
   width: 100%;
 }
 
+.c6:focus-visible {
+  outline: 2px solid #2684ff;
+  outline-offset: -2px;
+  box-shadow: 0 0 0 2px #2684ff;
+  z-index: 1;
+  position: relative;
+}
+
 @media only screen and (max-width: 768px) {
 
 }
@@ -6257,6 +6377,14 @@ exports[`Select medium drop container height 1`] = `
 .c6 {
   display: block;
   width: 100%;
+}
+
+.c6:focus-visible {
+  outline: 2px solid #2684ff;
+  outline-offset: -2px;
+  box-shadow: 0 0 0 2px #2684ff;
+  z-index: 1;
+  position: relative;
 }
 
 @media only screen and (max-width: 768px) {
@@ -7234,6 +7362,14 @@ exports[`Select onChange with valueKey object 2`] = `
   width: 100%;
 }
 
+.c6:focus-visible {
+  outline: 2px solid #2684ff;
+  outline-offset: -2px;
+  box-shadow: 0 0 0 2px #2684ff;
+  z-index: 1;
+  position: relative;
+}
+
 @media only screen and (max-width: 768px) {
 
 }
@@ -7972,6 +8108,14 @@ exports[`Select onChange with valueKey string 2`] = `
   width: 100%;
 }
 
+.c6:focus-visible {
+  outline: 2px solid #2684ff;
+  outline-offset: -2px;
+  box-shadow: 0 0 0 2px #2684ff;
+  z-index: 1;
+  position: relative;
+}
+
 @media only screen and (max-width: 768px) {
 
 }
@@ -8655,6 +8799,14 @@ exports[`Select onChange with valueLabel 2`] = `
   width: 100%;
 }
 
+.c6:focus-visible {
+  outline: 2px solid #2684ff;
+  outline-offset: -2px;
+  box-shadow: 0 0 0 2px #2684ff;
+  z-index: 1;
+  position: relative;
+}
+
 @media only screen and (max-width: 768px) {
 
 }
@@ -9125,6 +9277,14 @@ exports[`Select onChange without labelKey 2`] = `
 .c6 {
   display: block;
   width: 100%;
+}
+
+.c6:focus-visible {
+  outline: 2px solid #2684ff;
+  outline-offset: -2px;
+  box-shadow: 0 0 0 2px #2684ff;
+  z-index: 1;
+  position: relative;
 }
 
 @media only screen and (max-width: 768px) {
@@ -9865,6 +10025,14 @@ exports[`Select onChange without labelKey or valueKey 2`] = `
   width: 100%;
 }
 
+.c6:focus-visible {
+  outline: 2px solid #2684ff;
+  outline-offset: -2px;
+  box-shadow: 0 0 0 2px #2684ff;
+  z-index: 1;
+  position: relative;
+}
+
 @media only screen and (max-width: 768px) {
 
 }
@@ -10601,6 +10769,14 @@ exports[`Select onChange without valueKey 2`] = `
 .c6 {
   display: block;
   width: 100%;
+}
+
+.c6:focus-visible {
+  outline: 2px solid #2684ff;
+  outline-offset: -2px;
+  box-shadow: 0 0 0 2px #2684ff;
+  z-index: 1;
+  position: relative;
 }
 
 @media only screen and (max-width: 768px) {
@@ -11916,6 +12092,14 @@ exports[`Select prop: onOpen 3`] = `
   width: 100%;
 }
 
+.c6:focus-visible {
+  outline: 2px solid #2684ff;
+  outline-offset: -2px;
+  box-shadow: 0 0 0 2px #2684ff;
+  z-index: 1;
+  position: relative;
+}
+
 @media only screen and (max-width: 768px) {
 
 }
@@ -12020,7 +12204,7 @@ exports[`Select prop: onOpen 5`] = `
     aria-posinset="1"
     aria-selected="false"
     aria-setsize="2"
-    class="StyledButton-sc-323bzc-0 eKvjSA StyledSelect__SelectOption-sc-znp66n-3 iqnnfQ"
+    class="StyledButton-sc-323bzc-0 eKvjSA StyledSelect__SelectOption-sc-znp66n-3 bXFxDh"
     role="option"
     tabindex="-1"
     type="button"
@@ -12039,7 +12223,7 @@ exports[`Select prop: onOpen 5`] = `
     aria-posinset="2"
     aria-selected="false"
     aria-setsize="2"
-    class="StyledButton-sc-323bzc-0 eKvjSA StyledSelect__SelectOption-sc-znp66n-3 iqnnfQ"
+    class="StyledButton-sc-323bzc-0 eKvjSA StyledSelect__SelectOption-sc-znp66n-3 bXFxDh"
     role="option"
     tabindex="-1"
     type="button"
@@ -12536,11 +12720,27 @@ exports[`Select renders custom clear selection styling 2`] = `
   width: 100%;
 }
 
+.c10:focus-visible {
+  outline: 2px solid #2684ff;
+  outline-offset: -2px;
+  box-shadow: 0 0 0 2px #2684ff;
+  z-index: 1;
+  position: relative;
+}
+
 .c14 {
   background-color: #7D4CDB;
   color: #FFFFFF;
   display: block;
   width: 100%;
+}
+
+.c14:focus-visible {
+  outline: 2px solid #2684ff;
+  outline-offset: -2px;
+  box-shadow: 0 0 0 2px #2684ff;
+  z-index: 1;
+  position: relative;
 }
 
 .c5:focus {
@@ -13111,11 +13311,27 @@ exports[`Select renders custom listbox styling 1`] = `
   width: 100%;
 }
 
+.c6:focus-visible {
+  outline: 2px solid #2684ff;
+  outline-offset: -2px;
+  box-shadow: 0 0 0 2px #2684ff;
+  z-index: 1;
+  position: relative;
+}
+
 .c10 {
   background-color: #7D4CDB;
   color: #FFFFFF;
   display: block;
   width: 100%;
+}
+
+.c10:focus-visible {
+  outline: 2px solid #2684ff;
+  outline-offset: -2px;
+  box-shadow: 0 0 0 2px #2684ff;
+  z-index: 1;
+  position: relative;
 }
 
 @media only screen and (max-width: 768px) {
@@ -15381,11 +15597,27 @@ exports[`Select search 2`] = `
   width: 100%;
 }
 
+.c9:focus-visible {
+  outline: 2px solid #2684ff;
+  outline-offset: -2px;
+  box-shadow: 0 0 0 2px #2684ff;
+  z-index: 1;
+  position: relative;
+}
+
 .c13 {
   background-color: #7D4CDB;
   color: #FFFFFF;
   display: block;
   width: 100%;
+}
+
+.c13:focus-visible {
+  outline: 2px solid #2684ff;
+  outline-offset: -2px;
+  box-shadow: 0 0 0 2px #2684ff;
+  z-index: 1;
+  position: relative;
 }
 
 @media only screen and (max-width: 768px) {
@@ -15974,6 +16206,14 @@ exports[`Select search and select 2`] = `
 .c9 {
   display: block;
   width: 100%;
+}
+
+.c9:focus-visible {
+  outline: 2px solid #2684ff;
+  outline-offset: -2px;
+  box-shadow: 0 0 0 2px #2684ff;
+  z-index: 1;
+  position: relative;
 }
 
 @media only screen and (max-width: 768px) {
@@ -19062,6 +19302,14 @@ exports[`Select small drop container height 1`] = `
 .c6 {
   display: block;
   width: 100%;
+}
+
+.c6:focus-visible {
+  outline: 2px solid #2684ff;
+  outline-offset: -2px;
+  box-shadow: 0 0 0 2px #2684ff;
+  z-index: 1;
+  position: relative;
 }
 
 @media only screen and (max-width: 768px) {

--- a/src/js/components/SelectMultiple/__tests__/__snapshots__/SelectMultiple-test.tsx.snap
+++ b/src/js/components/SelectMultiple/__tests__/__snapshots__/SelectMultiple-test.tsx.snap
@@ -3335,6 +3335,14 @@ exports[`SelectMultiple showSelectionInline 1`] = `
   width: 100%;
 }
 
+.c13:focus-visible {
+  outline: 2px solid #2684ff;
+  outline-offset: -2px;
+  box-shadow: 0 0 0 2px #2684ff;
+  z-index: 1;
+  position: relative;
+}
+
 .c8 {
   cursor: pointer;
 }
@@ -3914,6 +3922,14 @@ exports[`SelectMultiple showSelectionInline with children 1`] = `
 .c13 {
   display: block;
   width: 100%;
+}
+
+.c13:focus-visible {
+  outline: 2px solid #2684ff;
+  outline-offset: -2px;
+  box-shadow: 0 0 0 2px #2684ff;
+  z-index: 1;
+  position: relative;
 }
 
 .c8 {
@@ -4519,6 +4535,14 @@ exports[`SelectMultiple showSelectionInline with disabled options 1`] = `
   cursor: default;
 }
 
+.c13:focus-visible {
+  outline: 2px solid #2684ff;
+  outline-offset: -2px;
+  box-shadow: 0 0 0 2px #2684ff;
+  z-index: 1;
+  position: relative;
+}
+
 .c8 {
   cursor: pointer;
 }
@@ -5018,6 +5042,14 @@ exports[`SelectMultiple valueKey and labelKey 1`] = `
 .c13 {
   display: block;
   width: 100%;
+}
+
+.c13:focus-visible {
+  outline: 2px solid #2684ff;
+  outline-offset: -2px;
+  box-shadow: 0 0 0 2px #2684ff;
+  z-index: 1;
+  position: relative;
 }
 
 .c8 {
@@ -6426,6 +6458,14 @@ exports[`SelectMultiple with portal renders custom listbox styling 1`] = `
 .c10 {
   display: block;
   width: 100%;
+}
+
+.c10:focus-visible {
+  outline: 2px solid #2684ff;
+  outline-offset: -2px;
+  box-shadow: 0 0 0 2px #2684ff;
+  z-index: 1;
+  position: relative;
 }
 
 .c11 {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->
#### What does this PR do?
Adds a focus-visible indicator to SelectOption components to improve keyboard navigation accessibility for SelectMultiple.

#### Where should the reviewer start?
src/js/components/Select/StyledSelect.js - check the added :focus-visible styling.

#### What testing has been done on this PR?
- Manual testing with keyboard navigation through SelectMultiple options
- All automated tests pass with updated snapshots

#### How should this be manually tested?
1. Open the Select or SelectMultiple component in storybook
2. Tab to focus on a SelectMultiple component
3. Open the dropdown and use keyboard navigation (arrow keys)
4. Verify that a distinct blue outline appears around options as you navigate

#### Do Jest tests follow these best practices?
- [x] `screen` is used for querying.
- [x] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [x] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
This enhancement improves keyboard accessibility for users who rely on visual focus indicators.

#### What are the relevant issues?
Fixes #7531

#### Screenshots 
<img width="331" alt="Screenshot 2025-03-11 at 9 01 22 AM" src="https://github.com/user-attachments/assets/2c79eff9-b01d-4d8c-abb9-a96d15fee418" />

<img width="332" alt="Screenshot 2025-03-11 at 9 00 59 AM" src="https://github.com/user-attachments/assets/fdce1f95-19ea-4b6d-a802-9ed80f437835" />

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Yes, as an accessibility improvement.

#### Is this change backwards compatible or is it a breaking change?
This change is fully backwards compatible.