### PR TITLE
Update SelectMultiple to use roving tab index

### DIFF
--- a/src/js/components/SelectMultiple/SelectMultipleContainer.js
+++ b/src/js/components/SelectMultiple/SelectMultipleContainer.js
@@ -591,7 +591,7 @@ const SelectMultipleContainer = forwardRef(
                       tabIndex={
                         optionSelected ||
                         activeIndex === index ||
-                        // when notthing is selected and entering listbox
+                        // when nothing is selected and entering listbox
                         // first option should be focused
                         (value.length === 0 &&
                           activeIndex === -1 &&

--- a/src/js/components/SelectMultiple/SelectMultipleContainer.js
+++ b/src/js/components/SelectMultiple/SelectMultipleContainer.js
@@ -69,12 +69,18 @@ const SelectMultipleContainer = forwardRef(
     ref,
   ) => {
     const { theme } = useThemeValue();
+    // the currently active option based on keyboard navigation
+    // or mouse hover, -1 means no active option
     const [activeIndex, setActiveIndex] = useState(-1);
     const [keyboardNavigation, setKeyboardNavigation] = useState(usingKeyboard);
     const { format } = useContext(MessageContext);
     const searchRef = useRef();
     const optionsRef = useRef();
     const [disabled, setDisabled] = useState(disabledProp);
+    // the node of the currently active option, as activeIndex changes
+    // this is updated too and the useEffect below ensures the
+    // active option remains in keyboard focus since we're
+    // following roving tab index pattern
     const activeRef = useRef();
     const [showA11yLimit, setShowA11yLimit] = useState();
     const clearRef = useRef();
@@ -187,7 +193,10 @@ const SelectMultipleContainer = forwardRef(
       (event) => {
         event.preventDefault();
         const nextActiveIndex = activeIndex + 1;
-        if (nextActiveIndex !== options?.length) {
+        // checking activeIndex > -1 ensures arrow keys don't
+        // move focus when select all/clear all button or search input
+        // are focused
+        if (nextActiveIndex !== options?.length && activeIndex > -1) {
           setActiveIndex(nextActiveIndex);
           setKeyboardNavigation(true);
         }
@@ -200,16 +209,11 @@ const SelectMultipleContainer = forwardRef(
         event.preventDefault();
         const nextActiveIndex = activeIndex - 1;
 
-        if (nextActiveIndex === -1) {
-          const searchInput = searchRef.current;
-          if (searchInput && searchInput.focus) {
-            setActiveIndex(nextActiveIndex);
-            setFocusWithoutScroll(searchInput);
-          }
-        }
-
-        if (nextActiveIndex >= 0) {
-          setActiveIndex(nextActiveIndex);
+        // checking activeIndex > -1 ensures arrow keys don't
+        // move focus when select all/clear all button or search input
+        // are focused
+        if (activeIndex > -1) {
+          setActiveIndex(Math.max(nextActiveIndex, 0));
           setKeyboardNavigation(true);
         }
       },
@@ -423,6 +427,7 @@ const SelectMultipleContainer = forwardRef(
                     setActiveIndex(-1);
                     onSearch(nextSearch);
                   }}
+                  onFocus={() => setActiveIndex(-1)}
                 />
               </Keyboard>
             </Box>
@@ -431,11 +436,10 @@ const SelectMultipleContainer = forwardRef(
           {options?.length > 0 ? (
             <OptionsContainer
               role="listbox"
-              tabIndex="0"
+              tabIndex="-1"
               ref={optionsRef}
               aria-multiselectable
               onMouseMove={() => setKeyboardNavigation(false)}
-              aria-activedescendant={optionsRef?.current?.children[activeIndex]}
               selectMultiple // internal prop
             >
               <InfiniteScroll
@@ -584,7 +588,17 @@ const SelectMultipleContainer = forwardRef(
                         if (optionRef) optionRef.current = node;
                         if (optionActive) activeRef.current = node;
                       }}
-                      tabIndex={optionSelected ? '0' : '-1'}
+                      tabIndex={
+                        optionSelected ||
+                        activeIndex === index ||
+                        // when notthing is selected and entering listbox
+                        // first option should be focused
+                        (value.length === 0 &&
+                          activeIndex === -1 &&
+                          index === 0)
+                          ? '0'
+                          : '-1'
+                      }
                       role="option"
                       id={`option${index}`}
                       aria-setsize={options.length}

--- a/src/js/components/SelectMultiple/__tests__/SelectMultiple-test.tsx
+++ b/src/js/components/SelectMultiple/__tests__/SelectMultiple-test.tsx
@@ -83,6 +83,12 @@ const TestObj = () => {
   );
 };
 
+// useFakeTimers() is global in scope for the test file.
+// Restore real timers so other tests that rely on real timers won't hang or timeout.
+afterEach(() => {
+  jest.useRealTimers();
+});
+
 describe('SelectMultiple', () => {
   test('should not have accessibility violations', async () => {
     const { container } = render(
@@ -281,6 +287,7 @@ describe('SelectMultiple', () => {
     // Mock scrollIntoView since JSDOM doesn't do layout.
     // https://github.com/jsdom/jsdom/issues/1695#issuecomment-449931788
     window.HTMLElement.prototype.scrollIntoView = jest.fn();
+    jest.useFakeTimers();
     const { container } = render(
       <Grommet>
         <SelectMultiple options={['one', 'two', 'three', 'four']} limit={2} />
@@ -288,8 +295,8 @@ describe('SelectMultiple', () => {
     );
 
     fireEvent.click(screen.getByRole('button', { name: /Open Drop/i }));
+    act(() => jest.advanceTimersByTime(200));
     const input = screen.getByRole('listbox');
-    fireEvent.keyDown(input, { keyCode: 40 }); // down
     fireEvent.keyDown(input, { keyCode: 13 }); // enter
     fireEvent.keyDown(input, { keyCode: 40 }); // down
     fireEvent.keyDown(input, { keyCode: 40 }); // down

--- a/src/js/components/SelectMultiple/__tests__/__snapshots__/SelectMultiple-test.tsx.snap
+++ b/src/js/components/SelectMultiple/__tests__/__snapshots__/SelectMultiple-test.tsx.snap
@@ -1020,6 +1020,14 @@ exports[`SelectMultiple keyboard interactions 1`] = `
 
 }
 
+@media only screen and (max-width: 768px) {
+
+}
+
+@media only screen and (max-width: 768px) {
+
+}
+
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
 
 }
@@ -1029,6 +1037,7 @@ exports[`SelectMultiple keyboard interactions 1`] = `
 }
 
 <div
+  aria-hidden="true"
   class="c0"
 >
   <div
@@ -1037,9 +1046,10 @@ exports[`SelectMultiple keyboard interactions 1`] = `
     <button
       aria-expanded="true"
       aria-haspopup="listbox"
-      aria-label="Open drop. 0 selected"
+      aria-label="Open drop. 2 selected"
       class="c2 c3"
-      tabindex="0"
+      data-g-tabindex="0"
+      tabindex="-1"
       type="button"
     >
       <div
@@ -1054,11 +1064,12 @@ exports[`SelectMultiple keyboard interactions 1`] = `
             <input
               autocomplete="off"
               class="c7 c8"
+              data-g-tabindex="-1"
               inert=""
               readonly=""
               tabindex="-1"
               type="text"
-              value=""
+              value="2 selected"
             />
           </div>
         </div>

--- a/src/js/components/SelectMultiple/__tests__/__snapshots__/SelectMultiple-test.tsx.snap
+++ b/src/js/components/SelectMultiple/__tests__/__snapshots__/SelectMultiple-test.tsx.snap
@@ -1020,14 +1020,6 @@ exports[`SelectMultiple keyboard interactions 1`] = `
 
 }
 
-@media only screen and (max-width: 768px) {
-
-}
-
-@media only screen and (max-width: 768px) {
-
-}
-
 @media screen and (-ms-high-contrast:active),(-ms-high-contrast:none) {
 
 }
@@ -1045,7 +1037,7 @@ exports[`SelectMultiple keyboard interactions 1`] = `
     <button
       aria-expanded="true"
       aria-haspopup="listbox"
-      aria-label="Open drop. 2 selected"
+      aria-label="Open drop. 0 selected"
       class="c2 c3"
       tabindex="0"
       type="button"
@@ -1066,7 +1058,7 @@ exports[`SelectMultiple keyboard interactions 1`] = `
               readonly=""
               tabindex="-1"
               type="text"
-              value="2 selected"
+              value=""
             />
           </div>
         </div>
@@ -6557,7 +6549,7 @@ exports[`SelectMultiple with portal renders custom listbox styling 1`] = `
       aria-multiselectable="true"
       class="c8"
       role="listbox"
-      tabindex="0"
+      tabindex="-1"
     >
       <button
         aria-label="morning not selected"
@@ -6567,7 +6559,7 @@ exports[`SelectMultiple with portal renders custom listbox styling 1`] = `
         class="c9 c10"
         id="option0"
         role="option"
-        tabindex="-1"
+        tabindex="0"
         type="button"
       >
         <label


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

This PR resolves focus visibility bug on SelectMultiple by:
- Removing nested interactive elements (previously we had tabIndex="0" on the listbox and on any selected option inside the listbox).
- Switching to a roving tab index approach to ensure there's still only one-ish tab stop (see sub-bullets here) for the listbox and arrow keys are used to navigate among options)
   - listbox has tabIndex="-1" (not in tab order)
   - If nothing is selected, the first option has tabIndex="0"
   - Using arrow keys updates the "active" option to tabIndex="0" and the rest to tabIndex="-1"
   - NOTE: If an option is selected, it also remains part of the tab order. This is existing behavior that I didn't change, but it does mean that it's possible for the listbox to have more than one tab stop (which goes against WCAG APG pattern recommendation. I can update if desired)
- Removes aria-activedescendant from listbox because this is not necessary when listbox doesn't have tabIndex="0"
- Removes incorrect keyboard behavior that was allowing arrow keys to be used to move from "Select all/Clear all" button to options / search input to options

NOTE: VoiceOver reads out options as "{label} not selected, selected" (This is existing behavior and also happens on WCAG APG pattern, so it seems like it's a VoiceOver bug or decision outside of our control. Just flagging that I saw and assessed if this was something we should try to overcome, but it seems not.)

#### Where should the reviewer start?
src/js/components/SelectMultiple/SelectMultipleContainer.js

#### What testing has been done on this PR?
Locally across the various storybook examples.

#### How should this be manually tested?
Storybook.

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #7671 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
Yes.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.