### PR TITLE
use timeout approach to keep the tooltip opened

### DIFF
--- a/src/js/components/Button/__tests__/__snapshots__/Button-test.tsx.snap
+++ b/src/js/components/Button/__tests__/__snapshots__/Button-test.tsx.snap
@@ -5153,6 +5153,7 @@ exports[`Button tip 1`] = `
   >
     Default Tip
   </button>
+  <div />
 </div>
 `;
 

--- a/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.tsx.snap
+++ b/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.tsx.snap
@@ -14741,6 +14741,7 @@ exports[`DateInput read only copy 1`] = `
           />
         </svg>
       </button>
+      <div />
     </div>
   </div>
 </DocumentFragment>

--- a/src/js/components/Text/__tests__/__snapshots__/Text-test.tsx.snap
+++ b/src/js/components/Text/__tests__/__snapshots__/Text-test.tsx.snap
@@ -429,6 +429,7 @@ exports[`renders tip 1`] = `
   >
     Default Tip
   </span>
+  <div />
 </div>
 `;
 

--- a/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.tsx.snap
+++ b/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.tsx.snap
@@ -2982,6 +2982,7 @@ exports[`TextInput read only copy 1`] = `
           />
         </svg>
       </button>
+      <div />
     </div>
   </div>
 </DocumentFragment>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
use `timeout` approach to keep the `tooltip` open when the user hovers from target to tooltip
#### Where should the reviewer start?
tip.js
#### What testing has been done on this PR?
locally 
#### How should this be manually tested?
locally in hpe theme
#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
hpe theme has `margin` around Drop so when the user hovers over that `margin` the tooltip closes
#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
