### PR TITLE
change aria labels for tabs

### DIFF
--- a/src/js/components/DataTableColumns/DataTableColumns.js
+++ b/src/js/components/DataTableColumns/DataTableColumns.js
@@ -112,6 +112,10 @@ const Content = ({ drop, options = [], ...rest }) => {
             id: 'dataTableColumns.select',
             messages: messages?.dataTableColumns,
           })}
+          aria-label={format({
+            id: 'dataTableColumns.selectAria',
+            messages: messages?.dataTableColumns,
+          })}
         >
           <Box pad={{ vertical: 'small' }} gap="xsmall">
             <TextInput
@@ -138,6 +142,10 @@ const Content = ({ drop, options = [], ...rest }) => {
 
         <Tab
           id={`${dataId}--order-columns-tab`}
+          aria-label={format({
+            id: 'dataTableColumns.orderAria',
+            messages: messages?.dataTableColumns,
+          })}
           title={format({
             id: 'dataTableColumns.order',
             messages: messages?.dataTableColumns,

--- a/src/js/components/DataTableColumns/__tests__/DataTableColumns-test.tsx
+++ b/src/js/components/DataTableColumns/__tests__/DataTableColumns-test.tsx
@@ -55,7 +55,11 @@ describe('DataTableColumns', () => {
     expect(firstTabPanel).toMatchSnapshot();
 
     // Click on the "Order columns" tab
-    fireEvent.click(screen.getByRole('tab', { name: 'Order columns' }));
+    fireEvent.click(
+      screen.getByRole('tab', {
+        name: 'Reorder the visible columns in the data table',
+      }),
+    );
 
     // Find the tab panel element using its role and aria-label
     const secondTabPanel = screen.getByRole('tabpanel', {
@@ -185,40 +189,51 @@ describe('DataTableColumns', () => {
 
     render(<App />);
 
+    // Open the drop button to reveal the column settings
     fireEvent.click(
-      screen.getByRole('button', { name: 'Open column selector' }),
+      screen.getByRole('button', {
+        name: 'Open column selector',
+      }),
     );
 
-    // advance timers so drop can open
+    // Let drop animation/timers complete
     act(() => jest.advanceTimersByTime(200));
 
-    fireEvent.click(screen.getByRole('tab', { name: 'Order columns' }));
+    // Click the "Reorder columns" tab using the full aria-label
+    fireEvent.click(
+      screen.getByRole('tab', {
+        name: 'Reorder the visible columns in the data table',
+      }),
+    );
 
-    // snap order tab
+    // Get the tab panel
     const tabPanel = screen.getByRole('tabpanel', {
       name: 'Order columns Tab Contents',
     });
-    // Take a snapshot of the tab panel
+
     expect(tabPanel).toMatchSnapshot();
 
+    // Click the move up button for "Percent"
     const bottomMoveUp = screen.getByRole('button', {
       name: '2 Percent move up',
     });
-
     fireEvent.click(bottomMoveUp);
+
     expect(onView).toBeCalledWith(
       expect.objectContaining({
         columns: ['percent', 'size', 'name'],
       }),
     );
 
+    // Check that another move button exists for "Name"
     screen.getByRole('button', { name: '2 Name move up' });
 
+    // Simulate drag and drop for reordering
     const list = screen.getByRole('list');
     const listItems = within(list).getAllByRole('listitem');
-
     const dragElement = listItems[2];
     const targetElement = listItems[0];
+
     expect(dragElement).toHaveAttribute('draggable', 'true');
 
     const dataTransfer = {

--- a/src/js/components/Grommet/index.d.ts
+++ b/src/js/components/Grommet/index.d.ts
@@ -82,6 +82,8 @@ export interface GrommetProps {
         order?: string;
         select?: string;
         tip?: string;
+        orderAria?: string;
+        selectAria?: string;
       };
       dataTableGroupBy?: {
         clear?: string;

--- a/src/js/components/Grommet/propTypes.js
+++ b/src/js/components/Grommet/propTypes.js
@@ -81,6 +81,8 @@ if (process.env.NODE_ENV !== 'production') {
           order: PropTypes.string,
           select: PropTypes.string,
           tip: PropTypes.string,
+          selectAria: PropTypes.string,
+          orderAria: PropTypes.string,
         }),
         dataTableGroupBy: PropTypes.shape({
           clear: PropTypes.string,

--- a/src/js/languages/default.json
+++ b/src/js/languages/default.json
@@ -59,7 +59,9 @@
     "open": "Open column selector",
     "order": "Order columns",
     "select": "Select columns",
-    "tip": "Manage columns"
+    "tip": "Manage columns",
+    "selectAria": "Select which columns to show in the data table",
+    "orderAria": "Reorder the visible columns in the data table"
   },
   "dataTableGroupBy": {
     "clear": "Clear group",


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR updates the `aria-label` to give a better description of what these items do for screen readers
#### Where should the reviewer start?
datatablecolumns.js
#### What testing has been done on this PR?
storybook with voice over
#### How should this be manually tested?
voice over with storybook 

Went through DataTableColumns component with Bill and he mentioned 

``` 
some feedback it would be nice if it actually told you what checkboxes did as well as the list. Ordering columns did not make it clear to Bill as what he was actually suppose to do he mentioned to say something like "here where you can select what data elements you want to show in the datatable"
#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
closes #7647 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
yes
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible 