### PR TITLE
add event listener to close tip on escape

### DIFF
--- a/src/js/components/Tip/Tip.js
+++ b/src/js/components/Tip/Tip.js
@@ -80,7 +80,6 @@ const Tip = forwardRef(
           onEsc={() => {
             setOver(false);
             setTooltipOver(false);
-            console.log('Escape key pressed');
           }}
         >
           <Drop

--- a/src/js/components/Tip/Tip.js
+++ b/src/js/components/Tip/Tip.js
@@ -21,6 +21,21 @@ const Tip = forwardRef(
 
     const componentRef = useForwardedRef(tipRef);
 
+    useEffect(() => {
+      const handleKeyDown = (event) => {
+        if (event.key === 'Escape') {
+          setOver(false);
+          setTooltipOver(false);
+        }
+      };
+
+      document.addEventListener('keydown', handleKeyDown);
+
+      return () => {
+        document.removeEventListener('keydown', handleKeyDown);
+      };
+    }, []);
+
     // Three use case for children
     // 1. Tip has a single child + it is a React Element => Great!
     // 2. Tip has a single child +  not React Element =>

--- a/src/js/components/Tip/Tip.js
+++ b/src/js/components/Tip/Tip.js
@@ -30,7 +30,6 @@ const Tip = forwardRef(
       };
 
       window.addEventListener('keydown', handleKeyDown);
-
       return () => {
         window.removeEventListener('keydown', handleKeyDown);
       };

--- a/src/js/components/Tip/Tip.js
+++ b/src/js/components/Tip/Tip.js
@@ -29,10 +29,10 @@ const Tip = forwardRef(
         }
       };
 
-      document.addEventListener('keydown', handleKeyDown);
+      window.addEventListener('keydown', handleKeyDown);
 
       return () => {
-        document.removeEventListener('keydown', handleKeyDown);
+        window.removeEventListener('keydown', handleKeyDown);
       };
     }, []);
 

--- a/src/js/components/Tip/Tip.js
+++ b/src/js/components/Tip/Tip.js
@@ -8,6 +8,7 @@ import React, {
 
 import { Box } from '../Box';
 import { Drop } from '../Drop';
+import { Keyboard } from '../Keyboard';
 import { useForwardedRef, useKeyboard } from '../../utils';
 import { TipPropTypes } from './propTypes';
 import { useThemeValue } from '../../utils/useThemeValue';
@@ -20,20 +21,6 @@ const Tip = forwardRef(
     const usingKeyboard = useKeyboard();
 
     const componentRef = useForwardedRef(tipRef);
-
-    useEffect(() => {
-      const handleKeyDown = (event) => {
-        if (event.key === 'Escape') {
-          setOver(false);
-          setTooltipOver(false);
-        }
-      };
-
-      window.addEventListener('keydown', handleKeyDown);
-      return () => {
-        window.removeEventListener('keydown', handleKeyDown);
-      };
-    }, []);
 
     // Three use case for children
     // 1. Tip has a single child + it is a React Element => Great!
@@ -88,17 +75,26 @@ const Tip = forwardRef(
     return [
       clonedChild,
       (over || tooltipOver) && (
-        <Drop
-          target={componentRef.current}
-          trapFocus={false}
-          key="tip-drop"
-          {...theme.tip.drop}
-          {...dropProps}
-          onMouseEnter={() => setTooltipOver(true)}
-          onMouseLeave={() => setTooltipOver(false)}
+        <Keyboard
+          key="tip-keyboard"
+          onEsc={() => {
+            setOver(false);
+            setTooltipOver(false);
+            console.log('Escape key pressed');
+          }}
         >
-          {plain ? content : <Box {...theme.tip.content}>{content}</Box>}
-        </Drop>
+          <Drop
+            target={componentRef.current}
+            trapFocus={false}
+            key="tip-drop"
+            {...theme.tip.drop}
+            {...dropProps}
+            onMouseEnter={() => setTooltipOver(true)}
+            onMouseLeave={() => setTooltipOver(false)}
+          >
+            {plain ? content : <Box {...theme.tip.content}>{content}</Box>}
+          </Drop>
+        </Keyboard>
       ),
     ];
   },

--- a/src/js/components/Tip/__tests__/Tip-test.tsx
+++ b/src/js/components/Tip/__tests__/Tip-test.tsx
@@ -218,22 +218,4 @@ describe('Tip', () => {
     const tooltip = await waitFor(() => screen.getByText('tooltip'));
     expect(tooltip?.parentNode?.parentNode).toMatchSnapshot();
   });
-
-  test('pressing Escape key closes tooltip', async () => {
-    const user = userEvent.setup();
-    render(
-      <Grommet>
-        <Tip content="tooltip text" defaultVisible>
-          <button>Hover me</button>
-        </Tip>
-      </Grommet>,
-    );
-    expect(screen.getByText('tooltip text')).toBeInTheDocument();
-
-    await user.keyboard('{Escape}');
-
-    await waitFor(() => {
-      expect(screen.queryByText('tooltip text')).not.toBeInTheDocument();
-    });
-  });
 });

--- a/src/js/components/Tip/__tests__/Tip-test.tsx
+++ b/src/js/components/Tip/__tests__/Tip-test.tsx
@@ -6,6 +6,7 @@ import 'jest-styled-components';
 import 'jest-axe/extend-expect';
 import 'regenerator-runtime/runtime';
 import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
 
 import { Box } from '../../Box';
 import { Button } from '../../Button';
@@ -216,5 +217,23 @@ describe('Tip', () => {
     fireEvent.mouseOver(getByText('Default Visible'));
     const tooltip = await waitFor(() => screen.getByText('tooltip'));
     expect(tooltip?.parentNode?.parentNode).toMatchSnapshot();
+  });
+
+  test('pressing Escape key closes tooltip', async () => {
+    const user = userEvent.setup();
+    render(
+      <Grommet>
+        <Tip content="tooltip text" defaultVisible>
+          <button>Hover me</button>
+        </Tip>
+      </Grommet>,
+    );
+    expect(screen.getByText('tooltip text')).toBeInTheDocument();
+
+    await user.keyboard('{Escape}');
+
+    await waitFor(() => {
+      expect(screen.queryByText('tooltip text')).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/js/components/Tip/__tests__/Tip-test.tsx
+++ b/src/js/components/Tip/__tests__/Tip-test.tsx
@@ -218,4 +218,32 @@ describe('Tip', () => {
     const tooltip = await waitFor(() => screen.getByText('tooltip'));
     expect(tooltip?.parentNode?.parentNode).toMatchSnapshot();
   });
+
+  test('pressing Escape key closes tooltip', async () => {
+    const user = userEvent.setup();
+    render(
+      <Grommet>
+        <Tip content="tooltip text">
+          <button>Hover me</button>
+        </Tip>
+      </Grommet>,
+    );
+
+    const button = screen.getByText('Hover me');
+    expect(button).toBeInTheDocument();
+
+    // Tab to the button
+    await user.tab();
+    expect(button).toHaveFocus();
+    await waitFor(() => {
+      expect(screen.queryByText('tooltip text')).toBeInTheDocument();
+    });
+
+    // pressing the Escape key
+    fireEvent.keyDown(document, { key: 'Escape', keyCode: 27 });
+
+    await waitFor(() => {
+      expect(screen.queryByText('tooltip text')).not.toBeInTheDocument();
+    });
+  });
 });


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR adds an event listener to the tooltip so that when a user clicks `escape` the tooltip will close
#### Where should the reviewer start?
tip.js
#### What testing has been done on this PR?
storybook
#### How should this be manually tested?
open storybook of any of the tip stories and open in a new window then hover over tip and press `escape`
#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
Tip is currently not passing these WCAG points for WCAG 1.4.13:

Dismissible
A [mechanism](https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html#dfn-mechanism) is available to dismiss the additional content without moving pointer hover or keyboard focus, unless the additional content communicates an [input error](https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html#dfn-input-error) or does not obscure or replace other content;
#### What are the relevant issues?
Part 1 of #7552 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible