### PR TITLE
#7562 fix file-input accessibility iasue 1.4.13

### DIFF
--- a/src/js/components/FileInput/FileInput.js
+++ b/src/js/components/FileInput/FileInput.js
@@ -18,6 +18,7 @@ import { Button } from '../Button';
 import { FormContext } from '../Form/FormContext';
 import { Keyboard } from '../Keyboard';
 import { Text } from '../Text';
+import { Tip } from '../Tip';
 
 import { StyledFileInput } from './StyledFileInput';
 import { FileInputPropTypes } from './propTypes';
@@ -461,29 +462,42 @@ const FileInput = forwardRef(
                 justify="between"
                 direction="row"
                 align="center"
+                style={{ zIndex: 0 }} // make the tip appear on file name hover
               >
                 {renderFile ? (
                   renderFile(file)
                 ) : (
-                  <Box
-                    {...theme.fileInput.label}
-                    gap="xsmall"
-                    align="center"
-                    direction="row"
+                  <Tip
+                    content={file.name}
+                    dropProps={{
+                      align: { top: 'bottom' },
+                      width: 'small',
+                      round: 'xsmall',
+                      background: { ...theme.tip.drop },
+                    }}
                   >
-                    {((maxSize && file.size > maxSize) ||
-                      (max && index >= max)) && <CircleAlert />}
-                    <Label
-                      weight={
-                        theme.global.input.weight ||
-                        theme.global.input.font.weight
-                      }
-                      truncate
-                      {...passThemeFlag}
+                    <Box
+                      {...theme.fileInput.label}
+                      gap="xsmall"
+                      align="center"
+                      direction="row"
+                      tabIndex={0} // make name focusable with keyboard
+                      flex // make file with shortname have larger hover area
                     >
-                      {file.name}
-                    </Label>
-                  </Box>
+                      {((maxSize && file.size > maxSize) ||
+                        (max && index >= max)) && <CircleAlert />}
+                      <Label
+                        weight={
+                          theme.global.input.weight ||
+                          theme.global.input.font.weight
+                        }
+                        truncate
+                        {...passThemeFlag}
+                      >
+                        {file.name}
+                      </Label>
+                    </Box>
+                  </Tip>
                 )}
                 <Box flex={false} direction="row" align="center">
                   <Button


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
- Fix accessibillity issue 1.4.13 for file input component
- fixes #7562 
- Integrate file input to use Grommet Tip for file name instead of native browser solution
![image](https://github.com/user-attachments/assets/343321b6-3227-4a5f-a82b-6ce45487f9e3)
![image](https://github.com/user-attachments/assets/64188462-ad83-4be7-9f2f-cde275990e08)


#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
