### PR TITLE
List -- Fix keyboard behavior with roving tab index

### DIFF
--- a/src/js/components/Box/Box.js
+++ b/src/js/components/Box/Box.js
@@ -309,7 +309,11 @@ const Box = forwardRef(
     }
 
     if (onClick) {
-      content = <Keyboard onEnter={onClick}>{content}</Keyboard>;
+      content = (
+        <Keyboard onEnter={onClick} onSpace={onClick}>
+          {content}
+        </Keyboard>
+      );
     }
 
     return content;

--- a/src/js/components/Box/Box.js
+++ b/src/js/components/Box/Box.js
@@ -310,7 +310,13 @@ const Box = forwardRef(
 
     if (onClick) {
       content = (
-        <Keyboard onEnter={onClick} onSpace={onClick}>
+        <Keyboard
+          onEnter={onClick}
+          onSpace={(e) => {
+            e.preventDefault(); // prevent page scroll
+            onClick(e);
+          }}
+        >
           {content}
         </Keyboard>
       );

--- a/src/js/components/Box/StyledBox.js
+++ b/src/js/components/Box/StyledBox.js
@@ -346,6 +346,8 @@ const StyledBox = styled.div.withConfig({
     props.onClick &&
     props.focus &&
     props.focusIndicator !== false &&
+    // only show focus styles when using keyboard navigation
+    // but not with mouse
     css`
       ${focusStyle()}
       &:focus:not(:focus-visible) {

--- a/src/js/components/Box/StyledBox.js
+++ b/src/js/components/Box/StyledBox.js
@@ -11,6 +11,7 @@ import {
   elevationStyle,
   fillStyle,
   focusStyle,
+  unfocusStyle,
   genericStyles,
   getBreakpointStyle,
   getHoverIndicatorStyle,
@@ -345,7 +346,12 @@ const StyledBox = styled.div.withConfig({
     props.onClick &&
     props.focus &&
     props.focusIndicator !== false &&
-    focusStyle()}
+    css`
+      ${focusStyle()}
+      &:focus:not(:focus-visible) {
+        ${unfocusStyle()}
+      }
+    `}
   ${(props) => props.theme.box && props.theme.box.extend}
   ${(props) => props.kindProp && props.kindProp.extend}
   ${(props) => (props.responsiveContainer ? responsiveContainerStyle : '')}

--- a/src/js/components/List/List.js
+++ b/src/js/components/List/List.js
@@ -18,11 +18,9 @@ import { MessageContext } from '../../contexts/MessageContext';
 import { Pagination } from '../Pagination';
 import { Text } from '../Text';
 import {
-  // focusStyle,
   genericStyles,
   normalizeColor,
   normalizeShow,
-  // unfocusStyle,
   useForwardedRef,
   usePagination,
   styledComponentsConfig,
@@ -97,16 +95,6 @@ const reorder = (array, pinnedArray, source, target) => {
   return result;
 };
 
-// getItemId returns something appropriate to use as a unique DOM
-// id for an item in the list
-// const getItemId = (item, index, itemKey, primaryKey) => {
-//   // we do primaryKey first to be backward compatible, even though
-//   // itemKey is probably technically the better choice for a DOM id.
-//   if (primaryKey) return getValue(item, index, primaryKey);
-//   if (itemKey) return getValue(item, index, itemKey);
-//   return getValue(item, index) ?? index; // do our best w/o *key properties
-// };
-
 const List = React.forwardRef(
   (
     {
@@ -178,7 +166,6 @@ const List = React.forwardRef(
       }
     }, [active, data]);
 
-    // const [itemFocus, setItemFocus] = useState();
     const [dragging, setDragging] = useState();
     const [orderingData, setOrderingData] = useState();
 
@@ -233,34 +220,6 @@ const List = React.forwardRef(
       role: onClickItem ? 'listbox' : 'list',
     };
 
-    // if (active >= 0) {
-    //   let activeId;
-    //   // We have an item that is 'focused' within the list. This could
-    //   // be the list item or one of the up/down ordering buttons.
-    //   // We need to figure out an id of the thing that will be
-    //   // shown as active
-    //   if (onOrder) {
-    //     // figure out which arrow button will be the active one.
-    //     const buttonId = active % 2 ? 'MoveDown' : 'MoveUp';
-    //     const itemIndex = Math.trunc(active / 2);
-    //     activeId = `${getItemId(
-    //       orderableData[itemIndex],
-    //       itemIndex,
-    //       itemKey,
-    //       primaryKey,
-    //     )}${buttonId}`;
-    //   } else if (onClickItem) {
-    //     // The whole list item is active. Figure out an id
-    //     activeId = getItemId(
-    //       orderableData[active],
-    //       active,
-    //       itemKey,
-    //       primaryKey,
-    //     );
-    //   }
-    //   ariaProps['aria-activedescendant'] = activeId;
-    // }
-
     const onSelectOption = (event, nextActive) => {
       if ((onClickItem || onOrder) && nextActive >= 0) {
         if (onOrder) {
@@ -313,19 +272,6 @@ const List = React.forwardRef(
     return (
       <Container {...containterProps}>
         <Keyboard
-          // onEnter={(event) => {
-          //   // if (onClickItem || onOrder) {
-          //   //   event.preventDefault();
-          //   // }
-          //   console.log('clicking');
-          //   onSelectOption(event);
-          // }}
-          // onSpace={(event) => {
-          //   // if (onClickItem || onOrder) {
-          //   //   event.preventDefault();
-          //   // }
-          //   onSelectOption(event);
-          // }}
           onUp={(event) => {
             if (onClickItem || onOrder) {
               event.preventDefault();
@@ -380,8 +326,6 @@ const List = React.forwardRef(
             aria-label={ariaLabel || a11yTitle}
             ref={listRef}
             as={as || 'ul'}
-            // itemFocus={itemFocus}
-            // tabIndex={onClickItem || onOrder ? 0 : undefined}
             tabIndex={-1}
             onFocus={() => {
               if (onOrder) {
@@ -588,16 +532,6 @@ const List = React.forwardRef(
                         onSelectOption(event, index);
                       }
                     },
-                    // onMouseOver: () => updateActive(index),
-                    // onMouseOut: () => updateActive(undefined),
-                    // onFocus: () => {
-                    //   // updateActive(index);
-                    //   // setItemFocus(true);
-                    // },
-                    // onBlur: () => {
-                    //   // updateActive(undefined);
-                    //   // setItemFocus(false);
-                    // },
                   };
                 }
 
@@ -687,9 +621,8 @@ const List = React.forwardRef(
                         a11yTitle={`${orderableIndex + 1} ${key} move up`}
                         icon={<Up />}
                         hoverIndicator
-                        // focusIndicator={false}
                         disabled={!orderableIndex}
-                        active={active === moveUpIndex} // TO DO likely remove
+                        active={active === moveUpIndex}
                         onClick={(event) => {
                           event.stopPropagation();
                           onSelectOption(event, moveUpIndex);
@@ -700,29 +633,16 @@ const List = React.forwardRef(
                             activeRef.current = node;
                           }
                         }}
-                        // onMouseOver={() => updateActive(moveUpIndex)}
-                        // onMouseOut={() => updateActive(undefined)}
-                        // onFocus={() => {
-                        //   console.log('focusing', moveUpIndex);
-                        //   updateActive(moveUpIndex);
-                        //   // setItemFocus(true);
-                        // }}
-                        // onBlur={() => {
-                        //   updateActive(undefined);
-                        //   // setItemFocus(false);
-                        // }}
                       />
                       <Button
                         id={`${key}MoveDown`}
                         a11yTitle={`${orderableIndex + 1} ${key} move down`}
                         icon={<Down />}
                         hoverIndicator
-                        // focusIndicator={false}
                         disabled={orderableIndex >= orderableData.length - 1}
                         active={active === moveDownIndex}
                         onClick={(event) => {
                           event.stopPropagation();
-                          // console.log('click', active);
                           onSelectOption(event, moveDownIndex);
                         }}
                         tabIndex={moveDownActive}
@@ -731,8 +651,6 @@ const List = React.forwardRef(
                             activeRef.current = node;
                           }
                         }}
-                        // onMouseOver={() => console.log({ moveDownIndex })}
-                        // onMouseOut={() => updateActive(undefined)}
                         onFocus={() => {
                           // make sure first "MoveDown" is focusable
                           if (
@@ -741,12 +659,7 @@ const List = React.forwardRef(
                           ) {
                             updateActive(moveDownIndex);
                           }
-                          // setItemFocus(true);
                         }}
-                        // onBlur={() => {
-                        //   updateActive(undefined);
-                        //   // setItemFocus(false);
-                        // }}
                       />
                     </Box>
                   );

--- a/src/js/components/List/List.js
+++ b/src/js/components/List/List.js
@@ -326,9 +326,10 @@ const List = React.forwardRef(
             ref={listRef}
             as={as || 'ul'}
             onFocus={() => {
-              if (onOrder) {
+              if (onOrder || onClickItem) {
                 if (active === undefined && lastActive === undefined) {
-                  updateActive(1); // first "MoveDown" button
+                  // first "MoveDown" button or first item
+                  updateActive(onOrder ? 1 : 0);
                 } else if (lastActive >= 0 && active === undefined) {
                   // if focus is returning to the list, make the last active
                   // item active again

--- a/src/js/components/List/List.js
+++ b/src/js/components/List/List.js
@@ -580,7 +580,7 @@ const List = React.forwardRef(
                   const Up = theme.list.icons.up;
                   const Down = theme.list.icons.down;
                   const moveUpIndex = orderableIndex * 2;
-                  const moveUpActive =
+                  const moveUpTabIndex =
                     // Don't allow focus on disabled buttons
                     // eslint-disable-next-line no-nested-ternary
                     !orderableIndex
@@ -593,7 +593,7 @@ const List = React.forwardRef(
                       ? 0
                       : -1;
                   const moveDownIndex = orderableIndex * 2 + 1;
-                  const moveDownActive =
+                  const moveDownTabIndex =
                     // Don't allow focus on disabled buttons
                     // eslint-disable-next-line no-nested-ternary
                     orderableIndex >= orderableData.length - 1
@@ -625,7 +625,7 @@ const List = React.forwardRef(
                           event.stopPropagation();
                           onSelectOption(event, moveUpIndex);
                         }}
-                        tabIndex={moveUpActive}
+                        tabIndex={moveUpTabIndex}
                         ref={(node) => {
                           if (active === moveUpIndex) {
                             activeRef.current = node;
@@ -643,7 +643,7 @@ const List = React.forwardRef(
                           event.stopPropagation();
                           onSelectOption(event, moveDownIndex);
                         }}
-                        tabIndex={moveDownActive}
+                        tabIndex={moveDownTabIndex}
                         ref={(node) => {
                           if (active === moveDownIndex) {
                             activeRef.current = node;

--- a/src/js/components/List/List.js
+++ b/src/js/components/List/List.js
@@ -152,9 +152,8 @@ const List = React.forwardRef(
       setActive(nextActive);
       // we occasionally call updateActive with undefined when it already is so,
       // no need to call onActive in that case
-      if (onActive && onClickItem && nextActive !== active) {
+      if (onActive && onClickItem && nextActive !== active)
         onActive(nextActive);
-      }
     };
 
     // roving tab index, ensure active item (when onClickItem)
@@ -326,7 +325,6 @@ const List = React.forwardRef(
             aria-label={ariaLabel || a11yTitle}
             ref={listRef}
             as={as || 'ul'}
-            tabIndex={-1}
             onFocus={() => {
               if (onOrder) {
                 if (active === undefined && lastActive === undefined) {

--- a/src/js/components/List/List.js
+++ b/src/js/components/List/List.js
@@ -95,6 +95,19 @@ const reorder = (array, pinnedArray, source, target) => {
   return result;
 };
 
+/** Calculate tabIndex for order control buttons. */
+const calculateTabIndex = (buttonIndex, active, lastActive, disabled) => {
+  if (disabled) return -1;
+  // is currently active
+  return (active !== undefined && active === buttonIndex) ||
+    // was last active
+    (active === undefined && lastActive === buttonIndex) ||
+    // first "move down" button when entering the list for first time
+    (active === undefined && lastActive === undefined && buttonIndex === 1)
+    ? 0
+    : -1;
+};
+
 const List = React.forwardRef(
   (
     {
@@ -580,38 +593,23 @@ const List = React.forwardRef(
 
                   const Up = theme.list.icons.up;
                   const Down = theme.list.icons.down;
+
                   const moveUpIndex = orderableIndex * 2;
-                  const moveUpTabIndex =
-                    // Don't allow focus on disabled buttons
-                    // eslint-disable-next-line no-nested-ternary
-                    !orderableIndex
-                      ? -1
-                      : // active is defined
-                      (active !== undefined && active === moveUpIndex) ||
-                        // focus is returning to list, make previously active
-                        // button active
-                        (active === undefined && lastActive === moveUpIndex)
-                      ? 0
-                      : -1;
+                  const moveUpTabIndex = calculateTabIndex(
+                    moveUpIndex,
+                    active,
+                    lastActive,
+                    !orderableIndex, // first item can't move up
+                  );
+
                   const moveDownIndex = orderableIndex * 2 + 1;
-                  const moveDownTabIndex =
-                    // Don't allow focus on disabled buttons
-                    // eslint-disable-next-line no-nested-ternary
-                    orderableIndex >= orderableData.length - 1
-                      ? -1
-                      : // active is defined
-                      (active !== undefined && active === moveDownIndex) ||
-                        // focus is returning to list, make previously active
-                        // button active
-                        (active === undefined &&
-                          lastActive === moveDownIndex) ||
-                        // focus entering list for first time
-                        // first "MoveDown" should be focusable
-                        (active === undefined &&
-                          lastActive === undefined &&
-                          moveDownIndex === 1)
-                      ? 0
-                      : -1;
+                  const moveDownTabIndex = calculateTabIndex(
+                    moveDownIndex,
+                    active,
+                    lastActive,
+                    // last item can't move down
+                    orderableIndex >= orderableData.length - 1,
+                  );
 
                   orderControls = !isPinned && (
                     <Box direction="row" align="center" justify="end">


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

This PR improves the List interactive behavior to be more closely aligned to [WCAG APG best practices for keyboard vs mouse interactions](https://www.w3.org/WAI/ARIA/apg/patterns/listbox/examples/listbox-rearrangeable/), but implements the approach using roving tabindex instead of aria-activedescendant.

Expected `onOrder` behavior:
- List should have a singe tab stop and arrow keys should be used to navigate between the "arrow" move up/move down buttons. (This is in alignment with existing behavior).
- When entering the list for the first time, the first "move down" button should have tabIndex 0 and should receive focus. (NEW behavior in alignment with WCAP APG pattern).
- Once arrow keys have been moved to navigate among the "arrow" buttons, if tab is used to leave the list, then tab is used to return to the list, the previously active "arrow" button should have tabIndex 0 and receive focus. (This is existing behavior in alignment with WCAG APG).
- Pressing Enter or Space should click the "arrow" button and re-order the data. The focus should "move with" the re-ordered item. (This is in alignment with existing behavior).
- Using mouse to hover over the "arrow" buttons should not update the active "arrow" button. Instead, mouse / keyboard should operate independently. (NEW behavior in alignment with WCAG APG. The current behavior is that mousing over an "arrow" button _will_ update the active "arrow" button, but this differs from the WCAG APG pattern.)
- Using mouse to click on an "arrow" button should re-order the data. The focus, in this case, doesn't "move with" the re-ordered item but rather remains where the mouse is (This is in alignment with existing behavior).

Expected `onClickItem` behavior:
- List should have a singe tab stop and arrow keys should be used to navigate between the items. (This is in alignment with existing behavior).
- When entering the list for the first time, the first item should have tabIndex 0 and should receive focus. (NEW behavior in alignment with WCAP APG pattern).
- Once arrow keys have been moved to navigate among items, if tab is used to leave the list, then tab is used to return to the list, the previously active item should have tabIndex 0 and receive focus. (This is existing behavior in alignment with WCAG APG).
- Pressing Enter or Space should trigger `onClickItem`. (This is in alignment with existing behavior).
- Using mouse to hover over an item should not update the active item. Instead, mouse / keyboard should operate independently. (NEW behavior in alignment with WCAG APG. The current behavior is that mousing over an item _will_ update the active item, but this differs from the WCAG APG pattern.)
- Using mouse to click on an item should trigger `onClickItem`. (This is in alignment with existing behavior).

Key differences to internal logic of "active" and `onActive`:
- Mousing over an item or an "arrow" button no longer triggers a change to the "active" DOM element. I believe this is an improvement because "hover" is not the same as focus. That said, this will affect the amount of times that `onActive` is called to purely be when keyboard is used to navigate among items / "arrow" buttons or when an item / "arrow" button is clicked. Happy to have any discussion on concerns to this change in behavior.

Adjustments to Box:
- Enhanced Box to allow `onSpace` to also activate its click event as this is native browser behavior for clickable elements like Button.
- Enhanced Box so `unfocusStyles` is called if a click event is triggered by a mouse instead of keyboard (similar to logic in other interactive components).

TO DO:
- [ ] When `onOrder`, clicking anywhere on a list item except for the "arrow" buttons should not trigger the first list item's "Down" button to be active.
- [ ] If people are comfortable with the changes to the interactive behavior/logic, tests need to be updated.

#### Where should the reviewer start?
List.js

#### What testing has been done on this PR?
Locally in List stories such as Order, Children, OnClickItem.

#### How should this be manually tested?
Deploy link in List stories such as Order, Children, OnClickItem.

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #7648 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
Yes.

#### Is this change backwards compatible or is it a breaking change?
