### PR TITLE
Add `message` support for pinned List and DataTableColumns item

### DIFF
--- a/src/js/components/Data/index.d.ts
+++ b/src/js/components/Data/index.d.ts
@@ -102,6 +102,7 @@ export interface DataProps {
     dataTableColumns?: {
       open?: string;
       order?: string;
+      pinned?: string;
       select?: string;
       tip?: string;
     };

--- a/src/js/components/Data/propTypes.js
+++ b/src/js/components/Data/propTypes.js
@@ -56,6 +56,7 @@ if (process.env.NODE_ENV !== 'production') {
       dataTableColumns: PropTypes.shape({
         open: PropTypes.string,
         order: PropTypes.string,
+        pinned: PropTypes.string,
         select: PropTypes.string,
         tip: PropTypes.string,
       }),

--- a/src/js/components/DataTableColumns/DataTableColumns.js
+++ b/src/js/components/DataTableColumns/DataTableColumns.js
@@ -152,6 +152,12 @@ const Content = ({ drop, options = [], ...rest }) => {
                 (v) =>
                   (objectOptions && options.find((o) => o.property === v)) || v,
               )}
+              messages={{
+                pinned: format({
+                  id: 'dataTableColumns.pinned',
+                  messages: messages?.dataTableColumns,
+                }),
+              }}
               onOrder={(nextData) => setValue(optionsToValue(nextData))}
               pad="none"
               primaryKey={(objectOptions && 'label') || undefined}

--- a/src/js/components/DataTableColumns/__tests__/__snapshots__/DataTableColumns-test.tsx.snap
+++ b/src/js/components/DataTableColumns/__tests__/__snapshots__/DataTableColumns-test.tsx.snap
@@ -517,7 +517,7 @@ exports[`DataTableColumns pinned 1`] = `
           class="c17"
         >
           <svg
-            aria-label="Lock"
+            aria-label="Item pinned, order cannot be changed."
             class="c18"
             viewBox="0 0 24 24"
           >

--- a/src/js/components/DataTableColumns/__tests__/__snapshots__/DataTableColumns-test.tsx.snap
+++ b/src/js/components/DataTableColumns/__tests__/__snapshots__/DataTableColumns-test.tsx.snap
@@ -517,7 +517,7 @@ exports[`DataTableColumns pinned 1`] = `
           class="c17"
         >
           <svg
-            aria-label="Item pinned, order cannot be changed."
+            aria-label="Column locked, order cannot be changed."
             class="c18"
             viewBox="0 0 24 24"
           >

--- a/src/js/components/Grommet/index.d.ts
+++ b/src/js/components/Grommet/index.d.ts
@@ -120,6 +120,9 @@ export interface GrommetProps {
           };
         };
       };
+      list?: {
+        pinned?: string;
+      };
       menu?: {
         openMenu?: string;
         closeMenu?: string;

--- a/src/js/components/Grommet/index.d.ts
+++ b/src/js/components/Grommet/index.d.ts
@@ -80,6 +80,7 @@ export interface GrommetProps {
       dataTableColumns?: {
         open?: string;
         order?: string;
+        pinned?: string;
         select?: string;
         tip?: string;
       };

--- a/src/js/components/Grommet/propTypes.js
+++ b/src/js/components/Grommet/propTypes.js
@@ -79,6 +79,7 @@ if (process.env.NODE_ENV !== 'production') {
         dataTableColumns: PropTypes.shape({
           open: PropTypes.string,
           order: PropTypes.string,
+          pinned: PropTypes.string,
           select: PropTypes.string,
           tip: PropTypes.string,
         }),

--- a/src/js/components/Grommet/propTypes.js
+++ b/src/js/components/Grommet/propTypes.js
@@ -119,6 +119,9 @@ if (process.env.NODE_ENV !== 'production') {
             }),
           }),
         }),
+        list: PropTypes.shape({
+          pinned: PropTypes.string,
+        }),
         menu: PropTypes.shape({
           openMenu: PropTypes.string,
           closeMenu: PropTypes.string,

--- a/src/js/components/List/List.js
+++ b/src/js/components/List/List.js
@@ -13,6 +13,7 @@ import { Box } from '../Box';
 import { Button } from '../Button';
 import { InfiniteScroll } from '../InfiniteScroll';
 import { Keyboard } from '../Keyboard';
+import { MessageContext } from '../../contexts/MessageContext';
 import { Pagination } from '../Pagination';
 import { Text } from '../Text';
 import {
@@ -140,6 +141,7 @@ const List = React.forwardRef(
       focus,
       itemKey: defaultItemKey,
       itemProps,
+      messages,
       onActive,
       onClickItem,
       onKeyDown,
@@ -161,6 +163,7 @@ const List = React.forwardRef(
     const { theme, passThemeFlag } = useThemeValue();
     const { data: contextData } = useContext(DataContext);
     const data = dataProp || contextData || emptyData;
+    const { format } = useContext(MessageContext);
 
     // fixes issue where itemKey is undefined when only primaryKey is provided
     const itemKey = defaultItemKey || primaryKey || null;
@@ -722,6 +725,10 @@ const List = React.forwardRef(
                     ...(!pinIcon.props?.color && pinnedColor
                       ? { color: pinnedColor }
                       : {}),
+                    a11yTitle: format({
+                      id: 'list.pinned',
+                      messages,
+                    }),
                     size: pinSize,
                   });
 

--- a/src/js/components/List/__tests__/List-test.tsx
+++ b/src/js/components/List/__tests__/List-test.tsx
@@ -305,6 +305,61 @@ describe('List', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
+  test('grommet messages', () => {
+    const onOrder = jest.fn();
+    const TestApp = () => {
+      const [ordered, setOrdered] = useState([
+        { city: 'Fort Collins', state: 'Colorado' },
+        { city: 'Boise', state: 'Idaho' },
+        { city: 'New Orleans', state: 'Louisiana' },
+      ]);
+      return (
+        <Grommet messages={{ messages: { list: { pinned: 'Item locked.' } } }}>
+          <List
+            data={ordered}
+            itemKey={(item) => item.state}
+            onOrder={(items) => {
+              onOrder(items);
+              setOrdered(items);
+            }}
+            pinned={['Idaho']}
+          />
+        </Grommet>
+      );
+    };
+    const { asFragment } = render(<TestApp />);
+    expect(asFragment()).toMatchSnapshot();
+    expect(screen.getByLabelText('Item locked.')).toBeInTheDocument();
+  });
+
+  test('prop messages', () => {
+    const onOrder = jest.fn();
+    const TestApp = () => {
+      const [ordered, setOrdered] = useState([
+        { city: 'Fort Collins', state: 'Colorado' },
+        { city: 'Boise', state: 'Idaho' },
+        { city: 'New Orleans', state: 'Louisiana' },
+      ]);
+      return (
+        <Grommet>
+          <List
+            data={ordered}
+            itemKey={(item) => item.state}
+            onOrder={(items) => {
+              onOrder(items);
+              setOrdered(items);
+            }}
+            messages={{ pinned: 'Item locked.' }}
+            pinned={['Idaho']}
+          />
+        </Grommet>
+      );
+    };
+    const { asFragment } = render(<TestApp />);
+    expect(asFragment()).toMatchSnapshot();
+    expect(screen.getByLabelText('Item locked.')).toBeInTheDocument();
+  });
+
   test('renders custom theme for primaryKey', () => {
     const theme = {
       list: {
@@ -1079,7 +1134,7 @@ describe('List pinned', () => {
     );
     const numberStyle = window.getComputedStyle(screen.getByText('2'));
     const iconStyle = window.getComputedStyle(
-      screen.getAllByLabelText('Lock')[0],
+      screen.getAllByLabelText('Item pinned, order cannot be changed.')[0],
     );
     expect(locationStyle.color).toBe(pinnedObject.color);
     expect(numberStyle.color).toBe(pinnedObject.color);
@@ -1108,7 +1163,7 @@ describe('List pinned', () => {
     );
     const numberStyle = window.getComputedStyle(screen.getByText('2'));
     const iconStyle = window.getComputedStyle(
-      screen.getAllByLabelText('Lock')[0],
+      screen.getAllByLabelText('Item pinned, order cannot be changed.')[0],
     );
     expect(locationStyle.color).toBe(pinnedObject.color);
     expect(numberStyle.color).toBe(pinnedObject.color);
@@ -1193,7 +1248,7 @@ describe('List pinned', () => {
 
     expect(asFragment()).toMatchSnapshot();
     const iconStyle = window.getComputedStyle(
-      screen.getAllByLabelText('Lock')[0],
+      screen.getAllByLabelText('Item pinned, order cannot be changed.')[0],
     );
     expect(iconStyle.stroke).toBe('pink');
     expect(iconStyle.fill).toBe('pink');

--- a/src/js/components/List/__tests__/__snapshots__/List-test.tsx.snap
+++ b/src/js/components/List/__tests__/__snapshots__/List-test.tsx.snap
@@ -12492,6 +12492,506 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
 </div>
 `;
 
+exports[`List grommet messages 1`] = `
+<DocumentFragment>
+  .c9 {
+  display: inline-block;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #666666;
+  stroke: #666666;
+}
+
+.c9 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c9 *:not([stroke])[fill='none'] {
+  stroke-width: 0;
+}
+
+.c9 *[stroke*='#'],
+.c9 *[STROKE*='#'] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c9 *[fill-rule],
+.c9 *[FILL-RULE],
+.c9 *[fill*='#'],
+.c9 *[FILL*='#'] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c2 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: center;
+  border-top: solid 1px rgba(0, 0, 0, 0.33);
+  border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  flex: 0 0 auto;
+  padding-left: 24px;
+  padding-right: 24px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+
+.c6 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  flex: 1 1;
+}
+
+.c7 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  justify-content: flex-end;
+}
+
+.c11 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: center;
+  background-color: #33333310;
+  color: #444444;
+  border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  flex: 0 0 auto;
+  padding-left: 24px;
+  padding-right: 24px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+
+.c13 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  justify-content: flex-end;
+  padding: 12px;
+}
+
+.c14 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: center;
+  border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  flex: 0 0 auto;
+  padding-left: 24px;
+  padding-right: 24px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+
+.c5 {
+  flex: 0 0 auto;
+  align-self: stretch;
+  width: 24px;
+}
+
+.c4 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c8 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  opacity: 0.3;
+  cursor: default;
+  line-height: 0;
+  padding: 12px;
+}
+
+.c8:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c8:focus:not(:focus-visible) >circle,
+.c8:focus:not(:focus-visible) >ellipse,
+.c8:focus:not(:focus-visible) >line,
+.c8:focus:not(:focus-visible) >path,
+.c8:focus:not(:focus-visible) >polygon,
+.c8:focus:not(:focus-visible) >polyline,
+.c8:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c8:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c10 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  line-height: 0;
+  padding: 12px;
+}
+
+.c10:hover {
+  background-color: rgba(221, 221, 221, 0.4);
+  color: #000000;
+}
+
+.c10:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c10:focus:not(:focus-visible) >circle,
+.c10:focus:not(:focus-visible) >ellipse,
+.c10:focus:not(:focus-visible) >line,
+.c10:focus:not(:focus-visible) >path,
+.c10:focus:not(:focus-visible) >polygon,
+.c10:focus:not(:focus-visible) >polyline,
+.c10:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c10:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c1 {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.c1:focus {
+  outline: 2px solid #6FFFB0;
+}
+
+.c3 {
+  cursor: move;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c12:focus {
+  outline: none;
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    border-top: solid 1px rgba(0, 0, 0, 0.33);
+    border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c11 {
+    border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c11 {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c11 {
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c13 {
+    padding: 6px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c14 {
+    border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c14 {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c14 {
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c5 {
+    width: 12px;
+  }
+}
+
+<div
+    class="c0"
+  >
+    <ul
+      class="c1"
+      role="list"
+      tabindex="0"
+    >
+      <li
+        class="c2 c3"
+        draggable="true"
+      >
+        <span
+          class="c4"
+        >
+          1
+        </span>
+        <div
+          class="c5"
+        />
+        <div
+          class="c6"
+        >
+          Fort Collins
+        </div>
+        <div
+          class="c5"
+        />
+        <div
+          class="c7"
+        >
+          <button
+            aria-label="1 Colorado move up"
+            class="c8"
+            disabled=""
+            id="ColoradoMoveUp"
+            tabindex="-1"
+            type="button"
+          >
+            <svg
+              aria-label="FormUp"
+              class="c9"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 15-6-6-6 6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+          <button
+            aria-label="1 Colorado move down"
+            class="c10"
+            id="ColoradoMoveDown"
+            tabindex="-1"
+            type="button"
+          >
+            <svg
+              aria-label="FormDown"
+              class="c9"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 9-6 6-6-6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </div>
+      </li>
+      <li
+        class="c11 c12"
+      >
+        <span
+          class="c4"
+        >
+          2
+        </span>
+        <div
+          class="c5"
+        />
+        <div
+          class="c6"
+        >
+          Boise
+        </div>
+        <div
+          class="c5"
+        />
+        <div
+          class="c13"
+        >
+          <svg
+            aria-label="Item locked."
+            class="c9"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="m4 19 4.455-4.454M12.273 5 18 10.727m-4.454-4.454L9.727 10.09s-2.545-.636-4.454 1.273l6.363 6.363c1.91-1.909 1.273-4.454 1.273-4.454l3.818-3.818-3.181-3.182Z"
+              fill="none"
+              stroke="#000"
+              stroke-width="2"
+            />
+          </svg>
+        </div>
+      </li>
+      <li
+        class="c14 c3"
+        draggable="true"
+      >
+        <span
+          class="c4"
+        >
+          3
+        </span>
+        <div
+          class="c5"
+        />
+        <div
+          class="c6"
+        >
+          New Orleans
+        </div>
+        <div
+          class="c5"
+        />
+        <div
+          class="c7"
+        >
+          <button
+            aria-label="2 Louisiana move up"
+            class="c10"
+            id="LouisianaMoveUp"
+            tabindex="-1"
+            type="button"
+          >
+            <svg
+              aria-label="FormUp"
+              class="c9"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 15-6-6-6 6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+          <button
+            aria-label="2 Louisiana move down"
+            class="c8"
+            disabled=""
+            id="LouisianaMoveDown"
+            tabindex="-1"
+            type="button"
+          >
+            <svg
+              aria-label="FormDown"
+              class="c9"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 9-6 6-6-6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </div>
+      </li>
+    </ul>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`List itemKey function 1`] = `
 <DocumentFragment>
   .c9 {
@@ -12908,7 +13408,7 @@ exports[`List itemKey function 1`] = `
           class="c13"
         >
           <svg
-            aria-label="FormPin"
+            aria-label="Item pinned, order cannot be changed."
             class="c9"
             viewBox="0 0 24 24"
           >
@@ -18500,7 +19000,7 @@ exports[`List pinned Pinned items should not be allowed to be re-ordered 1`] = `
           class="c13"
         >
           <svg
-            aria-label="FormPin"
+            aria-label="Item pinned, order cannot be changed."
             class="c9"
             viewBox="0 0 24 24"
           >
@@ -18601,7 +19101,7 @@ exports[`List pinned Pinned items should not be allowed to be re-ordered 1`] = `
           class="c13"
         >
           <svg
-            aria-label="FormPin"
+            aria-label="Item pinned, order cannot be changed."
             class="c9"
             viewBox="0 0 24 24"
           >
@@ -19187,7 +19687,7 @@ exports[`List pinned Pinned items should not be allowed to be re-ordered 2`] = `
           class="c13"
         >
           <svg
-            aria-label="FormPin"
+            aria-label="Item pinned, order cannot be changed."
             class="c9"
             viewBox="0 0 24 24"
           >
@@ -19288,7 +19788,7 @@ exports[`List pinned Pinned items should not be allowed to be re-ordered 2`] = `
           class="c13"
         >
           <svg
-            aria-label="FormPin"
+            aria-label="Item pinned, order cannot be changed."
             class="c9"
             viewBox="0 0 24 24"
           >
@@ -19603,7 +20103,7 @@ exports[`List pinned Should apply pinned styling to items 1`] = `
           class="c7"
         >
           <svg
-            aria-label="FormPin"
+            aria-label="Item pinned, order cannot be changed."
             class="c8"
             viewBox="0 0 24 24"
           >
@@ -19636,7 +20136,7 @@ exports[`List pinned Should apply pinned styling to items 1`] = `
           class="c7"
         >
           <svg
-            aria-label="FormPin"
+            aria-label="Item pinned, order cannot be changed."
             class="c8"
             viewBox="0 0 24 24"
           >
@@ -19921,7 +20421,7 @@ exports[`List pinned Should apply pinned styling to items when data are children
           class="c9"
         >
           <svg
-            aria-label="FormPin"
+            aria-label="Item pinned, order cannot be changed."
             class="c10"
             viewBox="0 0 24 24"
           >
@@ -19970,7 +20470,7 @@ exports[`List pinned Should apply pinned styling to items when data are children
           class="c9"
         >
           <svg
-            aria-label="FormPin"
+            aria-label="Item pinned, order cannot be changed."
             class="c10"
             viewBox="0 0 24 24"
           >
@@ -20232,7 +20732,7 @@ exports[`List pinned Should apply pinned styling to items when data are objects 
           class="c7"
         >
           <svg
-            aria-label="FormPin"
+            aria-label="Item pinned, order cannot be changed."
             class="c8"
             viewBox="0 0 24 24"
           >
@@ -20265,7 +20765,7 @@ exports[`List pinned Should apply pinned styling to items when data are objects 
           class="c7"
         >
           <svg
-            aria-label="FormPin"
+            aria-label="Item pinned, order cannot be changed."
             class="c8"
             viewBox="0 0 24 24"
           >
@@ -20745,7 +21245,7 @@ exports[`List pinned should apply pinned object styling to items when data are o
           class="c14"
         >
           <svg
-            aria-label="Lock"
+            aria-label="Item pinned, order cannot be changed."
             class="c15"
             viewBox="0 0 24 24"
           >
@@ -20850,7 +21350,7 @@ exports[`List pinned should apply pinned object styling to items when data are o
           class="c14"
         >
           <svg
-            aria-label="Lock"
+            aria-label="Item pinned, order cannot be changed."
             class="c15"
             viewBox="0 0 24 24"
           >
@@ -21391,7 +21891,7 @@ exports[`List pinned should apply pinned object styling to items when data are s
           class="c14"
         >
           <svg
-            aria-label="Lock"
+            aria-label="Item pinned, order cannot be changed."
             class="c15"
             viewBox="0 0 24 24"
           >
@@ -21496,7 +21996,7 @@ exports[`List pinned should apply pinned object styling to items when data are s
           class="c14"
         >
           <svg
-            aria-label="Lock"
+            aria-label="Item pinned, order cannot be changed."
             class="c15"
             viewBox="0 0 24 24"
           >
@@ -21859,7 +22359,7 @@ exports[`List pinned should apply pinned.color styling to primaryKey and seconda
           class="c11"
         >
           <svg
-            aria-label="Lock"
+            aria-label="Item pinned, order cannot be changed."
             class="c12"
             viewBox="0 0 24 24"
           >
@@ -21913,7 +22413,7 @@ exports[`List pinned should apply pinned.color styling to primaryKey and seconda
           class="c11"
         >
           <svg
-            aria-label="Lock"
+            aria-label="Item pinned, order cannot be changed."
             class="c12"
             viewBox="0 0 24 24"
           >
@@ -22188,7 +22688,7 @@ exports[`List pinned should apply pinned.icon but not pinned.color if icon color
           class="c8"
         >
           <svg
-            aria-label="Lock"
+            aria-label="Item pinned, order cannot be changed."
             class="c9"
             viewBox="0 0 24 24"
           >
@@ -22225,7 +22725,7 @@ exports[`List pinned should apply pinned.icon but not pinned.color if icon color
           class="c8"
         >
           <svg
-            aria-label="Lock"
+            aria-label="Item pinned, order cannot be changed."
             class="c9"
             viewBox="0 0 24 24"
           >
@@ -22515,7 +23015,7 @@ exports[`List pinned should not apply pinned.color to primaryKey and secondaryKe
           class="c9"
         >
           <svg
-            aria-label="Lock"
+            aria-label="Item pinned, order cannot be changed."
             class="c10"
             viewBox="0 0 24 24"
           >
@@ -22569,7 +23069,7 @@ exports[`List pinned should not apply pinned.color to primaryKey and secondaryKe
           class="c9"
         >
           <svg
-            aria-label="Lock"
+            aria-label="Item pinned, order cannot be changed."
             class="c10"
             viewBox="0 0 24 24"
           >
@@ -22730,6 +23230,506 @@ exports[`List primaryKey 1`] = `
     </li>
   </ul>
 </div>
+`;
+
+exports[`List prop messages 1`] = `
+<DocumentFragment>
+  .c9 {
+  display: inline-block;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #666666;
+  stroke: #666666;
+}
+
+.c9 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c9 *:not([stroke])[fill='none'] {
+  stroke-width: 0;
+}
+
+.c9 *[stroke*='#'],
+.c9 *[STROKE*='#'] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c9 *[fill-rule],
+.c9 *[FILL-RULE],
+.c9 *[fill*='#'],
+.c9 *[FILL*='#'] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c2 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: center;
+  border-top: solid 1px rgba(0, 0, 0, 0.33);
+  border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  flex: 0 0 auto;
+  padding-left: 24px;
+  padding-right: 24px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+
+.c6 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  flex: 1 1;
+}
+
+.c7 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  justify-content: flex-end;
+}
+
+.c11 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: center;
+  background-color: #33333310;
+  color: #444444;
+  border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  flex: 0 0 auto;
+  padding-left: 24px;
+  padding-right: 24px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+
+.c13 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  justify-content: flex-end;
+  padding: 12px;
+}
+
+.c14 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: center;
+  border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  flex: 0 0 auto;
+  padding-left: 24px;
+  padding-right: 24px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+
+.c5 {
+  flex: 0 0 auto;
+  align-self: stretch;
+  width: 24px;
+}
+
+.c4 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c8 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  opacity: 0.3;
+  cursor: default;
+  line-height: 0;
+  padding: 12px;
+}
+
+.c8:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c8:focus:not(:focus-visible) >circle,
+.c8:focus:not(:focus-visible) >ellipse,
+.c8:focus:not(:focus-visible) >line,
+.c8:focus:not(:focus-visible) >path,
+.c8:focus:not(:focus-visible) >polygon,
+.c8:focus:not(:focus-visible) >polyline,
+.c8:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c8:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c10 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  line-height: 0;
+  padding: 12px;
+}
+
+.c10:hover {
+  background-color: rgba(221, 221, 221, 0.4);
+  color: #000000;
+}
+
+.c10:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c10:focus:not(:focus-visible) >circle,
+.c10:focus:not(:focus-visible) >ellipse,
+.c10:focus:not(:focus-visible) >line,
+.c10:focus:not(:focus-visible) >path,
+.c10:focus:not(:focus-visible) >polygon,
+.c10:focus:not(:focus-visible) >polyline,
+.c10:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c10:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c1 {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.c1:focus {
+  outline: 2px solid #6FFFB0;
+}
+
+.c3 {
+  cursor: move;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c12:focus {
+  outline: none;
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    border-top: solid 1px rgba(0, 0, 0, 0.33);
+    border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c11 {
+    border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c11 {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c11 {
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c13 {
+    padding: 6px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c14 {
+    border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c14 {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c14 {
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c5 {
+    width: 12px;
+  }
+}
+
+<div
+    class="c0"
+  >
+    <ul
+      class="c1"
+      role="list"
+      tabindex="0"
+    >
+      <li
+        class="c2 c3"
+        draggable="true"
+      >
+        <span
+          class="c4"
+        >
+          1
+        </span>
+        <div
+          class="c5"
+        />
+        <div
+          class="c6"
+        >
+          Fort Collins
+        </div>
+        <div
+          class="c5"
+        />
+        <div
+          class="c7"
+        >
+          <button
+            aria-label="1 Colorado move up"
+            class="c8"
+            disabled=""
+            id="ColoradoMoveUp"
+            tabindex="-1"
+            type="button"
+          >
+            <svg
+              aria-label="FormUp"
+              class="c9"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 15-6-6-6 6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+          <button
+            aria-label="1 Colorado move down"
+            class="c10"
+            id="ColoradoMoveDown"
+            tabindex="-1"
+            type="button"
+          >
+            <svg
+              aria-label="FormDown"
+              class="c9"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 9-6 6-6-6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </div>
+      </li>
+      <li
+        class="c11 c12"
+      >
+        <span
+          class="c4"
+        >
+          2
+        </span>
+        <div
+          class="c5"
+        />
+        <div
+          class="c6"
+        >
+          Boise
+        </div>
+        <div
+          class="c5"
+        />
+        <div
+          class="c13"
+        >
+          <svg
+            aria-label="Item locked."
+            class="c9"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="m4 19 4.455-4.454M12.273 5 18 10.727m-4.454-4.454L9.727 10.09s-2.545-.636-4.454 1.273l6.363 6.363c1.91-1.909 1.273-4.454 1.273-4.454l3.818-3.818-3.181-3.182Z"
+              fill="none"
+              stroke="#000"
+              stroke-width="2"
+            />
+          </svg>
+        </div>
+      </li>
+      <li
+        class="c14 c3"
+        draggable="true"
+      >
+        <span
+          class="c4"
+        >
+          3
+        </span>
+        <div
+          class="c5"
+        />
+        <div
+          class="c6"
+        >
+          New Orleans
+        </div>
+        <div
+          class="c5"
+        />
+        <div
+          class="c7"
+        >
+          <button
+            aria-label="2 Louisiana move up"
+            class="c10"
+            id="LouisianaMoveUp"
+            tabindex="-1"
+            type="button"
+          >
+            <svg
+              aria-label="FormUp"
+              class="c9"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 15-6-6-6 6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+          <button
+            aria-label="2 Louisiana move down"
+            class="c8"
+            disabled=""
+            id="LouisianaMoveDown"
+            tabindex="-1"
+            type="button"
+          >
+            <svg
+              aria-label="FormDown"
+              class="c9"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 9-6 6-6-6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </div>
+      </li>
+    </ul>
+  </div>
+</DocumentFragment>
 `;
 
 exports[`List renders a11yTitle and aria-label 1`] = `

--- a/src/js/components/List/index.d.ts
+++ b/src/js/components/List/index.d.ts
@@ -60,6 +60,9 @@ export interface ListProps<ListItemType> {
     [_: string]: { background?: string; border?: BorderType; pad?: PadType };
   };
   margin?: MarginType;
+  messages?: {
+    pinned?: string;
+  };
   onActive?: (index: number) => void;
   onClickItem?: (
     event: React.MouseEvent & { item: ListItemType; index: number },

--- a/src/js/components/List/propTypes.js
+++ b/src/js/components/List/propTypes.js
@@ -67,6 +67,9 @@ if (process.env.NODE_ENV !== 'production') {
     showIndex: PropTypes.bool,
     itemKey: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
     itemProps: PropTypes.shape({}),
+    messages: PropTypes.shape({
+      pinned: PropTypes.string,
+    }),
     onActive: PropTypes.func,
     onClickItem: PropTypes.func,
     onMore: PropTypes.func,

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -594,6 +594,7 @@ exports[`Components loads 1`] = `
       "itemKey": [Function],
       "itemProps": [Function],
       "margin": [Function],
+      "messages": [Function],
       "onActive": [Function],
       "onClickItem": [Function],
       "onMore": [Function],

--- a/src/js/languages/default.json
+++ b/src/js/languages/default.json
@@ -104,6 +104,9 @@
       "validation": "Copied"
     }
   },
+  "list": {
+    "pinned": "Item pinned, order cannot be changed."
+  },
   "menu": {
     "openMenu": "Open Menu",
     "closeMenu": "Close Menu"

--- a/src/js/languages/default.json
+++ b/src/js/languages/default.json
@@ -58,6 +58,7 @@
   "dataTableColumns": {
     "open": "Open column selector",
     "order": "Order columns",
+    "pinned": "Column locked, order cannot be changed.",
     "select": "Select columns",
     "tip": "Manage columns"
   },


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Add `message` support for pinned List item. The use case the spurred this was for `pinned` columns in DataTableColumns, but since that is built with List it seemed appropriate to solve for it at the root component.

#### Where should the reviewer start?
src/js/components/List/List.js

#### What testing has been done on this PR?
Locally in storybook.

#### How should this be manually tested?
Locally in storybook.

#### Do Jest tests follow these best practices?

- [x] `screen` is used for querying.
- [x] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [x] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #7644 
 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Yes.

#### Should this PR be mentioned in the release notes?
Yes.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.