### PR TITLE
Add combobox props to MaskedInput with suggestions

### DIFF
--- a/src/js/components/MaskedInput/MaskedInput.js
+++ b/src/js/components/MaskedInput/MaskedInput.js
@@ -369,6 +369,34 @@ const MaskedInput = forwardRef(
 
     const maskedInputIcon = useSizedIcon(icon, rest.size, theme);
 
+    /*
+    If the masked input has a list of options, add the WAI-ARIA 1.2
+    combobox role and states.
+    */
+    let comboboxProps = {};
+    let activeOptionID;
+    const options = useMemo(() => {
+      let res;
+      if (!activeMaskIndex)
+        // ensures that comboboxProps gets set on input initially
+        res = mask.find((item) => item?.options?.length > 0)?.options;
+      else res = mask[activeMaskIndex]?.options;
+      return res;
+    }, [mask, activeMaskIndex]);
+
+    if (id && options?.length > 0) {
+      if (showDrop && options) {
+        activeOptionID = `listbox-option-${activeOptionIndex}__${id}`;
+      }
+      comboboxProps = {
+        'aria-activedescendant': activeOptionID,
+        'aria-autocomplete': 'list',
+        'aria-expanded': showDrop ? 'true' : 'false',
+        'aria-controls': showDrop ? `listbox__${id}` : undefined,
+        role: 'combobox',
+      };
+    }
+
     return (
       <StyledMaskedInputContainer plain={plain} {...passThemeFlag}>
         {maskedInputIcon && (
@@ -399,6 +427,7 @@ const MaskedInput = forwardRef(
             reverse={reverse}
             focus={focus}
             textAlign={textAlign}
+            {...comboboxProps}
             {...rest}
             value={value}
             theme={theme}
@@ -438,6 +467,8 @@ const MaskedInput = forwardRef(
               <ContainerBox
                 ref={dropRef}
                 overflow="auto"
+                id={id ? `listbox__${id}` : undefined}
+                role="listbox"
                 dropHeight={dropHeight}
                 {...passThemeFlag}
               >
@@ -454,6 +485,7 @@ const MaskedInput = forwardRef(
                   return (
                     <Box key={option} flex={false}>
                       <Button
+                        id={id ? `listbox-option-${index}__${id}` : undefined}
                         tabIndex="-1"
                         onClick={onOption(option)}
                         onMouseOver={() => setActiveOptionIndex(index)}

--- a/src/js/components/MaskedInput/__tests__/MaskedInput-test.tsx
+++ b/src/js/components/MaskedInput/__tests__/MaskedInput-test.tsx
@@ -242,7 +242,7 @@ describe('MaskedInput', () => {
       </Grommet>,
     );
 
-    await user.type(screen.getByRole('textbox'), 'abbb');
+    await user.type(screen.getByRole('combobox'), 'abbb');
 
     expect(onChange).toHaveBeenCalled();
     expect(onChange).toHaveReturnedWith('abb');
@@ -270,7 +270,7 @@ describe('MaskedInput', () => {
       </Grommet>,
     );
 
-    await user.type(screen.getByRole('textbox'), 'abbb');
+    await user.type(screen.getByRole('combobox'), 'abbb');
 
     expect(onChange).toHaveBeenCalled();
     expect(onChange).toHaveReturnedWith('abbb');

--- a/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.tsx.snap
+++ b/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.tsx.snap
@@ -89,12 +89,15 @@ exports[`MaskedInput applies custom global.hover theme to options 1`] = `
     class="c1"
   >
     <input
+      aria-autocomplete="list"
+      aria-expanded="false"
       autocomplete="off"
       class="c2"
       data-testid="test-input"
       id="item"
       name="item"
       placeholder="!"
+      role="combobox"
       value=""
     />
   </div>
@@ -199,6 +202,7 @@ exports[`MaskedInput applies custom global.hover theme to options 2`] = `
 
 <button
   class="c0"
+  id="listbox-option-1__item"
   tabindex="-1"
   type="button"
 >
@@ -828,12 +832,15 @@ exports[`MaskedInput event target props are available option via keyboard 1`] = 
     class="c1"
   >
     <input
+      aria-autocomplete="list"
+      aria-expanded="false"
       autocomplete="off"
       class="c2"
       data-testid="test-input"
       id="item"
       name="item"
       placeholder="!"
+      role="combobox"
       value=""
     />
   </div>
@@ -929,12 +936,15 @@ exports[`MaskedInput event target props are available option via mouse 1`] = `
     class="c1"
   >
     <input
+      aria-autocomplete="list"
+      aria-expanded="false"
       autocomplete="off"
       class="c2"
       data-testid="test-input"
       id="item"
       name="item"
       placeholder="!"
+      role="combobox"
       value=""
     />
   </div>
@@ -1102,12 +1112,15 @@ exports[`MaskedInput event target props are available option via mouse 2`] = `
 >
   <div
     class="c2 c3"
+    id="listbox__item"
+    role="listbox"
   >
     <div
       class="c4"
     >
       <button
         class="c5"
+        id="listbox-option-0__item"
         tabindex="-1"
         type="button"
       >
@@ -1123,6 +1136,7 @@ exports[`MaskedInput event target props are available option via mouse 2`] = `
     >
       <button
         class="c5"
+        id="listbox-option-1__item"
         tabindex="-1"
         type="button"
       >
@@ -1147,12 +1161,17 @@ exports[`MaskedInput event target props are available option via mouse 4`] = `
     class="StyledMaskedInput__StyledMaskedInputContainer-sc-99vkfa-1 fWbzkO"
   >
     <input
+      aria-activedescendant="listbox-option--1__item"
+      aria-autocomplete="list"
+      aria-controls="listbox__item"
+      aria-expanded="true"
       autocomplete="off"
       class="StyledMaskedInput-sc-99vkfa-0 dnAGMh"
       data-testid="test-input"
       id="item"
       name="item"
       placeholder="!"
+      role="combobox"
       value="aa!"
     />
   </div>
@@ -1552,12 +1571,15 @@ exports[`MaskedInput mask 1`] = `
     class="c1"
   >
     <input
+      aria-autocomplete="list"
+      aria-expanded="false"
       autocomplete="off"
       class="c2"
       data-testid="test-input"
       id="item"
       name="item"
       placeholder="!"
+      role="combobox"
       value="a"
     />
   </div>
@@ -1725,12 +1747,15 @@ exports[`MaskedInput mask 2`] = `
 >
   <div
     class="c2 c3"
+    id="listbox__item"
+    role="listbox"
   >
     <div
       class="c4"
     >
       <button
         class="c5"
+        id="listbox-option-0__item"
         tabindex="-1"
         type="button"
       >
@@ -1746,6 +1771,7 @@ exports[`MaskedInput mask 2`] = `
     >
       <button
         class="c5"
+        id="listbox-option-1__item"
         tabindex="-1"
         type="button"
       >
@@ -2305,12 +2331,15 @@ exports[`MaskedInput option via keyboard 1`] = `
     class="c1"
   >
     <input
+      aria-autocomplete="list"
+      aria-expanded="false"
       autocomplete="off"
       class="c2"
       data-testid="test-input"
       id="item"
       name="item"
       placeholder="!"
+      role="combobox"
       value=""
     />
   </div>
@@ -2406,12 +2435,15 @@ exports[`MaskedInput option via mouse 1`] = `
     class="c1"
   >
     <input
+      aria-autocomplete="list"
+      aria-expanded="false"
       autocomplete="off"
       class="c2"
       data-testid="test-input"
       id="item"
       name="item"
       placeholder="!"
+      role="combobox"
       value=""
     />
   </div>
@@ -2579,12 +2611,15 @@ exports[`MaskedInput option via mouse 2`] = `
 >
   <div
     class="c2 c3"
+    id="listbox__item"
+    role="listbox"
   >
     <div
       class="c4"
     >
       <button
         class="c5"
+        id="listbox-option-0__item"
         tabindex="-1"
         type="button"
       >
@@ -2600,6 +2635,7 @@ exports[`MaskedInput option via mouse 2`] = `
     >
       <button
         class="c5"
+        id="listbox-option-1__item"
         tabindex="-1"
         type="button"
       >
@@ -2624,12 +2660,17 @@ exports[`MaskedInput option via mouse 4`] = `
     class="StyledMaskedInput__StyledMaskedInputContainer-sc-99vkfa-1 fWbzkO"
   >
     <input
+      aria-activedescendant="listbox-option--1__item"
+      aria-autocomplete="list"
+      aria-controls="listbox__item"
+      aria-expanded="true"
       autocomplete="off"
       class="StyledMaskedInput-sc-99vkfa-0 dnAGMh"
       data-testid="test-input"
       id="item"
       name="item"
       placeholder="!"
+      role="combobox"
       value="aa!"
     />
   </div>

--- a/src/js/components/MaskedInput/stories/CustomBox.stories.js
+++ b/src/js/components/MaskedInput/stories/CustomBox.stories.js
@@ -21,6 +21,7 @@ export const CustomBoxMaskedInput = () => {
       </span>
       <Box flex width="medium" gap="medium">
         <MaskedInput
+          id="grommet-custom-box"
           plain
           dropProps={{ target: boxRef.current }}
           mask={[

--- a/src/js/components/MaskedInput/stories/Date.stories.js
+++ b/src/js/components/MaskedInput/stories/Date.stories.js
@@ -12,6 +12,7 @@ export const DateMaskedInput = () => {
     <Box fill align="center" justify="start" pad="large">
       <Box width="medium">
         <MaskedInput
+          id="grommet-date"
           mask={[
             {
               length: [1, 2],

--- a/src/js/components/MaskedInput/stories/DateRange.stories.js
+++ b/src/js/components/MaskedInput/stories/DateRange.stories.js
@@ -12,6 +12,7 @@ export const DateRange = () => {
     <Box fill align="center" justify="start" pad="large">
       <Box width="medium">
         <MaskedInput
+          id="grommet-daterange"
           mask={[
             {
               length: [1, 2],

--- a/src/js/components/MaskedInput/stories/DateTimeDrop.stories.js
+++ b/src/js/components/MaskedInput/stories/DateTimeDrop.stories.js
@@ -32,6 +32,7 @@ const DropContent = ({ date: initialDate, time: initialTime, onClose }) => {
           }}
         >
           <MaskedInput
+            id="grommet-date-time"
             mask={[
               {
                 length: [1, 2],

--- a/src/js/components/MaskedInput/stories/Filtered.stories.js
+++ b/src/js/components/MaskedInput/stories/Filtered.stories.js
@@ -38,6 +38,7 @@ export const Filtered = () => {
     <Box fill align="center" justify="start" pad="large">
       <Box width="medium">
         <MaskedInput
+          id="grommet-filtered"
           mask={[
             {
               options: poets,

--- a/src/js/components/MaskedInput/stories/SizeUnits.stories.js
+++ b/src/js/components/MaskedInput/stories/SizeUnits.stories.js
@@ -10,7 +10,7 @@ export const SizeUnitsMaskedInput = () => {
     <Box fill align="center" justify="start" pad="large">
       <Box width="medium">
         <MaskedInput
-          id="size-units"
+          id="grommet-size-units"
           mask={[
             {
               length: [1, 4],

--- a/src/js/components/MaskedInput/stories/SizeUnits.stories.js
+++ b/src/js/components/MaskedInput/stories/SizeUnits.stories.js
@@ -10,6 +10,7 @@ export const SizeUnitsMaskedInput = () => {
     <Box fill align="center" justify="start" pad="large">
       <Box width="medium">
         <MaskedInput
+          id="size-units"
           mask={[
             {
               length: [1, 4],

--- a/src/js/components/MaskedInput/stories/Time.stories.js
+++ b/src/js/components/MaskedInput/stories/Time.stories.js
@@ -10,6 +10,7 @@ export const Time = () => {
     <Box fill align="center" justify="start" pad="large">
       <Box width="medium">
         <MaskedInput
+          id="grommet-maskedinput-time"
           mask={[
             {
               length: [1, 2],

--- a/src/js/components/TextInput/stories/CustomThemed/CustomSuggestions.stories.tsx
+++ b/src/js/components/TextInput/stories/CustomThemed/CustomSuggestions.stories.tsx
@@ -156,6 +156,7 @@ export const CustomSuggestions = () => {
         >
           <Search color="brand" />
           <TextInput
+            id="grommet-custom-suggestions"
             dropTarget={boxRef.current}
             placeholder="Enter your name..."
             plain

--- a/src/js/components/TextInput/stories/CustomThemed/Themed.stories.js
+++ b/src/js/components/TextInput/stories/CustomThemed/Themed.stories.js
@@ -70,6 +70,7 @@ export const Themed = () => {
       <Box fill align="center" justify="start" pad="large">
         <Box width="medium">
           <TextInput
+            id="grommet-password"
             type="password"
             value={value}
             dropProps={{ height: 'small' }}

--- a/src/js/components/TextInput/stories/OnSelect.stories.js
+++ b/src/js/components/TextInput/stories/OnSelect.stories.js
@@ -30,6 +30,7 @@ export const OnSelect = () => {
     <Box fill align="center" justify="start" pad="large">
       <Box width="medium">
         <TextInput
+          id="grommet-onselect"
           value={value}
           onChange={onChange}
           onSelect={onHighlight}

--- a/src/js/components/TextInput/stories/WithTags.stories.js
+++ b/src/js/components/TextInput/stories/WithTags.stories.js
@@ -119,6 +119,7 @@ export const WithTags = () => {
     // <Grommet theme={...}>
     <Box pad="small">
       <TagInput
+        id="grommet-tag-input"
         placeholder="Search for aliases..."
         suggestions={suggestions}
         value={selectedTags}


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Adds [`combobox`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/combobox_role) props to MaskedInput (similar to TextInput logic).

Slight modifications to the logic so that each mask section can appropriately inform screen reader if it's expanded.

According to ARIA documentation, an "id" is needed to associate the input with the combobox, so added "id" to the stories in MaskedInput and TextInput that involve the suggestions.

#### Where should the reviewer start?
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/combobox_role

#### What testing has been done on this PR?
Locally in SizeUnits story with VoiceOver.

#### How should this be manually tested?
Same as above.

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [x] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #7573 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?
Yes. Fixed MaskedInput to support `combobox` aria properties for dropdown options.
 
#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.