### PR TITLE
add `imageProps` prop to `Avatar`

### DIFF
--- a/src/js/components/Avatar/Avatar.js
+++ b/src/js/components/Avatar/Avatar.js
@@ -11,6 +11,7 @@ const Avatar = ({
   align = 'center',
   children,
   height, // for warning check and discarding the value
+  imageProps,
   justify = 'center',
   round = 'full',
   size = 'medium',
@@ -61,7 +62,9 @@ const Avatar = ({
       </StyledAvatarText>
     );
   } else if (typeof src === 'string') {
-    content = <Image role="presentation" fit="contain" src={src} />;
+    content = (
+      <Image role="presentation" fit="contain" src={src} {...imageProps} />
+    );
   }
 
   if (typeof children === 'string' || typeof src === 'string') {

--- a/src/js/components/Avatar/index.d.ts
+++ b/src/js/components/Avatar/index.d.ts
@@ -1,9 +1,11 @@
 import * as React from 'react';
 import { BoxProps } from '../Box/index';
+import { ImageExtendedProps } from '../Image';
 
 export interface AvatarProps {
   size?: 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | string;
   src?: string;
+  imageProps?: ImageExtendedProps;
 }
 
 export interface AvatarExtendedProps

--- a/src/js/components/Avatar/propTypes.js
+++ b/src/js/components/Avatar/propTypes.js
@@ -18,6 +18,7 @@ if (process.env.NODE_ENV !== 'production') {
       PropTypes.string,
     ]),
     src: PropTypes.string,
+    imageProps: PropTypes.object,
   };
 }
 export const AvatarPropTypes = PropType;


### PR DESCRIPTION
#### What does this PR do?
adds the `imageProps` prop to `Avatar` to add missing props for the `Image` used internally by `Avatar`

#### Where should the reviewer start?
`Avatar.js`

#### What testing has been done on this PR?
manually tested with Storybook

#### How should this be manually tested?
Storybook

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
#6530
#### Screenshots (if appropriate)
![Screen Recording 2025-04-02 at 5 06 14 PM](https://github.com/user-attachments/assets/ace1b0dd-4ab9-42b7-b5ed-d6ef9b9005dd)
#### Do the grommet docs need to be updated?
Yes
#### Should this PR be mentioned in the release notes?
Yes
#### Is this change backwards compatible or is it a breaking change?
Backwards compatible