### PR TITLE
Ensure DataSort and DataFilter properly associate form label + Select

### DIFF
--- a/src/js/components/Data/__tests__/__snapshots__/Data-test.tsx.snap
+++ b/src/js/components/Data/__tests__/__snapshots__/Data-test.tsx.snap
@@ -4161,7 +4161,7 @@ exports[`Data should render property label and return property value to view whe
               >
                 <label
                   class="c6"
-                  for="data-selectMultiple"
+                  for="data-selectMultiple__input"
                 >
                   SelectMultiple Name
                 </label>
@@ -4236,7 +4236,7 @@ exports[`Data should render property label and return property value to view whe
               >
                 <label
                   class="c6"
-                  for="data-selectMultipleSimple"
+                  for="data-selectMultipleSimple__input"
                 >
                   SelectMultiple Simple Name
                 </label>

--- a/src/js/components/DataFilter/DataFilter.js
+++ b/src/js/components/DataFilter/DataFilter.js
@@ -8,6 +8,7 @@ import { SelectMultiple } from '../SelectMultiple';
 import { DataFilterPropTypes } from './propTypes';
 import { getDecimalCount } from '../RangeSelector/RangeSelector';
 import { DataFormContext } from '../../contexts/DataFormContext';
+import { selectInputId } from '../Select/utils';
 
 // empirical constants for when we change inputs
 const maxCheckBoxGroupOptions = 4;
@@ -149,6 +150,7 @@ export const DataFilter = ({
     ? `${properties?.[property]?.label || property}`
     : undefined;
 
+  let htmlFor = id;
   let content = children;
   if (!content) {
     if (range) {
@@ -231,6 +233,7 @@ export const DataFilter = ({
             valueKey={{ key: 'value', reduce: true }}
           />
         );
+        htmlFor = selectInputId(id);
       }
     }
   }
@@ -247,7 +250,7 @@ export const DataFilter = ({
   else
     content = (
       <FormField
-        htmlFor={id}
+        htmlFor={htmlFor}
         name={property}
         label={properties?.[property]?.label || property}
         {...rest}

--- a/src/js/components/DataSort/DataSort.js
+++ b/src/js/components/DataSort/DataSort.js
@@ -11,6 +11,7 @@ import { Select } from '../Select';
 import { MessageContext } from '../../contexts/MessageContext';
 import { DataSortPropTypes } from './propTypes';
 import { useThemeValue } from '../../utils/useThemeValue';
+import { selectInputId } from '../Select/utils';
 
 const dropProps = {
   align: { top: 'bottom', left: 'left' },
@@ -71,7 +72,7 @@ const Content = ({ options: optionsArg }) => {
   return [
     <FormField
       key="by"
-      htmlFor={sortPropertyId}
+      htmlFor={selectInputId(sortPropertyId)}
       label={format({
         id: 'dataSort.by',
         messages: messages?.dataSort,

--- a/src/js/components/DataSort/__tests__/__snapshots__/DataSort-test.tsx.snap
+++ b/src/js/components/DataSort/__tests__/__snapshots__/DataSort-test.tsx.snap
@@ -862,7 +862,7 @@ exports[`DataSort renders 1`] = `
             >
               <label
                 class="c6"
-                for="data--sort-property"
+                for="data--sort-property__input"
               >
                 Sort by
               </label>
@@ -1360,7 +1360,7 @@ exports[`DataSort sort when data array is empty 1`] = `
       >
         <label
           class="c4"
-          for="test-data--sort-property"
+          for="test-data--sort-property__input"
         >
           Sort by
         </label>

--- a/src/js/components/Select/Select.js
+++ b/src/js/components/Select/Select.js
@@ -26,6 +26,7 @@ import {
   getIconColor,
   formatValueForA11y,
   inertTrueValue,
+  selectInputId,
 } from './utils';
 import { DefaultSelectTextInput } from './DefaultSelectTextInput';
 import { MessageContext } from '../../contexts/MessageContext';
@@ -363,7 +364,7 @@ const Select = forwardRef(
                   <HiddenInput
                     type="text"
                     name={name}
-                    id={id ? `${id}__input` : undefined}
+                    id={id ? selectInputId(id) : undefined}
                     inert={inertTrueValue}
                     value={inputValue}
                     ref={inputRef}

--- a/src/js/components/Select/utils.js
+++ b/src/js/components/Select/utils.js
@@ -140,3 +140,11 @@ export const formatValueForA11y = (value, labelKey) => {
 // used to determine the react version because it is only available
 // in react 19 and above.
 export const inertTrueValue = React.use ? true : '';
+
+// Grommet manipulates the provided id by appending "__input" for
+// the id places on the DOM input. In order to properly associate
+// form label htmlFor with select input, we handle appending this
+// to htmlFor for internal components like DataSort and DataFilter.
+// Caller is responsible for appending this on their Select or
+// SelectMultiple instances.
+export const selectInputId = (id) => `${id}__input`;

--- a/src/js/components/SelectMultiple/SelectMultiple.js
+++ b/src/js/components/SelectMultiple/SelectMultiple.js
@@ -32,6 +32,7 @@ import {
   getDisplayLabelKey,
   arrayIncludes,
   inertTrueValue,
+  selectInputId,
 } from '../Select/utils';
 import { DefaultSelectTextInput } from '../Select/DefaultSelectTextInput';
 import { MessageContext } from '../../contexts/MessageContext';
@@ -475,7 +476,7 @@ const SelectMultiple = forwardRef(
                         a11yTitle={ariaLabel || a11yTitle}
                         defaultCursor={disabled === true || undefined}
                         focusIndicator={false}
-                        id={id ? `${id}__input` : undefined}
+                        id={id ? selectInputId(id) : undefined}
                         inert={inertTrueValue}
                         name={name}
                         width="100%"
@@ -508,7 +509,7 @@ const SelectMultiple = forwardRef(
                     <HiddenInput
                       type="text"
                       name={name}
-                      id={id ? `${id}__input` : undefined}
+                      id={id ? selectInputId(id) : undefined}
                       inert={inertTrueValue}
                       value={inputValue}
                       ref={inputRef}
@@ -559,7 +560,7 @@ const SelectMultiple = forwardRef(
                       <HiddenInput
                         type="text"
                         name={name}
-                        id={id ? `${id}__input` : undefined}
+                        id={id ? selectInputId(id) : undefined}
                         inert={inertTrueValue}
                         value={inputValue}
                         ref={inputRef}


### PR DESCRIPTION

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Ensures for Grommet components, we are properly associating form label + select input.

#### Where should the reviewer start?
src/js/components/Select/utils.js

#### What testing has been done on this PR?
Locally in storybook

DataFilter before
<img width="440" alt="Screenshot 2025-05-28 at 2 50 42 PM" src="https://github.com/user-attachments/assets/d4cfd187-ef26-4cd2-9676-4198c9b7ba43" />

DataFilter after
<img width="518" alt="Screenshot 2025-05-28 at 2 50 32 PM" src="https://github.com/user-attachments/assets/b3b61ef7-5a17-4516-998b-f0d26851b944" />

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Related to #7646 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?
Yes.

#### Is this change backwards compatible or is it a breaking change?
Yes.