### PR TITLE
Add test for FileInput disabled when a file is already uploaded

### DIFF
--- a/src/js/components/FileInput/__tests__/FileInput-test.tsx
+++ b/src/js/components/FileInput/__tests__/FileInput-test.tsx
@@ -4,6 +4,8 @@ import { render } from '@testing-library/react';
 
 import { Grommet } from '../../Grommet';
 import { FileInput } from '..';
+import { Form } from '../../Form';
+import { FormField } from '../../FormField';
 
 describe('FileInput', () => {
   test('basic', () => {
@@ -159,6 +161,32 @@ describe('FileInput', () => {
             max: 5,
           }}
         />
+      </Grommet>,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test('disabled with file selected', () => {
+    const exampleFile = { name: 'file-size-okay.csv', size: 15000 };
+    const Test = () => {
+      const [value, setValue] = React.useState({
+        fileInput: [exampleFile],
+      });
+      return (
+        <Form validate="change" value={value} onChange={setValue}>
+          <FormField
+            label="File input with max size"
+            htmlFor="fileInput"
+            name="fileInput"
+          >
+            <FileInput id="fileInput" name="fileInput" disabled />
+          </FormField>
+        </Form>
+      );
+    };
+    const { container } = render(
+      <Grommet>
+        <Test />
       </Grommet>,
     );
     expect(container.firstChild).toMatchSnapshot();

--- a/src/js/components/FileInput/__tests__/__snapshots__/FileInput-test.tsx.snap
+++ b/src/js/components/FileInput/__tests__/__snapshots__/FileInput-test.tsx.snap
@@ -1216,6 +1216,387 @@ exports[`FileInput disabled 1`] = `
 </div>
 `;
 
+exports[`FileInput disabled with file selected 1`] = `
+.c12 {
+  display: inline-block;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #666666;
+  stroke: #666666;
+}
+
+.c12 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c12 *:not([stroke])[fill='none'] {
+  stroke-width: 0;
+}
+
+.c12 *[stroke*='#'],
+.c12 *[STROKE*='#'] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c12 *[fill-rule],
+.c12 *[FILL-RULE],
+.c12 *[fill*='#'],
+.c12 *[FILL*='#'] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-bottom: 12px;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.c3 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border: dashed 2px rgba(0, 0, 0, 0.33);
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.c4 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: stretch;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  flex: 0 0 auto;
+  justify-content: center;
+}
+
+.c7 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  justify-content: space-between;
+}
+
+.c8 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin: 12px;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+}
+
+.c10 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  flex: 0 0 auto;
+}
+
+.c13 {
+  box-sizing: border-box;
+  display: inline-flex;
+  font-size: inherit;
+  line-height: inherit;
+  color: #7D4CDB;
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
+  margin: 12px;
+}
+
+.c13:hover {
+  text-decoration: underline;
+}
+
+.c2 {
+  margin-left: 12px;
+  margin-right: 12px;
+  margin-top: 6px;
+  margin-bottom: 6px;
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c9 {
+  font-size: 18px;
+  line-height: 24px;
+  white-space: nowrap;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 600;
+}
+
+.c11 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  opacity: 0.3;
+  cursor: default;
+  line-height: 0;
+  padding: 12px;
+}
+
+.c11:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus >circle,
+.c11:focus >ellipse,
+.c11:focus >line,
+.c11:focus >path,
+.c11:focus >polygon,
+.c11:focus >polyline,
+.c11:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c11:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c11:focus:not(:focus-visible) >circle,
+.c11:focus:not(:focus-visible) >ellipse,
+.c11:focus:not(:focus-visible) >line,
+.c11:focus:not(:focus-visible) >path,
+.c11:focus:not(:focus-visible) >polygon,
+.c11:focus:not(:focus-visible) >polyline,
+.c11:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c11:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c6 {
+  position: absolute;
+  height: 100%;
+  width: 100%;
+  box-sizing: border-box;
+  font-size: inherit;
+  font-family: inherit;
+  border: none;
+  -webkit-appearance: none;
+  background: transparent;
+  color: inherit;
+  width: 100%;
+  padding: 11px;
+  font-weight: 600;
+  margin: 0;
+  border: 1px solid rgba(0, 0, 0, 0.33);
+  border-radius: 4px;
+  font-size: 0;
+  opacity: 0;
+  border: none;
+  width: calc(100% - 24px);
+  right: 24px;
+}
+
+.c6::-webkit-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c6::-moz-placeholder {
+  color: #AAAAAA;
+}
+
+.c6:-ms-input-placeholder {
+  color: #AAAAAA;
+}
+
+.c6 ::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+.c6::-moz-focus-inner {
+  border: none;
+  outline: none;
+}
+
+.c6:-moz-placeholder,
+.c6::-moz-placeholder {
+  opacity: 1;
+}
+
+.c6::-moz-focus-inner {
+  border: none;
+  outline: none;
+}
+
+.c6::-webkit-file-upload-button {
+  cursor: pointer;
+}
+
+.c5 {
+  cursor: pointer;
+  position: relative;
+  opacity: 0.3;
+  cursor: default;
+  outline: none;
+  box-shadow: none;
+}
+
+.c5 >circle,
+.c5 >ellipse,
+.c5 >line,
+.c5 >path,
+.c5 >polygon,
+.c5 >polyline,
+.c5 >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c5 ::-moz-focus-inner {
+  border: 0;
+}
+
+@media only screen and (max-width: 768px) {
+  .c1 {
+    margin-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c3 {
+    border: dashed 2px rgba(0, 0, 0, 0.33);
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c8 {
+    margin: 6px;
+  }
+}
+
+<div
+  class="c0"
+>
+  <form>
+    <div
+      class="c1 "
+    >
+      <label
+        class="c2"
+        for="fileInput"
+      >
+        File input with max size
+      </label>
+      <div
+        class="c3 "
+      >
+        <div
+          class="c4 c5"
+          disabled=""
+        >
+          <input
+            class="c6"
+            disabled=""
+            id="fileInput"
+            name="fileInput"
+            type="file"
+          />
+          <div
+            class="c7"
+          >
+            <div
+              class="c8"
+            >
+              <span
+                class="c9 "
+              >
+                file-size-okay.csv
+              </span>
+            </div>
+            <div
+              class="c10"
+            >
+              <button
+                aria-label="remove file-size-okay.csv"
+                class="c11"
+                disabled=""
+                type="button"
+              >
+                <svg
+                  aria-label="FormClose"
+                  class="c12"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="m7 7 10 10M7 17 17 7"
+                    fill="none"
+                    stroke="#000"
+                    stroke-width="2"
+                  />
+                </svg>
+              </button>
+              <a
+                class="c13"
+                tabindex="-1"
+              >
+                browse
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </form>
+</div>
+`;
+
 exports[`FileInput margin 1`] = `
 .c0 {
   font-size: 18px;


### PR DESCRIPTION
#### What does this PR do?
Adds a test for the fix in https://github.com/grommet/grommet/pull/7512 to ensure the remove button is styled as disabled when the fileinput is disabled

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
backwards compatible