### PR TITLE
Popover experiment

### DIFF
--- a/src/js/components/Anchor/Anchor.js
+++ b/src/js/components/Anchor/Anchor.js
@@ -11,17 +11,19 @@ import { findButtonParent, normalizeColor, useSizedIcon } from '../../utils';
 
 import { Box } from '../Box';
 
-import { StyledAnchor } from './StyledAnchor';
+import { StyledAnchor, StyledPopover } from './StyledAnchor';
 import { AnchorPropTypes } from './propTypes';
 import { useAnalytics } from '../../contexts/AnalyticsContext';
 import { TextContext } from '../Text/TextContext';
 import { useThemeValue } from '../../utils/useThemeValue';
+import { useId } from '../../utils/useId';
 
 const Anchor = forwardRef(
   (
     {
       a11yTitle,
       'aria-label': ariaLabel,
+      as,
       children,
       color,
       disabled,
@@ -32,6 +34,7 @@ const Anchor = forwardRef(
       onBlur,
       onClick: onClickProp,
       onFocus,
+      popover,
       reverse,
       size: sizeProp,
       ...rest
@@ -42,6 +45,7 @@ const Anchor = forwardRef(
     const [focus, setFocus] = useState();
     const { size } = useContext(TextContext);
     const sendAnalytics = useAnalytics();
+    const popoverId = useId();
 
     const onClick = useCallback(
       (event) => {
@@ -83,9 +87,13 @@ const Anchor = forwardRef(
     const first = reverse ? label : anchorIcon;
     const second = reverse ? anchorIcon : label;
 
+    const domTag = as || (popover ? 'button' : 'a');
+
     return (
+      <>
       <StyledAnchor
         {...rest}
+        as={domTag}
         ref={ref}
         aria-label={ariaLabel || a11yTitle}
         colorProp={color}
@@ -104,6 +112,7 @@ const Anchor = forwardRef(
           setFocus(false);
           if (onBlur) onBlur(event);
         }}
+        popovertarget={popover ? popoverId : undefined}
         size={sizeProp || size}
         {...passThemeFlag}
       >
@@ -124,6 +133,12 @@ const Anchor = forwardRef(
           first || second || children
         )}
       </StyledAnchor>
+      {popover && (
+        <StyledPopover id={popoverId} popover="auto">
+          {popover}
+        </StyledPopover>
+      )}
+      </>
     );
   },
 );

--- a/src/js/components/Anchor/StyledAnchor.js
+++ b/src/js/components/Anchor/StyledAnchor.js
@@ -6,6 +6,8 @@ import {
   normalizeColor,
   styledComponentsConfig,
 } from '../../utils';
+import { edgeStyle, roundStyle } from '../../utils/styles';
+import { backgroundStyle } from '../../utils/background';
 
 const disabledStyle = `
   opacity: 0.3;
@@ -77,6 +79,30 @@ const StyledAnchor = styled.a.withConfig(styledComponentsConfig)`
   ${(props) => props.disabled && disabledStyle}
   ${(props) => props.focus && focusStyle()}
   ${(props) => props.theme.anchor.extend}
+  ${(props) => props.popovertarget && `
+    text-decoration: underline dotted;
+    text-underline-offset: 4px;
+    border: none;
+    background: none;
+  `}
 `;
 
-export { StyledAnchor };
+const StyledPopover = styled.div`
+    border: none;
+    padding: 0;
+    ${(props) => props.theme.anchor.popover?.round &&
+      roundStyle(props.theme.anchor.popover.round,
+        props.responsive,
+        props.theme)}
+    ${(props) => props.theme.anchor.popover?.background &&
+      backgroundStyle(props.theme.anchor.popover.background, props.theme)}
+    ${(props) => props.theme.anchor.popover?.pad &&
+      edgeStyle(
+        'padding',
+        props.theme.anchor.popover.pad,
+        props.responsive,
+        props.theme.box.responsiveBreakpoint,
+        props.theme,
+      )}
+  `; 
+export { StyledAnchor, StyledPopover };

--- a/src/js/components/Anchor/index.d.ts
+++ b/src/js/components/Anchor/index.d.ts
@@ -22,6 +22,7 @@ export interface AnchorProps {
   icon?: JSX.Element;
   label?: React.ReactNode;
   margin?: MarginType;
+  popover?: React.ReactNode;
   reverse?: boolean;
   size?:
     | 'xsmall'
@@ -39,7 +40,7 @@ type aProps = Omit<
     React.AnchorHTMLAttributes<HTMLAnchorElement>,
     HTMLAnchorElement
   >,
-  'color'
+  'color' | 'popover'
 >;
 
 export interface AnchorExtendedProps extends AnchorProps, aProps {}

--- a/src/js/components/Anchor/propTypes.js
+++ b/src/js/components/Anchor/propTypes.js
@@ -29,6 +29,7 @@ if (process.env.NODE_ENV !== 'production') {
     icon: PropTypes.element,
     label: PropTypes.node,
     onClick: PropTypes.func,
+    popup: PropTypes.node,
     reverse: PropTypes.bool,
     size: PropTypes.oneOfType([
       PropTypes.oneOf([

--- a/src/js/components/Anchor/stories/Popover.stories.js
+++ b/src/js/components/Anchor/stories/Popover.stories.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Anchor, Box, Paragraph } from 'grommet';
+
+const PopoverContent = ({ ...rest }) => (
+  <Paragraph margin="none" {...rest}>
+    This is the content for the popover
+  </Paragraph>
+);
+
+const PopoverExample = () => (
+  <Box gap="medium" align="center" pad="large">
+
+    <Anchor popover={<PopoverContent />} label="Link" />
+  </Box>
+);
+
+export const Popover  = () => <PopoverExample />;
+Popover.parameters = {
+  chromatic: { disable: true },
+};
+
+export default {
+  title: 'Controls/Anchor/Popover',
+};

--- a/src/js/components/Box/StyledBox.js
+++ b/src/js/components/Box/StyledBox.js
@@ -1,5 +1,4 @@
 import styled, { css } from 'styled-components';
-import isPropValid from '@emotion/is-prop-valid';
 
 import {
   alignContentStyle,
@@ -21,7 +20,11 @@ import {
   widthStyle,
 } from '../../utils';
 
-import { roundStyle, styledComponentsConfig } from '../../utils/styles';
+import {
+  roundStyle,
+  shouldForwardProp,
+  styledComponentsConfig,
+} from '../../utils/styles';
 
 import { animationBounds, animationObjectStyle } from '../../utils/animation';
 
@@ -295,7 +298,7 @@ const responsiveContainerStyle = css`
 // to the DOM, added a check to prevent this.
 const StyledBox = styled.div.withConfig({
   shouldForwardProp: (prop) =>
-    isPropValid(prop) && !['selected'].includes(prop),
+    shouldForwardProp(prop) && !['selected'].includes(prop),
 })`
   display: flex;
   box-sizing: border-box;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -404,6 +404,12 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       //   },
       // },
       // extend: undefined,
+      popover: {
+        round: 'small',
+        elevation: 'small',
+        background: 'background-contrast',
+        pad: 'small',
+      },
     },
     avatar: {
       // extend: undefined,

--- a/src/js/utils/styles.js
+++ b/src/js/utils/styles.js
@@ -6,8 +6,12 @@ import { getBreakpointStyle } from './responsive';
 import { breakpointStyle, parseMetricToNum } from './mixins';
 
 // ensure only valid DOM attributes are forwarded onto DOM
+const extendedProps = ['popover', 'popovertarget'];
+export const shouldForwardProp = (prop) =>
+  isPropValid(prop) || extendedProps.includes(prop);
+
 export const styledComponentsConfig = {
-  shouldForwardProp: isPropValid,
+  shouldForwardProp,
 };
 
 export const baseStyle = css`


### PR DESCRIPTION

#### What does this PR do?
This creates an initial example of using the `popover` and `popovertarget` attributes in HTML to implement a basic popover via an Anchor. The Anchor content is styled with a dotted underline when it is a popover trigger:

![image](https://github.com/user-attachments/assets/8e6c7fd4-7d0a-41a4-80a1-55b0e8be7376)

When clicked on, a simply styled popover is displayed. For example, from the Controls/Anchor/Popover story:

![image](https://github.com/user-attachments/assets/f19403c5-e370-4af2-9ca0-96b8805b5d0f)

This as implemented as:
```jsx
const PopoverContent = ({ ...rest }) => (
  <Paragraph margin="none" {...rest}>
    This is the content for the popover
  </Paragraph>
);

const PopoverExample = () => (
  <Anchor popover={<PopoverContent />} label="Link" />
);
```
#### Where should the reviewer start?
Anchor.js

#### What testing has been done on this PR?

#### How should this be manually tested?
Storybook Controls/Anchor/Popover

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
