### PR TITLE
look at marginProp before setting adjustedMargin

### DIFF
--- a/src/js/components/Drop/StyledDrop.js
+++ b/src/js/components/Drop/StyledDrop.js
@@ -29,6 +29,8 @@ const dropKeyFrames = keyframes`
 
 // The desired margin may be adjusted depending on drops alignment
 const marginStyle = (theme, align, data, responsive, marginProp) => {
+  // NOTE: If marginProp is passed, it overrides the alignment-aware
+  //  margin logic and uses the provided value instead.
   const margin = theme.global.edgeSize[data] || data;
   let adjustedMargin = {};
   // if user provides CSS string such as '50px 12px', apply that always

--- a/src/js/components/Drop/StyledDrop.js
+++ b/src/js/components/Drop/StyledDrop.js
@@ -54,7 +54,7 @@ const marginStyle = (theme, align, data, responsive, marginProp) => {
   }
   return edgeStyle(
     'margin',
-    adjustedMargin,
+    marginProp || adjustedMargin,
     responsive,
     theme.global.edgeSize.responsiveBreakpoint,
     theme,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR address that `tip.drop.margin` should take priority over `global.drop.margin` currently in our hpe theme we have `global.drop.margin` set as well as `intelligentMargin` so whats happening is those are being applied to Tip even though we have `tip.drop.margin` set to "none"

I have add the check that if `marginProp` is set to something then that should come before the adjustedMargin in the `marginStyle` function in Drop. 
#### Where should the reviewer start?
styledDrop
#### What testing has been done on this PR?
locally 
#### How should this be manually tested?
locally 

in hpe theme you will see that the only margin being applied is the `theme.tip.content.margin` in which we will update this value in the hpe them to either `6px` or `9px` depending on discussion with designers. 
#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
`margin` on the drop was causing the tooltip not to stay open as a user hovered from the target to the tooltip
#### What are the relevant issues?
closes #7552 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
 backwards compatible