### PR TITLE
add second option for adding another div for margin

### DIFF
--- a/src/js/components/Button/__tests__/__snapshots__/Button-test.tsx.snap
+++ b/src/js/components/Button/__tests__/__snapshots__/Button-test.tsx.snap
@@ -5139,6 +5139,22 @@ exports[`Button tip 1`] = `
 
 }
 
+@media only screen and (max-width: 768px) {
+
+}
+
+@media only screen and (max-width: 768px) {
+
+}
+
+@media only screen and (max-width: 768px) {
+
+}
+
+@media only screen and (max-width: 768px) {
+
+}
+
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
 
 }

--- a/src/js/components/DataFilter/__tests__/__snapshots__/DataFilter-test.tsx.snap
+++ b/src/js/components/DataFilter/__tests__/__snapshots__/DataFilter-test.tsx.snap
@@ -3083,6 +3083,22 @@ exports[`DataFilter select multiple options 1`] = `
 }
 
 @media only screen and (max-width: 768px) {
+
+}
+
+@media only screen and (max-width: 768px) {
+
+}
+
+@media only screen and (max-width: 768px) {
+
+}
+
+@media only screen and (max-width: 768px) {
+
+}
+
+@media only screen and (max-width: 768px) {
   .c8 {
     border-radius: 12px;
   }

--- a/src/js/components/DataFilters/__tests__/__snapshots__/DataFilters-test.tsx.snap
+++ b/src/js/components/DataFilters/__tests__/__snapshots__/DataFilters-test.tsx.snap
@@ -1529,6 +1529,22 @@ exports[`DataFilters layer 2`] = `
 }
 
 @media only screen and (max-width: 768px) {
+
+}
+
+@media only screen and (max-width: 768px) {
+
+}
+
+@media only screen and (max-width: 768px) {
+
+}
+
+@media only screen and (max-width: 768px) {
+
+}
+
+@media only screen and (max-width: 768px) {
   .c6 {
     padding-left: 12px;
     padding-right: 12px;

--- a/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.tsx.snap
+++ b/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.tsx.snap
@@ -14701,6 +14701,22 @@ exports[`DateInput read only copy 1`] = `
 
 }
 
+@media only screen and (max-width: 768px) {
+
+}
+
+@media only screen and (max-width: 768px) {
+
+}
+
+@media only screen and (max-width: 768px) {
+
+}
+
+@media only screen and (max-width: 768px) {
+
+}
+
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
 
 }

--- a/src/js/components/Drop/StyledDrop.js
+++ b/src/js/components/Drop/StyledDrop.js
@@ -54,7 +54,7 @@ const marginStyle = (theme, align, data, responsive, marginProp) => {
   }
   return edgeStyle(
     'margin',
-    adjustedMargin,
+    marginProp || adjustedMargin,
     responsive,
     theme.global.edgeSize.responsiveBreakpoint,
     theme,

--- a/src/js/components/Text/__tests__/__snapshots__/Text-test.tsx.snap
+++ b/src/js/components/Text/__tests__/__snapshots__/Text-test.tsx.snap
@@ -416,6 +416,22 @@ exports[`renders tip 1`] = `
 
 }
 
+@media only screen and (max-width: 768px) {
+
+}
+
+@media only screen and (max-width: 768px) {
+
+}
+
+@media only screen and (max-width: 768px) {
+
+}
+
+@media only screen and (max-width: 768px) {
+
+}
+
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
 
 }

--- a/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.tsx.snap
+++ b/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.tsx.snap
@@ -2947,6 +2947,22 @@ exports[`TextInput read only copy 1`] = `
 
 }
 
+@media only screen and (max-width: 768px) {
+
+}
+
+@media only screen and (max-width: 768px) {
+
+}
+
+@media only screen and (max-width: 768px) {
+
+}
+
+@media only screen and (max-width: 768px) {
+
+}
+
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
 
 }

--- a/src/js/components/Tip/Tip.js
+++ b/src/js/components/Tip/Tip.js
@@ -13,6 +13,85 @@ import { useForwardedRef, useKeyboard } from '../../utils';
 import { TipPropTypes } from './propTypes';
 import { useThemeValue } from '../../utils/useThemeValue';
 
+// Scenario 1:
+// 1. No dropProps.margin
+// 2. theme.global.drop.intelligentMargin = true
+// 3. theme.global.drop.margin is a string
+// 5. theme.tip.content.margin is none
+// Output: The correct margin based on the alignment should
+// be passed as the final margin to the div after the drop
+
+// Scenario 2:
+// 1. No dropProps.margin
+// 2. theme.global.drop.intelligentMargin = false
+// 3. theme.global.drop.margin is a string
+// 5. theme.tip.content.margin is none
+// Output: The margin will be set to all sides for the margin on
+// the div after the drop
+
+// Scenario 3:
+// 1. dropProps.margin
+// Output: If dropProps.margin is passed, it will be used as the margin
+// on the div after the drop regardless of the value of the
+// theme.global.drop.margin and the intelligentMargin property
+
+const calculateCombinedMargin = (theme, dropProps) => {
+  const finalMargin = { top: 0, bottom: 0, left: 0, right: 0 };
+
+  const themeDropMargin = theme.global.drop.margin;
+  const { intelligentMargin } = theme.global.drop;
+  const align = dropProps?.align ||
+    theme.tip.drop.align || {
+      top: 'top',
+      left: 'left',
+    };
+
+  // Convert a margin value from theme or string to a number in px
+  const getMarginValue = (value) =>
+    parseInt(theme.global.edgeSize?.[value], 10) || parseInt(value, 10) || 0;
+
+  // If intelligentMargin is true and theme.global.drop margin is a string,
+  // apply directional logic so that the margin is applied to the correct side
+  // of the drop.
+  if (intelligentMargin && typeof themeDropMargin === 'string') {
+    const pxValue = getMarginValue(themeDropMargin);
+    if (align.top === 'bottom') finalMargin.top = pxValue;
+    if (align.bottom === 'top') finalMargin.bottom = pxValue;
+    if (align.left === 'right') finalMargin.left = pxValue;
+    if (align.right === 'left') finalMargin.right = pxValue;
+  }
+  // If the theme margin is an object
+  else if (typeof themeDropMargin === 'object') {
+    Object.entries(themeDropMargin).forEach(([key, value]) => {
+      const pxValue = getMarginValue(value);
+      if (key === 'horizontal') {
+        finalMargin.left = pxValue;
+        finalMargin.right = pxValue;
+      } else if (key === 'vertical') {
+        finalMargin.top = pxValue;
+        finalMargin.bottom = pxValue;
+      } else {
+        finalMargin[key] = pxValue;
+      }
+    });
+  }
+  // If theme.global.drop is a string, and intelligent margin is
+  // false apply string value uniformly to all sides
+  else if (typeof themeDropMargin === 'string') {
+    const pxValue = getMarginValue(themeDropMargin);
+    ['top', 'bottom', 'left', 'right'].forEach((side) => {
+      finalMargin[side] = pxValue;
+    });
+  }
+
+  // add back in px to the margin values
+  Object.keys(finalMargin).forEach((key) => {
+    finalMargin[key] = `${finalMargin[key]}px`;
+  });
+
+  return finalMargin;
+};
+
 /*
  * This function getReactNodeRef is adapted from
  * [Material UI] (https://github.com/mui/material-ui)
@@ -90,6 +169,25 @@ const Tip = forwardRef(
       setOver(defaultVisible);
     }, [defaultVisible]);
 
+    // get the margin value from the theme
+    const adjustedMargin = calculateCombinedMargin(theme, dropProps);
+    // remove the non stylistic props from the theme tip drop object
+    const {
+      margin,
+      align,
+      inline,
+      onClickOutside,
+      onEsc,
+      overFlow,
+      responsive,
+      restrictFocus,
+      stretch,
+      target,
+      trapFocus,
+      ...tipDropStyles
+    } = theme.tip.drop || {};
+    const { background, elevation, round, ...dropPropsWithoutStyles } =
+      dropProps || {};
     return [
       clonedChild,
       (over || tooltipOver) && (
@@ -105,11 +203,37 @@ const Tip = forwardRef(
             trapFocus={false}
             key="tip-drop"
             {...theme.tip.drop}
-            {...dropProps}
+            {...dropPropsWithoutStyles}
             onMouseEnter={() => setTooltipOver(true)}
             onMouseLeave={() => setTooltipOver(false)}
+            // to allow cursor to move between drop target and tip,
+            // place margin on internal box and set margin to 0 on drop
+            // and set elevation to none to avoid shadow and background
+            margin="0px"
+            elevation="none"
+            background="transparent"
           >
-            {plain ? content : <Box {...theme.tip.content}>{content}</Box>}
+            <Box
+              // if margin is passed through dropProps, use it
+              // otherwise use the default margin from theme
+              // if margin is 'none' from theme, use combinedMargin
+              // this should be the place where margin is set from any drop
+              // margin
+              margin={
+                dropProps?.margin ||
+                (theme.tip.drop.margin !== 'none' && theme.tip.drop.margin) ||
+                adjustedMargin
+              }
+            >
+              <Box
+                {...tipDropStyles}
+                background={dropProps?.background || theme.tip.drop.background}
+                elevation={dropProps?.elevation}
+                round={dropProps?.round}
+              >
+                {plain ? content : <Box {...theme.tip.content}>{content}</Box>}
+              </Box>
+            </Box>
           </Drop>
         </Keyboard>
       ),

--- a/src/js/components/Tip/__tests__/__snapshots__/Tip-test.tsx.snap
+++ b/src/js/components/Tip/__tests__/__snapshots__/Tip-test.tsx.snap
@@ -5,13 +5,23 @@ exports[`Tip dropProps should pass props to Drop 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  margin: 0px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  margin-left: 0px;
+  margin-right: 0px;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.c1 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
   background: none;
   min-width: 0;
   min-height: 0;
   flex-direction: column;
-  overflow: auto;
-  box-shadow: none;
 }
 
 .c2 {
@@ -32,29 +42,31 @@ exports[`Tip dropProps should pass props to Drop 1`] = `
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.20);
 }
 
-.c1 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-  border-radius: 0px;
-  position: fixed;
-  z-index: 20;
-  outline: none;
-  background: none;
-  margin: 0px;
-  opacity: 0;
-  transform-origin: top left;
-  animation: kPQHBD 0.1s forwards;
-  animation-delay: 0.01s;
+@media only screen and (max-width: 768px) {
+
 }
 
 @media only screen and (max-width: 768px) {
   .c0 {
-    margin: 0px;
+    margin-top: 0px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c0 {
+    margin-bottom: 0px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c0 {
+    margin-left: 0px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c0 {
+    margin-right: 0px;
   }
 }
 
@@ -85,20 +97,14 @@ exports[`Tip dropProps should pass props to Drop 1`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c1 {
-    display: flex;
-    align-items: stretch;
-  }
+
 }
 
 <div
-  aria-hidden="false"
+  class="c0"
 >
   <div
-    class="c0 c1"
-    data-g-portal-id="0"
-    style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
-    tabindex="-1"
+    class="c1"
   >
     <div
       class="c2"
@@ -211,16 +217,13 @@ exports[`Tip mouseOver and mouseOut events on the Tip's child 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  margin: 0px;
   background: none;
   min-width: 0;
   min-height: 0;
   flex-direction: column;
-  overflow: auto;
-  box-shadow: none;
 }
 
-.c2 {
+.c1 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -238,10 +241,115 @@ exports[`Tip mouseOver and mouseOut events on the Tip's child 1`] = `
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.20);
 }
 
+.c2 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+}
+
+@media only screen and (max-width: 768px) {
+
+}
+
+@media only screen and (max-width: 768px) {
+
+}
+
+@media only screen and (max-width: 768px) {
+
+}
+
+@media only screen and (max-width: 768px) {
+
+}
+
+@media only screen and (max-width: 768px) {
+
+}
+
+@media only screen and (max-width: 768px) {
+  .c1 {
+    margin: 3px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c1 {
+    padding-left: 6px;
+    padding-right: 6px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c1 {
+    padding-top: 3px;
+    padding-bottom: 3px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c1 {
+    border-radius: 6px;
+  }
+}
+
+@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
+
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+  >
+    <div
+      class="c2"
+      data-testid="tooltip"
+      id="tooltip-id"
+    >
+      tooltip
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Tip plain 1`] = `
+.c0 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin: 0px;
+  background-color: transparent;
+  color: #444444;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  overflow: auto;
+  box-shadow: none;
+}
+
+.c2 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  margin-left: 0px;
+  margin-right: 0px;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+}
+
 .c3 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  background: none;
   min-width: 0;
   min-height: 0;
   flex-direction: column;
@@ -259,7 +367,8 @@ exports[`Tip mouseOver and mouseOut events on the Tip's child 1`] = `
   position: fixed;
   z-index: 20;
   outline: none;
-  background: none;
+  background-color: transparent;
+  color: #444444;
   margin: 0px;
   opacity: 0;
   transform-origin: top left;
@@ -275,27 +384,25 @@ exports[`Tip mouseOver and mouseOut events on the Tip's child 1`] = `
 
 @media only screen and (max-width: 768px) {
   .c2 {
-    margin: 3px;
+    margin-top: 0px;
   }
 }
 
 @media only screen and (max-width: 768px) {
   .c2 {
-    padding-left: 6px;
-    padding-right: 6px;
+    margin-bottom: 0px;
   }
 }
 
 @media only screen and (max-width: 768px) {
   .c2 {
-    padding-top: 3px;
-    padding-bottom: 3px;
+    margin-left: 0px;
   }
 }
 
 @media only screen and (max-width: 768px) {
   .c2 {
-    border-radius: 6px;
+    margin-right: 0px;
   }
 }
 
@@ -317,71 +424,6 @@ exports[`Tip mouseOver and mouseOut events on the Tip's child 1`] = `
   >
     <div
       class="c3"
-      data-testid="tooltip"
-      id="tooltip-id"
-    >
-      tooltip
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Tip plain 1`] = `
-.c0 {
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  margin: 0px;
-  background: none;
-  min-width: 0;
-  min-height: 0;
-  flex-direction: column;
-  overflow: auto;
-  box-shadow: none;
-}
-
-.c1 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-  border-radius: 0px;
-  position: fixed;
-  z-index: 20;
-  outline: none;
-  background: none;
-  margin: 0px;
-  opacity: 0;
-  transform-origin: top left;
-  animation: kPQHBD 0.1s forwards;
-  animation-delay: 0.01s;
-}
-
-@media only screen and (max-width: 768px) {
-  .c0 {
-    margin: 0px;
-  }
-}
-
-@media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c1 {
-    display: flex;
-    align-items: stretch;
-  }
-}
-
-<div>
-  <div
-    aria-hidden="false"
-  >
-    <div
-      class="c0 c1"
-      data-g-portal-id="0"
-      style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
-      tabindex="-1"
     >
       tooltip
     </div>
@@ -400,13 +442,23 @@ exports[`Tip should be visible by default 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  margin: 0px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  margin-left: 0px;
+  margin-right: 0px;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.c1 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
   background: none;
   min-width: 0;
   min-height: 0;
   flex-direction: column;
-  overflow: auto;
-  box-shadow: none;
 }
 
 .c2 {
@@ -427,29 +479,31 @@ exports[`Tip should be visible by default 1`] = `
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.20);
 }
 
-.c1 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-  border-radius: 0px;
-  position: fixed;
-  z-index: 20;
-  outline: none;
-  background: none;
-  margin: 0px;
-  opacity: 0;
-  transform-origin: top left;
-  animation: kPQHBD 0.1s forwards;
-  animation-delay: 0.01s;
+@media only screen and (max-width: 768px) {
+
 }
 
 @media only screen and (max-width: 768px) {
   .c0 {
-    margin: 0px;
+    margin-top: 0px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c0 {
+    margin-bottom: 0px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c0 {
+    margin-left: 0px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c0 {
+    margin-right: 0px;
   }
 }
 
@@ -480,20 +534,14 @@ exports[`Tip should be visible by default 1`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c1 {
-    display: flex;
-    align-items: stretch;
-  }
+
 }
 
 <div
-  aria-hidden="false"
+  class="c0"
 >
   <div
-    class="c0 c1"
-    data-g-portal-id="0"
-    style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
-    tabindex="-1"
+    class="c1"
   >
     <div
       class="c2"
@@ -568,13 +616,20 @@ exports[`Tip themed 1`] = `
   box-sizing: border-box;
   max-width: 100%;
   margin: 21px;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.c1 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
   background-color: #7D4CDB;
   color: #f8f8f8;
   min-width: 0;
   min-height: 0;
   flex-direction: column;
-  overflow: auto;
-  box-shadow: 0px 8px 16px rgba(255, 255, 255, 0.40);
 }
 
 .c2 {
@@ -595,25 +650,8 @@ exports[`Tip themed 1`] = `
   box-shadow: 0px 4px 4px rgba(255, 255, 255, 0.40);
 }
 
-.c1 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-  border-radius: 0px;
-  position: fixed;
-  z-index: 20;
-  outline: none;
-  background-color: #7D4CDB;
-  color: #f8f8f8;
-  margin: 21px;
-  opacity: 0;
-  transform-origin: top left;
-  animation: kPQHBD 0.1s forwards;
-  animation-delay: 0.01s;
+@media only screen and (max-width: 768px) {
+
 }
 
 @media only screen and (max-width: 768px) {
@@ -649,20 +687,14 @@ exports[`Tip themed 1`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c1 {
-    display: flex;
-    align-items: stretch;
-  }
+
 }
 
 <div
-  aria-hidden="false"
+  class="c0"
 >
   <div
-    class="c0 c1"
-    data-g-portal-id="0"
-    style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
-    tabindex="-1"
+    class="c1"
   >
     <div
       class="c2"

--- a/src/js/components/ToggleGroup/__tests__/__snapshots__/ToggleGroup-test.tsx.snap
+++ b/src/js/components/ToggleGroup/__tests__/__snapshots__/ToggleGroup-test.tsx.snap
@@ -2080,13 +2080,23 @@ exports[`ToggleGroup icon with tooltip 1`] = `
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
-  margin: 0px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  margin-left: 0px;
+  margin-right: 0px;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.c1 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
   background: none;
   min-width: 0;
   min-height: 0;
   flex-direction: column;
-  overflow: auto;
-  box-shadow: none;
 }
 
 .c2 {
@@ -2107,24 +2117,8 @@ exports[`ToggleGroup icon with tooltip 1`] = `
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.20);
 }
 
-.c1 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-  border-radius: 0px;
-  position: fixed;
-  z-index: 20;
-  outline: none;
-  background: none;
-  margin: 0px;
-  opacity: 0;
-  transform-origin: top left;
-  animation: kPQHBD 0.1s forwards;
-  animation-delay: 0.01s;
+@media only screen and (max-width: 768px) {
+
 }
 
 @media only screen and (max-width: 768px) {
@@ -2133,7 +2127,25 @@ exports[`ToggleGroup icon with tooltip 1`] = `
 
 @media only screen and (max-width: 768px) {
   .c0 {
-    margin: 0px;
+    margin-top: 0px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c0 {
+    margin-bottom: 0px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c0 {
+    margin-left: 0px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c0 {
+    margin-right: 0px;
   }
 }
 
@@ -2164,20 +2176,14 @@ exports[`ToggleGroup icon with tooltip 1`] = `
 }
 
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
-  .c1 {
-    display: flex;
-    align-items: stretch;
-  }
+
 }
 
 <div
-  aria-hidden="false"
+  class="c0"
 >
   <div
-    class="c0 c1"
-    data-g-portal-id="0"
-    style="left: 0px; width: 0.1px; top: 0px; max-height: 768px;"
-    tabindex="-1"
+    class="c1"
   >
     <div
       class="c2"


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR adds the additional of 2 divs in order to have the `margin` set on the outer `div` in order to allow the user to move their mouse from the target to the tooltip without the tooltip closing. 
#### Where should the reviewer start?
tip.js
#### What testing has been done on this PR?
storybook
#### How should this be manually tested?
storybook
#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
If `theme.global.drop.margin` is set and is a string as well as `theme.global.drop.intelligentMargin`  is true then we will go through to calculate where the `margin` should be placed depending on the alignment of the drop. 

Now if `theme.global.drop.intelligentMargin` is false then we just take the value that is either passed into `theme.global.drop.margin` or `theme.tip.drop.margin` or `dropProps.margin` 
#### What are the relevant issues?
closes #7552 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
 backwards compatible