### PR TITLE
add aria-role for when defaultsuggestion is applied

### DIFF
--- a/src/js/components/Grommet/index.d.ts
+++ b/src/js/components/Grommet/index.d.ts
@@ -177,6 +177,7 @@ export interface GrommetProps {
         suggestionsCount?: string;
         suggestionsExist?: string;
         suggestionIsOpen?: string;
+        defaultSuggestion?: string;
       };
       video?: {
         audioDescriptions?: string;

--- a/src/js/components/Grommet/propTypes.js
+++ b/src/js/components/Grommet/propTypes.js
@@ -176,6 +176,7 @@ if (process.env.NODE_ENV !== 'production') {
           suggestionsCount: PropTypes.string,
           suggestionsExist: PropTypes.string,
           suggestionIsOpen: PropTypes.string,
+          defaultSuggestions: PropTypes.string,
         }),
         video: PropTypes.shape({
           audioDescriptions: PropTypes.string,

--- a/src/js/components/TextInput/TextInput.js
+++ b/src/js/components/TextInput/TextInput.js
@@ -363,7 +363,8 @@ const TextInput = forwardRef(
           <ContainerBox
             aria-label={
               defaultSuggestion !== undefined
-                ? 'Suggestions list for text input'
+                ? `combobox with suggestions type
+                 text to display a list of suggestions`
                 : undefined
             }
             id={id ? `listbox__${id}` : undefined}
@@ -408,11 +409,6 @@ const TextInput = forwardRef(
                       ref={itemRef}
                     >
                       <Button
-                        aria-label={
-                          defaultSuggestion !== undefined
-                            ? `You are on the default suggestion ${index + 1}`
-                            : undefined
-                        }
                         id={id ? `listbox-option-${index}__${id}` : undefined}
                         role="option"
                         aria-selected={selected ? 'true' : 'false'}

--- a/src/js/components/TextInput/TextInput.js
+++ b/src/js/components/TextInput/TextInput.js
@@ -363,8 +363,10 @@ const TextInput = forwardRef(
           <ContainerBox
             aria-label={
               defaultSuggestion !== undefined
-                ? `combobox with suggestions type
-                 text to display a list of suggestions`
+                ? format({
+                    id: 'textInput.defaultSuggestion',
+                    messages,
+                  })
                 : undefined
             }
             id={id ? `listbox__${id}` : undefined}

--- a/src/js/components/TextInput/TextInput.js
+++ b/src/js/components/TextInput/TextInput.js
@@ -362,7 +362,7 @@ const TextInput = forwardRef(
         >
           <ContainerBox
             aria-label={
-              defaultSuggestion !== -1
+              defaultSuggestion !== undefined
                 ? 'Suggestions list for text input'
                 : undefined
             }
@@ -409,7 +409,7 @@ const TextInput = forwardRef(
                     >
                       <Button
                         aria-label={
-                          defaultSuggestion !== -1
+                          defaultSuggestion !== undefined
                             ? `You are on the default suggestion ${index + 1}`
                             : undefined
                         }

--- a/src/js/components/TextInput/TextInput.js
+++ b/src/js/components/TextInput/TextInput.js
@@ -23,7 +23,6 @@ import {
   sizeStyle,
   useForwardedRef,
   useSizedIcon,
-  useKeyboard,
 } from '../../utils';
 
 import {
@@ -122,22 +121,6 @@ const TextInput = forwardRef(
 
     const [focus, setFocus] = useState();
     const [showDrop, setShowDrop] = useState(false);
-    const [arrowDownInitiated, setArrowDownInitiated] = useState(false);
-
-    const usingKeyboard = useKeyboard();
-    useEffect(() => {
-      const handleKeyDown = (event) => {
-        if (event.key === 'ArrowDown') {
-          setArrowDownInitiated(true);
-        }
-      };
-
-      document.addEventListener('keydown', handleKeyDown);
-
-      return () => {
-        document.removeEventListener('keydown', handleKeyDown);
-      };
-    }, []);
 
     const handleSuggestionSelect = useMemo(
       () => (onSelect && !onSuggestionSelect ? onSelect : onSuggestionSelect),
@@ -378,6 +361,11 @@ const TextInput = forwardRef(
           {...dropProps}
         >
           <ContainerBox
+            aria-label={
+              defaultSuggestion !== -1
+                ? 'Suggestions list for text input'
+                : undefined
+            }
             id={id ? `listbox__${id}` : undefined}
             role="listbox"
             overflow="auto"
@@ -420,6 +408,11 @@ const TextInput = forwardRef(
                       ref={itemRef}
                     >
                       <Button
+                        aria-label={
+                          defaultSuggestion !== -1
+                            ? `You are on the default suggestion ${index + 1}`
+                            : undefined
+                        }
                         id={id ? `listbox-option-${index}__${id}` : undefined}
                         role="option"
                         aria-selected={selected ? 'true' : 'false'}
@@ -478,14 +471,8 @@ const TextInput = forwardRef(
       if (showDrop && activeSuggestionIndex > -1) {
         activeOptionID = `listbox-option-${activeSuggestionIndex}__${id}`;
       }
-      // The moment aria-expanded=true, and aria-activedescendant is set
-      // (which happens when activeSuggestionIndex is not -1), VoiceOver:
-      // assumes the focus is within the listbox Skips past the text input
-      // we want to avoid this, so we set aria-activedescendant only when
-      // the user is using the keyboard to navigate the listbox.
       comboboxProps = {
-        'aria-activedescendant':
-          !usingKeyboard || arrowDownInitiated ? activeOptionID : undefined,
+        'aria-activedescendant': activeOptionID,
         'aria-autocomplete': 'list',
         'aria-expanded': showDrop ? 'true' : 'false',
         'aria-controls': showDrop ? `listbox__${id}` : undefined,

--- a/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.tsx.snap
+++ b/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.tsx.snap
@@ -431,7 +431,6 @@ exports[`TextInput calls onSuggestionsClose 2`] = `
   tabindex="-1"
 >
   <div
-    aria-label="Suggestions list for text input"
     class="c2 c3"
     id="listbox__item"
     role="listbox"
@@ -441,7 +440,6 @@ exports[`TextInput calls onSuggestionsClose 2`] = `
     >
       <li>
         <button
-          aria-label="You are on the default suggestion 1"
           aria-selected="false"
           class="c5"
           id="listbox-option-0__item"
@@ -457,7 +455,6 @@ exports[`TextInput calls onSuggestionsClose 2`] = `
       </li>
       <li>
         <button
-          aria-label="You are on the default suggestion 2"
           aria-selected="false"
           class="c5"
           id="listbox-option-1__item"
@@ -649,7 +646,6 @@ exports[`TextInput calls onSuggestionsOpen 1`] = `
   tabindex="-1"
 >
   <div
-    aria-label="Suggestions list for text input"
     class="c2 c3"
     id="listbox__item"
     role="listbox"
@@ -659,7 +655,6 @@ exports[`TextInput calls onSuggestionsOpen 1`] = `
     >
       <li>
         <button
-          aria-label="You are on the default suggestion 1"
           aria-selected="false"
           class="c5"
           id="listbox-option-0__item"
@@ -675,7 +670,6 @@ exports[`TextInput calls onSuggestionsOpen 1`] = `
       </li>
       <li>
         <button
-          aria-label="You are on the default suggestion 2"
           aria-selected="false"
           class="c5"
           id="listbox-option-1__item"
@@ -944,7 +938,6 @@ exports[`TextInput close suggestion drop 2`] = `
   tabindex="-1"
 >
   <div
-    aria-label="Suggestions list for text input"
     class="c2 c3"
     id="listbox__item"
     role="listbox"
@@ -954,7 +947,6 @@ exports[`TextInput close suggestion drop 2`] = `
     >
       <li>
         <button
-          aria-label="You are on the default suggestion 1"
           aria-selected="false"
           class="c5"
           id="listbox-option-0__item"
@@ -970,7 +962,6 @@ exports[`TextInput close suggestion drop 2`] = `
       </li>
       <li>
         <button
-          aria-label="You are on the default suggestion 2"
           aria-selected="false"
           class="c5"
           id="listbox-option-1__item"
@@ -1260,7 +1251,6 @@ exports[`TextInput complex suggestions 2`] = `
   tabindex="-1"
 >
   <div
-    aria-label="Suggestions list for text input"
     class="c2 c3"
     id="listbox__item"
     role="listbox"
@@ -1270,7 +1260,6 @@ exports[`TextInput complex suggestions 2`] = `
     >
       <li>
         <button
-          aria-label="You are on the default suggestion 1"
           aria-selected="false"
           class="c5"
           id="listbox-option-0__item"
@@ -1286,7 +1275,6 @@ exports[`TextInput complex suggestions 2`] = `
       </li>
       <li>
         <button
-          aria-label="You are on the default suggestion 2"
           aria-selected="false"
           class="c5"
           id="listbox-option-1__item"
@@ -2020,7 +2008,6 @@ exports[`TextInput large drop height 1`] = `
   tabindex="-1"
 >
   <div
-    aria-label="Suggestions list for text input"
     class="c2 c3"
     id="listbox__item"
     role="listbox"
@@ -2030,7 +2017,6 @@ exports[`TextInput large drop height 1`] = `
     >
       <li>
         <button
-          aria-label="You are on the default suggestion 1"
           aria-selected="false"
           class="c5"
           id="listbox-option-0__item"
@@ -2046,7 +2032,6 @@ exports[`TextInput large drop height 1`] = `
       </li>
       <li>
         <button
-          aria-label="You are on the default suggestion 2"
           aria-selected="false"
           class="c5"
           id="listbox-option-1__item"
@@ -2614,7 +2599,6 @@ exports[`TextInput medium drop height 1`] = `
   tabindex="-1"
 >
   <div
-    aria-label="Suggestions list for text input"
     class="c2 c3"
     id="listbox__item"
     role="listbox"
@@ -2624,7 +2608,6 @@ exports[`TextInput medium drop height 1`] = `
     >
       <li>
         <button
-          aria-label="You are on the default suggestion 1"
           aria-selected="false"
           class="c5"
           id="listbox-option-0__item"
@@ -2640,7 +2623,6 @@ exports[`TextInput medium drop height 1`] = `
       </li>
       <li>
         <button
-          aria-label="You are on the default suggestion 2"
           aria-selected="false"
           class="c5"
           id="listbox-option-1__item"
@@ -4418,7 +4400,6 @@ exports[`TextInput select suggestion 2`] = `
   tabindex="-1"
 >
   <div
-    aria-label="Suggestions list for text input"
     class="c2 c3"
     id="listbox__item"
     role="listbox"
@@ -4428,7 +4409,6 @@ exports[`TextInput select suggestion 2`] = `
     >
       <li>
         <button
-          aria-label="You are on the default suggestion 1"
           aria-selected="false"
           class="c5"
           id="listbox-option-0__item"
@@ -4444,7 +4424,6 @@ exports[`TextInput select suggestion 2`] = `
       </li>
       <li>
         <button
-          aria-label="You are on the default suggestion 2"
           aria-selected="false"
           class="c5"
           id="listbox-option-1__item"
@@ -5353,7 +5332,6 @@ exports[`TextInput small drop height 1`] = `
   tabindex="-1"
 >
   <div
-    aria-label="Suggestions list for text input"
     class="c2 c3"
     id="listbox__item"
     role="listbox"
@@ -5363,7 +5341,6 @@ exports[`TextInput small drop height 1`] = `
     >
       <li>
         <button
-          aria-label="You are on the default suggestion 1"
           aria-selected="false"
           class="c5"
           id="listbox-option-0__item"
@@ -5379,7 +5356,6 @@ exports[`TextInput small drop height 1`] = `
       </li>
       <li>
         <button
-          aria-label="You are on the default suggestion 2"
           aria-selected="false"
           class="c5"
           id="listbox-option-1__item"
@@ -5634,7 +5610,6 @@ exports[`TextInput suggestions 2`] = `
   tabindex="-1"
 >
   <div
-    aria-label="Suggestions list for text input"
     class="c2 c3"
     id="listbox__item"
     role="listbox"
@@ -5644,7 +5619,6 @@ exports[`TextInput suggestions 2`] = `
     >
       <li>
         <button
-          aria-label="You are on the default suggestion 1"
           aria-selected="false"
           class="c5"
           id="listbox-option-0__item"
@@ -5660,7 +5634,6 @@ exports[`TextInput suggestions 2`] = `
       </li>
       <li>
         <button
-          aria-label="You are on the default suggestion 2"
           aria-selected="false"
           class="c5"
           id="listbox-option-1__item"

--- a/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.tsx.snap
+++ b/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.tsx.snap
@@ -431,6 +431,7 @@ exports[`TextInput calls onSuggestionsClose 2`] = `
   tabindex="-1"
 >
   <div
+    aria-label="Suggestions list for text input"
     class="c2 c3"
     id="listbox__item"
     role="listbox"
@@ -440,6 +441,7 @@ exports[`TextInput calls onSuggestionsClose 2`] = `
     >
       <li>
         <button
+          aria-label="You are on the default suggestion 1"
           aria-selected="false"
           class="c5"
           id="listbox-option-0__item"
@@ -455,6 +457,7 @@ exports[`TextInput calls onSuggestionsClose 2`] = `
       </li>
       <li>
         <button
+          aria-label="You are on the default suggestion 2"
           aria-selected="false"
           class="c5"
           id="listbox-option-1__item"
@@ -646,6 +649,7 @@ exports[`TextInput calls onSuggestionsOpen 1`] = `
   tabindex="-1"
 >
   <div
+    aria-label="Suggestions list for text input"
     class="c2 c3"
     id="listbox__item"
     role="listbox"
@@ -655,6 +659,7 @@ exports[`TextInput calls onSuggestionsOpen 1`] = `
     >
       <li>
         <button
+          aria-label="You are on the default suggestion 1"
           aria-selected="false"
           class="c5"
           id="listbox-option-0__item"
@@ -670,6 +675,7 @@ exports[`TextInput calls onSuggestionsOpen 1`] = `
       </li>
       <li>
         <button
+          aria-label="You are on the default suggestion 2"
           aria-selected="false"
           class="c5"
           id="listbox-option-1__item"
@@ -938,6 +944,7 @@ exports[`TextInput close suggestion drop 2`] = `
   tabindex="-1"
 >
   <div
+    aria-label="Suggestions list for text input"
     class="c2 c3"
     id="listbox__item"
     role="listbox"
@@ -947,6 +954,7 @@ exports[`TextInput close suggestion drop 2`] = `
     >
       <li>
         <button
+          aria-label="You are on the default suggestion 1"
           aria-selected="false"
           class="c5"
           id="listbox-option-0__item"
@@ -962,6 +970,7 @@ exports[`TextInput close suggestion drop 2`] = `
       </li>
       <li>
         <button
+          aria-label="You are on the default suggestion 2"
           aria-selected="false"
           class="c5"
           id="listbox-option-1__item"
@@ -1251,6 +1260,7 @@ exports[`TextInput complex suggestions 2`] = `
   tabindex="-1"
 >
   <div
+    aria-label="Suggestions list for text input"
     class="c2 c3"
     id="listbox__item"
     role="listbox"
@@ -1260,6 +1270,7 @@ exports[`TextInput complex suggestions 2`] = `
     >
       <li>
         <button
+          aria-label="You are on the default suggestion 1"
           aria-selected="false"
           class="c5"
           id="listbox-option-0__item"
@@ -1275,6 +1286,7 @@ exports[`TextInput complex suggestions 2`] = `
       </li>
       <li>
         <button
+          aria-label="You are on the default suggestion 2"
           aria-selected="false"
           class="c5"
           id="listbox-option-1__item"
@@ -2008,6 +2020,7 @@ exports[`TextInput large drop height 1`] = `
   tabindex="-1"
 >
   <div
+    aria-label="Suggestions list for text input"
     class="c2 c3"
     id="listbox__item"
     role="listbox"
@@ -2017,6 +2030,7 @@ exports[`TextInput large drop height 1`] = `
     >
       <li>
         <button
+          aria-label="You are on the default suggestion 1"
           aria-selected="false"
           class="c5"
           id="listbox-option-0__item"
@@ -2032,6 +2046,7 @@ exports[`TextInput large drop height 1`] = `
       </li>
       <li>
         <button
+          aria-label="You are on the default suggestion 2"
           aria-selected="false"
           class="c5"
           id="listbox-option-1__item"
@@ -2599,6 +2614,7 @@ exports[`TextInput medium drop height 1`] = `
   tabindex="-1"
 >
   <div
+    aria-label="Suggestions list for text input"
     class="c2 c3"
     id="listbox__item"
     role="listbox"
@@ -2608,6 +2624,7 @@ exports[`TextInput medium drop height 1`] = `
     >
       <li>
         <button
+          aria-label="You are on the default suggestion 1"
           aria-selected="false"
           class="c5"
           id="listbox-option-0__item"
@@ -2623,6 +2640,7 @@ exports[`TextInput medium drop height 1`] = `
       </li>
       <li>
         <button
+          aria-label="You are on the default suggestion 2"
           aria-selected="false"
           class="c5"
           id="listbox-option-1__item"
@@ -4400,6 +4418,7 @@ exports[`TextInput select suggestion 2`] = `
   tabindex="-1"
 >
   <div
+    aria-label="Suggestions list for text input"
     class="c2 c3"
     id="listbox__item"
     role="listbox"
@@ -4409,6 +4428,7 @@ exports[`TextInput select suggestion 2`] = `
     >
       <li>
         <button
+          aria-label="You are on the default suggestion 1"
           aria-selected="false"
           class="c5"
           id="listbox-option-0__item"
@@ -4424,6 +4444,7 @@ exports[`TextInput select suggestion 2`] = `
       </li>
       <li>
         <button
+          aria-label="You are on the default suggestion 2"
           aria-selected="false"
           class="c5"
           id="listbox-option-1__item"
@@ -5332,6 +5353,7 @@ exports[`TextInput small drop height 1`] = `
   tabindex="-1"
 >
   <div
+    aria-label="Suggestions list for text input"
     class="c2 c3"
     id="listbox__item"
     role="listbox"
@@ -5341,6 +5363,7 @@ exports[`TextInput small drop height 1`] = `
     >
       <li>
         <button
+          aria-label="You are on the default suggestion 1"
           aria-selected="false"
           class="c5"
           id="listbox-option-0__item"
@@ -5356,6 +5379,7 @@ exports[`TextInput small drop height 1`] = `
       </li>
       <li>
         <button
+          aria-label="You are on the default suggestion 2"
           aria-selected="false"
           class="c5"
           id="listbox-option-1__item"
@@ -5610,6 +5634,7 @@ exports[`TextInput suggestions 2`] = `
   tabindex="-1"
 >
   <div
+    aria-label="Suggestions list for text input"
     class="c2 c3"
     id="listbox__item"
     role="listbox"
@@ -5619,6 +5644,7 @@ exports[`TextInput suggestions 2`] = `
     >
       <li>
         <button
+          aria-label="You are on the default suggestion 1"
           aria-selected="false"
           class="c5"
           id="listbox-option-0__item"
@@ -5634,6 +5660,7 @@ exports[`TextInput suggestions 2`] = `
       </li>
       <li>
         <button
+          aria-label="You are on the default suggestion 2"
           aria-selected="false"
           class="c5"
           id="listbox-option-1__item"

--- a/src/js/components/TextInput/index.d.ts
+++ b/src/js/components/TextInput/index.d.ts
@@ -32,6 +32,7 @@ export interface TextInputProps
     suggestionsCount?: string;
     suggestionsExist?: string;
     suggestionIsOpen?: string;
+    defaultSuggestion?: string;
   };
   name?: string;
   onSelect?: (x: {

--- a/src/js/components/TextInput/propTypes.js
+++ b/src/js/components/TextInput/propTypes.js
@@ -26,6 +26,7 @@ if (process.env.NODE_ENV !== 'production') {
       suggestionsCount: PropTypes.string,
       suggestionsExist: PropTypes.string,
       suggestionIsOpen: PropTypes.string,
+      defaultSuggestions: PropTypes.string,
     }),
     name: PropTypes.string,
     onChange: PropTypes.func,

--- a/src/js/languages/default.json
+++ b/src/js/languages/default.json
@@ -165,7 +165,8 @@
     "enterSelect": "(Press Enter to Select)",
     "suggestionsCount": "suggestions available",
     "suggestionsExist": "This input has suggestions use arrow keys to navigate",
-    "suggestionIsOpen": "Suggestions drop is open, continue to use arrow keys to navigate"
+    "suggestionIsOpen": "Suggestions drop is open, continue to use arrow keys to navigate",
+    "defaultSuggestion": "TextInput with suggestions type text to display a list of suggestions"
   },
   "video": {
     "audioDescriptions": "video audio description",


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR fixes the voice over on the TextInput with `defaultSuggestion`
#### Where should the reviewer start?
textinput.js
#### What testing has been done on this PR?
locally with voice over
#### How should this be manually tested?
locally with voice over
#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
The moment `aria-expanded=true`, and `aria-activedescendant` is set (which happens when activeSuggestionIndex is not -1),
 VoiceOver:
* Assumes the focus is within the listbox,
* Skips past the text input, and
* Announces the active option right away.

Right now I added when a user is using `keyboard` the focus is set on the `textInput` until they `arrowdown` then set the `aria-activedescendant` to whatever the `defaultSuggestion` is 
#### What are the relevant issues?
closes #7551 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
 backwards compatible