### PR TITLE
RangeSelector - add theme value for the edge size

### DIFF
--- a/src/js/components/RangeSelector/EdgeControl.js
+++ b/src/js/components/RangeSelector/EdgeControl.js
@@ -29,7 +29,11 @@ const EdgeControl = forwardRef(
     const { theme } = useThemeValue();
     const [focus, setFocus] = useState(false);
     const { cursor, fill } = DIRECTION_PROPS[direction];
-    const size = parseMetricToNum(theme.global.spacing) / 2;
+    const themeSize = theme.rangeSelector?.edge?.size;
+    const size =
+      typeof themeSize === 'string'
+        ? parseMetricToNum(theme.global.edgeSize?.[themeSize] || themeSize)
+        : parseMetricToNum(theme.global.spacing) / 2;
     const keyboardProps =
       direction === 'vertical'
         ? { onUp: onDecrease, onDown: onIncrease }

--- a/src/js/components/RangeSelector/EdgeControl.js
+++ b/src/js/components/RangeSelector/EdgeControl.js
@@ -30,10 +30,11 @@ const EdgeControl = forwardRef(
     const [focus, setFocus] = useState(false);
     const { cursor, fill } = DIRECTION_PROPS[direction];
     const themeEdgeSize = theme.rangeSelector?.edge?.size;
-    const size =
-      typeof themeSize === 'string'
-        ? parseMetricToNum(theme.global.edgeSize?.[themeSize] || themeSize)
-        : parseMetricToNum(theme.global.spacing) / 2;
+    const size = themeEdgeSize
+      ? parseMetricToNum(
+          theme.global.edgeSize?.[themeEdgeSize] || themeEdgeSize,
+        )
+      : parseMetricToNum(theme.global.spacing) / 2;
     const keyboardProps =
       direction === 'vertical'
         ? { onUp: onDecrease, onDown: onIncrease }

--- a/src/js/components/RangeSelector/EdgeControl.js
+++ b/src/js/components/RangeSelector/EdgeControl.js
@@ -31,7 +31,7 @@ const EdgeControl = forwardRef(
     const { cursor, fill } = DIRECTION_PROPS[direction];
     const themeEdgeSize = theme.rangeSelector?.edge?.size;
     let size;
-    if (themeEdgeSize != null) {
+    if (themeEdgeSize) {
       // Try to look up the value in theme.global.edgeSize
       // If not found, assume it's a raw CSS value like '10px'.
       const themeEdge = theme.global.edgeSize?.[themeEdgeSize] || themeEdgeSize;

--- a/src/js/components/RangeSelector/EdgeControl.js
+++ b/src/js/components/RangeSelector/EdgeControl.js
@@ -29,7 +29,7 @@ const EdgeControl = forwardRef(
     const { theme } = useThemeValue();
     const [focus, setFocus] = useState(false);
     const { cursor, fill } = DIRECTION_PROPS[direction];
-    const themeSize = theme.rangeSelector?.edge?.size;
+    const themeEdgeSize = theme.rangeSelector?.edge?.size;
     const size =
       typeof themeSize === 'string'
         ? parseMetricToNum(theme.global.edgeSize?.[themeSize] || themeSize)

--- a/src/js/components/RangeSelector/EdgeControl.js
+++ b/src/js/components/RangeSelector/EdgeControl.js
@@ -30,11 +30,22 @@ const EdgeControl = forwardRef(
     const [focus, setFocus] = useState(false);
     const { cursor, fill } = DIRECTION_PROPS[direction];
     const themeEdgeSize = theme.rangeSelector?.edge?.size;
-    const size = themeEdgeSize
-      ? parseMetricToNum(
-          theme.global.edgeSize?.[themeEdgeSize] || themeEdgeSize,
-        )
-      : parseMetricToNum(theme.global.spacing) / 2;
+    let size;
+    if (themeEdgeSize != null) {
+      // Try to look up the value in theme.global.edgeSize
+      // If not found, assume it's a raw CSS value like '10px'.
+      const themeEdge = theme.global.edgeSize?.[themeEdgeSize] || themeEdgeSize;
+      const parsedSize = parseMetricToNum(themeEdge);
+      const isValid =
+        typeof parsedSize === 'number' && !Number.isNaN(parsedSize);
+
+      // If parsedSize is a valid number, use it.
+      // Otherwise, fallback to half of the theme's global spacing.
+      size = isValid ? parsedSize : parseMetricToNum(theme.global.spacing) / 2;
+    } else {
+      // If no edge size was specified use default.
+      size = parseMetricToNum(theme.global.spacing) / 2;
+    }
     const keyboardProps =
       direction === 'vertical'
         ? { onUp: onDecrease, onDown: onIncrease }

--- a/src/js/components/RangeSelector/__tests__/RangeSelector-test.tsx
+++ b/src/js/components/RangeSelector/__tests__/RangeSelector-test.tsx
@@ -40,6 +40,50 @@ describe('RangeSelector', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  const edgeSizes = ['small', 'medium', 'large', 'xlarge']; // use all supported sizes
+
+  edgeSizes.forEach((size) => {
+    test(`renders with edge size: ${size}`, () => {
+      const theme = {
+        rangeSelector: {
+          edge: { size },
+        },
+      };
+      const { container } = render(
+        <Grommet theme={theme}>
+          <RangeSelector values={[10, 40]} />
+        </Grommet>,
+      );
+      expect(container.firstChild).toMatchSnapshot();
+    });
+  });
+
+  test('renders with default edge size when not specified', () => {
+    const theme = {
+      rangeSelector: {},
+    };
+    const { container } = render(
+      <Grommet theme={theme}>
+        <RangeSelector values={[5, 25]} />
+      </Grommet>,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test('renders gracefully with invalid edge size', () => {
+    const theme = {
+      rangeSelector: {
+        edge: { size: 'not-a-real-size' },
+      },
+    };
+    const { container } = render(
+      <Grommet theme={theme}>
+        <RangeSelector values={[15, 35]} />
+      </Grommet>,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
   test('basic', () => {
     const { container } = render(
       <Grommet>

--- a/src/js/components/RangeSelector/__tests__/RangeSelector-test.tsx
+++ b/src/js/components/RangeSelector/__tests__/RangeSelector-test.tsx
@@ -22,6 +22,24 @@ describe('RangeSelector', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  test('basic with theme edge size', () => {
+    const theme = {
+      rangeSelector: {
+        edge: {
+          size: 'medium',
+        },
+      },
+    };
+
+    const { container } = render(
+      <Grommet theme={theme}>
+        <RangeSelector values={[20, 30]} />
+      </Grommet>,
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
   test('basic', () => {
     const { container } = render(
       <Grommet>

--- a/src/js/components/RangeSelector/__tests__/__snapshots__/RangeSelector-test.tsx.snap
+++ b/src/js/components/RangeSelector/__tests__/__snapshots__/RangeSelector-test.tsx.snap
@@ -290,6 +290,158 @@ exports[`RangeSelector basic outside grommet wrapper 1`] = `
 </div>
 `;
 
+exports[`RangeSelector basic with theme edge size 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  width: 100%;
+  height: 100%;
+  cursor: pointer;
+}
+
+.c3 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  height: 24px;
+  width: 100%;
+}
+
+.c4 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-self: stretch;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  justify-content: center;
+  overflow: visible;
+}
+
+.c5 {
+  display: flex;
+  box-sizing: border-box;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  flex-basis: 100%;
+  height: 100%;
+  justify-content: center;
+}
+
+.c6 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  background-color: #7D4CDB;
+  color: #f8f8f8;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  height: 24px;
+  width: 24px;
+  border-radius: 100%;
+}
+
+.c7 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  background-color: rgba(125, 76, 219, 0.4);
+  color: #444444;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  height: 24px;
+  width: 100%;
+}
+
+.c2 {
+  user-select: none;
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1 c2"
+    tabindex="-1"
+  >
+    <div
+      class="c3"
+      style="flex: 20 0 0px;"
+    />
+    <div
+      class="c4"
+      style="flex: 0 0 1px;"
+    >
+      <div
+        aria-label="Lower Bounds"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="20"
+        class="c5"
+        role="slider"
+        style="cursor: col-resize; outline: none; min-width: 24px; min-height: 24px; z-index: 1;"
+        tabindex="0"
+      >
+        <div
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+        />
+      </div>
+    </div>
+    <div
+      class="c7"
+      style="flex: 11 0 0px; cursor: ew-resize;"
+    />
+    <div
+      class="c4"
+      style="flex: 0 0 1px;"
+    >
+      <div
+        aria-label="Upper Bounds"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="30"
+        class="c5"
+        role="slider"
+        style="cursor: col-resize; outline: none; min-width: 24px; min-height: 24px; z-index: 1;"
+        tabindex="0"
+      >
+        <div
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+        />
+      </div>
+    </div>
+    <div
+      class="c3"
+      style="flex: 70 0 0px;"
+    />
+  </div>
+</div>
+`;
+
 exports[`RangeSelector color 1`] = `
 .c0 {
   font-size: 18px;

--- a/src/js/components/RangeSelector/__tests__/__snapshots__/RangeSelector-test.tsx.snap
+++ b/src/js/components/RangeSelector/__tests__/__snapshots__/RangeSelector-test.tsx.snap
@@ -2396,6 +2396,918 @@ exports[`RangeSelector opacity 1`] = `
 </div>
 `;
 
+exports[`RangeSelector renders gracefully with invalid edge size 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  width: 100%;
+  height: 100%;
+  cursor: pointer;
+}
+
+.c3 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  height: 24px;
+  width: 100%;
+}
+
+.c4 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-self: stretch;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  justify-content: center;
+  overflow: visible;
+}
+
+.c5 {
+  display: flex;
+  box-sizing: border-box;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  flex-basis: 100%;
+  height: 100%;
+  justify-content: center;
+}
+
+.c6 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  background-color: #7D4CDB;
+  color: #f8f8f8;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  height: 12px;
+  width: 12px;
+  border-radius: 100%;
+}
+
+.c7 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  background-color: rgba(125, 76, 219, 0.4);
+  color: #444444;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  height: 24px;
+  width: 100%;
+}
+
+.c2 {
+  user-select: none;
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1 c2"
+    tabindex="-1"
+  >
+    <div
+      class="c3"
+      style="flex: 15 0 0px;"
+    />
+    <div
+      class="c4"
+      style="flex: 0 0 1px;"
+    >
+      <div
+        aria-label="Lower Bounds"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="15"
+        class="c5"
+        role="slider"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 1;"
+        tabindex="0"
+      >
+        <div
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+        />
+      </div>
+    </div>
+    <div
+      class="c7"
+      style="flex: 21 0 0px; cursor: ew-resize;"
+    />
+    <div
+      class="c4"
+      style="flex: 0 0 1px;"
+    >
+      <div
+        aria-label="Upper Bounds"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="35"
+        class="c5"
+        role="slider"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 1;"
+        tabindex="0"
+      >
+        <div
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+        />
+      </div>
+    </div>
+    <div
+      class="c3"
+      style="flex: 65 0 0px;"
+    />
+  </div>
+</div>
+`;
+
+exports[`RangeSelector renders with default edge size when not specified 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  width: 100%;
+  height: 100%;
+  cursor: pointer;
+}
+
+.c3 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  height: 24px;
+  width: 100%;
+}
+
+.c4 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-self: stretch;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  justify-content: center;
+  overflow: visible;
+}
+
+.c5 {
+  display: flex;
+  box-sizing: border-box;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  flex-basis: 100%;
+  height: 100%;
+  justify-content: center;
+}
+
+.c6 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  background-color: #7D4CDB;
+  color: #f8f8f8;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  height: 12px;
+  width: 12px;
+  border-radius: 100%;
+}
+
+.c7 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  background-color: rgba(125, 76, 219, 0.4);
+  color: #444444;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  height: 24px;
+  width: 100%;
+}
+
+.c2 {
+  user-select: none;
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1 c2"
+    tabindex="-1"
+  >
+    <div
+      class="c3"
+      style="flex: 5 0 0px;"
+    />
+    <div
+      class="c4"
+      style="flex: 0 0 1px;"
+    >
+      <div
+        aria-label="Lower Bounds"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="5"
+        class="c5"
+        role="slider"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 1;"
+        tabindex="0"
+      >
+        <div
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+        />
+      </div>
+    </div>
+    <div
+      class="c7"
+      style="flex: 21 0 0px; cursor: ew-resize;"
+    />
+    <div
+      class="c4"
+      style="flex: 0 0 1px;"
+    >
+      <div
+        aria-label="Upper Bounds"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="25"
+        class="c5"
+        role="slider"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 1;"
+        tabindex="0"
+      >
+        <div
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+        />
+      </div>
+    </div>
+    <div
+      class="c3"
+      style="flex: 75 0 0px;"
+    />
+  </div>
+</div>
+`;
+
+exports[`RangeSelector renders with edge size: large 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  width: 100%;
+  height: 100%;
+  cursor: pointer;
+}
+
+.c3 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  height: 24px;
+  width: 100%;
+}
+
+.c4 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-self: stretch;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  justify-content: center;
+  overflow: visible;
+}
+
+.c5 {
+  display: flex;
+  box-sizing: border-box;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  flex-basis: 100%;
+  height: 100%;
+  justify-content: center;
+}
+
+.c6 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  background-color: #7D4CDB;
+  color: #f8f8f8;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  height: 48px;
+  width: 48px;
+  border-radius: 100%;
+}
+
+.c7 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  background-color: rgba(125, 76, 219, 0.4);
+  color: #444444;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  height: 24px;
+  width: 100%;
+}
+
+.c2 {
+  user-select: none;
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1 c2"
+    tabindex="-1"
+  >
+    <div
+      class="c3"
+      style="flex: 10 0 0px;"
+    />
+    <div
+      class="c4"
+      style="flex: 0 0 1px;"
+    >
+      <div
+        aria-label="Lower Bounds"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="10"
+        class="c5"
+        role="slider"
+        style="cursor: col-resize; outline: none; min-width: 48px; min-height: 48px; z-index: 1;"
+        tabindex="0"
+      >
+        <div
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+        />
+      </div>
+    </div>
+    <div
+      class="c7"
+      style="flex: 31 0 0px; cursor: ew-resize;"
+    />
+    <div
+      class="c4"
+      style="flex: 0 0 1px;"
+    >
+      <div
+        aria-label="Upper Bounds"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="40"
+        class="c5"
+        role="slider"
+        style="cursor: col-resize; outline: none; min-width: 48px; min-height: 48px; z-index: 1;"
+        tabindex="0"
+      >
+        <div
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+        />
+      </div>
+    </div>
+    <div
+      class="c3"
+      style="flex: 60 0 0px;"
+    />
+  </div>
+</div>
+`;
+
+exports[`RangeSelector renders with edge size: medium 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  width: 100%;
+  height: 100%;
+  cursor: pointer;
+}
+
+.c3 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  height: 24px;
+  width: 100%;
+}
+
+.c4 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-self: stretch;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  justify-content: center;
+  overflow: visible;
+}
+
+.c5 {
+  display: flex;
+  box-sizing: border-box;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  flex-basis: 100%;
+  height: 100%;
+  justify-content: center;
+}
+
+.c6 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  background-color: #7D4CDB;
+  color: #f8f8f8;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  height: 24px;
+  width: 24px;
+  border-radius: 100%;
+}
+
+.c7 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  background-color: rgba(125, 76, 219, 0.4);
+  color: #444444;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  height: 24px;
+  width: 100%;
+}
+
+.c2 {
+  user-select: none;
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1 c2"
+    tabindex="-1"
+  >
+    <div
+      class="c3"
+      style="flex: 10 0 0px;"
+    />
+    <div
+      class="c4"
+      style="flex: 0 0 1px;"
+    >
+      <div
+        aria-label="Lower Bounds"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="10"
+        class="c5"
+        role="slider"
+        style="cursor: col-resize; outline: none; min-width: 24px; min-height: 24px; z-index: 1;"
+        tabindex="0"
+      >
+        <div
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+        />
+      </div>
+    </div>
+    <div
+      class="c7"
+      style="flex: 31 0 0px; cursor: ew-resize;"
+    />
+    <div
+      class="c4"
+      style="flex: 0 0 1px;"
+    >
+      <div
+        aria-label="Upper Bounds"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="40"
+        class="c5"
+        role="slider"
+        style="cursor: col-resize; outline: none; min-width: 24px; min-height: 24px; z-index: 1;"
+        tabindex="0"
+      >
+        <div
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+        />
+      </div>
+    </div>
+    <div
+      class="c3"
+      style="flex: 60 0 0px;"
+    />
+  </div>
+</div>
+`;
+
+exports[`RangeSelector renders with edge size: small 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  width: 100%;
+  height: 100%;
+  cursor: pointer;
+}
+
+.c3 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  height: 24px;
+  width: 100%;
+}
+
+.c4 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-self: stretch;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  justify-content: center;
+  overflow: visible;
+}
+
+.c5 {
+  display: flex;
+  box-sizing: border-box;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  flex-basis: 100%;
+  height: 100%;
+  justify-content: center;
+}
+
+.c6 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  background-color: #7D4CDB;
+  color: #f8f8f8;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  height: 12px;
+  width: 12px;
+  border-radius: 100%;
+}
+
+.c7 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  background-color: rgba(125, 76, 219, 0.4);
+  color: #444444;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  height: 24px;
+  width: 100%;
+}
+
+.c2 {
+  user-select: none;
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1 c2"
+    tabindex="-1"
+  >
+    <div
+      class="c3"
+      style="flex: 10 0 0px;"
+    />
+    <div
+      class="c4"
+      style="flex: 0 0 1px;"
+    >
+      <div
+        aria-label="Lower Bounds"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="10"
+        class="c5"
+        role="slider"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 1;"
+        tabindex="0"
+      >
+        <div
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+        />
+      </div>
+    </div>
+    <div
+      class="c7"
+      style="flex: 31 0 0px; cursor: ew-resize;"
+    />
+    <div
+      class="c4"
+      style="flex: 0 0 1px;"
+    >
+      <div
+        aria-label="Upper Bounds"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="40"
+        class="c5"
+        role="slider"
+        style="cursor: col-resize; outline: none; min-width: 12px; min-height: 12px; z-index: 1;"
+        tabindex="0"
+      >
+        <div
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+        />
+      </div>
+    </div>
+    <div
+      class="c3"
+      style="flex: 60 0 0px;"
+    />
+  </div>
+</div>
+`;
+
+exports[`RangeSelector renders with edge size: xlarge 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  width: 100%;
+  height: 100%;
+  cursor: pointer;
+}
+
+.c3 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  height: 24px;
+  width: 100%;
+}
+
+.c4 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-self: stretch;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  justify-content: center;
+  overflow: visible;
+}
+
+.c5 {
+  display: flex;
+  box-sizing: border-box;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  flex-basis: 100%;
+  height: 100%;
+  justify-content: center;
+}
+
+.c6 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  background-color: #7D4CDB;
+  color: #f8f8f8;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  height: 96px;
+  width: 96px;
+  border-radius: 100%;
+}
+
+.c7 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  background-color: rgba(125, 76, 219, 0.4);
+  color: #444444;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  height: 24px;
+  width: 100%;
+}
+
+.c2 {
+  user-select: none;
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1 c2"
+    tabindex="-1"
+  >
+    <div
+      class="c3"
+      style="flex: 10 0 0px;"
+    />
+    <div
+      class="c4"
+      style="flex: 0 0 1px;"
+    >
+      <div
+        aria-label="Lower Bounds"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="10"
+        class="c5"
+        role="slider"
+        style="cursor: col-resize; outline: none; min-width: 96px; min-height: 96px; z-index: 1;"
+        tabindex="0"
+      >
+        <div
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+        />
+      </div>
+    </div>
+    <div
+      class="c7"
+      style="flex: 31 0 0px; cursor: ew-resize;"
+    />
+    <div
+      class="c4"
+      style="flex: 0 0 1px;"
+    >
+      <div
+        aria-label="Upper Bounds"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="40"
+        class="c5"
+        role="slider"
+        style="cursor: col-resize; outline: none; min-width: 96px; min-height: 96px; z-index: 1;"
+        tabindex="0"
+      >
+        <div
+          class="c6 EdgeControl__StyledBox-sc-1xo2yt9-0"
+        />
+      </div>
+    </div>
+    <div
+      class="c3"
+      style="flex: 60 0 0px;"
+    />
+  </div>
+</div>
+`;
+
 exports[`RangeSelector round 1`] = `
 .c0 {
   font-size: 18px;

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -1672,6 +1672,7 @@ export interface ThemeType {
     };
     edge?: {
       type?: string;
+      size?: string;
     };
   };
   select?: {

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -15,6 +15,7 @@ import {
   ColorType,
   DeepReadonly,
   DirectionType,
+  EdgeSizeType,
   ElevationType,
   GapType,
   GraphColorsType,
@@ -1672,7 +1673,7 @@ export interface ThemeType {
     };
     edge?: {
       type?: string;
-      size?: string;
+      size?: EdgeSizeType | string;
     };
   };
   select?: {

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1842,9 +1842,10 @@ export const generate = (baseSpacing = 24, scale = 6) => {
           color: 'light-4',
         },
       },
-      // edge: {
-      //   type: undefined,
-      // },
+      edge: {
+        // type: undefined,
+        // size: undefined,
+      },
     },
     select: {
       // background: undefined,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR adds a theme value for the theme to allow users to pass a value for `edge` size
#### Where should the reviewer start?
EdgeControl.js
#### What testing has been done on this PR?
locally and wrote a test 
#### How should this be manually tested?
pass in a value for `theme.rangeSelector?.edge?.size;`

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
The size needs to be at least 24X24 
right now we have it at 12X12 so we dont break the current size I have added a theme option for us to use in the hpe theme 
#### What are the relevant issues?
closes #7669 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
yes
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
 backwards compatible