### PR TITLE
add fix for select focus

### DIFF
--- a/src/js/components/Select/SelectContainer.js
+++ b/src/js/components/Select/SelectContainer.js
@@ -460,7 +460,7 @@ const SelectContainer = forwardRef(
                         if (optionRef) optionRef.current = node;
                         if (optionActive) activeRef.current = node;
                       }}
-                      tabIndex={optionSelected ? '0' : '-1'}
+                      tabIndex={usingKeyboard && activeIndex === index ? 0 : -1}
                       role="option"
                       aria-setsize={options.length}
                       aria-posinset={index + 1}

--- a/src/js/components/Select/__tests__/__snapshots__/Select-multiple-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-multiple-test.js.snap
@@ -973,7 +973,7 @@ exports[`Select Controlled multiple onChange toggle with valueKey reduce 2`] = `
         aria-setsize="2"
         class="c5 c6"
         role="option"
-        tabindex="0"
+        tabindex="-1"
         type="button"
       >
         <div
@@ -2461,7 +2461,7 @@ exports[`Select Controlled multiple onChange without labelKey 4`] = `
         aria-setsize="2"
         class="StyledButton-sc-323bzc-0 brhmKp StyledSelect__SelectOption-sc-znp66n-3 jdCSKT"
         role="option"
-        tabindex="0"
+        tabindex="-1"
         type="button"
       >
         <div
@@ -2534,7 +2534,7 @@ exports[`Select Controlled multiple onChange without labelKey 6`] = `
         aria-setsize="2"
         class="StyledButton-sc-323bzc-0 brhmKp StyledSelect__SelectOption-sc-znp66n-3 jdCSKT"
         role="option"
-        tabindex="0"
+        tabindex="-1"
         type="button"
       >
         <div
@@ -2553,7 +2553,7 @@ exports[`Select Controlled multiple onChange without labelKey 6`] = `
         aria-setsize="2"
         class="StyledButton-sc-323bzc-0 brhmKp StyledSelect__SelectOption-sc-znp66n-3 jdCSKT"
         role="option"
-        tabindex="0"
+        tabindex="-1"
         type="button"
       >
         <div
@@ -3346,7 +3346,7 @@ exports[`Select Controlled multiple onChange without valueKey 4`] = `
         aria-setsize="2"
         class="StyledButton-sc-323bzc-0 brhmKp StyledSelect__SelectOption-sc-znp66n-3 jdCSKT"
         role="option"
-        tabindex="0"
+        tabindex="-1"
         type="button"
       >
         <div
@@ -3419,7 +3419,7 @@ exports[`Select Controlled multiple onChange without valueKey 6`] = `
         aria-setsize="2"
         class="StyledButton-sc-323bzc-0 brhmKp StyledSelect__SelectOption-sc-znp66n-3 jdCSKT"
         role="option"
-        tabindex="0"
+        tabindex="-1"
         type="button"
       >
         <div
@@ -3438,7 +3438,7 @@ exports[`Select Controlled multiple onChange without valueKey 6`] = `
         aria-setsize="2"
         class="StyledButton-sc-323bzc-0 brhmKp StyledSelect__SelectOption-sc-znp66n-3 jdCSKT"
         role="option"
-        tabindex="0"
+        tabindex="-1"
         type="button"
       >
         <div
@@ -5099,7 +5099,7 @@ exports[`Select Controlled multiple values 3`] = `
         aria-setsize="2"
         class="c5 c6"
         role="option"
-        tabindex="0"
+        tabindex="-1"
         type="button"
       >
         <div
@@ -5118,7 +5118,7 @@ exports[`Select Controlled multiple values 3`] = `
         aria-setsize="2"
         class="c5 c6"
         role="option"
-        tabindex="0"
+        tabindex="-1"
         type="button"
       >
         <div

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -535,7 +535,7 @@ exports[`Select Clear option renders - bottom 1`] = `
         aria-setsize="2"
         class="c5 c6"
         role="option"
-        tabindex="0"
+        tabindex="-1"
         type="button"
       >
         <div
@@ -1333,7 +1333,7 @@ exports[`Select Clear option renders- top 1`] = `
         aria-setsize="2"
         class="c9 c10"
         role="option"
-        tabindex="0"
+        tabindex="-1"
         type="button"
       >
         <div
@@ -4189,7 +4189,7 @@ exports[`Select default value clear 1`] = `
         aria-setsize="2"
         class="c13 c14"
         role="option"
-        tabindex="0"
+        tabindex="-1"
         type="button"
       >
         <div
@@ -12649,7 +12649,7 @@ exports[`Select renders custom clear selection styling 2`] = `
         aria-setsize="3"
         class="c13 c14"
         role="option"
-        tabindex="0"
+        tabindex="-1"
         type="button"
       >
         <div
@@ -13182,7 +13182,7 @@ exports[`Select renders custom listbox styling 1`] = `
         aria-setsize="3"
         class="c9 c10"
         role="option"
-        tabindex="0"
+        tabindex="-1"
         type="button"
       >
         <div
@@ -15472,7 +15472,7 @@ exports[`Select search 2`] = `
         aria-setsize="2"
         class="c12 c13"
         role="option"
-        tabindex="0"
+        tabindex="-1"
         type="button"
       >
         <div


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR changes the tab index from `-1` to `0` when keyboard is true and the option is the currently active option. 
The Focus was leaving the drop because once it opens we were forcing the focus to be on the first option in the select however once someone hit `tab` there is nothing actually focusable in the select so that is why the focus would move we need to make an option have tab index in order to keep the focus inside and trap it. 
#### Where should the reviewer start?
selectContainer.js
#### What testing has been done on this PR?
locally 
#### How should this be manually tested?
focus on select open it with enter then tab focus again it should not move out of the drop
#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
see above
#### What are the relevant issues?
closes #7670 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
 backwards compatible