### PR TITLE
add buffer box to keep tooltip open

### DIFF
--- a/src/js/components/Tip/Tip.js
+++ b/src/js/components/Tip/Tip.js
@@ -23,14 +23,15 @@ const BufferBox = styled(Box)`
   width: ${(props) => props.width}px;
   height: ${(props) => props.height}px;
 `;
-const getMarginValue = (marginValue, theme, direction = 'vertical') => {
+const getMarginValue = (marginValue, theme, direction) => {
   const edgeSize = theme.global?.edgeSize || {};
 
   if (!marginValue || marginValue === 'none') return 0;
+  // if marginValue is a string get the value
   if (typeof marginValue === 'string') {
     const numericValue =
       parseInt(edgeSize[marginValue], 10) || parseInt(marginValue, 10);
-    return Number.isNaN(numericValue) ? 0 : numericValue;
+    return numericValue;
   }
 
   if (typeof marginValue === 'object') {
@@ -53,9 +54,13 @@ const getMarginValue = (marginValue, theme, direction = 'vertical') => {
   return 0;
 };
 
+/**
+ * Calculates the position and dimensions of a buffer element
+ * based on the alignment. The buffer element is used to
+ * create spacing between the tooltip and the target element.
+ */
 const calculateBufferPosition = (align, targetRect, margin, theme) => {
   const marginValue = getMarginValue(margin, theme);
-
   const position = {
     top: 0,
     left: 0,

--- a/src/js/components/Tip/Tip.js
+++ b/src/js/components/Tip/Tip.js
@@ -89,6 +89,13 @@ const calculateBufferPosition = (align, targetRect, margin, theme) => {
   return position;
 };
 
+/*
+ * This function getReactNodeRef is adapted from
+ * [Material UI] (https://github.com/mui/material-ui)
+ * Licensed under the MIT License (c) 2024 aarongarciah
+ * The function has been modified from its original version.
+ */
+
 const getReactNodeRef = (element) => {
   if (!element || !React.isValidElement(element)) {
     return null;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Added a `bufferBox` to lay on top of `margin` so that when the user hovers over that `bufferBox` the tip stays open.
#### Where should the reviewer start?
tip.js
#### What testing has been done on this PR?
storybook in hpe theme 
#### How should this be manually tested?
storybook in hpe theme
#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
In the current hpe theme we are passing `theme.global.drop.margin` in which a `margin` is being placed on the Drop component. When the user was hovering over this `margin` the tooltip was being closed. 

I have no added a `bufferBox` that will lay over the `margin` that is being set to that way when the user hovers over this space the tooltip stays open.
#### What are the relevant issues?
closes #7552
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible