### PR TITLE
Fix css gap responsiveness

### DIFF
--- a/src/js/components/Box/StyledBox.js
+++ b/src/js/components/Box/StyledBox.js
@@ -201,24 +201,34 @@ const gapStyle = (directionProp, gap, responsive, wrap, theme) => {
 
   const styles = [];
   if (typeof gap === 'object') {
+    const responsiveColumnMetric =
+      responsive && breakpoint && breakpoint.edgeSize[gap.column];
+    const responsiveRowMetric =
+      responsive && breakpoint && breakpoint.edgeSize[gap.row];
     if (gap.row !== undefined && gap.column !== undefined) {
       styles.push(
         `gap: ${theme.global.edgeSize[gap.row] || gap.row} ${
           theme.global.edgeSize[gap.column] || gap.column
         };`,
       );
-      if (responsiveMetric) {
+      if (responsiveRowMetric || responsiveColumnMetric) {
         styles.push(
-          breakpointStyle(breakpoint, `gap: ${responsiveMetric};`, responsive),
+          breakpointStyle(
+            breakpoint,
+            `gap: ${responsiveRowMetric || gap.row} ${
+              responsiveColumnMetric || gap.column
+            };`,
+            responsive,
+          ),
         );
       }
     } else if (gap.row !== undefined) {
       styles.push(`row-gap: ${theme.global.edgeSize[gap.row] || gap.row};`);
-      if (responsiveMetric) {
+      if (responsiveRowMetric) {
         styles.push(
           breakpointStyle(
             breakpoint,
-            `row-gap: ${responsiveMetric};`,
+            `row-gap: ${responsiveRowMetric};`,
             responsive,
           ),
         );
@@ -227,11 +237,11 @@ const gapStyle = (directionProp, gap, responsive, wrap, theme) => {
       styles.push(
         `column-gap: ${theme.global.edgeSize[gap.column] || gap.column};`,
       );
-      if (responsiveMetric) {
+      if (responsiveColumnMetric) {
         styles.push(
           breakpointStyle(
             breakpoint,
-            `column-gap: ${responsiveMetric};`,
+            `column-gap: ${responsiveColumnMetric};`,
             responsive,
           ),
         );

--- a/src/js/components/Box/__tests__/__snapshots__/Box-layout-test.tsx.snap
+++ b/src/js/components/Box/__tests__/__snapshots__/Box-layout-test.tsx.snap
@@ -2501,6 +2501,12 @@ exports[`Box row and column gap 1`] = `
 }
 
 @media only screen and (max-width: 768px) {
+  .c1 {
+    gap: 48px 30px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
   .c3 {
     height: 6px;
   }

--- a/src/js/components/Pagination/__tests__/__snapshots__/Pagination-test.tsx.snap
+++ b/src/js/components/Pagination/__tests__/__snapshots__/Pagination-test.tsx.snap
@@ -1092,6 +1092,18 @@ exports[`Pagination should apply a select component with default values for step
 }
 
 @media only screen and (max-width: 768px) {
+  .c1 {
+    gap: 6px 3px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c3 {
+    gap: 6px 3px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
   .c11 {
     padding: 11px;
   }
@@ -1792,6 +1804,18 @@ exports[`Pagination should apply a text component with summary 1`] = `
   font-weight: bold;
   font-size: 18px;
   line-height: 0;
+}
+
+@media only screen and (max-width: 768px) {
+  .c1 {
+    gap: 6px 3px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c5 {
+    gap: 6px 3px;
+  }
 }
 
 @media only screen and (max-width: 768px) {
@@ -10312,6 +10336,18 @@ exports[`Pagination should have no items 1`] = `
   max-width: 100%;
   height: 36px;
   min-width: 36px;
+}
+
+@media only screen and (max-width: 768px) {
+  .c1 {
+    gap: 6px 3px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c5 {
+    gap: 6px 3px;
+  }
 }
 
 @media only screen and (max-width: 768px) {


### PR DESCRIPTION

#### What does this PR do?
This PR fixes Box gap's which have been specified as an object to correctly have `@media` or `@container` styles which modify the gap at the small breakpoint like it would for a non-object gap.

#### Where should the reviewer start?
StyledBox.js

#### What testing has been done on this PR?
Storybook

#### How should this be manually tested?
Storybook Layout/Box/Responsive Container

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Fixes #7543 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Yes

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible