### PR TITLE
List -- roving tab index approach 2

### DIFF
--- a/src/js/components/Box/Box.js
+++ b/src/js/components/Box/Box.js
@@ -309,7 +309,11 @@ const Box = forwardRef(
     }
 
     if (onClick) {
-      content = <Keyboard onEnter={onClick}>{content}</Keyboard>;
+      content = (
+        <Keyboard onEnter={onClick} onSpace={onClick}>
+          {content}
+        </Keyboard>
+      );
     }
 
     return content;

--- a/src/js/components/Box/Box.js
+++ b/src/js/components/Box/Box.js
@@ -310,7 +310,13 @@ const Box = forwardRef(
 
     if (onClick) {
       content = (
-        <Keyboard onEnter={onClick} onSpace={onClick}>
+        <Keyboard
+          onEnter={onClick}
+          onSpace={(e) => {
+            e.preventDefault(); // prevent page scroll
+            onClick(e);
+          }}
+        >
           {content}
         </Keyboard>
       );

--- a/src/js/components/Box/StyledBox.js
+++ b/src/js/components/Box/StyledBox.js
@@ -346,6 +346,8 @@ const StyledBox = styled.div.withConfig({
     props.onClick &&
     props.focus &&
     props.focusIndicator !== false &&
+    // only show focus styles when using keyboard navigation
+    // but not with mouse
     css`
       ${focusStyle()}
       &:focus:not(:focus-visible) {

--- a/src/js/components/Box/StyledBox.js
+++ b/src/js/components/Box/StyledBox.js
@@ -11,6 +11,7 @@ import {
   elevationStyle,
   fillStyle,
   focusStyle,
+  unfocusStyle,
   genericStyles,
   getBreakpointStyle,
   getHoverIndicatorStyle,
@@ -345,7 +346,12 @@ const StyledBox = styled.div.withConfig({
     props.onClick &&
     props.focus &&
     props.focusIndicator !== false &&
-    focusStyle()}
+    css`
+      ${focusStyle()}
+      &:focus:not(:focus-visible) {
+        ${unfocusStyle()}
+      }
+    `}
   ${(props) => props.theme.box && props.theme.box.extend}
   ${(props) => props.kindProp && props.kindProp.extend}
   ${(props) => (props.responsiveContainer ? responsiveContainerStyle : '')}

--- a/src/js/components/DataFilters/__tests__/__snapshots__/DataFilters-test.tsx.snap
+++ b/src/js/components/DataFilters/__tests__/__snapshots__/DataFilters-test.tsx.snap
@@ -3049,7 +3049,7 @@ exports[`DataFilters should display all filter options regardless of result set 
   padding-bottom: 12px;
 }
 
-.c20 {
+.c19 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -3200,10 +3200,6 @@ exports[`DataFilters should display all filter options regardless of result set 
   padding: 0;
 }
 
-.c19:focus {
-  outline: none;
-}
-
 @media only screen and (max-width: 768px) {
   .c5 {
     margin-bottom: 6px;
@@ -3262,20 +3258,20 @@ exports[`DataFilters should display all filter options regardless of result set 
 }
 
 @media only screen and (max-width: 768px) {
-  .c20 {
+  .c19 {
     border-bottom: solid 1px rgba(0, 0, 0, 0.33);
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c20 {
+  .c19 {
     padding-left: 12px;
     padding-right: 12px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c20 {
+  .c19 {
     padding-top: 6px;
     padding-bottom: 6px;
   }
@@ -3443,12 +3439,12 @@ exports[`DataFilters should display all filter options regardless of result set 
         role="list"
       >
         <li
-          class="c18 c19"
+          class="c18 "
         >
           a
         </li>
         <li
-          class="c20 c19"
+          class="c19 "
         >
           b
         </li>

--- a/src/js/components/DataTableColumns/__tests__/__snapshots__/DataTableColumns-test.tsx.snap
+++ b/src/js/components/DataTableColumns/__tests__/__snapshots__/DataTableColumns-test.tsx.snap
@@ -60,7 +60,7 @@ exports[`DataTableColumns pinned 1`] = `
   padding: 0px;
 }
 
-.c17 {
+.c16 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -72,7 +72,7 @@ exports[`DataTableColumns pinned 1`] = `
   padding: 12px;
 }
 
-.c19 {
+.c18 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -123,7 +123,7 @@ exports[`DataTableColumns pinned 1`] = `
   stroke: none;
 }
 
-.c18 {
+.c17 {
   display: inline-block;
   flex: 0 0 auto;
   width: 24px;
@@ -132,25 +132,25 @@ exports[`DataTableColumns pinned 1`] = `
   stroke: #555555;
 }
 
-.c18 g {
+.c17 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c18 *:not([stroke])[fill='none'] {
+.c17 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c18 *[stroke*='#'],
-.c18 *[STROKE*='#'] {
+.c17 *[stroke*='#'],
+.c17 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c18 *[fill-rule],
-.c18 *[FILL-RULE],
-.c18 *[fill*='#'],
-.c18 *[FILL*='#'] {
+.c17 *[fill-rule],
+.c17 *[FILL-RULE],
+.c17 *[fill*='#'],
+.c17 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -166,13 +166,13 @@ exports[`DataTableColumns pinned 1`] = `
   font-weight: bold;
 }
 
-.c15 {
+.c14 {
   font-size: 18px;
   line-height: 24px;
   color: #555555;
 }
 
-.c16 {
+.c15 {
   font-size: 18px;
   line-height: 24px;
   color: #555555;
@@ -198,6 +198,26 @@ exports[`DataTableColumns pinned 1`] = `
   cursor: default;
   line-height: 0;
   padding: 12px;
+}
+
+.c10:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus >circle,
+.c10:focus >ellipse,
+.c10:focus >line,
+.c10:focus >path,
+.c10:focus >polygon,
+.c10:focus >polyline,
+.c10:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus ::-moz-focus-inner {
+  border: 0;
 }
 
 .c10:focus:not(:focus-visible) {
@@ -244,6 +264,26 @@ exports[`DataTableColumns pinned 1`] = `
   color: #000000;
 }
 
+.c12:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c12:focus >circle,
+.c12:focus >ellipse,
+.c12:focus >line,
+.c12:focus >path,
+.c12:focus >polygon,
+.c12:focus >polyline,
+.c12:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c12:focus ::-moz-focus-inner {
+  border: 0;
+}
+
 .c12:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -270,20 +310,8 @@ exports[`DataTableColumns pinned 1`] = `
   padding: 0;
 }
 
-.c2:focus {
-  outline: 2px solid #6FFFB0;
-}
-
 .c4 {
   cursor: move;
-}
-
-.c4:focus {
-  outline: none;
-}
-
-.c14:focus {
-  outline: none;
 }
 
 .c0 {
@@ -370,19 +398,19 @@ exports[`DataTableColumns pinned 1`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c17 {
+  .c16 {
     padding: 6px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c19 {
+  .c18 {
     border-bottom: solid 1px rgba(0, 0, 0, 0.33);
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c19 {
+  .c18 {
     padding: 0px;
   }
 }
@@ -418,7 +446,6 @@ exports[`DataTableColumns pinned 1`] = `
       class="c2"
       id="test-data--order-columns"
       role="list"
-      tabindex="0"
     >
       <li
         class="c3 c4"
@@ -472,7 +499,7 @@ exports[`DataTableColumns pinned 1`] = `
             aria-label="1 Name move down"
             class="c12"
             id="NameMoveDown"
-            tabindex="-1"
+            tabindex="0"
             type="button"
           >
             <svg
@@ -491,10 +518,10 @@ exports[`DataTableColumns pinned 1`] = `
         </div>
       </li>
       <li
-        class="c13 c14"
+        class="c13 "
       >
         <span
-          class="c15"
+          class="c14"
         >
           2
         </span>
@@ -505,7 +532,7 @@ exports[`DataTableColumns pinned 1`] = `
           class="c7"
         >
           <span
-            class="c16"
+            class="c15"
           >
             Size
           </span>
@@ -514,11 +541,11 @@ exports[`DataTableColumns pinned 1`] = `
           class="c6"
         />
         <div
-          class="c17"
+          class="c16"
         >
           <svg
             aria-label="Column locked, order cannot be changed."
-            class="c18"
+            class="c17"
             viewBox="0 0 24 24"
           >
             <path
@@ -531,7 +558,7 @@ exports[`DataTableColumns pinned 1`] = `
         </div>
       </li>
       <li
-        class="c19 c4"
+        class="c18 c4"
         draggable="true"
       >
         <span
@@ -2385,6 +2412,26 @@ exports[`DataTableColumns renders 3`] = `
   padding: 12px;
 }
 
+.c7:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c7:focus >circle,
+.c7:focus >ellipse,
+.c7:focus >line,
+.c7:focus >path,
+.c7:focus >polygon,
+.c7:focus >polyline,
+.c7:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c7:focus ::-moz-focus-inner {
+  border: 0;
+}
+
 .c7:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -2429,6 +2476,26 @@ exports[`DataTableColumns renders 3`] = `
   color: #000000;
 }
 
+.c9:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9:focus >circle,
+.c9:focus >ellipse,
+.c9:focus >line,
+.c9:focus >path,
+.c9:focus >polygon,
+.c9:focus >polyline,
+.c9:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9:focus ::-moz-focus-inner {
+  border: 0;
+}
+
 .c9:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -2455,16 +2522,8 @@ exports[`DataTableColumns renders 3`] = `
   padding: 0;
 }
 
-.c0:focus {
-  outline: 2px solid #6FFFB0;
-}
-
 .c2 {
   cursor: move;
-}
-
-.c2:focus {
-  outline: none;
 }
 
 @media only screen and (max-width: 768px) {
@@ -2571,7 +2630,6 @@ exports[`DataTableColumns renders 3`] = `
       class="c0"
       id="test-data--order-columns"
       role="list"
-      tabindex="0"
     >
       <li
         class="c1 c2"
@@ -2621,7 +2679,7 @@ exports[`DataTableColumns renders 3`] = `
             aria-label="1 name move down"
             class="c9"
             id="nameMoveDown"
-            tabindex="-1"
+            tabindex="0"
             type="button"
           >
             <svg

--- a/src/js/components/List/List.js
+++ b/src/js/components/List/List.js
@@ -251,8 +251,8 @@ const List = React.forwardRef(
         if (onOrder) {
           const index = Math.trunc(nextFocused / 2);
           // Call onOrder with the re-ordered data.
-          // Update the active control index so that the
-          // active control will stay on the same item
+          // Update the focused control index so that the
+          // focused control will stay on the same item
           // even though it moved up or down.
           const newIndex = nextFocused % 2 ? index + 1 : index - 1;
           onOrder(reorder(orderableData, pinnedInfo, index, newIndex));

--- a/src/js/components/List/List.js
+++ b/src/js/components/List/List.js
@@ -18,11 +18,9 @@ import { MessageContext } from '../../contexts/MessageContext';
 import { Pagination } from '../Pagination';
 import { Text } from '../Text';
 import {
-  // focusStyle,
   genericStyles,
   normalizeColor,
   normalizeShow,
-  // unfocusStyle,
   useForwardedRef,
   usePagination,
   styledComponentsConfig,
@@ -97,16 +95,6 @@ const reorder = (array, pinnedArray, source, target) => {
   return result;
 };
 
-// getItemId returns something appropriate to use as a unique DOM
-// id for an item in the list
-// const getItemId = (item, index, itemKey, primaryKey) => {
-//   // we do primaryKey first to be backward compatible, even though
-//   // itemKey is probably technically the better choice for a DOM id.
-//   if (primaryKey) return getValue(item, index, primaryKey);
-//   if (itemKey) return getValue(item, index, itemKey);
-//   return getValue(item, index) ?? index; // do our best w/o *key properties
-// };
-
 const List = React.forwardRef(
   (
     {
@@ -178,7 +166,6 @@ const List = React.forwardRef(
       }
     }, [active, data]);
 
-    // const [itemFocus, setItemFocus] = useState();
     const [dragging, setDragging] = useState();
     const [orderingData, setOrderingData] = useState();
 
@@ -233,34 +220,6 @@ const List = React.forwardRef(
       role: onClickItem ? 'listbox' : 'list',
     };
 
-    // if (active >= 0) {
-    //   let activeId;
-    //   // We have an item that is 'focused' within the list. This could
-    //   // be the list item or one of the up/down ordering buttons.
-    //   // We need to figure out an id of the thing that will be
-    //   // shown as active
-    //   if (onOrder) {
-    //     // figure out which arrow button will be the active one.
-    //     const buttonId = active % 2 ? 'MoveDown' : 'MoveUp';
-    //     const itemIndex = Math.trunc(active / 2);
-    //     activeId = `${getItemId(
-    //       orderableData[itemIndex],
-    //       itemIndex,
-    //       itemKey,
-    //       primaryKey,
-    //     )}${buttonId}`;
-    //   } else if (onClickItem) {
-    //     // The whole list item is active. Figure out an id
-    //     activeId = getItemId(
-    //       orderableData[active],
-    //       active,
-    //       itemKey,
-    //       primaryKey,
-    //     );
-    //   }
-    //   ariaProps['aria-activedescendant'] = activeId;
-    // }
-
     const onSelectOption = (event, nextActive) => {
       if ((onClickItem || onOrder) && nextActive >= 0) {
         if (onOrder) {
@@ -313,19 +272,6 @@ const List = React.forwardRef(
     return (
       <Container {...containterProps}>
         <Keyboard
-          // onEnter={(event) => {
-          //   // if (onClickItem || onOrder) {
-          //   //   event.preventDefault();
-          //   // }
-          //   console.log('clicking');
-          //   onSelectOption(event);
-          // }}
-          // onSpace={(event) => {
-          //   // if (onClickItem || onOrder) {
-          //   //   event.preventDefault();
-          //   // }
-          //   onSelectOption(event);
-          // }}
           onUp={(event) => {
             if (onClickItem || onOrder) {
               event.preventDefault();
@@ -380,8 +326,6 @@ const List = React.forwardRef(
             aria-label={ariaLabel || a11yTitle}
             ref={listRef}
             as={as || 'ul'}
-            // itemFocus={itemFocus}
-            // tabIndex={onClickItem || onOrder ? 0 : undefined}
             tabIndex={-1}
             onFocus={() => {
               if (onOrder) {
@@ -588,16 +532,6 @@ const List = React.forwardRef(
                         onSelectOption(event, index);
                       }
                     },
-                    // onMouseOver: () => updateActive(index),
-                    // onMouseOut: () => updateActive(undefined),
-                    // onFocus: () => {
-                    //   // updateActive(index);
-                    //   // setItemFocus(true);
-                    // },
-                    // onBlur: () => {
-                    //   // updateActive(undefined);
-                    //   // setItemFocus(false);
-                    // },
                   };
                 }
 
@@ -687,9 +621,8 @@ const List = React.forwardRef(
                         a11yTitle={`${orderableIndex + 1} ${key} move up`}
                         icon={<Up />}
                         hoverIndicator
-                        // focusIndicator={false}
                         disabled={!orderableIndex}
-                        active={active === moveUpIndex} // TO DO likely remove
+                        active={active === moveUpIndex}
                         onClick={(event) => {
                           event.stopPropagation();
                           onSelectOption(event, moveUpIndex);
@@ -700,29 +633,16 @@ const List = React.forwardRef(
                             activeRef.current = node;
                           }
                         }}
-                        // onMouseOver={() => updateActive(moveUpIndex)}
-                        // onMouseOut={() => updateActive(undefined)}
-                        // onFocus={() => {
-                        //   console.log('focusing', moveUpIndex);
-                        //   updateActive(moveUpIndex);
-                        //   // setItemFocus(true);
-                        // }}
-                        // onBlur={() => {
-                        //   updateActive(undefined);
-                        //   // setItemFocus(false);
-                        // }}
                       />
                       <Button
                         id={`${key}MoveDown`}
                         a11yTitle={`${orderableIndex + 1} ${key} move down`}
                         icon={<Down />}
                         hoverIndicator
-                        // focusIndicator={false}
                         disabled={orderableIndex >= orderableData.length - 1}
                         active={active === moveDownIndex}
                         onClick={(event) => {
                           event.stopPropagation();
-                          // console.log('click', active);
                           onSelectOption(event, moveDownIndex);
                         }}
                         tabIndex={moveDownActive}
@@ -731,8 +651,6 @@ const List = React.forwardRef(
                             activeRef.current = node;
                           }
                         }}
-                        // onMouseOver={() => console.log({ moveDownIndex })}
-                        // onMouseOut={() => updateActive(undefined)}
                         onFocus={() => {
                           // make sure first "MoveDown" is focusable
                           if (
@@ -741,12 +659,7 @@ const List = React.forwardRef(
                           ) {
                             updateActive(moveDownIndex);
                           }
-                          // setItemFocus(true);
                         }}
-                        // onBlur={() => {
-                        //   updateActive(undefined);
-                        //   // setItemFocus(false);
-                        // }}
                       />
                     </Box>
                   );

--- a/src/js/components/List/List.js
+++ b/src/js/components/List/List.js
@@ -326,9 +326,10 @@ const List = React.forwardRef(
             ref={listRef}
             as={as || 'ul'}
             onFocus={() => {
-              if (onOrder) {
+              if (onOrder || onClickItem) {
                 if (active === undefined && lastActive === undefined) {
-                  updateActive(1); // first "MoveDown" button
+                  // first "MoveDown" button or first item
+                  updateActive(onOrder ? 1 : 0);
                 } else if (lastActive >= 0 && active === undefined) {
                   // if focus is returning to the list, make the last active
                   // item active again

--- a/src/js/components/List/List.js
+++ b/src/js/components/List/List.js
@@ -580,7 +580,7 @@ const List = React.forwardRef(
                   const Up = theme.list.icons.up;
                   const Down = theme.list.icons.down;
                   const moveUpIndex = orderableIndex * 2;
-                  const moveUpActive =
+                  const moveUpTabIndex =
                     // Don't allow focus on disabled buttons
                     // eslint-disable-next-line no-nested-ternary
                     !orderableIndex
@@ -593,7 +593,7 @@ const List = React.forwardRef(
                       ? 0
                       : -1;
                   const moveDownIndex = orderableIndex * 2 + 1;
-                  const moveDownActive =
+                  const moveDownTabIndex =
                     // Don't allow focus on disabled buttons
                     // eslint-disable-next-line no-nested-ternary
                     orderableIndex >= orderableData.length - 1
@@ -625,7 +625,7 @@ const List = React.forwardRef(
                           event.stopPropagation();
                           onSelectOption(event, moveUpIndex);
                         }}
-                        tabIndex={moveUpActive}
+                        tabIndex={moveUpTabIndex}
                         ref={(node) => {
                           if (active === moveUpIndex) {
                             activeRef.current = node;
@@ -643,7 +643,7 @@ const List = React.forwardRef(
                           event.stopPropagation();
                           onSelectOption(event, moveDownIndex);
                         }}
-                        tabIndex={moveDownActive}
+                        tabIndex={moveDownTabIndex}
                         ref={(node) => {
                           if (active === moveDownIndex) {
                             activeRef.current = node;

--- a/src/js/components/List/List.js
+++ b/src/js/components/List/List.js
@@ -152,9 +152,8 @@ const List = React.forwardRef(
       setActive(nextActive);
       // we occasionally call updateActive with undefined when it already is so,
       // no need to call onActive in that case
-      if (onActive && onClickItem && nextActive !== active) {
+      if (onActive && onClickItem && nextActive !== active)
         onActive(nextActive);
-      }
     };
 
     // roving tab index, ensure active item (when onClickItem)
@@ -326,7 +325,6 @@ const List = React.forwardRef(
             aria-label={ariaLabel || a11yTitle}
             ref={listRef}
             as={as || 'ul'}
-            tabIndex={-1}
             onFocus={() => {
               if (onOrder) {
                 if (active === undefined && lastActive === undefined) {

--- a/src/js/components/List/List.js
+++ b/src/js/components/List/List.js
@@ -95,6 +95,19 @@ const reorder = (array, pinnedArray, source, target) => {
   return result;
 };
 
+/** Calculate tabIndex for order control buttons. */
+const calculateTabIndex = (buttonIndex, active, lastActive, disabled) => {
+  if (disabled) return -1;
+  // is currently active
+  return (active !== undefined && active === buttonIndex) ||
+    // was last active
+    (active === undefined && lastActive === buttonIndex) ||
+    // first "move down" button when entering the list for first time
+    (active === undefined && lastActive === undefined && buttonIndex === 1)
+    ? 0
+    : -1;
+};
+
 const List = React.forwardRef(
   (
     {
@@ -580,38 +593,23 @@ const List = React.forwardRef(
 
                   const Up = theme.list.icons.up;
                   const Down = theme.list.icons.down;
+
                   const moveUpIndex = orderableIndex * 2;
-                  const moveUpTabIndex =
-                    // Don't allow focus on disabled buttons
-                    // eslint-disable-next-line no-nested-ternary
-                    !orderableIndex
-                      ? -1
-                      : // active is defined
-                      (active !== undefined && active === moveUpIndex) ||
-                        // focus is returning to list, make previously active
-                        // button active
-                        (active === undefined && lastActive === moveUpIndex)
-                      ? 0
-                      : -1;
+                  const moveUpTabIndex = calculateTabIndex(
+                    moveUpIndex,
+                    active,
+                    lastActive,
+                    !orderableIndex, // first item can't move up
+                  );
+
                   const moveDownIndex = orderableIndex * 2 + 1;
-                  const moveDownTabIndex =
-                    // Don't allow focus on disabled buttons
-                    // eslint-disable-next-line no-nested-ternary
-                    orderableIndex >= orderableData.length - 1
-                      ? -1
-                      : // active is defined
-                      (active !== undefined && active === moveDownIndex) ||
-                        // focus is returning to list, make previously active
-                        // button active
-                        (active === undefined &&
-                          lastActive === moveDownIndex) ||
-                        // focus entering list for first time
-                        // first "MoveDown" should be focusable
-                        (active === undefined &&
-                          lastActive === undefined &&
-                          moveDownIndex === 1)
-                      ? 0
-                      : -1;
+                  const moveDownTabIndex = calculateTabIndex(
+                    moveDownIndex,
+                    active,
+                    lastActive,
+                    // last item can't move down
+                    orderableIndex >= orderableData.length - 1,
+                  );
 
                   orderControls = !isPinned && (
                     <Box direction="row" align="center" justify="end">

--- a/src/js/components/List/__tests__/List-test.tsx
+++ b/src/js/components/List/__tests__/List-test.tsx
@@ -420,10 +420,7 @@ describe('List events', () => {
       which: 13,
     });
     expect(onActive).toHaveBeenCalledTimes(1);
-    // Reported bug: onEnter calls onClickItem twice instead of once.
-    // Issue #4173. Once fixed it should be
-    // `expect(onClickItem).toHaveBeenCalledTimes(2);`
-    expect(onClickItem).toHaveBeenCalledTimes(3);
+    expect(onClickItem).toHaveBeenCalledTimes(2);
     // Both focus and active should be placed on 'beta'
     expect(container.firstChild).toMatchSnapshot();
   });
@@ -626,53 +623,33 @@ describe('List onOrder', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test('Keyboard move down', () => {
-    const { container, getByText } = render(<App />);
+  test('Keyboard move down', async () => {
+    const user = userEvent.setup();
+    const { asFragment } = render(<App />);
 
-    expect(container.firstChild).toMatchSnapshot();
-    fireEvent.click(getByText('alpha'));
-    fireEvent.mouseOver(getByText('alpha'));
-    fireEvent.keyDown(getByText('alpha'), {
-      key: 'ArrowDown',
-      keyCode: 40,
-      which: 40,
-    });
-    // alpha's down arrow control should be active
-    expect(container.firstChild).toMatchSnapshot();
-    fireEvent.keyDown(getByText('alpha'), {
-      key: 'Enter',
-      keyCode: 13,
-      which: 13,
-    });
-    expect(onOrder).toHaveBeenCalled();
-    expect(container.firstChild).toMatchSnapshot();
+    expect(asFragment()).toMatchSnapshot();
+    await user.tab(); // focus into list
+    await user.keyboard('{ArrowDown}'); // move to beta
+    // beta's up arrow control should be active
+    expect(asFragment()).toMatchSnapshot();
+    await user.keyboard('{Enter}');
+    expect(onOrder).toHaveBeenCalledTimes(1);
+    expect(asFragment()).toMatchSnapshot();
   });
 
-  test('Keyboard move up', () => {
-    const { container, getByText } = render(<App />);
+  test('Keyboard move up', async () => {
+    const user = userEvent.setup();
+    const { asFragment } = render(<App />);
 
-    expect(container.firstChild).toMatchSnapshot();
-    fireEvent.click(getByText('alpha'));
-    fireEvent.mouseOver(getByText('alpha'));
-    fireEvent.keyDown(getByText('alpha'), {
-      key: 'ArrowDown',
-      keyCode: 40,
-      which: 40,
-    });
-    fireEvent.keyDown(getByText('alpha'), {
-      key: 'ArrowDown',
-      keyCode: 40,
-      which: 40,
-    });
+    expect(asFragment()).toMatchSnapshot();
+    await user.tab(); // focus into list
+    await user.keyboard('{ArrowDown}'); // move to beta up arrow
     // beta's up arrow control should be active
-    expect(container.firstChild).toMatchSnapshot();
-    fireEvent.keyDown(getByText('alpha'), {
-      key: 'Space',
-      keyCode: 32,
-      which: 32,
-    });
+    expect(asFragment()).toMatchSnapshot();
+    await user.keyboard('{ArrowUp}'); // move to alpha down arrow
+    await user.keyboard('{Enter}'); // move alpha down
     expect(onOrder).toHaveBeenCalledWith([{ a: 'beta' }, { a: 'alpha' }]);
-    expect(container.firstChild).toMatchSnapshot();
+    expect(asFragment()).toMatchSnapshot();
   });
 });
 
@@ -713,53 +690,33 @@ describe('List onOrder with no-index', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test('Keyboard move down', () => {
-    const { container, getByText } = render(<App />);
+  test('Keyboard move down', async () => {
+    const user = userEvent.setup();
+    const { asFragment } = render(<App />);
 
-    expect(container.firstChild).toMatchSnapshot();
-    fireEvent.click(getByText('alpha'));
-    fireEvent.mouseOver(getByText('alpha'));
-    fireEvent.keyDown(getByText('alpha'), {
-      key: 'ArrowDown',
-      keyCode: 40,
-      which: 40,
-    });
-    // alpha's down arrow control should be active
-    expect(container.firstChild).toMatchSnapshot();
-    fireEvent.keyDown(getByText('alpha'), {
-      key: 'Enter',
-      keyCode: 13,
-      which: 13,
-    });
-    expect(onOrder).toHaveBeenCalled();
-    expect(container.firstChild).toMatchSnapshot();
+    expect(asFragment()).toMatchSnapshot();
+    await user.tab(); // focus into list
+    await user.keyboard('{ArrowDown}'); // move to beta
+    // beta's up arrow control should be active
+    expect(asFragment()).toMatchSnapshot();
+    await user.keyboard('{Enter}');
+    expect(onOrder).toHaveBeenCalledTimes(1);
+    expect(asFragment()).toMatchSnapshot();
   });
 
-  test('Keyboard move up', () => {
-    const { container, getByText } = render(<App />);
+  test('Keyboard move up', async () => {
+    const user = userEvent.setup();
+    const { asFragment } = render(<App />);
 
-    expect(container.firstChild).toMatchSnapshot();
-    fireEvent.click(getByText('alpha'));
-    fireEvent.mouseOver(getByText('alpha'));
-    fireEvent.keyDown(getByText('alpha'), {
-      key: 'ArrowDown',
-      keyCode: 40,
-      which: 40,
-    });
-    fireEvent.keyDown(getByText('alpha'), {
-      key: 'ArrowDown',
-      keyCode: 40,
-      which: 40,
-    });
+    expect(asFragment()).toMatchSnapshot();
+    await user.tab(); // focus into list
+    await user.keyboard('{ArrowDown}'); // move to beta up arrow
     // beta's up arrow control should be active
-    expect(container.firstChild).toMatchSnapshot();
-    fireEvent.keyDown(getByText('alpha'), {
-      key: 'Space',
-      keyCode: 32,
-      which: 32,
-    });
+    expect(asFragment()).toMatchSnapshot();
+    await user.keyboard('{ArrowUp}'); // move to alpha down arrow
+    await user.keyboard('{Enter}'); // move alpha down
     expect(onOrder).toHaveBeenCalledWith([{ a: 'beta' }, { a: 'alpha' }]);
-    expect(container.firstChild).toMatchSnapshot();
+    expect(asFragment()).toMatchSnapshot();
   });
 });
 
@@ -931,9 +888,9 @@ describe('List disabled', () => {
     );
     render(<App />);
 
-    const list = screen.getByRole('listbox');
+    const item = screen.getByRole('option', { name: locations[0] });
     await user.tab();
-    expect(list).toHaveFocus();
+    expect(item).toHaveFocus();
     // user.keyboard is not behaving as expected
     // await user.keyboard('[ArrowUp][Enter]');
     const enabledItems = locations.filter(

--- a/src/js/components/List/__tests__/__snapshots__/List-test.tsx.snap
+++ b/src/js/components/List/__tests__/__snapshots__/List-test.tsx.snap
@@ -29,7 +29,7 @@ exports[`List background array 1`] = `
   padding-bottom: 12px;
 }
 
-.c4 {
+.c3 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -46,7 +46,7 @@ exports[`List background array 1`] = `
   padding-bottom: 12px;
 }
 
-.c5 {
+.c4 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -67,10 +67,6 @@ exports[`List background array 1`] = `
   list-style: none;
   margin: 0;
   padding: 0;
-}
-
-.c3:focus {
-  outline: none;
 }
 
 @media only screen and (max-width: 768px) {
@@ -95,40 +91,40 @@ exports[`List background array 1`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c4 {
+  .c3 {
     border-bottom: solid 1px rgba(0, 0, 0, 0.33);
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c4 {
+  .c3 {
     padding-left: 12px;
     padding-right: 12px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c4 {
+  .c3 {
     padding-top: 6px;
     padding-bottom: 6px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c5 {
+  .c4 {
     border-bottom: solid 1px rgba(0, 0, 0, 0.33);
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c5 {
+  .c4 {
     padding-left: 12px;
     padding-right: 12px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c5 {
+  .c4 {
     padding-top: 6px;
     padding-bottom: 6px;
   }
@@ -142,22 +138,22 @@ exports[`List background array 1`] = `
     role="list"
   >
     <li
-      class="c2 c3"
+      class="c2 "
     >
       one
     </li>
     <li
-      class="c4 c3"
+      class="c3 "
     >
       two
     </li>
     <li
-      class="c5 c3"
+      class="c4 "
     >
       three
     </li>
     <li
-      class="c4 c3"
+      class="c3 "
     >
       four
     </li>
@@ -194,7 +190,7 @@ exports[`List background string 1`] = `
   padding-bottom: 12px;
 }
 
-.c4 {
+.c3 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -215,10 +211,6 @@ exports[`List background string 1`] = `
   list-style: none;
   margin: 0;
   padding: 0;
-}
-
-.c3:focus {
-  outline: none;
 }
 
 @media only screen and (max-width: 768px) {
@@ -243,20 +235,20 @@ exports[`List background string 1`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c4 {
+  .c3 {
     border-bottom: solid 1px rgba(0, 0, 0, 0.33);
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c4 {
+  .c3 {
     padding-left: 12px;
     padding-right: 12px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c4 {
+  .c3 {
     padding-top: 6px;
     padding-bottom: 6px;
   }
@@ -270,12 +262,12 @@ exports[`List background string 1`] = `
     role="list"
   >
     <li
-      class="c2 c3"
+      class="c2 "
     >
       one
     </li>
     <li
-      class="c4 c3"
+      class="c3 "
     >
       two
     </li>
@@ -314,10 +306,6 @@ exports[`List border boolean false 1`] = `
   padding: 0;
 }
 
-.c3:focus {
-  outline: none;
-}
-
 @media only screen and (max-width: 768px) {
   .c2 {
     padding-left: 12px;
@@ -340,12 +328,12 @@ exports[`List border boolean false 1`] = `
     role="list"
   >
     <li
-      class="c2 c3"
+      class="c2 "
     >
       one
     </li>
     <li
-      class="c2 c3"
+      class="c2 "
     >
       two
     </li>
@@ -385,10 +373,6 @@ exports[`List border boolean true 1`] = `
   padding: 0;
 }
 
-.c3:focus {
-  outline: none;
-}
-
 @media only screen and (max-width: 768px) {
   .c2 {
     border: solid 1px rgba(0, 0, 0, 0.33);
@@ -417,12 +401,12 @@ exports[`List border boolean true 1`] = `
     role="list"
   >
     <li
-      class="c2 c3"
+      class="c2 "
     >
       one
     </li>
     <li
-      class="c2 c3"
+      class="c2 "
     >
       two
     </li>
@@ -463,10 +447,6 @@ exports[`List border object 1`] = `
   padding: 0;
 }
 
-.c3:focus {
-  outline: none;
-}
-
 @media only screen and (max-width: 768px) {
   .c2 {
     border-top: solid 6px #6FFFB0;
@@ -496,12 +476,12 @@ exports[`List border object 1`] = `
     role="list"
   >
     <li
-      class="c2 c3"
+      class="c2 "
     >
       one
     </li>
     <li
-      class="c2 c3"
+      class="c2 "
     >
       two
     </li>
@@ -536,7 +516,7 @@ exports[`List border side 1`] = `
   padding-bottom: 12px;
 }
 
-.c4 {
+.c3 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -555,10 +535,6 @@ exports[`List border side 1`] = `
   list-style: none;
   margin: 0;
   padding: 0;
-}
-
-.c3:focus {
-  outline: none;
 }
 
 @media only screen and (max-width: 768px) {
@@ -583,20 +559,20 @@ exports[`List border side 1`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c4 {
+  .c3 {
     border-bottom: solid 1px rgba(0, 0, 0, 0.33);
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c4 {
+  .c3 {
     padding-left: 12px;
     padding-right: 12px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c4 {
+  .c3 {
     padding-top: 6px;
     padding-bottom: 6px;
   }
@@ -610,12 +586,12 @@ exports[`List border side 1`] = `
     role="list"
   >
     <li
-      class="c2 c3"
+      class="c2 "
     >
       one
     </li>
     <li
-      class="c4 c3"
+      class="c3 "
     >
       two
     </li>
@@ -650,7 +626,7 @@ exports[`List children render 1`] = `
   padding-bottom: 12px;
 }
 
-.c4 {
+.c3 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -669,10 +645,6 @@ exports[`List children render 1`] = `
   list-style: none;
   margin: 0;
   padding: 0;
-}
-
-.c3:focus {
-  outline: none;
 }
 
 @media only screen and (max-width: 768px) {
@@ -697,20 +669,20 @@ exports[`List children render 1`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c4 {
+  .c3 {
     border-bottom: solid 1px rgba(0, 0, 0, 0.33);
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c4 {
+  .c3 {
     padding-left: 12px;
     padding-right: 12px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c4 {
+  .c3 {
     padding-top: 6px;
     padding-bottom: 6px;
   }
@@ -724,12 +696,12 @@ exports[`List children render 1`] = `
     role="list"
   >
     <li
-      class="c2 c3"
+      class="c2 "
     >
       one - 0
     </li>
     <li
-      class="c4 c3"
+      class="c3 "
     >
       two - 1
     </li>
@@ -764,7 +736,7 @@ exports[`List data objects 1`] = `
   padding-bottom: 12px;
 }
 
-.c4 {
+.c3 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -783,10 +755,6 @@ exports[`List data objects 1`] = `
   list-style: none;
   margin: 0;
   padding: 0;
-}
-
-.c3:focus {
-  outline: none;
 }
 
 @media only screen and (max-width: 768px) {
@@ -811,20 +779,20 @@ exports[`List data objects 1`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c4 {
+  .c3 {
     border-bottom: solid 1px rgba(0, 0, 0, 0.33);
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c4 {
+  .c3 {
     padding-left: 12px;
     padding-right: 12px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c4 {
+  .c3 {
     padding-top: 6px;
     padding-bottom: 6px;
   }
@@ -838,12 +806,12 @@ exports[`List data objects 1`] = `
     role="list"
   >
     <li
-      class="c2 c3"
+      class="c2 "
     >
       one
     </li>
     <li
-      class="c4 c3"
+      class="c3 "
     >
       two
     </li>
@@ -878,7 +846,7 @@ exports[`List data strings 1`] = `
   padding-bottom: 12px;
 }
 
-.c4 {
+.c3 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -897,10 +865,6 @@ exports[`List data strings 1`] = `
   list-style: none;
   margin: 0;
   padding: 0;
-}
-
-.c3:focus {
-  outline: none;
 }
 
 @media only screen and (max-width: 768px) {
@@ -925,20 +889,20 @@ exports[`List data strings 1`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c4 {
+  .c3 {
     border-bottom: solid 1px rgba(0, 0, 0, 0.33);
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c4 {
+  .c3 {
     padding-left: 12px;
     padding-right: 12px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c4 {
+  .c3 {
     padding-top: 6px;
     padding-bottom: 6px;
   }
@@ -952,12 +916,12 @@ exports[`List data strings 1`] = `
     role="list"
   >
     <li
-      class="c2 c3"
+      class="c2 "
     >
       one
     </li>
     <li
-      class="c4 c3"
+      class="c3 "
     >
       two
     </li>
@@ -995,7 +959,7 @@ exports[`List defaultItemProps 1`] = `
   padding-bottom: 12px;
 }
 
-.c4 {
+.c3 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -1017,10 +981,6 @@ exports[`List defaultItemProps 1`] = `
   list-style: none;
   margin: 0;
   padding: 0;
-}
-
-.c3:focus {
-  outline: none;
 }
 
 @media only screen and (max-width: 768px) {
@@ -1045,20 +1005,20 @@ exports[`List defaultItemProps 1`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c4 {
+  .c3 {
     border-bottom: solid 1px rgba(0, 0, 0, 0.33);
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c4 {
+  .c3 {
     padding-left: 12px;
     padding-right: 12px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c4 {
+  .c3 {
     padding-top: 6px;
     padding-bottom: 6px;
   }
@@ -1072,12 +1032,12 @@ exports[`List defaultItemProps 1`] = `
     role="list"
   >
     <li
-      class="c2 c3"
+      class="c2 "
     >
       one
     </li>
     <li
-      class="c4 c3"
+      class="c3 "
     >
       two
     </li>
@@ -1215,6 +1175,26 @@ exports[`List disabled Disabled items should be allowed to be re-ordered 1`] = `
   padding: 12px;
 }
 
+.c8:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus >circle,
+.c8:focus >ellipse,
+.c8:focus >line,
+.c8:focus >path,
+.c8:focus >polygon,
+.c8:focus >polyline,
+.c8:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus ::-moz-focus-inner {
+  border: 0;
+}
+
 .c8:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -1259,6 +1239,26 @@ exports[`List disabled Disabled items should be allowed to be re-ordered 1`] = `
   color: #000000;
 }
 
+.c10:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus >circle,
+.c10:focus >ellipse,
+.c10:focus >line,
+.c10:focus >path,
+.c10:focus >polygon,
+.c10:focus >polyline,
+.c10:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus ::-moz-focus-inner {
+  border: 0;
+}
+
 .c10:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -1285,25 +1285,13 @@ exports[`List disabled Disabled items should be allowed to be re-ordered 1`] = `
   padding: 0;
 }
 
-.c1:focus {
-  outline: 2px solid #6FFFB0;
-}
-
 .c3 {
   cursor: move;
-}
-
-.c3:focus {
-  outline: none;
 }
 
 .c12 {
   color: #CCCCCC;
   cursor: default;
-}
-
-.c12:focus {
-  outline: none;
 }
 
 .c12:hover {
@@ -1363,7 +1351,6 @@ exports[`List disabled Disabled items should be allowed to be re-ordered 1`] = `
     <ul
       class="c1"
       role="list"
-      tabindex="0"
     >
       <li
         class="c2 c3"
@@ -1413,7 +1400,7 @@ exports[`List disabled Disabled items should be allowed to be re-ordered 1`] = `
             aria-label="1 Boise move down"
             class="c10"
             id="BoiseMoveDown"
-            tabindex="-1"
+            tabindex="0"
             type="button"
           >
             <svg
@@ -1829,6 +1816,26 @@ exports[`List disabled Disabled items should be allowed to be re-ordered 2`] = `
   padding: 12px;
 }
 
+.c8:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus >circle,
+.c8:focus >ellipse,
+.c8:focus >line,
+.c8:focus >path,
+.c8:focus >polygon,
+.c8:focus >polyline,
+.c8:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus ::-moz-focus-inner {
+  border: 0;
+}
+
 .c8:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -1873,6 +1880,26 @@ exports[`List disabled Disabled items should be allowed to be re-ordered 2`] = `
   color: #000000;
 }
 
+.c10:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus >circle,
+.c10:focus >ellipse,
+.c10:focus >line,
+.c10:focus >path,
+.c10:focus >polygon,
+.c10:focus >polyline,
+.c10:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus ::-moz-focus-inner {
+  border: 0;
+}
+
 .c10:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -1914,9 +1941,24 @@ exports[`List disabled Disabled items should be allowed to be re-ordered 2`] = `
   padding: 12px;
 }
 
-.c13:hover {
-  background-color: rgba(221, 221, 221, 0.4);
-  color: #000000;
+.c13:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c13:focus >circle,
+.c13:focus >ellipse,
+.c13:focus >line,
+.c13:focus >path,
+.c13:focus >polygon,
+.c13:focus >polyline,
+.c13:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c13:focus ::-moz-focus-inner {
+  border: 0;
 }
 
 .c13:focus:not(:focus-visible) {
@@ -1945,25 +1987,13 @@ exports[`List disabled Disabled items should be allowed to be re-ordered 2`] = `
   padding: 0;
 }
 
-.c1:focus {
-  outline: 2px solid #6FFFB0;
-}
-
 .c12 {
   cursor: move;
-}
-
-.c12:focus {
-  outline: none;
 }
 
 .c3 {
   color: #CCCCCC;
   cursor: default;
-}
-
-.c3:focus {
-  outline: none;
 }
 
 .c3:hover {
@@ -2021,10 +2051,8 @@ exports[`List disabled Disabled items should be allowed to be re-ordered 2`] = `
     class="c0"
   >
     <ul
-      aria-activedescendant="BoiseMoveUp"
       class="c1"
       role="list"
-      tabindex="0"
     >
       <li
         aria-disabled="true"
@@ -2120,7 +2148,7 @@ exports[`List disabled Disabled items should be allowed to be re-ordered 2`] = `
             aria-label="2 Boise move up"
             class="c13"
             id="BoiseMoveUp"
-            tabindex="-1"
+            tabindex="0"
             type="button"
           >
             <svg
@@ -2388,7 +2416,7 @@ exports[`List disabled Should apply disabled styling to items 1`] = `
   padding-bottom: 12px;
 }
 
-.c4 {
+.c3 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -2409,20 +2437,12 @@ exports[`List disabled Should apply disabled styling to items 1`] = `
   padding: 0;
 }
 
-.c3:focus {
-  outline: none;
-}
-
-.c5 {
+.c4 {
   color: #CCCCCC;
   cursor: default;
 }
 
-.c5:focus {
-  outline: none;
-}
-
-.c5:hover {
+.c4:hover {
   background-color: unset;
 }
 
@@ -2448,20 +2468,20 @@ exports[`List disabled Should apply disabled styling to items 1`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c4 {
+  .c3 {
     border-bottom: solid 1px rgba(0, 0, 0, 0.33);
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c4 {
+  .c3 {
     padding-left: 12px;
     padding-right: 12px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c4 {
+  .c3 {
     padding-top: 6px;
     padding-bottom: 6px;
   }
@@ -2475,29 +2495,29 @@ exports[`List disabled Should apply disabled styling to items 1`] = `
       role="list"
     >
       <li
-        class="c2 c3"
+        class="c2 "
       >
         Boise
       </li>
       <li
         aria-disabled="true"
-        class="c4 c5"
+        class="c3 c4"
       >
         Fort Collins
       </li>
       <li
-        class="c4 c3"
+        class="c3 "
       >
         Los Gatos
       </li>
       <li
         aria-disabled="true"
-        class="c4 c5"
+        class="c3 c4"
       >
         Palo Alto
       </li>
       <li
-        class="c4 c3"
+        class="c3 "
       >
         San Francisco
       </li>
@@ -2534,7 +2554,7 @@ exports[`List disabled Should apply disabled styling to items when data are chil
   padding-bottom: 12px;
 }
 
-.c4 {
+.c3 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -2543,7 +2563,7 @@ exports[`List disabled Should apply disabled styling to items when data are chil
   flex-direction: column;
 }
 
-.c6 {
+.c5 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -2558,7 +2578,7 @@ exports[`List disabled Should apply disabled styling to items when data are chil
   padding-bottom: 12px;
 }
 
-.c5 {
+.c4 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
@@ -2570,20 +2590,12 @@ exports[`List disabled Should apply disabled styling to items when data are chil
   padding: 0;
 }
 
-.c3:focus {
-  outline: none;
-}
-
-.c7 {
+.c6 {
   color: #CCCCCC;
   cursor: default;
 }
 
-.c7:focus {
-  outline: none;
-}
-
-.c7:hover {
+.c6:hover {
   background-color: unset;
 }
 
@@ -2609,20 +2621,20 @@ exports[`List disabled Should apply disabled styling to items when data are chil
 }
 
 @media only screen and (max-width: 768px) {
-  .c6 {
+  .c5 {
     border-bottom: solid 1px rgba(0, 0, 0, 0.33);
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c6 {
+  .c5 {
     padding-left: 12px;
     padding-right: 12px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c6 {
+  .c5 {
     padding-top: 6px;
     padding-bottom: 6px;
   }
@@ -2636,13 +2648,13 @@ exports[`List disabled Should apply disabled styling to items when data are chil
       role="list"
     >
       <li
-        class="c2 c3"
+        class="c2 "
       >
         <div
-          class="c4"
+          class="c3"
         >
           <span
-            class="c5"
+            class="c4"
           >
             Boise
           </span>
@@ -2650,26 +2662,26 @@ exports[`List disabled Should apply disabled styling to items when data are chil
       </li>
       <li
         aria-disabled="true"
-        class="c6 c7"
+        class="c5 c6"
       >
         <div
-          class="c4"
+          class="c3"
         >
           <span
-            class="c5"
+            class="c4"
           >
             Fort Collins
           </span>
         </div>
       </li>
       <li
-        class="c6 c3"
+        class="c5 "
       >
         <div
-          class="c4"
+          class="c3"
         >
           <span
-            class="c5"
+            class="c4"
           >
             Los Gatos
           </span>
@@ -2677,26 +2689,26 @@ exports[`List disabled Should apply disabled styling to items when data are chil
       </li>
       <li
         aria-disabled="true"
-        class="c6 c7"
+        class="c5 c6"
       >
         <div
-          class="c4"
+          class="c3"
         >
           <span
-            class="c5"
+            class="c4"
           >
             Palo Alto
           </span>
         </div>
       </li>
       <li
-        class="c6 c3"
+        class="c5 "
       >
         <div
-          class="c4"
+          class="c3"
         >
           <span
-            class="c5"
+            class="c4"
           >
             San Francisco
           </span>
@@ -2735,7 +2747,7 @@ exports[`List disabled Should apply disabled styling to items when data are obje
   padding-bottom: 12px;
 }
 
-.c4 {
+.c3 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -2756,20 +2768,12 @@ exports[`List disabled Should apply disabled styling to items when data are obje
   padding: 0;
 }
 
-.c3:focus {
-  outline: none;
-}
-
-.c5 {
+.c4 {
   color: #CCCCCC;
   cursor: default;
 }
 
-.c5:focus {
-  outline: none;
-}
-
-.c5:hover {
+.c4:hover {
   background-color: unset;
 }
 
@@ -2795,20 +2799,20 @@ exports[`List disabled Should apply disabled styling to items when data are obje
 }
 
 @media only screen and (max-width: 768px) {
-  .c4 {
+  .c3 {
     border-bottom: solid 1px rgba(0, 0, 0, 0.33);
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c4 {
+  .c3 {
     padding-left: 12px;
     padding-right: 12px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c4 {
+  .c3 {
     padding-top: 6px;
     padding-bottom: 6px;
   }
@@ -2822,29 +2826,29 @@ exports[`List disabled Should apply disabled styling to items when data are obje
       role="list"
     >
       <li
-        class="c2 c3"
+        class="c2 "
       >
         Boise
       </li>
       <li
         aria-disabled="true"
-        class="c4 c5"
+        class="c3 c4"
       >
         Fort Collins
       </li>
       <li
-        class="c4 c3"
+        class="c3 "
       >
         Los Gatos
       </li>
       <li
         aria-disabled="true"
-        class="c4 c5"
+        class="c3 c4"
       >
         Palo Alto
       </li>
       <li
-        class="c4 c3"
+        class="c3 "
       >
         San Francisco
       </li>
@@ -2908,6 +2912,11 @@ exports[`List events ArrowDown key 1`] = `
   cursor: pointer;
 }
 
+.c2:hover {
+  background-color: rgba(221, 221, 221, 0.4);
+  color: #000000;
+}
+
 .c4 {
   display: flex;
   box-sizing: border-box;
@@ -2924,6 +2933,48 @@ exports[`List events ArrowDown key 1`] = `
   padding-top: 12px;
   padding-bottom: 12px;
   cursor: pointer;
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:hover {
+  background-color: rgba(221, 221, 221, 0.4);
+  color: #000000;
+}
+
+.c4 >circle,
+.c4 >ellipse,
+.c4 >line,
+.c4 >path,
+.c4 >polygon,
+.c4 >polyline,
+.c4 >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4 ::-moz-focus-inner {
+  border: 0;
+}
+
+.c4:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c4:focus:not(:focus-visible) >circle,
+.c4:focus:not(:focus-visible) >ellipse,
+.c4:focus:not(:focus-visible) >line,
+.c4:focus:not(:focus-visible) >path,
+.c4:focus:not(:focus-visible) >polygon,
+.c4:focus:not(:focus-visible) >polyline,
+.c4:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c4:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
 }
 
 .c1 {
@@ -2932,16 +2983,8 @@ exports[`List events ArrowDown key 1`] = `
   padding: 0;
 }
 
-.c1:focus {
-  outline: 2px solid #6FFFB0;
-}
-
 .c3 {
   cursor: pointer;
-}
-
-.c3:focus {
-  outline: none;
 }
 
 @media only screen and (max-width: 768px) {
@@ -2963,6 +3006,18 @@ exports[`List events ArrowDown key 1`] = `
     padding-top: 6px;
     padding-bottom: 6px;
   }
+}
+
+@media only screen and (max-width: 768px) {
+
+}
+
+@media only screen and (max-width: 768px) {
+
+}
+
+@media only screen and (max-width: 768px) {
+
 }
 
 @media only screen and (max-width: 768px) {
@@ -3013,10 +3068,8 @@ exports[`List events ArrowDown key 1`] = `
   class="c0"
 >
   <ul
-    aria-activedescendant="1"
     class="c1"
     role="listbox"
-    tabindex="0"
   >
     <li
       class="c2 c3"
@@ -3028,7 +3081,7 @@ exports[`List events ArrowDown key 1`] = `
     <li
       class="c4 c3"
       role="option"
-      tabindex="-1"
+      tabindex="0"
     >
       beta
     </li>
@@ -3064,6 +3117,11 @@ exports[`List events ArrowDown key on last element 1`] = `
   cursor: pointer;
 }
 
+.c2:hover {
+  background-color: rgba(221, 221, 221, 0.4);
+  color: #000000;
+}
+
 .c4 {
   display: flex;
   box-sizing: border-box;
@@ -3080,6 +3138,48 @@ exports[`List events ArrowDown key on last element 1`] = `
   padding-top: 12px;
   padding-bottom: 12px;
   cursor: pointer;
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:hover {
+  background-color: rgba(221, 221, 221, 0.4);
+  color: #000000;
+}
+
+.c4 >circle,
+.c4 >ellipse,
+.c4 >line,
+.c4 >path,
+.c4 >polygon,
+.c4 >polyline,
+.c4 >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4 ::-moz-focus-inner {
+  border: 0;
+}
+
+.c4:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c4:focus:not(:focus-visible) >circle,
+.c4:focus:not(:focus-visible) >ellipse,
+.c4:focus:not(:focus-visible) >line,
+.c4:focus:not(:focus-visible) >path,
+.c4:focus:not(:focus-visible) >polygon,
+.c4:focus:not(:focus-visible) >polyline,
+.c4:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c4:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
 }
 
 .c1 {
@@ -3088,16 +3188,8 @@ exports[`List events ArrowDown key on last element 1`] = `
   padding: 0;
 }
 
-.c1:focus {
-  outline: 2px solid #6FFFB0;
-}
-
 .c3 {
   cursor: pointer;
-}
-
-.c3:focus {
-  outline: none;
 }
 
 @media only screen and (max-width: 768px) {
@@ -3119,6 +3211,18 @@ exports[`List events ArrowDown key on last element 1`] = `
     padding-top: 6px;
     padding-bottom: 6px;
   }
+}
+
+@media only screen and (max-width: 768px) {
+
+}
+
+@media only screen and (max-width: 768px) {
+
+}
+
+@media only screen and (max-width: 768px) {
+
 }
 
 @media only screen and (max-width: 768px) {
@@ -3157,10 +3261,8 @@ exports[`List events ArrowDown key on last element 1`] = `
   class="c0"
 >
   <ul
-    aria-activedescendant="1"
     class="c1"
     role="listbox"
-    tabindex="0"
   >
     <li
       class="c2 c3"
@@ -3172,7 +3274,7 @@ exports[`List events ArrowDown key on last element 1`] = `
     <li
       class="c4 c3"
       role="option"
-      tabindex="-1"
+      tabindex="0"
     >
       beta
     </li>
@@ -3207,6 +3309,11 @@ exports[`List events ArrowUp key 1`] = `
   cursor: pointer;
 }
 
+.c4:hover {
+  background-color: rgba(221, 221, 221, 0.4);
+  color: #000000;
+}
+
 .c2 {
   display: flex;
   box-sizing: border-box;
@@ -3224,6 +3331,48 @@ exports[`List events ArrowUp key 1`] = `
   padding-top: 12px;
   padding-bottom: 12px;
   cursor: pointer;
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c2:hover {
+  background-color: rgba(221, 221, 221, 0.4);
+  color: #000000;
+}
+
+.c2 >circle,
+.c2 >ellipse,
+.c2 >line,
+.c2 >path,
+.c2 >polygon,
+.c2 >polyline,
+.c2 >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c2 ::-moz-focus-inner {
+  border: 0;
+}
+
+.c2:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c2:focus:not(:focus-visible) >circle,
+.c2:focus:not(:focus-visible) >ellipse,
+.c2:focus:not(:focus-visible) >line,
+.c2:focus:not(:focus-visible) >path,
+.c2:focus:not(:focus-visible) >polygon,
+.c2:focus:not(:focus-visible) >polyline,
+.c2:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c2:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
 }
 
 .c1 {
@@ -3232,16 +3381,8 @@ exports[`List events ArrowUp key 1`] = `
   padding: 0;
 }
 
-.c1:focus {
-  outline: 2px solid #6FFFB0;
-}
-
 .c3 {
   cursor: pointer;
-}
-
-.c3:focus {
-  outline: none;
 }
 
 @media only screen and (max-width: 768px) {
@@ -3274,6 +3415,18 @@ exports[`List events ArrowUp key 1`] = `
     padding-top: 6px;
     padding-bottom: 6px;
   }
+}
+
+@media only screen and (max-width: 768px) {
+
+}
+
+@media only screen and (max-width: 768px) {
+
+}
+
+@media only screen and (max-width: 768px) {
+
 }
 
 @media only screen and (max-width: 768px) {
@@ -3313,15 +3466,13 @@ exports[`List events ArrowUp key 1`] = `
   class="c0"
 >
   <ul
-    aria-activedescendant="0"
     class="c1"
     role="listbox"
-    tabindex="0"
   >
     <li
       class="c2 c3"
       role="option"
-      tabindex="-1"
+      tabindex="0"
     >
       alpha
     </li>
@@ -3364,6 +3515,11 @@ exports[`List events Enter key 1`] = `
   cursor: pointer;
 }
 
+.c2:hover {
+  background-color: rgba(221, 221, 221, 0.4);
+  color: #000000;
+}
+
 .c4 {
   display: flex;
   box-sizing: border-box;
@@ -3380,22 +3536,19 @@ exports[`List events Enter key 1`] = `
   cursor: pointer;
 }
 
+.c4:hover {
+  background-color: rgba(221, 221, 221, 0.4);
+  color: #000000;
+}
+
 .c1 {
   list-style: none;
   margin: 0;
   padding: 0;
 }
 
-.c1:focus {
-  outline: 2px solid #6FFFB0;
-}
-
 .c3 {
   cursor: pointer;
-}
-
-.c3:focus {
-  outline: none;
 }
 
 @media only screen and (max-width: 768px) {
@@ -3445,12 +3598,11 @@ exports[`List events Enter key 1`] = `
   <ul
     class="c1"
     role="listbox"
-    tabindex="0"
   >
     <li
       class="c2 c3"
       role="option"
-      tabindex="-1"
+      tabindex="0"
     >
       alpha
     </li>
@@ -3470,22 +3622,20 @@ exports[`List events Enter key 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 cBoJUe"
 >
   <ul
-    aria-activedescendant="1"
-    class="List__StyledList-sc-130gdqg-0 dHNMqI"
+    class="List__StyledList-sc-130gdqg-0 gjWLKL"
     role="listbox"
-    tabindex="0"
   >
     <li
-      class="StyledBox-sc-13pk1d4-0 hiUzJD List__StyledItem-sc-130gdqg-1 kepUQz"
+      class="StyledBox-sc-13pk1d4-0 inkIdT List__StyledItem-sc-130gdqg-1 hjLXfR"
       role="option"
       tabindex="-1"
     >
       alpha
     </li>
     <li
-      class="StyledBox-sc-13pk1d4-0 hFRtvp List__StyledItem-sc-130gdqg-1 kepUQz"
+      class="StyledBox-sc-13pk1d4-0 jjcdqE List__StyledItem-sc-130gdqg-1 hjLXfR"
       role="option"
-      tabindex="-1"
+      tabindex="0"
     >
       beta
     </li>
@@ -3521,10 +3671,17 @@ exports[`List events focus and blur 1`] = `
   cursor: pointer;
 }
 
+.c2:hover {
+  background-color: rgba(221, 221, 221, 0.4);
+  color: #000000;
+}
+
 .c4 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  background-color: rgba(221, 221, 221, 0.4);
+  color: #444444;
   border-bottom: solid 1px rgba(0, 0, 0, 0.33);
   min-width: 0;
   min-height: 0;
@@ -3535,6 +3692,48 @@ exports[`List events focus and blur 1`] = `
   padding-top: 12px;
   padding-bottom: 12px;
   cursor: pointer;
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:hover {
+  background-color: rgba(221, 221, 221, 0.4);
+  color: #000000;
+}
+
+.c4 >circle,
+.c4 >ellipse,
+.c4 >line,
+.c4 >path,
+.c4 >polygon,
+.c4 >polyline,
+.c4 >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4 ::-moz-focus-inner {
+  border: 0;
+}
+
+.c4:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c4:focus:not(:focus-visible) >circle,
+.c4:focus:not(:focus-visible) >ellipse,
+.c4:focus:not(:focus-visible) >line,
+.c4:focus:not(:focus-visible) >path,
+.c4:focus:not(:focus-visible) >polygon,
+.c4:focus:not(:focus-visible) >polyline,
+.c4:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c4:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
 }
 
 .c1 {
@@ -3543,16 +3742,8 @@ exports[`List events focus and blur 1`] = `
   padding: 0;
 }
 
-.c1:focus {
-  outline: 2px solid #6FFFB0;
-}
-
 .c3 {
   cursor: pointer;
-}
-
-.c3:focus {
-  outline: none;
 }
 
 @media only screen and (max-width: 768px) {
@@ -3574,6 +3765,18 @@ exports[`List events focus and blur 1`] = `
     padding-top: 6px;
     padding-bottom: 6px;
   }
+}
+
+@media only screen and (max-width: 768px) {
+
+}
+
+@media only screen and (max-width: 768px) {
+
+}
+
+@media only screen and (max-width: 768px) {
+
 }
 
 @media only screen and (max-width: 768px) {
@@ -3602,7 +3805,6 @@ exports[`List events focus and blur 1`] = `
   <ul
     class="c1"
     role="listbox"
-    tabindex="0"
   >
     <li
       class="c2 c3"
@@ -3614,7 +3816,7 @@ exports[`List events focus and blur 1`] = `
     <li
       class="c4 c3"
       role="option"
-      tabindex="-1"
+      tabindex="0"
     >
       beta
     </li>
@@ -3627,21 +3829,20 @@ exports[`List events focus and blur 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 cBoJUe"
 >
   <ul
-    class="List__StyledList-sc-130gdqg-0 dHNMqI"
+    class="List__StyledList-sc-130gdqg-0 gjWLKL"
     role="listbox"
-    tabindex="0"
   >
     <li
-      class="StyledBox-sc-13pk1d4-0 hiUzJD List__StyledItem-sc-130gdqg-1 kepUQz"
+      class="StyledBox-sc-13pk1d4-0 inkIdT List__StyledItem-sc-130gdqg-1 hjLXfR"
       role="option"
       tabindex="-1"
     >
       alpha
     </li>
     <li
-      class="StyledBox-sc-13pk1d4-0 gojVVh List__StyledItem-sc-130gdqg-1 kepUQz"
+      class="StyledBox-sc-13pk1d4-0 jefBcl List__StyledItem-sc-130gdqg-1 hjLXfR"
       role="option"
-      tabindex="-1"
+      tabindex="0"
     >
       beta
     </li>
@@ -3677,6 +3878,11 @@ exports[`List events mouse events 1`] = `
   cursor: pointer;
 }
 
+.c2:hover {
+  background-color: rgba(221, 221, 221, 0.4);
+  color: #000000;
+}
+
 .c4 {
   display: flex;
   box-sizing: border-box;
@@ -3695,22 +3901,19 @@ exports[`List events mouse events 1`] = `
   cursor: pointer;
 }
 
+.c4:hover {
+  background-color: rgba(221, 221, 221, 0.4);
+  color: #000000;
+}
+
 .c1 {
   list-style: none;
   margin: 0;
   padding: 0;
 }
 
-.c1:focus {
-  outline: 2px solid #6FFFB0;
-}
-
 .c3 {
   cursor: pointer;
-}
-
-.c3:focus {
-  outline: none;
 }
 
 @media only screen and (max-width: 768px) {
@@ -3770,15 +3973,13 @@ exports[`List events mouse events 1`] = `
   class="c0"
 >
   <ul
-    aria-activedescendant="1"
     class="c1"
     role="listbox"
-    tabindex="0"
   >
     <li
       class="c2 c3"
       role="option"
-      tabindex="-1"
+      tabindex="0"
     >
       alpha
     </li>
@@ -3798,19 +3999,18 @@ exports[`List events mouse events 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 cBoJUe"
 >
   <ul
-    class="List__StyledList-sc-130gdqg-0 dHNMqI"
+    class="List__StyledList-sc-130gdqg-0 gjWLKL"
     role="listbox"
-    tabindex="0"
   >
     <li
-      class="StyledBox-sc-13pk1d4-0 hiUzJD List__StyledItem-sc-130gdqg-1 kepUQz"
+      class="StyledBox-sc-13pk1d4-0 inkIdT List__StyledItem-sc-130gdqg-1 hjLXfR"
       role="option"
-      tabindex="-1"
+      tabindex="0"
     >
       alpha
     </li>
     <li
-      class="StyledBox-sc-13pk1d4-0 gojVVh List__StyledItem-sc-130gdqg-1 kepUQz"
+      class="StyledBox-sc-13pk1d4-0 hBnuHV List__StyledItem-sc-130gdqg-1 hjLXfR"
       role="option"
       tabindex="-1"
     >
@@ -3821,7 +4021,7 @@ exports[`List events mouse events 2`] = `
 `;
 
 exports[`List events should apply pagination styling 1`] = `
-.c13 {
+.c12 {
   display: inline-block;
   flex: 0 0 auto;
   width: 24px;
@@ -3830,30 +4030,30 @@ exports[`List events should apply pagination styling 1`] = `
   stroke: #666666;
 }
 
-.c13 g {
+.c12 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c13 *:not([stroke])[fill='none'] {
+.c12 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c13 *[stroke*='#'],
-.c13 *[STROKE*='#'] {
+.c12 *[stroke*='#'],
+.c12 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c13 *[fill-rule],
-.c13 *[FILL-RULE],
-.c13 *[fill*='#'],
-.c13 *[FILL*='#'] {
+.c12 *[fill-rule],
+.c12 *[FILL-RULE],
+.c12 *[fill*='#'],
+.c12 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
 
-.c17 {
+.c16 {
   display: inline-block;
   flex: 0 0 auto;
   width: 24px;
@@ -3862,25 +4062,25 @@ exports[`List events should apply pagination styling 1`] = `
   stroke: #000000;
 }
 
-.c17 g {
+.c16 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c17 *:not([stroke])[fill='none'] {
+.c16 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c17 *[stroke*='#'],
-.c17 *[STROKE*='#'] {
+.c16 *[stroke*='#'],
+.c16 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c17 *[fill-rule],
-.c17 *[FILL-RULE],
-.c17 *[fill*='#'],
-.c17 *[FILL*='#'] {
+.c16 *[fill-rule],
+.c16 *[FILL-RULE],
+.c16 *[fill*='#'],
+.c16 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -3920,7 +4120,7 @@ exports[`List events should apply pagination styling 1`] = `
   padding-bottom: 12px;
 }
 
-.c5 {
+.c4 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -3935,7 +4135,7 @@ exports[`List events should apply pagination styling 1`] = `
   padding-bottom: 12px;
 }
 
-.c7 {
+.c6 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -3947,7 +4147,7 @@ exports[`List events should apply pagination styling 1`] = `
   flex: 0 0 auto;
 }
 
-.c8 {
+.c7 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -3957,7 +4157,7 @@ exports[`List events should apply pagination styling 1`] = `
   flex: 0 0 auto;
 }
 
-.c9 {
+.c8 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -3970,13 +4170,13 @@ exports[`List events should apply pagination styling 1`] = `
   column-gap: 3px;
 }
 
-.c6 {
+.c5 {
   flex: 0 0 auto;
   align-self: stretch;
   height: 6px;
 }
 
-.c11 {
+.c10 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -4003,53 +4203,53 @@ exports[`List events should apply pagination styling 1`] = `
   flex: 1 0 auto;
 }
 
-.c11 >svg {
+.c10 >svg {
   display: flex;
   align-self: center;
   vertical-align: middle;
 }
 
-.c11:focus {
+.c10:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus >circle,
-.c11:focus >ellipse,
-.c11:focus >line,
-.c11:focus >path,
-.c11:focus >polygon,
-.c11:focus >polyline,
-.c11:focus >rect {
+.c10:focus >circle,
+.c10:focus >ellipse,
+.c10:focus >line,
+.c10:focus >path,
+.c10:focus >polygon,
+.c10:focus >polyline,
+.c10:focus >rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus ::-moz-focus-inner {
+.c10:focus ::-moz-focus-inner {
   border: 0;
 }
 
-.c11:focus:not(:focus-visible) {
+.c10:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c11:focus:not(:focus-visible) >circle,
-.c11:focus:not(:focus-visible) >ellipse,
-.c11:focus:not(:focus-visible) >line,
-.c11:focus:not(:focus-visible) >path,
-.c11:focus:not(:focus-visible) >polygon,
-.c11:focus:not(:focus-visible) >polyline,
-.c11:focus:not(:focus-visible) >rect {
+.c10:focus:not(:focus-visible) >circle,
+.c10:focus:not(:focus-visible) >ellipse,
+.c10:focus:not(:focus-visible) >line,
+.c10:focus:not(:focus-visible) >path,
+.c10:focus:not(:focus-visible) >polygon,
+.c10:focus:not(:focus-visible) >polyline,
+.c10:focus:not(:focus-visible) >rect {
   outline: none;
   box-shadow: none;
 }
 
-.c11:focus:not(:focus-visible) ::-moz-focus-inner {
+.c10:focus:not(:focus-visible) ::-moz-focus-inner {
   border: 0;
 }
 
-.c14 {
+.c13 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -4068,6 +4268,76 @@ exports[`List events should apply pagination styling 1`] = `
   line-height: 24px;
   background-color: rgba(51, 51, 51, 0.06274509803921569);
   color: #444444;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c13:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c13:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c13:focus >circle,
+.c13:focus >ellipse,
+.c13:focus >line,
+.c13:focus >path,
+.c13:focus >polygon,
+.c13:focus >polyline,
+.c13:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c13:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c13:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c13:focus:not(:focus-visible) >circle,
+.c13:focus:not(:focus-visible) >ellipse,
+.c13:focus:not(:focus-visible) >line,
+.c13:focus:not(:focus-visible) >path,
+.c13:focus:not(:focus-visible) >polygon,
+.c13:focus:not(:focus-visible) >polyline,
+.c13:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c13:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c14 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  color: #000000;
   text-align: center;
   transition-property: color,background-color,border-color,box-shadow;
   transition-duration: 0.1s;
@@ -4136,7 +4406,7 @@ exports[`List events should apply pagination styling 1`] = `
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   color: #000000;
   text-align: center;
   transition-property: color,background-color,border-color,box-shadow;
@@ -4146,6 +4416,12 @@ exports[`List events should apply pagination styling 1`] = `
   height: 100%;
   max-width: none;
   flex: 1 0 auto;
+}
+
+.c15 >svg {
+  display: flex;
+  align-self: center;
+  vertical-align: middle;
 }
 
 .c15:hover {
@@ -4192,92 +4468,16 @@ exports[`List events should apply pagination styling 1`] = `
   border: 0;
 }
 
-.c16 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 0;
-  color: #000000;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c16 >svg {
-  display: flex;
-  align-self: center;
-  vertical-align: middle;
-}
-
-.c16:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-}
-
-.c16:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c16:focus >circle,
-.c16:focus >ellipse,
-.c16:focus >line,
-.c16:focus >path,
-.c16:focus >polygon,
-.c16:focus >polyline,
-.c16:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c16:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c16:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c16:focus:not(:focus-visible) >circle,
-.c16:focus:not(:focus-visible) >ellipse,
-.c16:focus:not(:focus-visible) >line,
-.c16:focus:not(:focus-visible) >path,
-.c16:focus:not(:focus-visible) >polygon,
-.c16:focus:not(:focus-visible) >polyline,
-.c16:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c16:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c12 {
+.c11 {
   font-size: 18px;
   line-height: 0;
 }
 
-.c12 >svg {
+.c11 >svg {
   margin: 0 auto;
 }
 
-.c10 {
+.c9 {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -4290,10 +4490,6 @@ exports[`List events should apply pagination styling 1`] = `
   list-style: none;
   margin: 0;
   padding: 0;
-}
-
-.c4:focus {
-  outline: none;
 }
 
 @media only screen and (max-width: 768px) {
@@ -4318,51 +4514,51 @@ exports[`List events should apply pagination styling 1`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c5 {
+  .c4 {
     border-bottom: solid 1px rgba(0, 0, 0, 0.33);
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c5 {
+  .c4 {
     padding-left: 12px;
     padding-right: 12px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c5 {
+  .c4 {
     padding-top: 6px;
     padding-bottom: 6px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c7 {
+  .c6 {
     margin: 24px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c9 {
+  .c8 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c9 {
+  .c8 {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c9 {
+  .c8 {
     column-gap: 2px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c6 {
+  .c5 {
     height: 3px;
   }
 }
@@ -4378,282 +4574,282 @@ exports[`List events should apply pagination styling 1`] = `
       role="list"
     >
       <li
-        class="c3 c4"
+        class="c3 "
       >
         entry-0
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-1
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-2
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-3
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-4
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-5
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-6
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-7
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-8
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-9
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-10
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-11
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-12
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-13
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-14
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-15
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-16
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-17
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-18
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-19
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-20
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-21
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-22
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-23
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-24
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-25
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-26
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-27
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-28
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-29
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-30
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-31
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-32
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-33
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-34
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-35
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-36
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-37
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-38
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-39
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-40
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-41
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-42
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-43
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-44
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-45
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-46
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-47
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-48
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-49
       </li>
     </ul>
     <div
-      class="c6"
+      class="c5"
     />
     <div
-      class="c7 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
+      class="c6 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
     >
       <nav
         aria-label="Pagination Navigation"
-        class="c8"
+        class="c7"
       >
         <ul
-          class="c9"
+          class="c8"
         >
           <li
-            class="c10"
+            class="c9"
           >
             <button
               aria-disabled="true"
               aria-label="Go to previous page"
-              class="c11 c12"
+              class="c10 c11"
               disabled=""
               type="button"
             >
               <svg
                 aria-label="Previous"
-                class="c13"
+                class="c12"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -4666,39 +4862,39 @@ exports[`List events should apply pagination styling 1`] = `
             </button>
           </li>
           <li
-            class="c10"
+            class="c9"
           >
             <button
               aria-current="page"
               aria-label="Go to page 1"
-              class="c14 c12"
+              class="c13 c11"
               type="button"
             >
               1
             </button>
           </li>
           <li
-            class="c10"
+            class="c9"
           >
             <button
               aria-label="Go to page 2"
-              class="c15 c12"
+              class="c14 c11"
               type="button"
             >
               2
             </button>
           </li>
           <li
-            class="c10"
+            class="c9"
           >
             <button
               aria-label="Go to next page"
-              class="c16 c12"
+              class="c15 c11"
               type="button"
             >
               <svg
                 aria-label="Next"
-                class="c17"
+                class="c16"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -4753,7 +4949,7 @@ exports[`List events should not show paginate controls when length of data < ste
   padding-bottom: 12px;
 }
 
-.c5 {
+.c4 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -4772,10 +4968,6 @@ exports[`List events should not show paginate controls when length of data < ste
   list-style: none;
   margin: 0;
   padding: 0;
-}
-
-.c4:focus {
-  outline: none;
 }
 
 @media only screen and (max-width: 768px) {
@@ -4800,20 +4992,20 @@ exports[`List events should not show paginate controls when length of data < ste
 }
 
 @media only screen and (max-width: 768px) {
-  .c5 {
+  .c4 {
     border-bottom: solid 1px rgba(0, 0, 0, 0.33);
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c5 {
+  .c4 {
     padding-left: 12px;
     padding-right: 12px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c5 {
+  .c4 {
     padding-top: 6px;
     padding-bottom: 6px;
   }
@@ -4830,17 +5022,17 @@ exports[`List events should not show paginate controls when length of data < ste
       role="list"
     >
       <li
-        class="c3 c4"
+        class="c3 "
       >
         entry-1
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-2
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-3
       </li>
@@ -4850,7 +5042,7 @@ exports[`List events should not show paginate controls when length of data < ste
 `;
 
 exports[`List events should paginate 1`] = `
-.c13 {
+.c12 {
   display: inline-block;
   flex: 0 0 auto;
   width: 24px;
@@ -4859,30 +5051,30 @@ exports[`List events should paginate 1`] = `
   stroke: #666666;
 }
 
-.c13 g {
+.c12 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c13 *:not([stroke])[fill='none'] {
+.c12 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c13 *[stroke*='#'],
-.c13 *[STROKE*='#'] {
+.c12 *[stroke*='#'],
+.c12 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c13 *[fill-rule],
-.c13 *[FILL-RULE],
-.c13 *[fill*='#'],
-.c13 *[FILL*='#'] {
+.c12 *[fill-rule],
+.c12 *[FILL-RULE],
+.c12 *[fill*='#'],
+.c12 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
 
-.c17 {
+.c16 {
   display: inline-block;
   flex: 0 0 auto;
   width: 24px;
@@ -4891,25 +5083,25 @@ exports[`List events should paginate 1`] = `
   stroke: #000000;
 }
 
-.c17 g {
+.c16 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c17 *:not([stroke])[fill='none'] {
+.c16 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c17 *[stroke*='#'],
-.c17 *[STROKE*='#'] {
+.c16 *[stroke*='#'],
+.c16 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c17 *[fill-rule],
-.c17 *[FILL-RULE],
-.c17 *[fill*='#'],
-.c17 *[FILL*='#'] {
+.c16 *[fill-rule],
+.c16 *[FILL-RULE],
+.c16 *[fill*='#'],
+.c16 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -4949,7 +5141,7 @@ exports[`List events should paginate 1`] = `
   padding-bottom: 12px;
 }
 
-.c5 {
+.c4 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -4964,7 +5156,7 @@ exports[`List events should paginate 1`] = `
   padding-bottom: 12px;
 }
 
-.c7 {
+.c6 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -4975,7 +5167,7 @@ exports[`List events should paginate 1`] = `
   flex: 0 0 auto;
 }
 
-.c8 {
+.c7 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -4985,7 +5177,7 @@ exports[`List events should paginate 1`] = `
   flex: 0 0 auto;
 }
 
-.c9 {
+.c8 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -4998,13 +5190,13 @@ exports[`List events should paginate 1`] = `
   column-gap: 3px;
 }
 
-.c6 {
+.c5 {
   flex: 0 0 auto;
   align-self: stretch;
   height: 6px;
 }
 
-.c11 {
+.c10 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -5031,53 +5223,53 @@ exports[`List events should paginate 1`] = `
   flex: 1 0 auto;
 }
 
-.c11 >svg {
+.c10 >svg {
   display: flex;
   align-self: center;
   vertical-align: middle;
 }
 
-.c11:focus {
+.c10:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus >circle,
-.c11:focus >ellipse,
-.c11:focus >line,
-.c11:focus >path,
-.c11:focus >polygon,
-.c11:focus >polyline,
-.c11:focus >rect {
+.c10:focus >circle,
+.c10:focus >ellipse,
+.c10:focus >line,
+.c10:focus >path,
+.c10:focus >polygon,
+.c10:focus >polyline,
+.c10:focus >rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus ::-moz-focus-inner {
+.c10:focus ::-moz-focus-inner {
   border: 0;
 }
 
-.c11:focus:not(:focus-visible) {
+.c10:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c11:focus:not(:focus-visible) >circle,
-.c11:focus:not(:focus-visible) >ellipse,
-.c11:focus:not(:focus-visible) >line,
-.c11:focus:not(:focus-visible) >path,
-.c11:focus:not(:focus-visible) >polygon,
-.c11:focus:not(:focus-visible) >polyline,
-.c11:focus:not(:focus-visible) >rect {
+.c10:focus:not(:focus-visible) >circle,
+.c10:focus:not(:focus-visible) >ellipse,
+.c10:focus:not(:focus-visible) >line,
+.c10:focus:not(:focus-visible) >path,
+.c10:focus:not(:focus-visible) >polygon,
+.c10:focus:not(:focus-visible) >polyline,
+.c10:focus:not(:focus-visible) >rect {
   outline: none;
   box-shadow: none;
 }
 
-.c11:focus:not(:focus-visible) ::-moz-focus-inner {
+.c10:focus:not(:focus-visible) ::-moz-focus-inner {
   border: 0;
 }
 
-.c14 {
+.c13 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -5096,6 +5288,76 @@ exports[`List events should paginate 1`] = `
   line-height: 24px;
   background-color: rgba(51, 51, 51, 0.06274509803921569);
   color: #444444;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c13:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c13:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c13:focus >circle,
+.c13:focus >ellipse,
+.c13:focus >line,
+.c13:focus >path,
+.c13:focus >polygon,
+.c13:focus >polyline,
+.c13:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c13:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c13:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c13:focus:not(:focus-visible) >circle,
+.c13:focus:not(:focus-visible) >ellipse,
+.c13:focus:not(:focus-visible) >line,
+.c13:focus:not(:focus-visible) >path,
+.c13:focus:not(:focus-visible) >polygon,
+.c13:focus:not(:focus-visible) >polyline,
+.c13:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c13:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c14 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  color: #000000;
   text-align: center;
   transition-property: color,background-color,border-color,box-shadow;
   transition-duration: 0.1s;
@@ -5164,7 +5426,7 @@ exports[`List events should paginate 1`] = `
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   color: #000000;
   text-align: center;
   transition-property: color,background-color,border-color,box-shadow;
@@ -5174,6 +5436,12 @@ exports[`List events should paginate 1`] = `
   height: 100%;
   max-width: none;
   flex: 1 0 auto;
+}
+
+.c15 >svg {
+  display: flex;
+  align-self: center;
+  vertical-align: middle;
 }
 
 .c15:hover {
@@ -5220,92 +5488,16 @@ exports[`List events should paginate 1`] = `
   border: 0;
 }
 
-.c16 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 0;
-  color: #000000;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c16 >svg {
-  display: flex;
-  align-self: center;
-  vertical-align: middle;
-}
-
-.c16:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-}
-
-.c16:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c16:focus >circle,
-.c16:focus >ellipse,
-.c16:focus >line,
-.c16:focus >path,
-.c16:focus >polygon,
-.c16:focus >polyline,
-.c16:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c16:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c16:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c16:focus:not(:focus-visible) >circle,
-.c16:focus:not(:focus-visible) >ellipse,
-.c16:focus:not(:focus-visible) >line,
-.c16:focus:not(:focus-visible) >path,
-.c16:focus:not(:focus-visible) >polygon,
-.c16:focus:not(:focus-visible) >polyline,
-.c16:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c16:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c12 {
+.c11 {
   font-size: 18px;
   line-height: 0;
 }
 
-.c12 >svg {
+.c11 >svg {
   margin: 0 auto;
 }
 
-.c10 {
+.c9 {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -5318,10 +5510,6 @@ exports[`List events should paginate 1`] = `
   list-style: none;
   margin: 0;
   padding: 0;
-}
-
-.c4:focus {
-  outline: none;
 }
 
 @media only screen and (max-width: 768px) {
@@ -5346,45 +5534,45 @@ exports[`List events should paginate 1`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c5 {
+  .c4 {
     border-bottom: solid 1px rgba(0, 0, 0, 0.33);
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c5 {
+  .c4 {
     padding-left: 12px;
     padding-right: 12px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c5 {
+  .c4 {
     padding-top: 6px;
     padding-bottom: 6px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c9 {
+  .c8 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c9 {
+  .c8 {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c9 {
+  .c8 {
     column-gap: 2px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c6 {
+  .c5 {
     height: 3px;
   }
 }
@@ -5400,282 +5588,282 @@ exports[`List events should paginate 1`] = `
       role="list"
     >
       <li
-        class="c3 c4"
+        class="c3 "
       >
         entry-0
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-1
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-2
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-3
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-4
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-5
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-6
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-7
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-8
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-9
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-10
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-11
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-12
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-13
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-14
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-15
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-16
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-17
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-18
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-19
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-20
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-21
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-22
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-23
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-24
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-25
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-26
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-27
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-28
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-29
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-30
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-31
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-32
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-33
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-34
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-35
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-36
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-37
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-38
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-39
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-40
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-41
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-42
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-43
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-44
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-45
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-46
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-47
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-48
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-49
       </li>
     </ul>
     <div
-      class="c6"
+      class="c5"
     />
     <div
-      class="c7 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
+      class="c6 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
     >
       <nav
         aria-label="Pagination Navigation"
-        class="c8"
+        class="c7"
       >
         <ul
-          class="c9"
+          class="c8"
         >
           <li
-            class="c10"
+            class="c9"
           >
             <button
               aria-disabled="true"
               aria-label="Go to previous page"
-              class="c11 c12"
+              class="c10 c11"
               disabled=""
               type="button"
             >
               <svg
                 aria-label="Previous"
-                class="c13"
+                class="c12"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -5688,39 +5876,39 @@ exports[`List events should paginate 1`] = `
             </button>
           </li>
           <li
-            class="c10"
+            class="c9"
           >
             <button
               aria-current="page"
               aria-label="Go to page 1"
-              class="c14 c12"
+              class="c13 c11"
               type="button"
             >
               1
             </button>
           </li>
           <li
-            class="c10"
+            class="c9"
           >
             <button
               aria-label="Go to page 2"
-              class="c15 c12"
+              class="c14 c11"
               type="button"
             >
               2
             </button>
           </li>
           <li
-            class="c10"
+            class="c9"
           >
             <button
               aria-label="Go to next page"
-              class="c16 c12"
+              class="c15 c11"
               type="button"
             >
               <svg
                 aria-label="Next"
-                class="c17"
+                class="c16"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -5740,7 +5928,7 @@ exports[`List events should paginate 1`] = `
 `;
 
 exports[`List events should render correct num items per page (step) 1`] = `
-.c13 {
+.c12 {
   display: inline-block;
   flex: 0 0 auto;
   width: 24px;
@@ -5749,30 +5937,30 @@ exports[`List events should render correct num items per page (step) 1`] = `
   stroke: #666666;
 }
 
-.c13 g {
+.c12 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c13 *:not([stroke])[fill='none'] {
+.c12 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c13 *[stroke*='#'],
-.c13 *[STROKE*='#'] {
+.c12 *[stroke*='#'],
+.c12 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c13 *[fill-rule],
-.c13 *[FILL-RULE],
-.c13 *[fill*='#'],
-.c13 *[FILL*='#'] {
+.c12 *[fill-rule],
+.c12 *[FILL-RULE],
+.c12 *[fill*='#'],
+.c12 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
 
-.c17 {
+.c16 {
   display: inline-block;
   flex: 0 0 auto;
   width: 24px;
@@ -5781,25 +5969,25 @@ exports[`List events should render correct num items per page (step) 1`] = `
   stroke: #000000;
 }
 
-.c17 g {
+.c16 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c17 *:not([stroke])[fill='none'] {
+.c16 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c17 *[stroke*='#'],
-.c17 *[STROKE*='#'] {
+.c16 *[stroke*='#'],
+.c16 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c17 *[fill-rule],
-.c17 *[FILL-RULE],
-.c17 *[fill*='#'],
-.c17 *[FILL*='#'] {
+.c16 *[fill-rule],
+.c16 *[FILL-RULE],
+.c16 *[fill*='#'],
+.c16 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -5839,7 +6027,7 @@ exports[`List events should render correct num items per page (step) 1`] = `
   padding-bottom: 12px;
 }
 
-.c5 {
+.c4 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -5854,7 +6042,7 @@ exports[`List events should render correct num items per page (step) 1`] = `
   padding-bottom: 12px;
 }
 
-.c7 {
+.c6 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -5865,7 +6053,7 @@ exports[`List events should render correct num items per page (step) 1`] = `
   flex: 0 0 auto;
 }
 
-.c8 {
+.c7 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -5875,7 +6063,7 @@ exports[`List events should render correct num items per page (step) 1`] = `
   flex: 0 0 auto;
 }
 
-.c9 {
+.c8 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -5888,13 +6076,13 @@ exports[`List events should render correct num items per page (step) 1`] = `
   column-gap: 3px;
 }
 
-.c6 {
+.c5 {
   flex: 0 0 auto;
   align-self: stretch;
   height: 6px;
 }
 
-.c11 {
+.c10 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -5921,53 +6109,53 @@ exports[`List events should render correct num items per page (step) 1`] = `
   flex: 1 0 auto;
 }
 
-.c11 >svg {
+.c10 >svg {
   display: flex;
   align-self: center;
   vertical-align: middle;
 }
 
-.c11:focus {
+.c10:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus >circle,
-.c11:focus >ellipse,
-.c11:focus >line,
-.c11:focus >path,
-.c11:focus >polygon,
-.c11:focus >polyline,
-.c11:focus >rect {
+.c10:focus >circle,
+.c10:focus >ellipse,
+.c10:focus >line,
+.c10:focus >path,
+.c10:focus >polygon,
+.c10:focus >polyline,
+.c10:focus >rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus ::-moz-focus-inner {
+.c10:focus ::-moz-focus-inner {
   border: 0;
 }
 
-.c11:focus:not(:focus-visible) {
+.c10:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c11:focus:not(:focus-visible) >circle,
-.c11:focus:not(:focus-visible) >ellipse,
-.c11:focus:not(:focus-visible) >line,
-.c11:focus:not(:focus-visible) >path,
-.c11:focus:not(:focus-visible) >polygon,
-.c11:focus:not(:focus-visible) >polyline,
-.c11:focus:not(:focus-visible) >rect {
+.c10:focus:not(:focus-visible) >circle,
+.c10:focus:not(:focus-visible) >ellipse,
+.c10:focus:not(:focus-visible) >line,
+.c10:focus:not(:focus-visible) >path,
+.c10:focus:not(:focus-visible) >polygon,
+.c10:focus:not(:focus-visible) >polyline,
+.c10:focus:not(:focus-visible) >rect {
   outline: none;
   box-shadow: none;
 }
 
-.c11:focus:not(:focus-visible) ::-moz-focus-inner {
+.c10:focus:not(:focus-visible) ::-moz-focus-inner {
   border: 0;
 }
 
-.c14 {
+.c13 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -5986,6 +6174,76 @@ exports[`List events should render correct num items per page (step) 1`] = `
   line-height: 24px;
   background-color: rgba(51, 51, 51, 0.06274509803921569);
   color: #444444;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c13:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c13:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c13:focus >circle,
+.c13:focus >ellipse,
+.c13:focus >line,
+.c13:focus >path,
+.c13:focus >polygon,
+.c13:focus >polyline,
+.c13:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c13:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c13:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c13:focus:not(:focus-visible) >circle,
+.c13:focus:not(:focus-visible) >ellipse,
+.c13:focus:not(:focus-visible) >line,
+.c13:focus:not(:focus-visible) >path,
+.c13:focus:not(:focus-visible) >polygon,
+.c13:focus:not(:focus-visible) >polyline,
+.c13:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c13:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c14 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  color: #000000;
   text-align: center;
   transition-property: color,background-color,border-color,box-shadow;
   transition-duration: 0.1s;
@@ -6054,7 +6312,7 @@ exports[`List events should render correct num items per page (step) 1`] = `
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   color: #000000;
   text-align: center;
   transition-property: color,background-color,border-color,box-shadow;
@@ -6064,6 +6322,12 @@ exports[`List events should render correct num items per page (step) 1`] = `
   height: 100%;
   max-width: none;
   flex: 1 0 auto;
+}
+
+.c15 >svg {
+  display: flex;
+  align-self: center;
+  vertical-align: middle;
 }
 
 .c15:hover {
@@ -6110,92 +6374,16 @@ exports[`List events should render correct num items per page (step) 1`] = `
   border: 0;
 }
 
-.c16 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 0;
-  color: #000000;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c16 >svg {
-  display: flex;
-  align-self: center;
-  vertical-align: middle;
-}
-
-.c16:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-}
-
-.c16:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c16:focus >circle,
-.c16:focus >ellipse,
-.c16:focus >line,
-.c16:focus >path,
-.c16:focus >polygon,
-.c16:focus >polyline,
-.c16:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c16:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c16:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c16:focus:not(:focus-visible) >circle,
-.c16:focus:not(:focus-visible) >ellipse,
-.c16:focus:not(:focus-visible) >line,
-.c16:focus:not(:focus-visible) >path,
-.c16:focus:not(:focus-visible) >polygon,
-.c16:focus:not(:focus-visible) >polyline,
-.c16:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c16:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c12 {
+.c11 {
   font-size: 18px;
   line-height: 0;
 }
 
-.c12 >svg {
+.c11 >svg {
   margin: 0 auto;
 }
 
-.c10 {
+.c9 {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -6208,10 +6396,6 @@ exports[`List events should render correct num items per page (step) 1`] = `
   list-style: none;
   margin: 0;
   padding: 0;
-}
-
-.c4:focus {
-  outline: none;
 }
 
 @media only screen and (max-width: 768px) {
@@ -6236,45 +6420,45 @@ exports[`List events should render correct num items per page (step) 1`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c5 {
+  .c4 {
     border-bottom: solid 1px rgba(0, 0, 0, 0.33);
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c5 {
+  .c4 {
     padding-left: 12px;
     padding-right: 12px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c5 {
+  .c4 {
     padding-top: 6px;
     padding-bottom: 6px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c9 {
+  .c8 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c9 {
+  .c8 {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c9 {
+  .c8 {
     column-gap: 2px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c6 {
+  .c5 {
     height: 3px;
   }
 }
@@ -6290,102 +6474,102 @@ exports[`List events should render correct num items per page (step) 1`] = `
       role="list"
     >
       <li
-        class="c3 c4"
+        class="c3 "
       >
         entry-0
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-1
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-2
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-3
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-4
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-5
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-6
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-7
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-8
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-9
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-10
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-11
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-12
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-13
       </li>
     </ul>
     <div
-      class="c6"
+      class="c5"
     />
     <div
-      class="c7 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
+      class="c6 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
     >
       <nav
         aria-label="Pagination Navigation"
-        class="c8"
+        class="c7"
       >
         <ul
-          class="c9"
+          class="c8"
         >
           <li
-            class="c10"
+            class="c9"
           >
             <button
               aria-disabled="true"
               aria-label="Go to previous page"
-              class="c11 c12"
+              class="c10 c11"
               disabled=""
               type="button"
             >
               <svg
                 aria-label="Previous"
-                class="c13"
+                class="c12"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -6398,94 +6582,94 @@ exports[`List events should render correct num items per page (step) 1`] = `
             </button>
           </li>
           <li
-            class="c10"
+            class="c9"
           >
             <button
               aria-current="page"
               aria-label="Go to page 1"
-              class="c14 c12"
+              class="c13 c11"
               type="button"
             >
               1
             </button>
           </li>
           <li
-            class="c10"
+            class="c9"
           >
             <button
               aria-label="Go to page 2"
-              class="c15 c12"
+              class="c14 c11"
               type="button"
             >
               2
             </button>
           </li>
           <li
-            class="c10"
+            class="c9"
           >
             <button
               aria-label="Go to page 3"
-              class="c15 c12"
+              class="c14 c11"
               type="button"
             >
               3
             </button>
           </li>
           <li
-            class="c10"
+            class="c9"
           >
             <button
               aria-label="Go to page 4"
-              class="c15 c12"
+              class="c14 c11"
               type="button"
             >
               4
             </button>
           </li>
           <li
-            class="c10"
+            class="c9"
           >
             <button
               aria-label="Go to page 5"
-              class="c15 c12"
+              class="c14 c11"
               type="button"
             >
               5
             </button>
           </li>
           <li
-            class="c10"
+            class="c9"
           >
             <button
               aria-label="Go to page 6"
-              class="c15 c12"
+              class="c14 c11"
               type="button"
             >
               6
             </button>
           </li>
           <li
-            class="c10"
+            class="c9"
           >
             <button
               aria-label="Go to page 7"
-              class="c15 c12"
+              class="c14 c11"
               type="button"
             >
               7
             </button>
           </li>
           <li
-            class="c10"
+            class="c9"
           >
             <button
               aria-label="Go to next page"
-              class="c16 c12"
+              class="c15 c11"
               type="button"
             >
               <svg
                 aria-label="Next"
-                class="c17"
+                class="c16"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -6505,7 +6689,7 @@ exports[`List events should render correct num items per page (step) 1`] = `
 `;
 
 exports[`List events should render new data when page changes 1`] = `
-.c13 {
+.c12 {
   display: inline-block;
   flex: 0 0 auto;
   width: 24px;
@@ -6514,30 +6698,30 @@ exports[`List events should render new data when page changes 1`] = `
   stroke: #666666;
 }
 
-.c13 g {
+.c12 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c13 *:not([stroke])[fill='none'] {
+.c12 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c13 *[stroke*='#'],
-.c13 *[STROKE*='#'] {
+.c12 *[stroke*='#'],
+.c12 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c13 *[fill-rule],
-.c13 *[FILL-RULE],
-.c13 *[fill*='#'],
-.c13 *[FILL*='#'] {
+.c12 *[fill-rule],
+.c12 *[FILL-RULE],
+.c12 *[fill*='#'],
+.c12 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
 
-.c17 {
+.c16 {
   display: inline-block;
   flex: 0 0 auto;
   width: 24px;
@@ -6546,25 +6730,25 @@ exports[`List events should render new data when page changes 1`] = `
   stroke: #000000;
 }
 
-.c17 g {
+.c16 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c17 *:not([stroke])[fill='none'] {
+.c16 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c17 *[stroke*='#'],
-.c17 *[STROKE*='#'] {
+.c16 *[stroke*='#'],
+.c16 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c17 *[fill-rule],
-.c17 *[FILL-RULE],
-.c17 *[fill*='#'],
-.c17 *[FILL*='#'] {
+.c16 *[fill-rule],
+.c16 *[FILL-RULE],
+.c16 *[fill*='#'],
+.c16 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -6604,7 +6788,7 @@ exports[`List events should render new data when page changes 1`] = `
   padding-bottom: 12px;
 }
 
-.c5 {
+.c4 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -6619,7 +6803,7 @@ exports[`List events should render new data when page changes 1`] = `
   padding-bottom: 12px;
 }
 
-.c7 {
+.c6 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -6630,7 +6814,7 @@ exports[`List events should render new data when page changes 1`] = `
   flex: 0 0 auto;
 }
 
-.c8 {
+.c7 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -6640,7 +6824,7 @@ exports[`List events should render new data when page changes 1`] = `
   flex: 0 0 auto;
 }
 
-.c9 {
+.c8 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -6653,13 +6837,13 @@ exports[`List events should render new data when page changes 1`] = `
   column-gap: 3px;
 }
 
-.c6 {
+.c5 {
   flex: 0 0 auto;
   align-self: stretch;
   height: 6px;
 }
 
-.c11 {
+.c10 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -6686,53 +6870,53 @@ exports[`List events should render new data when page changes 1`] = `
   flex: 1 0 auto;
 }
 
-.c11 >svg {
+.c10 >svg {
   display: flex;
   align-self: center;
   vertical-align: middle;
 }
 
-.c11:focus {
+.c10:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus >circle,
-.c11:focus >ellipse,
-.c11:focus >line,
-.c11:focus >path,
-.c11:focus >polygon,
-.c11:focus >polyline,
-.c11:focus >rect {
+.c10:focus >circle,
+.c10:focus >ellipse,
+.c10:focus >line,
+.c10:focus >path,
+.c10:focus >polygon,
+.c10:focus >polyline,
+.c10:focus >rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus ::-moz-focus-inner {
+.c10:focus ::-moz-focus-inner {
   border: 0;
 }
 
-.c11:focus:not(:focus-visible) {
+.c10:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c11:focus:not(:focus-visible) >circle,
-.c11:focus:not(:focus-visible) >ellipse,
-.c11:focus:not(:focus-visible) >line,
-.c11:focus:not(:focus-visible) >path,
-.c11:focus:not(:focus-visible) >polygon,
-.c11:focus:not(:focus-visible) >polyline,
-.c11:focus:not(:focus-visible) >rect {
+.c10:focus:not(:focus-visible) >circle,
+.c10:focus:not(:focus-visible) >ellipse,
+.c10:focus:not(:focus-visible) >line,
+.c10:focus:not(:focus-visible) >path,
+.c10:focus:not(:focus-visible) >polygon,
+.c10:focus:not(:focus-visible) >polyline,
+.c10:focus:not(:focus-visible) >rect {
   outline: none;
   box-shadow: none;
 }
 
-.c11:focus:not(:focus-visible) ::-moz-focus-inner {
+.c10:focus:not(:focus-visible) ::-moz-focus-inner {
   border: 0;
 }
 
-.c14 {
+.c13 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -6751,6 +6935,76 @@ exports[`List events should render new data when page changes 1`] = `
   line-height: 24px;
   background-color: rgba(51, 51, 51, 0.06274509803921569);
   color: #444444;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c13:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c13:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c13:focus >circle,
+.c13:focus >ellipse,
+.c13:focus >line,
+.c13:focus >path,
+.c13:focus >polygon,
+.c13:focus >polyline,
+.c13:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c13:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c13:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c13:focus:not(:focus-visible) >circle,
+.c13:focus:not(:focus-visible) >ellipse,
+.c13:focus:not(:focus-visible) >line,
+.c13:focus:not(:focus-visible) >path,
+.c13:focus:not(:focus-visible) >polygon,
+.c13:focus:not(:focus-visible) >polyline,
+.c13:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c13:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c14 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  color: #000000;
   text-align: center;
   transition-property: color,background-color,border-color,box-shadow;
   transition-duration: 0.1s;
@@ -6819,7 +7073,7 @@ exports[`List events should render new data when page changes 1`] = `
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   color: #000000;
   text-align: center;
   transition-property: color,background-color,border-color,box-shadow;
@@ -6829,6 +7083,12 @@ exports[`List events should render new data when page changes 1`] = `
   height: 100%;
   max-width: none;
   flex: 1 0 auto;
+}
+
+.c15 >svg {
+  display: flex;
+  align-self: center;
+  vertical-align: middle;
 }
 
 .c15:hover {
@@ -6875,92 +7135,16 @@ exports[`List events should render new data when page changes 1`] = `
   border: 0;
 }
 
-.c16 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 0;
-  color: #000000;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c16 >svg {
-  display: flex;
-  align-self: center;
-  vertical-align: middle;
-}
-
-.c16:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-}
-
-.c16:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c16:focus >circle,
-.c16:focus >ellipse,
-.c16:focus >line,
-.c16:focus >path,
-.c16:focus >polygon,
-.c16:focus >polyline,
-.c16:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c16:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c16:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c16:focus:not(:focus-visible) >circle,
-.c16:focus:not(:focus-visible) >ellipse,
-.c16:focus:not(:focus-visible) >line,
-.c16:focus:not(:focus-visible) >path,
-.c16:focus:not(:focus-visible) >polygon,
-.c16:focus:not(:focus-visible) >polyline,
-.c16:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c16:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c12 {
+.c11 {
   font-size: 18px;
   line-height: 0;
 }
 
-.c12 >svg {
+.c11 >svg {
   margin: 0 auto;
 }
 
-.c10 {
+.c9 {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -6973,10 +7157,6 @@ exports[`List events should render new data when page changes 1`] = `
   list-style: none;
   margin: 0;
   padding: 0;
-}
-
-.c4:focus {
-  outline: none;
 }
 
 @media only screen and (max-width: 768px) {
@@ -7001,45 +7181,45 @@ exports[`List events should render new data when page changes 1`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c5 {
+  .c4 {
     border-bottom: solid 1px rgba(0, 0, 0, 0.33);
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c5 {
+  .c4 {
     padding-left: 12px;
     padding-right: 12px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c5 {
+  .c4 {
     padding-top: 6px;
     padding-bottom: 6px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c9 {
+  .c8 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c9 {
+  .c8 {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c9 {
+  .c8 {
     column-gap: 2px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c6 {
+  .c5 {
     height: 3px;
   }
 }
@@ -7055,282 +7235,282 @@ exports[`List events should render new data when page changes 1`] = `
       role="list"
     >
       <li
-        class="c3 c4"
+        class="c3 "
       >
         entry-0
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-1
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-2
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-3
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-4
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-5
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-6
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-7
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-8
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-9
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-10
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-11
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-12
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-13
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-14
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-15
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-16
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-17
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-18
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-19
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-20
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-21
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-22
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-23
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-24
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-25
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-26
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-27
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-28
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-29
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-30
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-31
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-32
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-33
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-34
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-35
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-36
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-37
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-38
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-39
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-40
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-41
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-42
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-43
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-44
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-45
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-46
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-47
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-48
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-49
       </li>
     </ul>
     <div
-      class="c6"
+      class="c5"
     />
     <div
-      class="c7 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
+      class="c6 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
     >
       <nav
         aria-label="Pagination Navigation"
-        class="c8"
+        class="c7"
       >
         <ul
-          class="c9"
+          class="c8"
         >
           <li
-            class="c10"
+            class="c9"
           >
             <button
               aria-disabled="true"
               aria-label="Go to previous page"
-              class="c11 c12"
+              class="c10 c11"
               disabled=""
               type="button"
             >
               <svg
                 aria-label="Previous"
-                class="c13"
+                class="c12"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -7343,39 +7523,39 @@ exports[`List events should render new data when page changes 1`] = `
             </button>
           </li>
           <li
-            class="c10"
+            class="c9"
           >
             <button
               aria-current="page"
               aria-label="Go to page 1"
-              class="c14 c12"
+              class="c13 c11"
               type="button"
             >
               1
             </button>
           </li>
           <li
-            class="c10"
+            class="c9"
           >
             <button
               aria-label="Go to page 2"
-              class="c15 c12"
+              class="c14 c11"
               type="button"
             >
               2
             </button>
           </li>
           <li
-            class="c10"
+            class="c9"
           >
             <button
               aria-label="Go to next page"
-              class="c16 c12"
+              class="c15 c11"
               type="button"
             >
               <svg
                 aria-label="Next"
-                class="c17"
+                class="c16"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -7402,7 +7582,7 @@ exports[`List events should render new data when page changes 2`] = `
     class="StyledBox-sc-13pk1d4-0 hKCfLv List__StyledContainer-sc-130gdqg-2 geKNab"
   >
     <ul
-      class="List__StyledList-sc-130gdqg-0 fHzSzX"
+      class="List__StyledList-sc-130gdqg-0 gjWLKL"
       role="list"
     >
       .c0 {
@@ -7419,10 +7599,6 @@ exports[`List events should render new data when page changes 2`] = `
   padding-right: 24px;
   padding-top: 12px;
   padding-bottom: 12px;
-}
-
-.c1:focus {
-  outline: none;
 }
 
 @media only screen and (max-width: 768px) {
@@ -7475,7 +7651,7 @@ exports[`List events should render new data when page changes 2`] = `
 }
 
 <li
-        class="c0 c1"
+        class="c0 "
       >
         entry-50
       </li>
@@ -7494,10 +7670,6 @@ exports[`List events should render new data when page changes 2`] = `
   padding-bottom: 12px;
 }
 
-.c1:focus {
-  outline: none;
-}
-
 @media only screen and (max-width: 768px) {
 
 }
@@ -7547,7 +7719,7 @@ exports[`List events should render new data when page changes 2`] = `
 }
 
 <li
-        class="c0 c1"
+        class="c0 "
       >
         entry-51
       </li>
@@ -7566,10 +7738,6 @@ exports[`List events should render new data when page changes 2`] = `
   padding-bottom: 12px;
 }
 
-.c1:focus {
-  outline: none;
-}
-
 @media only screen and (max-width: 768px) {
 
 }
@@ -7619,7 +7787,7 @@ exports[`List events should render new data when page changes 2`] = `
 }
 
 <li
-        class="c0 c1"
+        class="c0 "
       >
         entry-52
       </li>
@@ -7638,10 +7806,6 @@ exports[`List events should render new data when page changes 2`] = `
   padding-bottom: 12px;
 }
 
-.c1:focus {
-  outline: none;
-}
-
 @media only screen and (max-width: 768px) {
 
 }
@@ -7691,7 +7855,7 @@ exports[`List events should render new data when page changes 2`] = `
 }
 
 <li
-        class="c0 c1"
+        class="c0 "
       >
         entry-53
       </li>
@@ -7710,10 +7874,6 @@ exports[`List events should render new data when page changes 2`] = `
   padding-bottom: 12px;
 }
 
-.c1:focus {
-  outline: none;
-}
-
 @media only screen and (max-width: 768px) {
 
 }
@@ -7763,7 +7923,7 @@ exports[`List events should render new data when page changes 2`] = `
 }
 
 <li
-        class="c0 c1"
+        class="c0 "
       >
         entry-54
       </li>
@@ -7782,10 +7942,6 @@ exports[`List events should render new data when page changes 2`] = `
   padding-bottom: 12px;
 }
 
-.c1:focus {
-  outline: none;
-}
-
 @media only screen and (max-width: 768px) {
 
 }
@@ -7835,7 +7991,7 @@ exports[`List events should render new data when page changes 2`] = `
 }
 
 <li
-        class="c0 c1"
+        class="c0 "
       >
         entry-55
       </li>
@@ -7854,10 +8010,6 @@ exports[`List events should render new data when page changes 2`] = `
   padding-bottom: 12px;
 }
 
-.c1:focus {
-  outline: none;
-}
-
 @media only screen and (max-width: 768px) {
 
 }
@@ -7907,7 +8059,7 @@ exports[`List events should render new data when page changes 2`] = `
 }
 
 <li
-        class="c0 c1"
+        class="c0 "
       >
         entry-56
       </li>
@@ -7926,10 +8078,6 @@ exports[`List events should render new data when page changes 2`] = `
   padding-bottom: 12px;
 }
 
-.c1:focus {
-  outline: none;
-}
-
 @media only screen and (max-width: 768px) {
 
 }
@@ -7979,7 +8127,7 @@ exports[`List events should render new data when page changes 2`] = `
 }
 
 <li
-        class="c0 c1"
+        class="c0 "
       >
         entry-57
       </li>
@@ -7998,10 +8146,6 @@ exports[`List events should render new data when page changes 2`] = `
   padding-bottom: 12px;
 }
 
-.c1:focus {
-  outline: none;
-}
-
 @media only screen and (max-width: 768px) {
 
 }
@@ -8051,7 +8195,7 @@ exports[`List events should render new data when page changes 2`] = `
 }
 
 <li
-        class="c0 c1"
+        class="c0 "
       >
         entry-58
       </li>
@@ -8070,10 +8214,6 @@ exports[`List events should render new data when page changes 2`] = `
   padding-bottom: 12px;
 }
 
-.c1:focus {
-  outline: none;
-}
-
 @media only screen and (max-width: 768px) {
 
 }
@@ -8123,7 +8263,7 @@ exports[`List events should render new data when page changes 2`] = `
 }
 
 <li
-        class="c0 c1"
+        class="c0 "
       >
         entry-59
       </li>
@@ -8142,10 +8282,6 @@ exports[`List events should render new data when page changes 2`] = `
   padding-bottom: 12px;
 }
 
-.c1:focus {
-  outline: none;
-}
-
 @media only screen and (max-width: 768px) {
 
 }
@@ -8195,7 +8331,7 @@ exports[`List events should render new data when page changes 2`] = `
 }
 
 <li
-        class="c0 c1"
+        class="c0 "
       >
         entry-60
       </li>
@@ -8214,10 +8350,6 @@ exports[`List events should render new data when page changes 2`] = `
   padding-bottom: 12px;
 }
 
-.c1:focus {
-  outline: none;
-}
-
 @media only screen and (max-width: 768px) {
 
 }
@@ -8267,7 +8399,7 @@ exports[`List events should render new data when page changes 2`] = `
 }
 
 <li
-        class="c0 c1"
+        class="c0 "
       >
         entry-61
       </li>
@@ -8286,10 +8418,6 @@ exports[`List events should render new data when page changes 2`] = `
   padding-bottom: 12px;
 }
 
-.c1:focus {
-  outline: none;
-}
-
 @media only screen and (max-width: 768px) {
 
 }
@@ -8339,7 +8467,7 @@ exports[`List events should render new data when page changes 2`] = `
 }
 
 <li
-        class="c0 c1"
+        class="c0 "
       >
         entry-62
       </li>
@@ -8358,10 +8486,6 @@ exports[`List events should render new data when page changes 2`] = `
   padding-bottom: 12px;
 }
 
-.c1:focus {
-  outline: none;
-}
-
 @media only screen and (max-width: 768px) {
 
 }
@@ -8411,7 +8535,7 @@ exports[`List events should render new data when page changes 2`] = `
 }
 
 <li
-        class="c0 c1"
+        class="c0 "
       >
         entry-63
       </li>
@@ -8430,10 +8554,6 @@ exports[`List events should render new data when page changes 2`] = `
   padding-bottom: 12px;
 }
 
-.c1:focus {
-  outline: none;
-}
-
 @media only screen and (max-width: 768px) {
 
 }
@@ -8483,7 +8603,7 @@ exports[`List events should render new data when page changes 2`] = `
 }
 
 <li
-        class="c0 c1"
+        class="c0 "
       >
         entry-64
       </li>
@@ -8502,10 +8622,6 @@ exports[`List events should render new data when page changes 2`] = `
   padding-bottom: 12px;
 }
 
-.c1:focus {
-  outline: none;
-}
-
 @media only screen and (max-width: 768px) {
 
 }
@@ -8555,7 +8671,7 @@ exports[`List events should render new data when page changes 2`] = `
 }
 
 <li
-        class="c0 c1"
+        class="c0 "
       >
         entry-65
       </li>
@@ -8574,10 +8690,6 @@ exports[`List events should render new data when page changes 2`] = `
   padding-bottom: 12px;
 }
 
-.c1:focus {
-  outline: none;
-}
-
 @media only screen and (max-width: 768px) {
 
 }
@@ -8627,7 +8739,7 @@ exports[`List events should render new data when page changes 2`] = `
 }
 
 <li
-        class="c0 c1"
+        class="c0 "
       >
         entry-66
       </li>
@@ -8646,10 +8758,6 @@ exports[`List events should render new data when page changes 2`] = `
   padding-bottom: 12px;
 }
 
-.c1:focus {
-  outline: none;
-}
-
 @media only screen and (max-width: 768px) {
 
 }
@@ -8699,7 +8807,7 @@ exports[`List events should render new data when page changes 2`] = `
 }
 
 <li
-        class="c0 c1"
+        class="c0 "
       >
         entry-67
       </li>
@@ -8718,10 +8826,6 @@ exports[`List events should render new data when page changes 2`] = `
   padding-bottom: 12px;
 }
 
-.c1:focus {
-  outline: none;
-}
-
 @media only screen and (max-width: 768px) {
 
 }
@@ -8771,7 +8875,7 @@ exports[`List events should render new data when page changes 2`] = `
 }
 
 <li
-        class="c0 c1"
+        class="c0 "
       >
         entry-68
       </li>
@@ -8790,10 +8894,6 @@ exports[`List events should render new data when page changes 2`] = `
   padding-bottom: 12px;
 }
 
-.c1:focus {
-  outline: none;
-}
-
 @media only screen and (max-width: 768px) {
 
 }
@@ -8843,7 +8943,7 @@ exports[`List events should render new data when page changes 2`] = `
 }
 
 <li
-        class="c0 c1"
+        class="c0 "
       >
         entry-69
       </li>
@@ -8862,10 +8962,6 @@ exports[`List events should render new data when page changes 2`] = `
   padding-bottom: 12px;
 }
 
-.c1:focus {
-  outline: none;
-}
-
 @media only screen and (max-width: 768px) {
 
 }
@@ -8915,7 +9011,7 @@ exports[`List events should render new data when page changes 2`] = `
 }
 
 <li
-        class="c0 c1"
+        class="c0 "
       >
         entry-70
       </li>
@@ -8934,10 +9030,6 @@ exports[`List events should render new data when page changes 2`] = `
   padding-bottom: 12px;
 }
 
-.c1:focus {
-  outline: none;
-}
-
 @media only screen and (max-width: 768px) {
 
 }
@@ -8987,7 +9079,7 @@ exports[`List events should render new data when page changes 2`] = `
 }
 
 <li
-        class="c0 c1"
+        class="c0 "
       >
         entry-71
       </li>
@@ -9006,10 +9098,6 @@ exports[`List events should render new data when page changes 2`] = `
   padding-bottom: 12px;
 }
 
-.c1:focus {
-  outline: none;
-}
-
 @media only screen and (max-width: 768px) {
 
 }
@@ -9059,7 +9147,7 @@ exports[`List events should render new data when page changes 2`] = `
 }
 
 <li
-        class="c0 c1"
+        class="c0 "
       >
         entry-72
       </li>
@@ -9078,10 +9166,6 @@ exports[`List events should render new data when page changes 2`] = `
   padding-bottom: 12px;
 }
 
-.c1:focus {
-  outline: none;
-}
-
 @media only screen and (max-width: 768px) {
 
 }
@@ -9131,7 +9215,7 @@ exports[`List events should render new data when page changes 2`] = `
 }
 
 <li
-        class="c0 c1"
+        class="c0 "
       >
         entry-73
       </li>
@@ -9150,10 +9234,6 @@ exports[`List events should render new data when page changes 2`] = `
   padding-bottom: 12px;
 }
 
-.c1:focus {
-  outline: none;
-}
-
 @media only screen and (max-width: 768px) {
 
 }
@@ -9203,7 +9283,7 @@ exports[`List events should render new data when page changes 2`] = `
 }
 
 <li
-        class="c0 c1"
+        class="c0 "
       >
         entry-74
       </li>
@@ -9222,10 +9302,6 @@ exports[`List events should render new data when page changes 2`] = `
   padding-bottom: 12px;
 }
 
-.c1:focus {
-  outline: none;
-}
-
 @media only screen and (max-width: 768px) {
 
 }
@@ -9275,7 +9351,7 @@ exports[`List events should render new data when page changes 2`] = `
 }
 
 <li
-        class="c0 c1"
+        class="c0 "
       >
         entry-75
       </li>
@@ -9294,10 +9370,6 @@ exports[`List events should render new data when page changes 2`] = `
   padding-bottom: 12px;
 }
 
-.c1:focus {
-  outline: none;
-}
-
 @media only screen and (max-width: 768px) {
 
 }
@@ -9347,7 +9419,7 @@ exports[`List events should render new data when page changes 2`] = `
 }
 
 <li
-        class="c0 c1"
+        class="c0 "
       >
         entry-76
       </li>
@@ -9366,10 +9438,6 @@ exports[`List events should render new data when page changes 2`] = `
   padding-bottom: 12px;
 }
 
-.c1:focus {
-  outline: none;
-}
-
 @media only screen and (max-width: 768px) {
 
 }
@@ -9419,7 +9487,7 @@ exports[`List events should render new data when page changes 2`] = `
 }
 
 <li
-        class="c0 c1"
+        class="c0 "
       >
         entry-77
       </li>
@@ -9438,10 +9506,6 @@ exports[`List events should render new data when page changes 2`] = `
   padding-bottom: 12px;
 }
 
-.c1:focus {
-  outline: none;
-}
-
 @media only screen and (max-width: 768px) {
 
 }
@@ -9491,7 +9555,7 @@ exports[`List events should render new data when page changes 2`] = `
 }
 
 <li
-        class="c0 c1"
+        class="c0 "
       >
         entry-78
       </li>
@@ -9510,10 +9574,6 @@ exports[`List events should render new data when page changes 2`] = `
   padding-bottom: 12px;
 }
 
-.c1:focus {
-  outline: none;
-}
-
 @media only screen and (max-width: 768px) {
 
 }
@@ -9563,7 +9623,7 @@ exports[`List events should render new data when page changes 2`] = `
 }
 
 <li
-        class="c0 c1"
+        class="c0 "
       >
         entry-79
       </li>
@@ -9582,10 +9642,6 @@ exports[`List events should render new data when page changes 2`] = `
   padding-bottom: 12px;
 }
 
-.c1:focus {
-  outline: none;
-}
-
 @media only screen and (max-width: 768px) {
 
 }
@@ -9635,7 +9691,7 @@ exports[`List events should render new data when page changes 2`] = `
 }
 
 <li
-        class="c0 c1"
+        class="c0 "
       >
         entry-80
       </li>
@@ -9654,10 +9710,6 @@ exports[`List events should render new data when page changes 2`] = `
   padding-bottom: 12px;
 }
 
-.c1:focus {
-  outline: none;
-}
-
 @media only screen and (max-width: 768px) {
 
 }
@@ -9707,7 +9759,7 @@ exports[`List events should render new data when page changes 2`] = `
 }
 
 <li
-        class="c0 c1"
+        class="c0 "
       >
         entry-81
       </li>
@@ -9726,10 +9778,6 @@ exports[`List events should render new data when page changes 2`] = `
   padding-bottom: 12px;
 }
 
-.c1:focus {
-  outline: none;
-}
-
 @media only screen and (max-width: 768px) {
 
 }
@@ -9779,7 +9827,7 @@ exports[`List events should render new data when page changes 2`] = `
 }
 
 <li
-        class="c0 c1"
+        class="c0 "
       >
         entry-82
       </li>
@@ -9798,10 +9846,6 @@ exports[`List events should render new data when page changes 2`] = `
   padding-bottom: 12px;
 }
 
-.c1:focus {
-  outline: none;
-}
-
 @media only screen and (max-width: 768px) {
 
 }
@@ -9851,7 +9895,7 @@ exports[`List events should render new data when page changes 2`] = `
 }
 
 <li
-        class="c0 c1"
+        class="c0 "
       >
         entry-83
       </li>
@@ -9870,10 +9914,6 @@ exports[`List events should render new data when page changes 2`] = `
   padding-bottom: 12px;
 }
 
-.c1:focus {
-  outline: none;
-}
-
 @media only screen and (max-width: 768px) {
 
 }
@@ -9923,7 +9963,7 @@ exports[`List events should render new data when page changes 2`] = `
 }
 
 <li
-        class="c0 c1"
+        class="c0 "
       >
         entry-84
       </li>
@@ -9942,10 +9982,6 @@ exports[`List events should render new data when page changes 2`] = `
   padding-bottom: 12px;
 }
 
-.c1:focus {
-  outline: none;
-}
-
 @media only screen and (max-width: 768px) {
 
 }
@@ -9995,7 +10031,7 @@ exports[`List events should render new data when page changes 2`] = `
 }
 
 <li
-        class="c0 c1"
+        class="c0 "
       >
         entry-85
       </li>
@@ -10014,10 +10050,6 @@ exports[`List events should render new data when page changes 2`] = `
   padding-bottom: 12px;
 }
 
-.c1:focus {
-  outline: none;
-}
-
 @media only screen and (max-width: 768px) {
 
 }
@@ -10067,7 +10099,7 @@ exports[`List events should render new data when page changes 2`] = `
 }
 
 <li
-        class="c0 c1"
+        class="c0 "
       >
         entry-86
       </li>
@@ -10086,10 +10118,6 @@ exports[`List events should render new data when page changes 2`] = `
   padding-bottom: 12px;
 }
 
-.c1:focus {
-  outline: none;
-}
-
 @media only screen and (max-width: 768px) {
 
 }
@@ -10139,7 +10167,7 @@ exports[`List events should render new data when page changes 2`] = `
 }
 
 <li
-        class="c0 c1"
+        class="c0 "
       >
         entry-87
       </li>
@@ -10158,10 +10186,6 @@ exports[`List events should render new data when page changes 2`] = `
   padding-bottom: 12px;
 }
 
-.c1:focus {
-  outline: none;
-}
-
 @media only screen and (max-width: 768px) {
 
 }
@@ -10211,7 +10235,7 @@ exports[`List events should render new data when page changes 2`] = `
 }
 
 <li
-        class="c0 c1"
+        class="c0 "
       >
         entry-88
       </li>
@@ -10230,10 +10254,6 @@ exports[`List events should render new data when page changes 2`] = `
   padding-bottom: 12px;
 }
 
-.c1:focus {
-  outline: none;
-}
-
 @media only screen and (max-width: 768px) {
 
 }
@@ -10283,7 +10303,7 @@ exports[`List events should render new data when page changes 2`] = `
 }
 
 <li
-        class="c0 c1"
+        class="c0 "
       >
         entry-89
       </li>
@@ -10302,10 +10322,6 @@ exports[`List events should render new data when page changes 2`] = `
   padding-bottom: 12px;
 }
 
-.c1:focus {
-  outline: none;
-}
-
 @media only screen and (max-width: 768px) {
 
 }
@@ -10355,7 +10371,7 @@ exports[`List events should render new data when page changes 2`] = `
 }
 
 <li
-        class="c0 c1"
+        class="c0 "
       >
         entry-90
       </li>
@@ -10374,10 +10390,6 @@ exports[`List events should render new data when page changes 2`] = `
   padding-bottom: 12px;
 }
 
-.c1:focus {
-  outline: none;
-}
-
 @media only screen and (max-width: 768px) {
 
 }
@@ -10427,7 +10439,7 @@ exports[`List events should render new data when page changes 2`] = `
 }
 
 <li
-        class="c0 c1"
+        class="c0 "
       >
         entry-91
       </li>
@@ -10446,10 +10458,6 @@ exports[`List events should render new data when page changes 2`] = `
   padding-bottom: 12px;
 }
 
-.c1:focus {
-  outline: none;
-}
-
 @media only screen and (max-width: 768px) {
 
 }
@@ -10499,7 +10507,7 @@ exports[`List events should render new data when page changes 2`] = `
 }
 
 <li
-        class="c0 c1"
+        class="c0 "
       >
         entry-92
       </li>
@@ -10518,10 +10526,6 @@ exports[`List events should render new data when page changes 2`] = `
   padding-bottom: 12px;
 }
 
-.c1:focus {
-  outline: none;
-}
-
 @media only screen and (max-width: 768px) {
 
 }
@@ -10571,7 +10575,7 @@ exports[`List events should render new data when page changes 2`] = `
 }
 
 <li
-        class="c0 c1"
+        class="c0 "
       >
         entry-93
       </li>
@@ -10590,10 +10594,6 @@ exports[`List events should render new data when page changes 2`] = `
   padding-bottom: 12px;
 }
 
-.c1:focus {
-  outline: none;
-}
-
 @media only screen and (max-width: 768px) {
 
 }
@@ -10643,7 +10643,7 @@ exports[`List events should render new data when page changes 2`] = `
 }
 
 <li
-        class="c0 c1"
+        class="c0 "
       >
         entry-94
       </li>
@@ -10738,7 +10738,7 @@ exports[`List events should render new data when page changes 2`] = `
 `;
 
 exports[`List events should show correct item index when "show" is a number 1`] = `
-.c13 {
+.c12 {
   display: inline-block;
   flex: 0 0 auto;
   width: 24px;
@@ -10747,30 +10747,30 @@ exports[`List events should show correct item index when "show" is a number 1`] 
   stroke: #666666;
 }
 
-.c13 g {
+.c12 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c13 *:not([stroke])[fill='none'] {
+.c12 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c13 *[stroke*='#'],
-.c13 *[STROKE*='#'] {
+.c12 *[stroke*='#'],
+.c12 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c13 *[fill-rule],
-.c13 *[FILL-RULE],
-.c13 *[fill*='#'],
-.c13 *[FILL*='#'] {
+.c12 *[fill-rule],
+.c12 *[FILL-RULE],
+.c12 *[fill*='#'],
+.c12 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
 
-.c17 {
+.c16 {
   display: inline-block;
   flex: 0 0 auto;
   width: 24px;
@@ -10779,25 +10779,25 @@ exports[`List events should show correct item index when "show" is a number 1`] 
   stroke: #000000;
 }
 
-.c17 g {
+.c16 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c17 *:not([stroke])[fill='none'] {
+.c16 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c17 *[stroke*='#'],
-.c17 *[STROKE*='#'] {
+.c16 *[stroke*='#'],
+.c16 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c17 *[fill-rule],
-.c17 *[FILL-RULE],
-.c17 *[fill*='#'],
-.c17 *[FILL*='#'] {
+.c16 *[fill-rule],
+.c16 *[FILL-RULE],
+.c16 *[fill*='#'],
+.c16 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -10837,7 +10837,7 @@ exports[`List events should show correct item index when "show" is a number 1`] 
   padding-bottom: 12px;
 }
 
-.c5 {
+.c4 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -10852,7 +10852,7 @@ exports[`List events should show correct item index when "show" is a number 1`] 
   padding-bottom: 12px;
 }
 
-.c7 {
+.c6 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -10863,7 +10863,7 @@ exports[`List events should show correct item index when "show" is a number 1`] 
   flex: 0 0 auto;
 }
 
-.c8 {
+.c7 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -10873,7 +10873,7 @@ exports[`List events should show correct item index when "show" is a number 1`] 
   flex: 0 0 auto;
 }
 
-.c9 {
+.c8 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -10886,13 +10886,13 @@ exports[`List events should show correct item index when "show" is a number 1`] 
   column-gap: 3px;
 }
 
-.c6 {
+.c5 {
   flex: 0 0 auto;
   align-self: stretch;
   height: 6px;
 }
 
-.c11 {
+.c10 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -10919,53 +10919,53 @@ exports[`List events should show correct item index when "show" is a number 1`] 
   flex: 1 0 auto;
 }
 
-.c11 >svg {
+.c10 >svg {
   display: flex;
   align-self: center;
   vertical-align: middle;
 }
 
-.c11:focus {
+.c10:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus >circle,
-.c11:focus >ellipse,
-.c11:focus >line,
-.c11:focus >path,
-.c11:focus >polygon,
-.c11:focus >polyline,
-.c11:focus >rect {
+.c10:focus >circle,
+.c10:focus >ellipse,
+.c10:focus >line,
+.c10:focus >path,
+.c10:focus >polygon,
+.c10:focus >polyline,
+.c10:focus >rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus ::-moz-focus-inner {
+.c10:focus ::-moz-focus-inner {
   border: 0;
 }
 
-.c11:focus:not(:focus-visible) {
+.c10:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c11:focus:not(:focus-visible) >circle,
-.c11:focus:not(:focus-visible) >ellipse,
-.c11:focus:not(:focus-visible) >line,
-.c11:focus:not(:focus-visible) >path,
-.c11:focus:not(:focus-visible) >polygon,
-.c11:focus:not(:focus-visible) >polyline,
-.c11:focus:not(:focus-visible) >rect {
+.c10:focus:not(:focus-visible) >circle,
+.c10:focus:not(:focus-visible) >ellipse,
+.c10:focus:not(:focus-visible) >line,
+.c10:focus:not(:focus-visible) >path,
+.c10:focus:not(:focus-visible) >polygon,
+.c10:focus:not(:focus-visible) >polyline,
+.c10:focus:not(:focus-visible) >rect {
   outline: none;
   box-shadow: none;
 }
 
-.c11:focus:not(:focus-visible) ::-moz-focus-inner {
+.c10:focus:not(:focus-visible) ::-moz-focus-inner {
   border: 0;
 }
 
-.c14 {
+.c13 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -10984,6 +10984,76 @@ exports[`List events should show correct item index when "show" is a number 1`] 
   line-height: 24px;
   background-color: rgba(51, 51, 51, 0.06274509803921569);
   color: #444444;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c13:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c13:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c13:focus >circle,
+.c13:focus >ellipse,
+.c13:focus >line,
+.c13:focus >path,
+.c13:focus >polygon,
+.c13:focus >polyline,
+.c13:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c13:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c13:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c13:focus:not(:focus-visible) >circle,
+.c13:focus:not(:focus-visible) >ellipse,
+.c13:focus:not(:focus-visible) >line,
+.c13:focus:not(:focus-visible) >path,
+.c13:focus:not(:focus-visible) >polygon,
+.c13:focus:not(:focus-visible) >polyline,
+.c13:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c13:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c14 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  color: #000000;
   text-align: center;
   transition-property: color,background-color,border-color,box-shadow;
   transition-duration: 0.1s;
@@ -11052,7 +11122,7 @@ exports[`List events should show correct item index when "show" is a number 1`] 
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
+  line-height: 0;
   color: #000000;
   text-align: center;
   transition-property: color,background-color,border-color,box-shadow;
@@ -11062,6 +11132,12 @@ exports[`List events should show correct item index when "show" is a number 1`] 
   height: 100%;
   max-width: none;
   flex: 1 0 auto;
+}
+
+.c15 >svg {
+  display: flex;
+  align-self: center;
+  vertical-align: middle;
 }
 
 .c15:hover {
@@ -11108,92 +11184,16 @@ exports[`List events should show correct item index when "show" is a number 1`] 
   border: 0;
 }
 
-.c16 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 0;
-  color: #000000;
-  text-align: center;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c16 >svg {
-  display: flex;
-  align-self: center;
-  vertical-align: middle;
-}
-
-.c16:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-}
-
-.c16:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c16:focus >circle,
-.c16:focus >ellipse,
-.c16:focus >line,
-.c16:focus >path,
-.c16:focus >polygon,
-.c16:focus >polyline,
-.c16:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c16:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c16:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c16:focus:not(:focus-visible) >circle,
-.c16:focus:not(:focus-visible) >ellipse,
-.c16:focus:not(:focus-visible) >line,
-.c16:focus:not(:focus-visible) >path,
-.c16:focus:not(:focus-visible) >polygon,
-.c16:focus:not(:focus-visible) >polyline,
-.c16:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c16:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c12 {
+.c11 {
   font-size: 18px;
   line-height: 0;
 }
 
-.c12 >svg {
+.c11 >svg {
   margin: 0 auto;
 }
 
-.c10 {
+.c9 {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -11206,10 +11206,6 @@ exports[`List events should show correct item index when "show" is a number 1`] 
   list-style: none;
   margin: 0;
   padding: 0;
-}
-
-.c4:focus {
-  outline: none;
 }
 
 @media only screen and (max-width: 768px) {
@@ -11234,45 +11230,45 @@ exports[`List events should show correct item index when "show" is a number 1`] 
 }
 
 @media only screen and (max-width: 768px) {
-  .c5 {
+  .c4 {
     border-bottom: solid 1px rgba(0, 0, 0, 0.33);
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c5 {
+  .c4 {
     padding-left: 12px;
     padding-right: 12px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c5 {
+  .c4 {
     padding-top: 6px;
     padding-bottom: 6px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c9 {
+  .c8 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c9 {
+  .c8 {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c9 {
+  .c8 {
     column-gap: 2px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c6 {
+  .c5 {
     height: 3px;
   }
 }
@@ -11288,282 +11284,282 @@ exports[`List events should show correct item index when "show" is a number 1`] 
       role="list"
     >
       <li
-        class="c3 c4"
+        class="c3 "
       >
         entry-0
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-1
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-2
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-3
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-4
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-5
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-6
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-7
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-8
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-9
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-10
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-11
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-12
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-13
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-14
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-15
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-16
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-17
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-18
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-19
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-20
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-21
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-22
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-23
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-24
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-25
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-26
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-27
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-28
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-29
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-30
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-31
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-32
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-33
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-34
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-35
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-36
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-37
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-38
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-39
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-40
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-41
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-42
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-43
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-44
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-45
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-46
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-47
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-48
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-49
       </li>
     </ul>
     <div
-      class="c6"
+      class="c5"
     />
     <div
-      class="c7 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
+      class="c6 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
     >
       <nav
         aria-label="Pagination Navigation"
-        class="c8"
+        class="c7"
       >
         <ul
-          class="c9"
+          class="c8"
         >
           <li
-            class="c10"
+            class="c9"
           >
             <button
               aria-disabled="true"
               aria-label="Go to previous page"
-              class="c11 c12"
+              class="c10 c11"
               disabled=""
               type="button"
             >
               <svg
                 aria-label="Previous"
-                class="c13"
+                class="c12"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -11576,39 +11572,39 @@ exports[`List events should show correct item index when "show" is a number 1`] 
             </button>
           </li>
           <li
-            class="c10"
+            class="c9"
           >
             <button
               aria-current="page"
               aria-label="Go to page 1"
-              class="c14 c12"
+              class="c13 c11"
               type="button"
             >
               1
             </button>
           </li>
           <li
-            class="c10"
+            class="c9"
           >
             <button
               aria-label="Go to page 2"
-              class="c15 c12"
+              class="c14 c11"
               type="button"
             >
               2
             </button>
           </li>
           <li
-            class="c10"
+            class="c9"
           >
             <button
               aria-label="Go to next page"
-              class="c16 c12"
+              class="c15 c11"
               type="button"
             >
               <svg
                 aria-label="Next"
-                class="c17"
+                class="c16"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -11628,7 +11624,7 @@ exports[`List events should show correct item index when "show" is a number 1`] 
 `;
 
 exports[`List events should show correct page when "show" is { page: # } 1`] = `
-.c13 {
+.c12 {
   display: inline-block;
   flex: 0 0 auto;
   width: 24px;
@@ -11637,30 +11633,30 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
   stroke: #000000;
 }
 
-.c13 g {
+.c12 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c13 *:not([stroke])[fill='none'] {
+.c12 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c13 *[stroke*='#'],
-.c13 *[STROKE*='#'] {
+.c12 *[stroke*='#'],
+.c12 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c13 *[fill-rule],
-.c13 *[FILL-RULE],
-.c13 *[fill*='#'],
-.c13 *[FILL*='#'] {
+.c12 *[fill-rule],
+.c12 *[FILL-RULE],
+.c12 *[fill*='#'],
+.c12 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
 
-.c17 {
+.c16 {
   display: inline-block;
   flex: 0 0 auto;
   width: 24px;
@@ -11669,25 +11665,25 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
   stroke: #666666;
 }
 
-.c17 g {
+.c16 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c17 *:not([stroke])[fill='none'] {
+.c16 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c17 *[stroke*='#'],
-.c17 *[STROKE*='#'] {
+.c16 *[stroke*='#'],
+.c16 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c17 *[fill-rule],
-.c17 *[FILL-RULE],
-.c17 *[fill*='#'],
-.c17 *[FILL*='#'] {
+.c16 *[fill-rule],
+.c16 *[FILL-RULE],
+.c16 *[fill*='#'],
+.c16 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -11727,7 +11723,7 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
   padding-bottom: 12px;
 }
 
-.c5 {
+.c4 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -11742,7 +11738,7 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
   padding-bottom: 12px;
 }
 
-.c7 {
+.c6 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -11753,7 +11749,7 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
   flex: 0 0 auto;
 }
 
-.c8 {
+.c7 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -11763,7 +11759,7 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
   flex: 0 0 auto;
 }
 
-.c9 {
+.c8 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -11776,13 +11772,13 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
   column-gap: 3px;
 }
 
-.c6 {
+.c5 {
   flex: 0 0 auto;
   align-self: stretch;
   height: 6px;
 }
 
-.c11 {
+.c10 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -11808,57 +11804,57 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
   flex: 1 0 auto;
 }
 
-.c11 >svg {
+.c10 >svg {
   display: flex;
   align-self: center;
   vertical-align: middle;
 }
 
-.c11:hover {
+.c10:hover {
   background-color: rgba(51, 51, 51, 0.06274509803921569);
 }
 
-.c11:focus {
+.c10:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus >circle,
-.c11:focus >ellipse,
-.c11:focus >line,
-.c11:focus >path,
-.c11:focus >polygon,
-.c11:focus >polyline,
-.c11:focus >rect {
+.c10:focus >circle,
+.c10:focus >ellipse,
+.c10:focus >line,
+.c10:focus >path,
+.c10:focus >polygon,
+.c10:focus >polyline,
+.c10:focus >rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c11:focus ::-moz-focus-inner {
+.c10:focus ::-moz-focus-inner {
   border: 0;
 }
 
-.c11:focus:not(:focus-visible) {
+.c10:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c11:focus:not(:focus-visible) >circle,
-.c11:focus:not(:focus-visible) >ellipse,
-.c11:focus:not(:focus-visible) >line,
-.c11:focus:not(:focus-visible) >path,
-.c11:focus:not(:focus-visible) >polygon,
-.c11:focus:not(:focus-visible) >polyline,
-.c11:focus:not(:focus-visible) >rect {
+.c10:focus:not(:focus-visible) >circle,
+.c10:focus:not(:focus-visible) >ellipse,
+.c10:focus:not(:focus-visible) >line,
+.c10:focus:not(:focus-visible) >path,
+.c10:focus:not(:focus-visible) >polygon,
+.c10:focus:not(:focus-visible) >polyline,
+.c10:focus:not(:focus-visible) >rect {
   outline: none;
   box-shadow: none;
 }
 
-.c11:focus:not(:focus-visible) ::-moz-focus-inner {
+.c10:focus:not(:focus-visible) ::-moz-focus-inner {
   border: 0;
 }
 
-.c14 {
+.c13 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -11874,6 +11870,79 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
   font-size: 18px;
   line-height: 24px;
   color: #000000;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  flex: 1 0 auto;
+}
+
+.c13:hover {
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+}
+
+.c13:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c13:focus >circle,
+.c13:focus >ellipse,
+.c13:focus >line,
+.c13:focus >path,
+.c13:focus >polygon,
+.c13:focus >polyline,
+.c13:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c13:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c13:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c13:focus:not(:focus-visible) >circle,
+.c13:focus:not(:focus-visible) >ellipse,
+.c13:focus:not(:focus-visible) >line,
+.c13:focus:not(:focus-visible) >path,
+.c13:focus:not(:focus-visible) >polygon,
+.c13:focus:not(:focus-visible) >polyline,
+.c13:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c13:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c14 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  background-color: rgba(221, 221, 221, 0.4);
+  color: #000000;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 4px;
+  font-size: 18px;
+  line-height: 24px;
+  background-color: rgba(51, 51, 51, 0.06274509803921569);
+  color: #444444;
   text-align: center;
   transition-property: color,background-color,border-color,box-shadow;
   transition-duration: 0.1s;
@@ -11938,16 +12007,14 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
   background: transparent;
   overflow: visible;
   text-transform: none;
-  background-color: rgba(221, 221, 221, 0.4);
-  color: #000000;
   border: none;
   border-radius: 4px;
   padding: 4px 4px;
   font-size: 18px;
-  line-height: 24px;
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
-  color: #444444;
+  line-height: 0;
   text-align: center;
+  opacity: 0.3;
+  cursor: default;
   transition-property: color,background-color,border-color,box-shadow;
   transition-duration: 0.1s;
   transition-timing-function: ease-in-out;
@@ -11957,8 +12024,10 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
   flex: 1 0 auto;
 }
 
-.c15:hover {
-  background-color: rgba(51, 51, 51, 0.06274509803921569);
+.c15 >svg {
+  display: flex;
+  align-self: center;
+  vertical-align: middle;
 }
 
 .c15:focus {
@@ -12001,89 +12070,16 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
   border: 0;
 }
 
-.c16 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 4px;
-  font-size: 18px;
-  line-height: 0;
-  text-align: center;
-  opacity: 0.3;
-  cursor: default;
-  transition-property: color,background-color,border-color,box-shadow;
-  transition-duration: 0.1s;
-  transition-timing-function: ease-in-out;
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  flex: 1 0 auto;
-}
-
-.c16 >svg {
-  display: flex;
-  align-self: center;
-  vertical-align: middle;
-}
-
-.c16:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c16:focus >circle,
-.c16:focus >ellipse,
-.c16:focus >line,
-.c16:focus >path,
-.c16:focus >polygon,
-.c16:focus >polyline,
-.c16:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c16:focus ::-moz-focus-inner {
-  border: 0;
-}
-
-.c16:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.c16:focus:not(:focus-visible) >circle,
-.c16:focus:not(:focus-visible) >ellipse,
-.c16:focus:not(:focus-visible) >line,
-.c16:focus:not(:focus-visible) >path,
-.c16:focus:not(:focus-visible) >polygon,
-.c16:focus:not(:focus-visible) >polyline,
-.c16:focus:not(:focus-visible) >rect {
-  outline: none;
-  box-shadow: none;
-}
-
-.c16:focus:not(:focus-visible) ::-moz-focus-inner {
-  border: 0;
-}
-
-.c12 {
+.c11 {
   font-size: 18px;
   line-height: 0;
 }
 
-.c12 >svg {
+.c11 >svg {
   margin: 0 auto;
 }
 
-.c10 {
+.c9 {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -12096,10 +12092,6 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
   list-style: none;
   margin: 0;
   padding: 0;
-}
-
-.c4:focus {
-  outline: none;
 }
 
 @media only screen and (max-width: 768px) {
@@ -12124,45 +12116,45 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c5 {
+  .c4 {
     border-bottom: solid 1px rgba(0, 0, 0, 0.33);
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c5 {
+  .c4 {
     padding-left: 12px;
     padding-right: 12px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c5 {
+  .c4 {
     padding-top: 6px;
     padding-bottom: 6px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c9 {
+  .c8 {
     margin: 0px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c9 {
+  .c8 {
     padding: 0px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c9 {
+  .c8 {
     column-gap: 2px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c6 {
+  .c5 {
     height: 3px;
   }
 }
@@ -12178,255 +12170,255 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
       role="list"
     >
       <li
-        class="c3 c4"
+        class="c3 "
       >
         entry-50
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-51
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-52
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-53
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-54
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-55
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-56
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-57
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-58
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-59
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-60
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-61
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-62
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-63
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-64
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-65
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-66
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-67
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-68
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-69
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-70
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-71
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-72
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-73
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-74
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-75
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-76
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-77
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-78
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-79
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-80
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-81
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-82
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-83
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-84
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-85
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-86
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-87
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-88
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-89
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-90
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-91
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-92
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-93
       </li>
       <li
-        class="c5 c4"
+        class="c4 "
       >
         entry-94
       </li>
     </ul>
     <div
-      class="c6"
+      class="c5"
     />
     <div
-      class="c7 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
+      class="c6 Pagination__StyledPaginationContainer-sc-rnlw6m-0"
     >
       <nav
         aria-label="Pagination Navigation"
-        class="c8"
+        class="c7"
       >
         <ul
-          class="c9"
+          class="c8"
         >
           <li
-            class="c10"
+            class="c9"
           >
             <button
               aria-label="Go to previous page"
-              class="c11 c12"
+              class="c10 c11"
               type="button"
             >
               <svg
                 aria-label="Previous"
-                class="c13"
+                class="c12"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -12439,41 +12431,41 @@ exports[`List events should show correct page when "show" is { page: # } 1`] = `
             </button>
           </li>
           <li
-            class="c10"
+            class="c9"
           >
             <button
               aria-label="Go to page 1"
-              class="c14 c12"
+              class="c13 c11"
               type="button"
             >
               1
             </button>
           </li>
           <li
-            class="c10"
+            class="c9"
           >
             <button
               aria-current="page"
               aria-label="Go to page 2"
-              class="c15 c12"
+              class="c14 c11"
               type="button"
             >
               2
             </button>
           </li>
           <li
-            class="c10"
+            class="c9"
           >
             <button
               aria-disabled="true"
               aria-label="Go to next page"
-              class="c16 c12"
+              class="c15 c11"
               disabled=""
               type="button"
             >
               <svg
                 aria-label="Next"
-                class="c17"
+                class="c16"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -12592,7 +12584,7 @@ exports[`List grommet messages 1`] = `
   padding-bottom: 12px;
 }
 
-.c13 {
+.c12 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -12604,7 +12596,7 @@ exports[`List grommet messages 1`] = `
   padding: 12px;
 }
 
-.c14 {
+.c13 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -12652,6 +12644,26 @@ exports[`List grommet messages 1`] = `
   padding: 12px;
 }
 
+.c8:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus >circle,
+.c8:focus >ellipse,
+.c8:focus >line,
+.c8:focus >path,
+.c8:focus >polygon,
+.c8:focus >polyline,
+.c8:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus ::-moz-focus-inner {
+  border: 0;
+}
+
 .c8:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -12696,6 +12708,26 @@ exports[`List grommet messages 1`] = `
   color: #000000;
 }
 
+.c10:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus >circle,
+.c10:focus >ellipse,
+.c10:focus >line,
+.c10:focus >path,
+.c10:focus >polygon,
+.c10:focus >polyline,
+.c10:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus ::-moz-focus-inner {
+  border: 0;
+}
+
 .c10:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -12722,20 +12754,8 @@ exports[`List grommet messages 1`] = `
   padding: 0;
 }
 
-.c1:focus {
-  outline: 2px solid #6FFFB0;
-}
-
 .c3 {
   cursor: move;
-}
-
-.c3:focus {
-  outline: none;
-}
-
-.c12:focus {
-  outline: none;
 }
 
 @media only screen and (max-width: 768px) {
@@ -12780,26 +12800,26 @@ exports[`List grommet messages 1`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c13 {
+  .c12 {
     padding: 6px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c14 {
+  .c13 {
     border-bottom: solid 1px rgba(0, 0, 0, 0.33);
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c14 {
+  .c13 {
     padding-left: 12px;
     padding-right: 12px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c14 {
+  .c13 {
     padding-top: 6px;
     padding-bottom: 6px;
   }
@@ -12817,7 +12837,6 @@ exports[`List grommet messages 1`] = `
     <ul
       class="c1"
       role="list"
-      tabindex="0"
     >
       <li
         class="c2 c3"
@@ -12867,7 +12886,7 @@ exports[`List grommet messages 1`] = `
             aria-label="1 Colorado move down"
             class="c10"
             id="ColoradoMoveDown"
-            tabindex="-1"
+            tabindex="0"
             type="button"
           >
             <svg
@@ -12886,7 +12905,7 @@ exports[`List grommet messages 1`] = `
         </div>
       </li>
       <li
-        class="c11 c12"
+        class="c11 "
       >
         <span
           class="c4"
@@ -12905,7 +12924,7 @@ exports[`List grommet messages 1`] = `
           class="c5"
         />
         <div
-          class="c13"
+          class="c12"
         >
           <svg
             aria-label="Item locked."
@@ -12922,7 +12941,7 @@ exports[`List grommet messages 1`] = `
         </div>
       </li>
       <li
-        class="c14 c3"
+        class="c13 c3"
         draggable="true"
       >
         <span
@@ -13092,7 +13111,7 @@ exports[`List itemKey function 1`] = `
   padding-bottom: 12px;
 }
 
-.c13 {
+.c12 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -13104,7 +13123,7 @@ exports[`List itemKey function 1`] = `
   padding: 12px;
 }
 
-.c14 {
+.c13 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -13152,6 +13171,26 @@ exports[`List itemKey function 1`] = `
   padding: 12px;
 }
 
+.c8:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus >circle,
+.c8:focus >ellipse,
+.c8:focus >line,
+.c8:focus >path,
+.c8:focus >polygon,
+.c8:focus >polyline,
+.c8:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus ::-moz-focus-inner {
+  border: 0;
+}
+
 .c8:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -13196,6 +13235,26 @@ exports[`List itemKey function 1`] = `
   color: #000000;
 }
 
+.c10:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus >circle,
+.c10:focus >ellipse,
+.c10:focus >line,
+.c10:focus >path,
+.c10:focus >polygon,
+.c10:focus >polyline,
+.c10:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus ::-moz-focus-inner {
+  border: 0;
+}
+
 .c10:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -13222,20 +13281,8 @@ exports[`List itemKey function 1`] = `
   padding: 0;
 }
 
-.c1:focus {
-  outline: 2px solid #6FFFB0;
-}
-
 .c3 {
   cursor: move;
-}
-
-.c3:focus {
-  outline: none;
-}
-
-.c12:focus {
-  outline: none;
 }
 
 @media only screen and (max-width: 768px) {
@@ -13280,26 +13327,26 @@ exports[`List itemKey function 1`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c13 {
+  .c12 {
     padding: 6px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c14 {
+  .c13 {
     border-bottom: solid 1px rgba(0, 0, 0, 0.33);
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c14 {
+  .c13 {
     padding-left: 12px;
     padding-right: 12px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c14 {
+  .c13 {
     padding-top: 6px;
     padding-bottom: 6px;
   }
@@ -13317,7 +13364,6 @@ exports[`List itemKey function 1`] = `
     <ul
       class="c1"
       role="list"
-      tabindex="0"
     >
       <li
         class="c2 c3"
@@ -13386,7 +13432,7 @@ exports[`List itemKey function 1`] = `
         </div>
       </li>
       <li
-        class="c11 c12"
+        class="c11 "
       >
         <span
           class="c4"
@@ -13405,7 +13451,7 @@ exports[`List itemKey function 1`] = `
           class="c5"
         />
         <div
-          class="c13"
+          class="c12"
         >
           <svg
             aria-label="Item pinned, order cannot be changed."
@@ -13422,7 +13468,7 @@ exports[`List itemKey function 1`] = `
         </div>
       </li>
       <li
-        class="c14 c3"
+        class="c13 c3"
         draggable="true"
       >
         <span
@@ -13519,7 +13565,7 @@ exports[`List itemProps 1`] = `
   padding-bottom: 12px;
 }
 
-.c4 {
+.c3 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -13538,10 +13584,6 @@ exports[`List itemProps 1`] = `
   list-style: none;
   margin: 0;
   padding: 0;
-}
-
-.c3:focus {
-  outline: none;
 }
 
 @media only screen and (max-width: 768px) {
@@ -13566,14 +13608,14 @@ exports[`List itemProps 1`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c4 {
+  .c3 {
     border-top: solid 2px rgba(0, 0, 0, 0.33);
     border-bottom: solid 2px rgba(0, 0, 0, 0.33);
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c4 {
+  .c3 {
     padding: 24px;
   }
 }
@@ -13586,12 +13628,12 @@ exports[`List itemProps 1`] = `
     role="list"
   >
     <li
-      class="c2 c3"
+      class="c2 "
     >
       one
     </li>
     <li
-      class="c4 c3"
+      class="c3 "
     >
       two
     </li>
@@ -13626,7 +13668,7 @@ exports[`List margin object 1`] = `
   padding-bottom: 12px;
 }
 
-.c4 {
+.c3 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -13646,10 +13688,6 @@ exports[`List margin object 1`] = `
   padding: 0;
   margin-left: 48px;
   margin-right: 48px;
-}
-
-.c3:focus {
-  outline: none;
 }
 
 @media only screen and (max-width: 768px) {
@@ -13674,20 +13712,20 @@ exports[`List margin object 1`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c4 {
+  .c3 {
     border-bottom: solid 1px rgba(0, 0, 0, 0.33);
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c4 {
+  .c3 {
     padding-left: 12px;
     padding-right: 12px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c4 {
+  .c3 {
     padding-top: 6px;
     padding-bottom: 6px;
   }
@@ -13701,12 +13739,12 @@ exports[`List margin object 1`] = `
     role="list"
   >
     <li
-      class="c2 c3"
+      class="c2 "
     >
       one
     </li>
     <li
-      class="c4 c3"
+      class="c3 "
     >
       two
     </li>
@@ -13741,7 +13779,7 @@ exports[`List margin string 1`] = `
   padding-bottom: 12px;
 }
 
-.c4 {
+.c3 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -13760,10 +13798,6 @@ exports[`List margin string 1`] = `
   list-style: none;
   padding: 0;
   margin: 48px;
-}
-
-.c3:focus {
-  outline: none;
 }
 
 @media only screen and (max-width: 768px) {
@@ -13788,20 +13822,20 @@ exports[`List margin string 1`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c4 {
+  .c3 {
     border-bottom: solid 1px rgba(0, 0, 0, 0.33);
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c4 {
+  .c3 {
     padding-left: 12px;
     padding-right: 12px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c4 {
+  .c3 {
     padding-top: 6px;
     padding-bottom: 6px;
   }
@@ -13815,12 +13849,12 @@ exports[`List margin string 1`] = `
     role="list"
   >
     <li
-      class="c2 c3"
+      class="c2 "
     >
       one
     </li>
     <li
-      class="c4 c3"
+      class="c3 "
     >
       two
     </li>
@@ -13856,6 +13890,11 @@ exports[`List onClickItem 1`] = `
   cursor: pointer;
 }
 
+.c2:hover {
+  background-color: rgba(221, 221, 221, 0.4);
+  color: #000000;
+}
+
 .c4 {
   display: flex;
   box-sizing: border-box;
@@ -13872,22 +13911,19 @@ exports[`List onClickItem 1`] = `
   cursor: pointer;
 }
 
+.c4:hover {
+  background-color: rgba(221, 221, 221, 0.4);
+  color: #000000;
+}
+
 .c1 {
   list-style: none;
   margin: 0;
   padding: 0;
 }
 
-.c1:focus {
-  outline: 2px solid #6FFFB0;
-}
-
 .c3 {
   cursor: pointer;
-}
-
-.c3:focus {
-  outline: none;
 }
 
 @media only screen and (max-width: 768px) {
@@ -13937,12 +13973,11 @@ exports[`List onClickItem 1`] = `
   <ul
     class="c1"
     role="listbox"
-    tabindex="0"
   >
     <li
       class="c2 c3"
       role="option"
-      tabindex="-1"
+      tabindex="0"
     >
       alpha
     </li>
@@ -13962,21 +13997,20 @@ exports[`List onClickItem 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 cBoJUe"
 >
   <ul
-    class="List__StyledList-sc-130gdqg-0 dHNMqI"
+    class="List__StyledList-sc-130gdqg-0 gjWLKL"
     role="listbox"
-    tabindex="0"
   >
     <li
-      class="StyledBox-sc-13pk1d4-0 hiUzJD List__StyledItem-sc-130gdqg-1 kepUQz"
+      class="StyledBox-sc-13pk1d4-0 inkIdT List__StyledItem-sc-130gdqg-1 hjLXfR"
       role="option"
       tabindex="-1"
     >
       alpha
     </li>
     <li
-      class="StyledBox-sc-13pk1d4-0 gojVVh List__StyledItem-sc-130gdqg-1 kepUQz"
+      class="StyledBox-sc-13pk1d4-0 jjcdqE List__StyledItem-sc-130gdqg-1 hjLXfR"
       role="option"
-      tabindex="-1"
+      tabindex="0"
     >
       beta
     </li>
@@ -13985,7 +14019,8 @@ exports[`List onClickItem 2`] = `
 `;
 
 exports[`List onOrder Keyboard move down 1`] = `
-.c10 {
+<DocumentFragment>
+  .c10 {
   display: inline-block;
   flex: 0 0 auto;
   width: 24px;
@@ -14119,6 +14154,26 @@ exports[`List onOrder Keyboard move down 1`] = `
   padding: 12px;
 }
 
+.c9:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9:focus >circle,
+.c9:focus >ellipse,
+.c9:focus >line,
+.c9:focus >path,
+.c9:focus >polygon,
+.c9:focus >polyline,
+.c9:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9:focus ::-moz-focus-inner {
+  border: 0;
+}
+
 .c9:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -14163,6 +14218,26 @@ exports[`List onOrder Keyboard move down 1`] = `
   color: #000000;
 }
 
+.c11:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus >circle,
+.c11:focus >ellipse,
+.c11:focus >line,
+.c11:focus >path,
+.c11:focus >polygon,
+.c11:focus >polyline,
+.c11:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus ::-moz-focus-inner {
+  border: 0;
+}
+
 .c11:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -14189,16 +14264,8 @@ exports[`List onOrder Keyboard move down 1`] = `
   padding: 0;
 }
 
-.c1:focus {
-  outline: 2px solid #6FFFB0;
-}
-
 .c3 {
   cursor: move;
-}
-
-.c3:focus {
-  outline: none;
 }
 
 @media only screen and (max-width: 768px) {
@@ -14249,467 +14316,160 @@ exports[`List onOrder Keyboard move down 1`] = `
 }
 
 <div
-  class="c0"
->
-  <ul
-    class="c1"
-    role="list"
-    tabindex="0"
+    class="c0"
   >
-    <li
-      class="c2 c3"
-      draggable="true"
+    <ul
+      class="c1"
+      role="list"
     >
-      <span
-        class="c4"
-      >
-        1
-      </span>
-      <div
-        class="c5"
-      />
-      <div
-        class="c6"
+      <li
+        class="c2 c3"
+        draggable="true"
       >
         <span
-          class="c7"
+          class="c4"
         >
-          alpha
+          1
         </span>
-      </div>
-      <div
-        class="c5"
-      />
-      <div
-        class="c8"
-      >
-        <button
-          aria-label="1 alpha move up"
-          class="c9"
-          disabled=""
-          id="alphaMoveUp"
-          tabindex="-1"
-          type="button"
+        <div
+          class="c5"
+        />
+        <div
+          class="c6"
         >
-          <svg
-            aria-label="FormUp"
-            class="c10"
-            viewBox="0 0 24 24"
+          <span
+            class="c7"
           >
-            <path
-              d="m18 15-6-6-6 6"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-        <button
-          aria-label="1 alpha move down"
-          class="c11"
-          id="alphaMoveDown"
-          tabindex="-1"
-          type="button"
+            alpha
+          </span>
+        </div>
+        <div
+          class="c5"
+        />
+        <div
+          class="c8"
         >
-          <svg
-            aria-label="FormDown"
-            class="c10"
-            viewBox="0 0 24 24"
+          <button
+            aria-label="1 alpha move up"
+            class="c9"
+            disabled=""
+            id="alphaMoveUp"
+            tabindex="-1"
+            type="button"
           >
-            <path
-              d="m18 9-6 6-6-6"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-      </div>
-    </li>
-    <li
-      class="c12 c3"
-      draggable="true"
-    >
-      <span
-        class="c4"
-      >
-        2
-      </span>
-      <div
-        class="c5"
-      />
-      <div
-        class="c6"
+            <svg
+              aria-label="FormUp"
+              class="c10"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 15-6-6-6 6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+          <button
+            aria-label="1 alpha move down"
+            class="c11"
+            id="alphaMoveDown"
+            tabindex="0"
+            type="button"
+          >
+            <svg
+              aria-label="FormDown"
+              class="c10"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 9-6 6-6-6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </div>
+      </li>
+      <li
+        class="c12 c3"
+        draggable="true"
       >
         <span
-          class="c7"
+          class="c4"
         >
-          beta
+          2
         </span>
-      </div>
-      <div
-        class="c5"
-      />
-      <div
-        class="c8"
-      >
-        <button
-          aria-label="2 beta move up"
-          class="c11"
-          id="betaMoveUp"
-          tabindex="-1"
-          type="button"
+        <div
+          class="c5"
+        />
+        <div
+          class="c6"
         >
-          <svg
-            aria-label="FormUp"
-            class="c10"
-            viewBox="0 0 24 24"
+          <span
+            class="c7"
           >
-            <path
-              d="m18 15-6-6-6 6"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-        <button
-          aria-label="2 beta move down"
-          class="c9"
-          disabled=""
-          id="betaMoveDown"
-          tabindex="-1"
-          type="button"
+            beta
+          </span>
+        </div>
+        <div
+          class="c5"
+        />
+        <div
+          class="c8"
         >
-          <svg
-            aria-label="FormDown"
-            class="c10"
-            viewBox="0 0 24 24"
+          <button
+            aria-label="2 beta move up"
+            class="c11"
+            id="betaMoveUp"
+            tabindex="-1"
+            type="button"
           >
-            <path
-              d="m18 9-6 6-6-6"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-      </div>
-    </li>
-  </ul>
-</div>
+            <svg
+              aria-label="FormUp"
+              class="c10"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 15-6-6-6 6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+          <button
+            aria-label="2 beta move down"
+            class="c9"
+            disabled=""
+            id="betaMoveDown"
+            tabindex="-1"
+            type="button"
+          >
+            <svg
+              aria-label="FormDown"
+              class="c10"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 9-6 6-6-6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </div>
+      </li>
+    </ul>
+  </div>
+</DocumentFragment>
 `;
 
 exports[`List onOrder Keyboard move down 2`] = `
-<div
-  class="StyledGrommet-sc-19lkkz7-0 cBoJUe"
->
-  <ul
-    aria-activedescendant="alphaMoveDown"
-    class="List__StyledList-sc-130gdqg-0 dHNMqI"
-    role="list"
-    tabindex="0"
-  >
-    <li
-      class="StyledBox-sc-13pk1d4-0 geglev List__StyledItem-sc-130gdqg-1 bIUWQJ"
-      draggable="true"
-    >
-      <span
-        class="StyledText-sc-1sadyjn-0 ldA-DUE"
-      >
-        1
-      </span>
-      <div
-        class="StyledBox__StyledBoxGap-sc-13pk1d4-1 iGPQzj"
-      />
-      <div
-        class="StyledBox-sc-13pk1d4-0 jNsTaV"
-      >
-        <span
-          class="StyledText-sc-1sadyjn-0 cUpCuS"
-        >
-          alpha
-        </span>
-      </div>
-      <div
-        class="StyledBox__StyledBoxGap-sc-13pk1d4-1 iGPQzj"
-      />
-      <div
-        class="StyledBox-sc-13pk1d4-0 hKXGyN"
-      >
-        <button
-          aria-label="1 alpha move up"
-          class="StyledButton-sc-323bzc-0 fVKxFa"
-          disabled=""
-          id="alphaMoveUp"
-          tabindex="-1"
-          type="button"
-        >
-          <svg
-            aria-label="FormUp"
-            class="StyledIcon-sc-ofa7kd-0 jCZnaS"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="m18 15-6-6-6 6"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-        <button
-          aria-label="1 alpha move down"
-          class="StyledButton-sc-323bzc-0 hpYwyU"
-          id="alphaMoveDown"
-          tabindex="-1"
-          type="button"
-        >
-          <svg
-            aria-label="FormDown"
-            class="StyledIcon-sc-ofa7kd-0 jCZnaS"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="m18 9-6 6-6-6"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-      </div>
-    </li>
-    <li
-      class="StyledBox-sc-13pk1d4-0 jBetvR List__StyledItem-sc-130gdqg-1 bIUWQJ"
-      draggable="true"
-    >
-      <span
-        class="StyledText-sc-1sadyjn-0 ldA-DUE"
-      >
-        2
-      </span>
-      <div
-        class="StyledBox__StyledBoxGap-sc-13pk1d4-1 iGPQzj"
-      />
-      <div
-        class="StyledBox-sc-13pk1d4-0 jNsTaV"
-      >
-        <span
-          class="StyledText-sc-1sadyjn-0 cUpCuS"
-        >
-          beta
-        </span>
-      </div>
-      <div
-        class="StyledBox__StyledBoxGap-sc-13pk1d4-1 iGPQzj"
-      />
-      <div
-        class="StyledBox-sc-13pk1d4-0 hKXGyN"
-      >
-        <button
-          aria-label="2 beta move up"
-          class="StyledButton-sc-323bzc-0 eYvQIM"
-          id="betaMoveUp"
-          tabindex="-1"
-          type="button"
-        >
-          <svg
-            aria-label="FormUp"
-            class="StyledIcon-sc-ofa7kd-0 jCZnaS"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="m18 15-6-6-6 6"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-        <button
-          aria-label="2 beta move down"
-          class="StyledButton-sc-323bzc-0 fVKxFa"
-          disabled=""
-          id="betaMoveDown"
-          tabindex="-1"
-          type="button"
-        >
-          <svg
-            aria-label="FormDown"
-            class="StyledIcon-sc-ofa7kd-0 jCZnaS"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="m18 9-6 6-6-6"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-      </div>
-    </li>
-  </ul>
-</div>
-`;
-
-exports[`List onOrder Keyboard move down 3`] = `
-<div
-  class="StyledGrommet-sc-19lkkz7-0 cBoJUe"
->
-  <ul
-    aria-activedescendant="alphaMoveUp"
-    class="List__StyledList-sc-130gdqg-0 dHNMqI"
-    role="list"
-    tabindex="0"
-  >
-    <li
-      class="StyledBox-sc-13pk1d4-0 geglev List__StyledItem-sc-130gdqg-1 bIUWQJ"
-      draggable="true"
-    >
-      <span
-        class="StyledText-sc-1sadyjn-0 ldA-DUE"
-      >
-        1
-      </span>
-      <div
-        class="StyledBox__StyledBoxGap-sc-13pk1d4-1 iGPQzj"
-      />
-      <div
-        class="StyledBox-sc-13pk1d4-0 jNsTaV"
-      >
-        <span
-          class="StyledText-sc-1sadyjn-0 cUpCuS"
-        >
-          beta
-        </span>
-      </div>
-      <div
-        class="StyledBox__StyledBoxGap-sc-13pk1d4-1 iGPQzj"
-      />
-      <div
-        class="StyledBox-sc-13pk1d4-0 hKXGyN"
-      >
-        <button
-          aria-label="1 beta move up"
-          class="StyledButton-sc-323bzc-0 fVKxFa"
-          disabled=""
-          id="betaMoveUp"
-          tabindex="-1"
-          type="button"
-        >
-          <svg
-            aria-label="FormUp"
-            class="StyledIcon-sc-ofa7kd-0 jCZnaS"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="m18 15-6-6-6 6"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-        <button
-          aria-label="1 beta move down"
-          class="StyledButton-sc-323bzc-0 eYvQIM"
-          id="betaMoveDown"
-          tabindex="-1"
-          type="button"
-        >
-          <svg
-            aria-label="FormDown"
-            class="StyledIcon-sc-ofa7kd-0 jCZnaS"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="m18 9-6 6-6-6"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-      </div>
-    </li>
-    <li
-      class="StyledBox-sc-13pk1d4-0 jBetvR List__StyledItem-sc-130gdqg-1 bIUWQJ"
-      draggable="true"
-    >
-      <span
-        class="StyledText-sc-1sadyjn-0 ldA-DUE"
-      >
-        2
-      </span>
-      <div
-        class="StyledBox__StyledBoxGap-sc-13pk1d4-1 iGPQzj"
-      />
-      <div
-        class="StyledBox-sc-13pk1d4-0 jNsTaV"
-      >
-        <span
-          class="StyledText-sc-1sadyjn-0 cUpCuS"
-        >
-          alpha
-        </span>
-      </div>
-      <div
-        class="StyledBox__StyledBoxGap-sc-13pk1d4-1 iGPQzj"
-      />
-      <div
-        class="StyledBox-sc-13pk1d4-0 hKXGyN"
-      >
-        <button
-          aria-label="2 alpha move up"
-          class="StyledButton-sc-323bzc-0 hpYwyU"
-          id="alphaMoveUp"
-          tabindex="-1"
-          type="button"
-        >
-          <svg
-            aria-label="FormUp"
-            class="StyledIcon-sc-ofa7kd-0 jCZnaS"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="m18 15-6-6-6 6"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-        <button
-          aria-label="2 alpha move down"
-          class="StyledButton-sc-323bzc-0 fVKxFa"
-          disabled=""
-          id="alphaMoveDown"
-          tabindex="-1"
-          type="button"
-        >
-          <svg
-            aria-label="FormDown"
-            class="StyledIcon-sc-ofa7kd-0 jCZnaS"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="m18 9-6 6-6-6"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-      </div>
-    </li>
-  </ul>
-</div>
-`;
-
-exports[`List onOrder Keyboard move up 1`] = `
-.c10 {
+<DocumentFragment>
+  .c10 {
   display: inline-block;
   flex: 0 0 auto;
   width: 24px;
@@ -14843,6 +14603,26 @@ exports[`List onOrder Keyboard move up 1`] = `
   padding: 12px;
 }
 
+.c9:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9:focus >circle,
+.c9:focus >ellipse,
+.c9:focus >line,
+.c9:focus >path,
+.c9:focus >polygon,
+.c9:focus >polyline,
+.c9:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9:focus ::-moz-focus-inner {
+  border: 0;
+}
+
 .c9:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -14863,7 +14643,7 @@ exports[`List onOrder Keyboard move up 1`] = `
   border: 0;
 }
 
-.c11 {
+.c13 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -14882,9 +14662,90 @@ exports[`List onOrder Keyboard move up 1`] = `
   padding: 12px;
 }
 
-.c11:hover {
+.c13:hover {
   background-color: rgba(221, 221, 221, 0.4);
   color: #000000;
+}
+
+.c13:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c13:focus >circle,
+.c13:focus >ellipse,
+.c13:focus >line,
+.c13:focus >path,
+.c13:focus >polygon,
+.c13:focus >polyline,
+.c13:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c13:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c13:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c13:focus:not(:focus-visible) >circle,
+.c13:focus:not(:focus-visible) >ellipse,
+.c13:focus:not(:focus-visible) >line,
+.c13:focus:not(:focus-visible) >path,
+.c13:focus:not(:focus-visible) >polygon,
+.c13:focus:not(:focus-visible) >polyline,
+.c13:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c13:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c11 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  background-color: rgba(221, 221, 221, 0.4);
+  color: #000000;
+  line-height: 0;
+  padding: 12px;
+}
+
+.c11:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus >circle,
+.c11:focus >ellipse,
+.c11:focus >line,
+.c11:focus >path,
+.c11:focus >polygon,
+.c11:focus >polyline,
+.c11:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus ::-moz-focus-inner {
+  border: 0;
 }
 
 .c11:focus:not(:focus-visible) {
@@ -14913,16 +14774,8 @@ exports[`List onOrder Keyboard move up 1`] = `
   padding: 0;
 }
 
-.c1:focus {
-  outline: 2px solid #6FFFB0;
-}
-
 .c3 {
   cursor: move;
-}
-
-.c3:focus {
-  outline: none;
 }
 
 @media only screen and (max-width: 768px) {
@@ -14973,463 +14826,2134 @@ exports[`List onOrder Keyboard move up 1`] = `
 }
 
 <div
-  class="c0"
->
-  <ul
-    class="c1"
-    role="list"
-    tabindex="0"
+    class="c0"
   >
-    <li
-      class="c2 c3"
-      draggable="true"
+    <ul
+      class="c1"
+      role="list"
     >
-      <span
-        class="c4"
-      >
-        1
-      </span>
-      <div
-        class="c5"
-      />
-      <div
-        class="c6"
+      <li
+        class="c2 c3"
+        draggable="true"
       >
         <span
-          class="c7"
+          class="c4"
         >
-          alpha
+          1
         </span>
-      </div>
-      <div
-        class="c5"
-      />
-      <div
-        class="c8"
-      >
-        <button
-          aria-label="1 alpha move up"
-          class="c9"
-          disabled=""
-          id="alphaMoveUp"
-          tabindex="-1"
-          type="button"
+        <div
+          class="c5"
+        />
+        <div
+          class="c6"
         >
-          <svg
-            aria-label="FormUp"
-            class="c10"
-            viewBox="0 0 24 24"
+          <span
+            class="c7"
           >
-            <path
-              d="m18 15-6-6-6 6"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-        <button
-          aria-label="1 alpha move down"
-          class="c11"
-          id="alphaMoveDown"
-          tabindex="-1"
-          type="button"
+            alpha
+          </span>
+        </div>
+        <div
+          class="c5"
+        />
+        <div
+          class="c8"
         >
-          <svg
-            aria-label="FormDown"
-            class="c10"
-            viewBox="0 0 24 24"
+          <button
+            aria-label="1 alpha move up"
+            class="c9"
+            disabled=""
+            id="alphaMoveUp"
+            tabindex="-1"
+            type="button"
           >
-            <path
-              d="m18 9-6 6-6-6"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-      </div>
-    </li>
-    <li
-      class="c12 c3"
-      draggable="true"
-    >
-      <span
-        class="c4"
-      >
-        2
-      </span>
-      <div
-        class="c5"
-      />
-      <div
-        class="c6"
+            <svg
+              aria-label="FormUp"
+              class="c10"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 15-6-6-6 6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+          <button
+            aria-label="1 alpha move down"
+            class="c11"
+            id="alphaMoveDown"
+            tabindex="0"
+            type="button"
+          >
+            <svg
+              aria-label="FormDown"
+              class="c10"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 9-6 6-6-6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </div>
+      </li>
+      <li
+        class="c12 c3"
+        draggable="true"
       >
         <span
-          class="c7"
+          class="c4"
         >
-          beta
+          2
         </span>
-      </div>
-      <div
-        class="c5"
-      />
-      <div
-        class="c8"
+        <div
+          class="c5"
+        />
+        <div
+          class="c6"
+        >
+          <span
+            class="c7"
+          >
+            beta
+          </span>
+        </div>
+        <div
+          class="c5"
+        />
+        <div
+          class="c8"
+        >
+          <button
+            aria-label="2 beta move up"
+            class="c13"
+            id="betaMoveUp"
+            tabindex="-1"
+            type="button"
+          >
+            <svg
+              aria-label="FormUp"
+              class="c10"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 15-6-6-6 6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+          <button
+            aria-label="2 beta move down"
+            class="c9"
+            disabled=""
+            id="betaMoveDown"
+            tabindex="-1"
+            type="button"
+          >
+            <svg
+              aria-label="FormDown"
+              class="c10"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 9-6 6-6-6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </div>
+      </li>
+    </ul>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`List onOrder Keyboard move down 3`] = `
+<DocumentFragment>
+  .c10 {
+  display: inline-block;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #666666;
+  stroke: #666666;
+}
+
+.c10 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c10 *:not([stroke])[fill='none'] {
+  stroke-width: 0;
+}
+
+.c10 *[stroke*='#'],
+.c10 *[STROKE*='#'] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c10 *[fill-rule],
+.c10 *[FILL-RULE],
+.c10 *[fill*='#'],
+.c10 *[FILL*='#'] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c2 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: center;
+  border-top: solid 1px rgba(0, 0, 0, 0.33);
+  border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  flex: 0 0 auto;
+  padding-left: 24px;
+  padding-right: 24px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+
+.c6 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  flex: 1 1;
+}
+
+.c8 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  justify-content: flex-end;
+}
+
+.c12 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: center;
+  border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  flex: 0 0 auto;
+  padding-left: 24px;
+  padding-right: 24px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+
+.c5 {
+  flex: 0 0 auto;
+  align-self: stretch;
+  width: 24px;
+}
+
+.c4 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c7 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c9 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  opacity: 0.3;
+  cursor: default;
+  line-height: 0;
+  padding: 12px;
+}
+
+.c9:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9:focus >circle,
+.c9:focus >ellipse,
+.c9:focus >line,
+.c9:focus >path,
+.c9:focus >polygon,
+.c9:focus >polyline,
+.c9:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c9:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c9:focus:not(:focus-visible) >circle,
+.c9:focus:not(:focus-visible) >ellipse,
+.c9:focus:not(:focus-visible) >line,
+.c9:focus:not(:focus-visible) >path,
+.c9:focus:not(:focus-visible) >polygon,
+.c9:focus:not(:focus-visible) >polyline,
+.c9:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c9:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c11 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  line-height: 0;
+  padding: 12px;
+}
+
+.c11:hover {
+  background-color: rgba(221, 221, 221, 0.4);
+  color: #000000;
+}
+
+.c11:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus >circle,
+.c11:focus >ellipse,
+.c11:focus >line,
+.c11:focus >path,
+.c11:focus >polygon,
+.c11:focus >polyline,
+.c11:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c11:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c11:focus:not(:focus-visible) >circle,
+.c11:focus:not(:focus-visible) >ellipse,
+.c11:focus:not(:focus-visible) >line,
+.c11:focus:not(:focus-visible) >path,
+.c11:focus:not(:focus-visible) >polygon,
+.c11:focus:not(:focus-visible) >polyline,
+.c11:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c11:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c13 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  background-color: rgba(221, 221, 221, 0.4);
+  color: #000000;
+  line-height: 0;
+  padding: 12px;
+}
+
+.c13:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c13:focus >circle,
+.c13:focus >ellipse,
+.c13:focus >line,
+.c13:focus >path,
+.c13:focus >polygon,
+.c13:focus >polyline,
+.c13:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c13:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c13:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c13:focus:not(:focus-visible) >circle,
+.c13:focus:not(:focus-visible) >ellipse,
+.c13:focus:not(:focus-visible) >line,
+.c13:focus:not(:focus-visible) >path,
+.c13:focus:not(:focus-visible) >polygon,
+.c13:focus:not(:focus-visible) >polyline,
+.c13:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c13:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c1 {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.c3 {
+  cursor: move;
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    border-top: solid 1px rgba(0, 0, 0, 0.33);
+    border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c12 {
+    border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c12 {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c12 {
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c5 {
+    width: 12px;
+  }
+}
+
+<div
+    class="c0"
+  >
+    <ul
+      class="c1"
+      role="list"
+    >
+      <li
+        class="c2 c3"
+        draggable="true"
       >
-        <button
-          aria-label="2 beta move up"
-          class="c11"
-          id="betaMoveUp"
-          tabindex="-1"
-          type="button"
+        <span
+          class="c4"
         >
-          <svg
-            aria-label="FormUp"
-            class="c10"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="m18 15-6-6-6 6"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-        <button
-          aria-label="2 beta move down"
-          class="c9"
-          disabled=""
-          id="betaMoveDown"
-          tabindex="-1"
-          type="button"
+          1
+        </span>
+        <div
+          class="c5"
+        />
+        <div
+          class="c6"
         >
-          <svg
-            aria-label="FormDown"
-            class="c10"
-            viewBox="0 0 24 24"
+          <span
+            class="c7"
           >
-            <path
-              d="m18 9-6 6-6-6"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-      </div>
-    </li>
-  </ul>
-</div>
+            beta
+          </span>
+        </div>
+        <div
+          class="c5"
+        />
+        <div
+          class="c8"
+        >
+          <button
+            aria-label="1 beta move up"
+            class="c9"
+            disabled=""
+            id="betaMoveUp"
+            tabindex="-1"
+            type="button"
+          >
+            <svg
+              aria-label="FormUp"
+              class="c10"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 15-6-6-6 6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+          <button
+            aria-label="1 beta move down"
+            class="c11"
+            id="betaMoveDown"
+            tabindex="-1"
+            type="button"
+          >
+            <svg
+              aria-label="FormDown"
+              class="c10"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 9-6 6-6-6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </div>
+      </li>
+      <li
+        class="c12 c3"
+        draggable="true"
+      >
+        <span
+          class="c4"
+        >
+          2
+        </span>
+        <div
+          class="c5"
+        />
+        <div
+          class="c6"
+        >
+          <span
+            class="c7"
+          >
+            alpha
+          </span>
+        </div>
+        <div
+          class="c5"
+        />
+        <div
+          class="c8"
+        >
+          <button
+            aria-label="2 alpha move up"
+            class="c13"
+            id="alphaMoveUp"
+            tabindex="0"
+            type="button"
+          >
+            <svg
+              aria-label="FormUp"
+              class="c10"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 15-6-6-6 6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+          <button
+            aria-label="2 alpha move down"
+            class="c9"
+            disabled=""
+            id="alphaMoveDown"
+            tabindex="-1"
+            type="button"
+          >
+            <svg
+              aria-label="FormDown"
+              class="c10"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 9-6 6-6-6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </div>
+      </li>
+    </ul>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`List onOrder Keyboard move up 1`] = `
+<DocumentFragment>
+  .c10 {
+  display: inline-block;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #666666;
+  stroke: #666666;
+}
+
+.c10 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c10 *:not([stroke])[fill='none'] {
+  stroke-width: 0;
+}
+
+.c10 *[stroke*='#'],
+.c10 *[STROKE*='#'] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c10 *[fill-rule],
+.c10 *[FILL-RULE],
+.c10 *[fill*='#'],
+.c10 *[FILL*='#'] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c2 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: center;
+  border-top: solid 1px rgba(0, 0, 0, 0.33);
+  border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  flex: 0 0 auto;
+  padding-left: 24px;
+  padding-right: 24px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+
+.c6 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  flex: 1 1;
+}
+
+.c8 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  justify-content: flex-end;
+}
+
+.c12 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: center;
+  border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  flex: 0 0 auto;
+  padding-left: 24px;
+  padding-right: 24px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+
+.c5 {
+  flex: 0 0 auto;
+  align-self: stretch;
+  width: 24px;
+}
+
+.c4 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c7 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c9 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  opacity: 0.3;
+  cursor: default;
+  line-height: 0;
+  padding: 12px;
+}
+
+.c9:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9:focus >circle,
+.c9:focus >ellipse,
+.c9:focus >line,
+.c9:focus >path,
+.c9:focus >polygon,
+.c9:focus >polyline,
+.c9:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c9:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c9:focus:not(:focus-visible) >circle,
+.c9:focus:not(:focus-visible) >ellipse,
+.c9:focus:not(:focus-visible) >line,
+.c9:focus:not(:focus-visible) >path,
+.c9:focus:not(:focus-visible) >polygon,
+.c9:focus:not(:focus-visible) >polyline,
+.c9:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c9:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c11 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  line-height: 0;
+  padding: 12px;
+}
+
+.c11:hover {
+  background-color: rgba(221, 221, 221, 0.4);
+  color: #000000;
+}
+
+.c11:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus >circle,
+.c11:focus >ellipse,
+.c11:focus >line,
+.c11:focus >path,
+.c11:focus >polygon,
+.c11:focus >polyline,
+.c11:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c11:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c11:focus:not(:focus-visible) >circle,
+.c11:focus:not(:focus-visible) >ellipse,
+.c11:focus:not(:focus-visible) >line,
+.c11:focus:not(:focus-visible) >path,
+.c11:focus:not(:focus-visible) >polygon,
+.c11:focus:not(:focus-visible) >polyline,
+.c11:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c11:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c1 {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.c3 {
+  cursor: move;
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    border-top: solid 1px rgba(0, 0, 0, 0.33);
+    border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c12 {
+    border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c12 {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c12 {
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c5 {
+    width: 12px;
+  }
+}
+
+<div
+    class="c0"
+  >
+    <ul
+      class="c1"
+      role="list"
+    >
+      <li
+        class="c2 c3"
+        draggable="true"
+      >
+        <span
+          class="c4"
+        >
+          1
+        </span>
+        <div
+          class="c5"
+        />
+        <div
+          class="c6"
+        >
+          <span
+            class="c7"
+          >
+            alpha
+          </span>
+        </div>
+        <div
+          class="c5"
+        />
+        <div
+          class="c8"
+        >
+          <button
+            aria-label="1 alpha move up"
+            class="c9"
+            disabled=""
+            id="alphaMoveUp"
+            tabindex="-1"
+            type="button"
+          >
+            <svg
+              aria-label="FormUp"
+              class="c10"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 15-6-6-6 6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+          <button
+            aria-label="1 alpha move down"
+            class="c11"
+            id="alphaMoveDown"
+            tabindex="0"
+            type="button"
+          >
+            <svg
+              aria-label="FormDown"
+              class="c10"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 9-6 6-6-6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </div>
+      </li>
+      <li
+        class="c12 c3"
+        draggable="true"
+      >
+        <span
+          class="c4"
+        >
+          2
+        </span>
+        <div
+          class="c5"
+        />
+        <div
+          class="c6"
+        >
+          <span
+            class="c7"
+          >
+            beta
+          </span>
+        </div>
+        <div
+          class="c5"
+        />
+        <div
+          class="c8"
+        >
+          <button
+            aria-label="2 beta move up"
+            class="c11"
+            id="betaMoveUp"
+            tabindex="-1"
+            type="button"
+          >
+            <svg
+              aria-label="FormUp"
+              class="c10"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 15-6-6-6 6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+          <button
+            aria-label="2 beta move down"
+            class="c9"
+            disabled=""
+            id="betaMoveDown"
+            tabindex="-1"
+            type="button"
+          >
+            <svg
+              aria-label="FormDown"
+              class="c10"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 9-6 6-6-6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </div>
+      </li>
+    </ul>
+  </div>
+</DocumentFragment>
 `;
 
 exports[`List onOrder Keyboard move up 2`] = `
+<DocumentFragment>
+  .c10 {
+  display: inline-block;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #666666;
+  stroke: #666666;
+}
+
+.c10 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c10 *:not([stroke])[fill='none'] {
+  stroke-width: 0;
+}
+
+.c10 *[stroke*='#'],
+.c10 *[STROKE*='#'] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c10 *[fill-rule],
+.c10 *[FILL-RULE],
+.c10 *[fill*='#'],
+.c10 *[FILL*='#'] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c2 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: center;
+  border-top: solid 1px rgba(0, 0, 0, 0.33);
+  border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  flex: 0 0 auto;
+  padding-left: 24px;
+  padding-right: 24px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+
+.c6 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  flex: 1 1;
+}
+
+.c8 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  justify-content: flex-end;
+}
+
+.c12 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: center;
+  border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  flex: 0 0 auto;
+  padding-left: 24px;
+  padding-right: 24px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+
+.c5 {
+  flex: 0 0 auto;
+  align-self: stretch;
+  width: 24px;
+}
+
+.c4 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c7 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c9 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  opacity: 0.3;
+  cursor: default;
+  line-height: 0;
+  padding: 12px;
+}
+
+.c9:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9:focus >circle,
+.c9:focus >ellipse,
+.c9:focus >line,
+.c9:focus >path,
+.c9:focus >polygon,
+.c9:focus >polyline,
+.c9:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c9:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c9:focus:not(:focus-visible) >circle,
+.c9:focus:not(:focus-visible) >ellipse,
+.c9:focus:not(:focus-visible) >line,
+.c9:focus:not(:focus-visible) >path,
+.c9:focus:not(:focus-visible) >polygon,
+.c9:focus:not(:focus-visible) >polyline,
+.c9:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c9:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c13 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  line-height: 0;
+  padding: 12px;
+}
+
+.c13:hover {
+  background-color: rgba(221, 221, 221, 0.4);
+  color: #000000;
+}
+
+.c13:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c13:focus >circle,
+.c13:focus >ellipse,
+.c13:focus >line,
+.c13:focus >path,
+.c13:focus >polygon,
+.c13:focus >polyline,
+.c13:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c13:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c13:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c13:focus:not(:focus-visible) >circle,
+.c13:focus:not(:focus-visible) >ellipse,
+.c13:focus:not(:focus-visible) >line,
+.c13:focus:not(:focus-visible) >path,
+.c13:focus:not(:focus-visible) >polygon,
+.c13:focus:not(:focus-visible) >polyline,
+.c13:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c13:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c11 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  background-color: rgba(221, 221, 221, 0.4);
+  color: #000000;
+  line-height: 0;
+  padding: 12px;
+}
+
+.c11:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus >circle,
+.c11:focus >ellipse,
+.c11:focus >line,
+.c11:focus >path,
+.c11:focus >polygon,
+.c11:focus >polyline,
+.c11:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c11:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c11:focus:not(:focus-visible) >circle,
+.c11:focus:not(:focus-visible) >ellipse,
+.c11:focus:not(:focus-visible) >line,
+.c11:focus:not(:focus-visible) >path,
+.c11:focus:not(:focus-visible) >polygon,
+.c11:focus:not(:focus-visible) >polyline,
+.c11:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c11:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c1 {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.c3 {
+  cursor: move;
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    border-top: solid 1px rgba(0, 0, 0, 0.33);
+    border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c12 {
+    border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c12 {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c12 {
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c5 {
+    width: 12px;
+  }
+}
+
 <div
-  class="StyledGrommet-sc-19lkkz7-0 cBoJUe"
->
-  <ul
-    aria-activedescendant="betaMoveUp"
-    class="List__StyledList-sc-130gdqg-0 dHNMqI"
-    role="list"
-    tabindex="0"
+    class="c0"
   >
-    <li
-      class="StyledBox-sc-13pk1d4-0 geglev List__StyledItem-sc-130gdqg-1 bIUWQJ"
-      draggable="true"
+    <ul
+      class="c1"
+      role="list"
     >
-      <span
-        class="StyledText-sc-1sadyjn-0 ldA-DUE"
-      >
-        1
-      </span>
-      <div
-        class="StyledBox__StyledBoxGap-sc-13pk1d4-1 iGPQzj"
-      />
-      <div
-        class="StyledBox-sc-13pk1d4-0 jNsTaV"
+      <li
+        class="c2 c3"
+        draggable="true"
       >
         <span
-          class="StyledText-sc-1sadyjn-0 cUpCuS"
+          class="c4"
         >
-          alpha
+          1
         </span>
-      </div>
-      <div
-        class="StyledBox__StyledBoxGap-sc-13pk1d4-1 iGPQzj"
-      />
-      <div
-        class="StyledBox-sc-13pk1d4-0 hKXGyN"
-      >
-        <button
-          aria-label="1 alpha move up"
-          class="StyledButton-sc-323bzc-0 fVKxFa"
-          disabled=""
-          id="alphaMoveUp"
-          tabindex="-1"
-          type="button"
+        <div
+          class="c5"
+        />
+        <div
+          class="c6"
         >
-          <svg
-            aria-label="FormUp"
-            class="StyledIcon-sc-ofa7kd-0 jCZnaS"
-            viewBox="0 0 24 24"
+          <span
+            class="c7"
           >
-            <path
-              d="m18 15-6-6-6 6"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-        <button
-          aria-label="1 alpha move down"
-          class="StyledButton-sc-323bzc-0 eYvQIM"
-          id="alphaMoveDown"
-          tabindex="-1"
-          type="button"
+            alpha
+          </span>
+        </div>
+        <div
+          class="c5"
+        />
+        <div
+          class="c8"
         >
-          <svg
-            aria-label="FormDown"
-            class="StyledIcon-sc-ofa7kd-0 jCZnaS"
-            viewBox="0 0 24 24"
+          <button
+            aria-label="1 alpha move up"
+            class="c9"
+            disabled=""
+            id="alphaMoveUp"
+            tabindex="-1"
+            type="button"
           >
-            <path
-              d="m18 9-6 6-6-6"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-      </div>
-    </li>
-    <li
-      class="StyledBox-sc-13pk1d4-0 jBetvR List__StyledItem-sc-130gdqg-1 bIUWQJ"
-      draggable="true"
-    >
-      <span
-        class="StyledText-sc-1sadyjn-0 ldA-DUE"
-      >
-        2
-      </span>
-      <div
-        class="StyledBox__StyledBoxGap-sc-13pk1d4-1 iGPQzj"
-      />
-      <div
-        class="StyledBox-sc-13pk1d4-0 jNsTaV"
+            <svg
+              aria-label="FormUp"
+              class="c10"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 15-6-6-6 6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+          <button
+            aria-label="1 alpha move down"
+            class="c11"
+            id="alphaMoveDown"
+            tabindex="0"
+            type="button"
+          >
+            <svg
+              aria-label="FormDown"
+              class="c10"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 9-6 6-6-6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </div>
+      </li>
+      <li
+        class="c12 c3"
+        draggable="true"
       >
         <span
-          class="StyledText-sc-1sadyjn-0 cUpCuS"
+          class="c4"
         >
-          beta
+          2
         </span>
-      </div>
-      <div
-        class="StyledBox__StyledBoxGap-sc-13pk1d4-1 iGPQzj"
-      />
-      <div
-        class="StyledBox-sc-13pk1d4-0 hKXGyN"
-      >
-        <button
-          aria-label="2 beta move up"
-          class="StyledButton-sc-323bzc-0 hpYwyU"
-          id="betaMoveUp"
-          tabindex="-1"
-          type="button"
+        <div
+          class="c5"
+        />
+        <div
+          class="c6"
         >
-          <svg
-            aria-label="FormUp"
-            class="StyledIcon-sc-ofa7kd-0 jCZnaS"
-            viewBox="0 0 24 24"
+          <span
+            class="c7"
           >
-            <path
-              d="m18 15-6-6-6 6"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-        <button
-          aria-label="2 beta move down"
-          class="StyledButton-sc-323bzc-0 fVKxFa"
-          disabled=""
-          id="betaMoveDown"
-          tabindex="-1"
-          type="button"
+            beta
+          </span>
+        </div>
+        <div
+          class="c5"
+        />
+        <div
+          class="c8"
         >
-          <svg
-            aria-label="FormDown"
-            class="StyledIcon-sc-ofa7kd-0 jCZnaS"
-            viewBox="0 0 24 24"
+          <button
+            aria-label="2 beta move up"
+            class="c13"
+            id="betaMoveUp"
+            tabindex="-1"
+            type="button"
           >
-            <path
-              d="m18 9-6 6-6-6"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-      </div>
-    </li>
-  </ul>
-</div>
+            <svg
+              aria-label="FormUp"
+              class="c10"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 15-6-6-6 6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+          <button
+            aria-label="2 beta move down"
+            class="c9"
+            disabled=""
+            id="betaMoveDown"
+            tabindex="-1"
+            type="button"
+          >
+            <svg
+              aria-label="FormDown"
+              class="c10"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 9-6 6-6-6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </div>
+      </li>
+    </ul>
+  </div>
+</DocumentFragment>
 `;
 
 exports[`List onOrder Keyboard move up 3`] = `
+<DocumentFragment>
+  .c10 {
+  display: inline-block;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #666666;
+  stroke: #666666;
+}
+
+.c10 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c10 *:not([stroke])[fill='none'] {
+  stroke-width: 0;
+}
+
+.c10 *[stroke*='#'],
+.c10 *[STROKE*='#'] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c10 *[fill-rule],
+.c10 *[FILL-RULE],
+.c10 *[fill*='#'],
+.c10 *[FILL*='#'] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c2 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: center;
+  border-top: solid 1px rgba(0, 0, 0, 0.33);
+  border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  flex: 0 0 auto;
+  padding-left: 24px;
+  padding-right: 24px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+
+.c6 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  flex: 1 1;
+}
+
+.c8 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  justify-content: flex-end;
+}
+
+.c12 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: center;
+  border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  flex: 0 0 auto;
+  padding-left: 24px;
+  padding-right: 24px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+
+.c5 {
+  flex: 0 0 auto;
+  align-self: stretch;
+  width: 24px;
+}
+
+.c4 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c7 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c9 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  opacity: 0.3;
+  cursor: default;
+  line-height: 0;
+  padding: 12px;
+}
+
+.c9:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9:focus >circle,
+.c9:focus >ellipse,
+.c9:focus >line,
+.c9:focus >path,
+.c9:focus >polygon,
+.c9:focus >polyline,
+.c9:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c9:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c9:focus:not(:focus-visible) >circle,
+.c9:focus:not(:focus-visible) >ellipse,
+.c9:focus:not(:focus-visible) >line,
+.c9:focus:not(:focus-visible) >path,
+.c9:focus:not(:focus-visible) >polygon,
+.c9:focus:not(:focus-visible) >polyline,
+.c9:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c9:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c11 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  line-height: 0;
+  padding: 12px;
+}
+
+.c11:hover {
+  background-color: rgba(221, 221, 221, 0.4);
+  color: #000000;
+}
+
+.c11:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus >circle,
+.c11:focus >ellipse,
+.c11:focus >line,
+.c11:focus >path,
+.c11:focus >polygon,
+.c11:focus >polyline,
+.c11:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c11:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c11:focus:not(:focus-visible) >circle,
+.c11:focus:not(:focus-visible) >ellipse,
+.c11:focus:not(:focus-visible) >line,
+.c11:focus:not(:focus-visible) >path,
+.c11:focus:not(:focus-visible) >polygon,
+.c11:focus:not(:focus-visible) >polyline,
+.c11:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c11:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c13 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  background-color: rgba(221, 221, 221, 0.4);
+  color: #000000;
+  line-height: 0;
+  padding: 12px;
+}
+
+.c13:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c13:focus >circle,
+.c13:focus >ellipse,
+.c13:focus >line,
+.c13:focus >path,
+.c13:focus >polygon,
+.c13:focus >polyline,
+.c13:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c13:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c13:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c13:focus:not(:focus-visible) >circle,
+.c13:focus:not(:focus-visible) >ellipse,
+.c13:focus:not(:focus-visible) >line,
+.c13:focus:not(:focus-visible) >path,
+.c13:focus:not(:focus-visible) >polygon,
+.c13:focus:not(:focus-visible) >polyline,
+.c13:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c13:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c1 {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.c3 {
+  cursor: move;
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    border-top: solid 1px rgba(0, 0, 0, 0.33);
+    border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c12 {
+    border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c12 {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c12 {
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c5 {
+    width: 12px;
+  }
+}
+
 <div
-  class="StyledGrommet-sc-19lkkz7-0 cBoJUe"
->
-  <ul
-    aria-activedescendant="betaMoveDown"
-    class="List__StyledList-sc-130gdqg-0 dHNMqI"
-    role="list"
-    tabindex="0"
+    class="c0"
   >
-    <li
-      class="StyledBox-sc-13pk1d4-0 geglev List__StyledItem-sc-130gdqg-1 bIUWQJ"
-      draggable="true"
+    <ul
+      class="c1"
+      role="list"
     >
-      <span
-        class="StyledText-sc-1sadyjn-0 ldA-DUE"
-      >
-        1
-      </span>
-      <div
-        class="StyledBox__StyledBoxGap-sc-13pk1d4-1 iGPQzj"
-      />
-      <div
-        class="StyledBox-sc-13pk1d4-0 jNsTaV"
+      <li
+        class="c2 c3"
+        draggable="true"
       >
         <span
-          class="StyledText-sc-1sadyjn-0 cUpCuS"
+          class="c4"
         >
-          beta
+          1
         </span>
-      </div>
-      <div
-        class="StyledBox__StyledBoxGap-sc-13pk1d4-1 iGPQzj"
-      />
-      <div
-        class="StyledBox-sc-13pk1d4-0 hKXGyN"
-      >
-        <button
-          aria-label="1 beta move up"
-          class="StyledButton-sc-323bzc-0 fVKxFa"
-          disabled=""
-          id="betaMoveUp"
-          tabindex="-1"
-          type="button"
+        <div
+          class="c5"
+        />
+        <div
+          class="c6"
         >
-          <svg
-            aria-label="FormUp"
-            class="StyledIcon-sc-ofa7kd-0 jCZnaS"
-            viewBox="0 0 24 24"
+          <span
+            class="c7"
           >
-            <path
-              d="m18 15-6-6-6 6"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-        <button
-          aria-label="1 beta move down"
-          class="StyledButton-sc-323bzc-0 hpYwyU"
-          id="betaMoveDown"
-          tabindex="-1"
-          type="button"
+            beta
+          </span>
+        </div>
+        <div
+          class="c5"
+        />
+        <div
+          class="c8"
         >
-          <svg
-            aria-label="FormDown"
-            class="StyledIcon-sc-ofa7kd-0 jCZnaS"
-            viewBox="0 0 24 24"
+          <button
+            aria-label="1 beta move up"
+            class="c9"
+            disabled=""
+            id="betaMoveUp"
+            tabindex="-1"
+            type="button"
           >
-            <path
-              d="m18 9-6 6-6-6"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-      </div>
-    </li>
-    <li
-      class="StyledBox-sc-13pk1d4-0 jBetvR List__StyledItem-sc-130gdqg-1 bIUWQJ"
-      draggable="true"
-    >
-      <span
-        class="StyledText-sc-1sadyjn-0 ldA-DUE"
-      >
-        2
-      </span>
-      <div
-        class="StyledBox__StyledBoxGap-sc-13pk1d4-1 iGPQzj"
-      />
-      <div
-        class="StyledBox-sc-13pk1d4-0 jNsTaV"
+            <svg
+              aria-label="FormUp"
+              class="c10"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 15-6-6-6 6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+          <button
+            aria-label="1 beta move down"
+            class="c11"
+            id="betaMoveDown"
+            tabindex="-1"
+            type="button"
+          >
+            <svg
+              aria-label="FormDown"
+              class="c10"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 9-6 6-6-6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </div>
+      </li>
+      <li
+        class="c12 c3"
+        draggable="true"
       >
         <span
-          class="StyledText-sc-1sadyjn-0 cUpCuS"
+          class="c4"
         >
-          alpha
+          2
         </span>
-      </div>
-      <div
-        class="StyledBox__StyledBoxGap-sc-13pk1d4-1 iGPQzj"
-      />
-      <div
-        class="StyledBox-sc-13pk1d4-0 hKXGyN"
-      >
-        <button
-          aria-label="2 alpha move up"
-          class="StyledButton-sc-323bzc-0 eYvQIM"
-          id="alphaMoveUp"
-          tabindex="-1"
-          type="button"
+        <div
+          class="c5"
+        />
+        <div
+          class="c6"
         >
-          <svg
-            aria-label="FormUp"
-            class="StyledIcon-sc-ofa7kd-0 jCZnaS"
-            viewBox="0 0 24 24"
+          <span
+            class="c7"
           >
-            <path
-              d="m18 15-6-6-6 6"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-        <button
-          aria-label="2 alpha move down"
-          class="StyledButton-sc-323bzc-0 fVKxFa"
-          disabled=""
-          id="alphaMoveDown"
-          tabindex="-1"
-          type="button"
+            alpha
+          </span>
+        </div>
+        <div
+          class="c5"
+        />
+        <div
+          class="c8"
         >
-          <svg
-            aria-label="FormDown"
-            class="StyledIcon-sc-ofa7kd-0 jCZnaS"
-            viewBox="0 0 24 24"
+          <button
+            aria-label="2 alpha move up"
+            class="c13"
+            id="alphaMoveUp"
+            tabindex="0"
+            type="button"
           >
-            <path
-              d="m18 9-6 6-6-6"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-      </div>
-    </li>
-  </ul>
-</div>
+            <svg
+              aria-label="FormUp"
+              class="c10"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 15-6-6-6 6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+          <button
+            aria-label="2 alpha move down"
+            class="c9"
+            disabled=""
+            id="alphaMoveDown"
+            tabindex="-1"
+            type="button"
+          >
+            <svg
+              aria-label="FormDown"
+              class="c10"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 9-6 6-6-6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </div>
+      </li>
+    </ul>
+  </div>
+</DocumentFragment>
 `;
 
 exports[`List onOrder Mouse move down 1`] = `
@@ -15567,6 +17091,26 @@ exports[`List onOrder Mouse move down 1`] = `
   padding: 12px;
 }
 
+.c9:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9:focus >circle,
+.c9:focus >ellipse,
+.c9:focus >line,
+.c9:focus >path,
+.c9:focus >polygon,
+.c9:focus >polyline,
+.c9:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c9:focus ::-moz-focus-inner {
+  border: 0;
+}
+
 .c9:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -15611,6 +17155,26 @@ exports[`List onOrder Mouse move down 1`] = `
   color: #000000;
 }
 
+.c11:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus >circle,
+.c11:focus >ellipse,
+.c11:focus >line,
+.c11:focus >path,
+.c11:focus >polygon,
+.c11:focus >polyline,
+.c11:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus ::-moz-focus-inner {
+  border: 0;
+}
+
 .c11:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -15637,16 +17201,8 @@ exports[`List onOrder Mouse move down 1`] = `
   padding: 0;
 }
 
-.c1:focus {
-  outline: 2px solid #6FFFB0;
-}
-
 .c3 {
   cursor: move;
-}
-
-.c3:focus {
-  outline: none;
 }
 
 @media only screen and (max-width: 768px) {
@@ -15702,7 +17258,6 @@ exports[`List onOrder Mouse move down 1`] = `
   <ul
     class="c1"
     role="list"
-    tabindex="0"
   >
     <li
       class="c2 c3"
@@ -15756,7 +17311,7 @@ exports[`List onOrder Mouse move down 1`] = `
           aria-label="1 alpha move down"
           class="c11"
           id="alphaMoveDown"
-          tabindex="-1"
+          tabindex="0"
           type="button"
         >
           <svg
@@ -15853,12 +17408,11 @@ exports[`List onOrder Mouse move down 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 cBoJUe"
 >
   <ul
-    class="List__StyledList-sc-130gdqg-0 dHNMqI"
+    class="List__StyledList-sc-130gdqg-0 gjWLKL"
     role="list"
-    tabindex="0"
   >
     <li
-      class="StyledBox-sc-13pk1d4-0 geglev List__StyledItem-sc-130gdqg-1 bIUWQJ"
+      class="StyledBox-sc-13pk1d4-0 geglev List__StyledItem-sc-130gdqg-1 bvxxXX"
       draggable="true"
     >
       <span
@@ -15886,7 +17440,7 @@ exports[`List onOrder Mouse move down 2`] = `
       >
         <button
           aria-label="1 beta move up"
-          class="StyledButton-sc-323bzc-0 fVKxFa"
+          class="StyledButton-sc-323bzc-0 ciYqzT"
           disabled=""
           id="betaMoveUp"
           tabindex="-1"
@@ -15907,7 +17461,7 @@ exports[`List onOrder Mouse move down 2`] = `
         </button>
         <button
           aria-label="1 beta move down"
-          class="StyledButton-sc-323bzc-0 eYvQIM"
+          class="StyledButton-sc-323bzc-0 hzRFzp"
           id="betaMoveDown"
           tabindex="-1"
           type="button"
@@ -15928,7 +17482,7 @@ exports[`List onOrder Mouse move down 2`] = `
       </div>
     </li>
     <li
-      class="StyledBox-sc-13pk1d4-0 jBetvR List__StyledItem-sc-130gdqg-1 bIUWQJ"
+      class="StyledBox-sc-13pk1d4-0 jBetvR List__StyledItem-sc-130gdqg-1 bvxxXX"
       draggable="true"
     >
       <span
@@ -15956,7 +17510,7 @@ exports[`List onOrder Mouse move down 2`] = `
       >
         <button
           aria-label="2 alpha move up"
-          class="StyledButton-sc-323bzc-0 eYvQIM"
+          class="StyledButton-sc-323bzc-0 hzRFzp"
           id="alphaMoveUp"
           tabindex="-1"
           type="button"
@@ -15976,7 +17530,7 @@ exports[`List onOrder Mouse move down 2`] = `
         </button>
         <button
           aria-label="2 alpha move down"
-          class="StyledButton-sc-323bzc-0 fVKxFa"
+          class="StyledButton-sc-323bzc-0 ciYqzT"
           disabled=""
           id="alphaMoveDown"
           tabindex="-1"
@@ -16214,6 +17768,26 @@ exports[`List onOrder with action Render 1`] = `
   padding: 12px;
 }
 
+.c11:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus >circle,
+.c11:focus >ellipse,
+.c11:focus >line,
+.c11:focus >path,
+.c11:focus >polygon,
+.c11:focus >polyline,
+.c11:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c11:focus ::-moz-focus-inner {
+  border: 0;
+}
+
 .c11:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -16258,6 +17832,26 @@ exports[`List onOrder with action Render 1`] = `
   color: #000000;
 }
 
+.c13:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c13:focus >circle,
+.c13:focus >ellipse,
+.c13:focus >line,
+.c13:focus >path,
+.c13:focus >polygon,
+.c13:focus >polyline,
+.c13:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c13:focus ::-moz-focus-inner {
+  border: 0;
+}
+
 .c13:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -16284,16 +17878,8 @@ exports[`List onOrder with action Render 1`] = `
   padding: 0;
 }
 
-.c1:focus {
-  outline: 2px solid #6FFFB0;
-}
-
 .c3 {
   cursor: move;
-}
-
-.c3:focus {
-  outline: none;
 }
 
 @media only screen and (max-width: 768px) {
@@ -16349,7 +17935,6 @@ exports[`List onOrder with action Render 1`] = `
     <ul
       class="c1"
       role="list"
-      tabindex="0"
     >
       <li
         class="c2 c3"
@@ -16416,7 +18001,7 @@ exports[`List onOrder with action Render 1`] = `
             aria-label="1 alpha move down"
             class="c13"
             id="alphaMoveDown"
-            tabindex="-1"
+            tabindex="0"
             type="button"
           >
             <svg
@@ -16523,7 +18108,8 @@ exports[`List onOrder with action Render 1`] = `
 `;
 
 exports[`List onOrder with no-index Keyboard move down 1`] = `
-.c9 {
+<DocumentFragment>
+  .c9 {
   display: inline-block;
   flex: 0 0 auto;
   width: 24px;
@@ -16652,6 +18238,26 @@ exports[`List onOrder with no-index Keyboard move down 1`] = `
   padding: 12px;
 }
 
+.c8:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus >circle,
+.c8:focus >ellipse,
+.c8:focus >line,
+.c8:focus >path,
+.c8:focus >polygon,
+.c8:focus >polyline,
+.c8:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus ::-moz-focus-inner {
+  border: 0;
+}
+
 .c8:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -16696,6 +18302,26 @@ exports[`List onOrder with no-index Keyboard move down 1`] = `
   color: #000000;
 }
 
+.c10:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus >circle,
+.c10:focus >ellipse,
+.c10:focus >line,
+.c10:focus >path,
+.c10:focus >polygon,
+.c10:focus >polyline,
+.c10:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus ::-moz-focus-inner {
+  border: 0;
+}
+
 .c10:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -16722,16 +18348,8 @@ exports[`List onOrder with no-index Keyboard move down 1`] = `
   padding: 0;
 }
 
-.c1:focus {
-  outline: 2px solid #6FFFB0;
-}
-
 .c3 {
   cursor: move;
-}
-
-.c3:focus {
-  outline: none;
 }
 
 @media only screen and (max-width: 768px) {
@@ -16782,419 +18400,144 @@ exports[`List onOrder with no-index Keyboard move down 1`] = `
 }
 
 <div
-  class="c0"
->
-  <ul
-    class="c1"
-    role="list"
-    tabindex="0"
+    class="c0"
   >
-    <li
-      class="c2 c3"
-      draggable="true"
+    <ul
+      class="c1"
+      role="list"
     >
-      <div
-        class="c4"
+      <li
+        class="c2 c3"
+        draggable="true"
       >
-        <span
-          class="c5"
+        <div
+          class="c4"
         >
-          alpha
-        </span>
-      </div>
-      <div
-        class="c6"
-      />
-      <div
-        class="c7"
+          <span
+            class="c5"
+          >
+            alpha
+          </span>
+        </div>
+        <div
+          class="c6"
+        />
+        <div
+          class="c7"
+        >
+          <button
+            aria-label="1 alpha move up"
+            class="c8"
+            disabled=""
+            id="alphaMoveUp"
+            tabindex="-1"
+            type="button"
+          >
+            <svg
+              aria-label="FormUp"
+              class="c9"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 15-6-6-6 6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+          <button
+            aria-label="1 alpha move down"
+            class="c10"
+            id="alphaMoveDown"
+            tabindex="0"
+            type="button"
+          >
+            <svg
+              aria-label="FormDown"
+              class="c9"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 9-6 6-6-6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </div>
+      </li>
+      <li
+        class="c11 c3"
+        draggable="true"
       >
-        <button
-          aria-label="1 alpha move up"
-          class="c8"
-          disabled=""
-          id="alphaMoveUp"
-          tabindex="-1"
-          type="button"
+        <div
+          class="c4"
         >
-          <svg
-            aria-label="FormUp"
-            class="c9"
-            viewBox="0 0 24 24"
+          <span
+            class="c5"
           >
-            <path
-              d="m18 15-6-6-6 6"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-        <button
-          aria-label="1 alpha move down"
-          class="c10"
-          id="alphaMoveDown"
-          tabindex="-1"
-          type="button"
+            beta
+          </span>
+        </div>
+        <div
+          class="c6"
+        />
+        <div
+          class="c7"
         >
-          <svg
-            aria-label="FormDown"
-            class="c9"
-            viewBox="0 0 24 24"
+          <button
+            aria-label="2 beta move up"
+            class="c10"
+            id="betaMoveUp"
+            tabindex="-1"
+            type="button"
           >
-            <path
-              d="m18 9-6 6-6-6"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-      </div>
-    </li>
-    <li
-      class="c11 c3"
-      draggable="true"
-    >
-      <div
-        class="c4"
-      >
-        <span
-          class="c5"
-        >
-          beta
-        </span>
-      </div>
-      <div
-        class="c6"
-      />
-      <div
-        class="c7"
-      >
-        <button
-          aria-label="2 beta move up"
-          class="c10"
-          id="betaMoveUp"
-          tabindex="-1"
-          type="button"
-        >
-          <svg
-            aria-label="FormUp"
-            class="c9"
-            viewBox="0 0 24 24"
+            <svg
+              aria-label="FormUp"
+              class="c9"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 15-6-6-6 6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+          <button
+            aria-label="2 beta move down"
+            class="c8"
+            disabled=""
+            id="betaMoveDown"
+            tabindex="-1"
+            type="button"
           >
-            <path
-              d="m18 15-6-6-6 6"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-        <button
-          aria-label="2 beta move down"
-          class="c8"
-          disabled=""
-          id="betaMoveDown"
-          tabindex="-1"
-          type="button"
-        >
-          <svg
-            aria-label="FormDown"
-            class="c9"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="m18 9-6 6-6-6"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-      </div>
-    </li>
-  </ul>
-</div>
+            <svg
+              aria-label="FormDown"
+              class="c9"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 9-6 6-6-6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </div>
+      </li>
+    </ul>
+  </div>
+</DocumentFragment>
 `;
 
 exports[`List onOrder with no-index Keyboard move down 2`] = `
-<div
-  class="StyledGrommet-sc-19lkkz7-0 cBoJUe"
->
-  <ul
-    aria-activedescendant="alphaMoveDown"
-    class="List__StyledList-sc-130gdqg-0 dHNMqI"
-    role="list"
-    tabindex="0"
-  >
-    <li
-      class="StyledBox-sc-13pk1d4-0 geglev List__StyledItem-sc-130gdqg-1 bIUWQJ"
-      draggable="true"
-    >
-      <div
-        class="StyledBox-sc-13pk1d4-0 jNsTaV"
-      >
-        <span
-          class="StyledText-sc-1sadyjn-0 cUpCuS"
-        >
-          alpha
-        </span>
-      </div>
-      <div
-        class="StyledBox__StyledBoxGap-sc-13pk1d4-1 iGPQzj"
-      />
-      <div
-        class="StyledBox-sc-13pk1d4-0 hKXGyN"
-      >
-        <button
-          aria-label="1 alpha move up"
-          class="StyledButton-sc-323bzc-0 fVKxFa"
-          disabled=""
-          id="alphaMoveUp"
-          tabindex="-1"
-          type="button"
-        >
-          <svg
-            aria-label="FormUp"
-            class="StyledIcon-sc-ofa7kd-0 jCZnaS"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="m18 15-6-6-6 6"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-        <button
-          aria-label="1 alpha move down"
-          class="StyledButton-sc-323bzc-0 hpYwyU"
-          id="alphaMoveDown"
-          tabindex="-1"
-          type="button"
-        >
-          <svg
-            aria-label="FormDown"
-            class="StyledIcon-sc-ofa7kd-0 jCZnaS"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="m18 9-6 6-6-6"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-      </div>
-    </li>
-    <li
-      class="StyledBox-sc-13pk1d4-0 jBetvR List__StyledItem-sc-130gdqg-1 bIUWQJ"
-      draggable="true"
-    >
-      <div
-        class="StyledBox-sc-13pk1d4-0 jNsTaV"
-      >
-        <span
-          class="StyledText-sc-1sadyjn-0 cUpCuS"
-        >
-          beta
-        </span>
-      </div>
-      <div
-        class="StyledBox__StyledBoxGap-sc-13pk1d4-1 iGPQzj"
-      />
-      <div
-        class="StyledBox-sc-13pk1d4-0 hKXGyN"
-      >
-        <button
-          aria-label="2 beta move up"
-          class="StyledButton-sc-323bzc-0 eYvQIM"
-          id="betaMoveUp"
-          tabindex="-1"
-          type="button"
-        >
-          <svg
-            aria-label="FormUp"
-            class="StyledIcon-sc-ofa7kd-0 jCZnaS"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="m18 15-6-6-6 6"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-        <button
-          aria-label="2 beta move down"
-          class="StyledButton-sc-323bzc-0 fVKxFa"
-          disabled=""
-          id="betaMoveDown"
-          tabindex="-1"
-          type="button"
-        >
-          <svg
-            aria-label="FormDown"
-            class="StyledIcon-sc-ofa7kd-0 jCZnaS"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="m18 9-6 6-6-6"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-      </div>
-    </li>
-  </ul>
-</div>
-`;
-
-exports[`List onOrder with no-index Keyboard move down 3`] = `
-<div
-  class="StyledGrommet-sc-19lkkz7-0 cBoJUe"
->
-  <ul
-    aria-activedescendant="alphaMoveUp"
-    class="List__StyledList-sc-130gdqg-0 dHNMqI"
-    role="list"
-    tabindex="0"
-  >
-    <li
-      class="StyledBox-sc-13pk1d4-0 geglev List__StyledItem-sc-130gdqg-1 bIUWQJ"
-      draggable="true"
-    >
-      <div
-        class="StyledBox-sc-13pk1d4-0 jNsTaV"
-      >
-        <span
-          class="StyledText-sc-1sadyjn-0 cUpCuS"
-        >
-          beta
-        </span>
-      </div>
-      <div
-        class="StyledBox__StyledBoxGap-sc-13pk1d4-1 iGPQzj"
-      />
-      <div
-        class="StyledBox-sc-13pk1d4-0 hKXGyN"
-      >
-        <button
-          aria-label="1 beta move up"
-          class="StyledButton-sc-323bzc-0 fVKxFa"
-          disabled=""
-          id="betaMoveUp"
-          tabindex="-1"
-          type="button"
-        >
-          <svg
-            aria-label="FormUp"
-            class="StyledIcon-sc-ofa7kd-0 jCZnaS"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="m18 15-6-6-6 6"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-        <button
-          aria-label="1 beta move down"
-          class="StyledButton-sc-323bzc-0 eYvQIM"
-          id="betaMoveDown"
-          tabindex="-1"
-          type="button"
-        >
-          <svg
-            aria-label="FormDown"
-            class="StyledIcon-sc-ofa7kd-0 jCZnaS"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="m18 9-6 6-6-6"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-      </div>
-    </li>
-    <li
-      class="StyledBox-sc-13pk1d4-0 jBetvR List__StyledItem-sc-130gdqg-1 bIUWQJ"
-      draggable="true"
-    >
-      <div
-        class="StyledBox-sc-13pk1d4-0 jNsTaV"
-      >
-        <span
-          class="StyledText-sc-1sadyjn-0 cUpCuS"
-        >
-          alpha
-        </span>
-      </div>
-      <div
-        class="StyledBox__StyledBoxGap-sc-13pk1d4-1 iGPQzj"
-      />
-      <div
-        class="StyledBox-sc-13pk1d4-0 hKXGyN"
-      >
-        <button
-          aria-label="2 alpha move up"
-          class="StyledButton-sc-323bzc-0 hpYwyU"
-          id="alphaMoveUp"
-          tabindex="-1"
-          type="button"
-        >
-          <svg
-            aria-label="FormUp"
-            class="StyledIcon-sc-ofa7kd-0 jCZnaS"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="m18 15-6-6-6 6"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-        <button
-          aria-label="2 alpha move down"
-          class="StyledButton-sc-323bzc-0 fVKxFa"
-          disabled=""
-          id="alphaMoveDown"
-          tabindex="-1"
-          type="button"
-        >
-          <svg
-            aria-label="FormDown"
-            class="StyledIcon-sc-ofa7kd-0 jCZnaS"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="m18 9-6 6-6-6"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-      </div>
-    </li>
-  </ul>
-</div>
-`;
-
-exports[`List onOrder with no-index Keyboard move up 1`] = `
-.c9 {
+<DocumentFragment>
+  .c9 {
   display: inline-block;
   flex: 0 0 auto;
   width: 24px;
@@ -17323,6 +18666,26 @@ exports[`List onOrder with no-index Keyboard move up 1`] = `
   padding: 12px;
 }
 
+.c8:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus >circle,
+.c8:focus >ellipse,
+.c8:focus >line,
+.c8:focus >path,
+.c8:focus >polygon,
+.c8:focus >polyline,
+.c8:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus ::-moz-focus-inner {
+  border: 0;
+}
+
 .c8:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -17343,7 +18706,7 @@ exports[`List onOrder with no-index Keyboard move up 1`] = `
   border: 0;
 }
 
-.c10 {
+.c12 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -17362,9 +18725,90 @@ exports[`List onOrder with no-index Keyboard move up 1`] = `
   padding: 12px;
 }
 
-.c10:hover {
+.c12:hover {
   background-color: rgba(221, 221, 221, 0.4);
   color: #000000;
+}
+
+.c12:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c12:focus >circle,
+.c12:focus >ellipse,
+.c12:focus >line,
+.c12:focus >path,
+.c12:focus >polygon,
+.c12:focus >polyline,
+.c12:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c12:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c12:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c12:focus:not(:focus-visible) >circle,
+.c12:focus:not(:focus-visible) >ellipse,
+.c12:focus:not(:focus-visible) >line,
+.c12:focus:not(:focus-visible) >path,
+.c12:focus:not(:focus-visible) >polygon,
+.c12:focus:not(:focus-visible) >polyline,
+.c12:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c12:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c10 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  background-color: rgba(221, 221, 221, 0.4);
+  color: #000000;
+  line-height: 0;
+  padding: 12px;
+}
+
+.c10:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus >circle,
+.c10:focus >ellipse,
+.c10:focus >line,
+.c10:focus >path,
+.c10:focus >polygon,
+.c10:focus >polyline,
+.c10:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus ::-moz-focus-inner {
+  border: 0;
 }
 
 .c10:focus:not(:focus-visible) {
@@ -17393,16 +18837,8 @@ exports[`List onOrder with no-index Keyboard move up 1`] = `
   padding: 0;
 }
 
-.c1:focus {
-  outline: 2px solid #6FFFB0;
-}
-
 .c3 {
   cursor: move;
-}
-
-.c3:focus {
-  outline: none;
 }
 
 @media only screen and (max-width: 768px) {
@@ -17453,415 +18889,2034 @@ exports[`List onOrder with no-index Keyboard move up 1`] = `
 }
 
 <div
-  class="c0"
->
-  <ul
-    class="c1"
-    role="list"
-    tabindex="0"
+    class="c0"
   >
-    <li
-      class="c2 c3"
-      draggable="true"
+    <ul
+      class="c1"
+      role="list"
     >
-      <div
-        class="c4"
+      <li
+        class="c2 c3"
+        draggable="true"
       >
-        <span
-          class="c5"
+        <div
+          class="c4"
         >
-          alpha
-        </span>
-      </div>
-      <div
-        class="c6"
-      />
-      <div
-        class="c7"
+          <span
+            class="c5"
+          >
+            alpha
+          </span>
+        </div>
+        <div
+          class="c6"
+        />
+        <div
+          class="c7"
+        >
+          <button
+            aria-label="1 alpha move up"
+            class="c8"
+            disabled=""
+            id="alphaMoveUp"
+            tabindex="-1"
+            type="button"
+          >
+            <svg
+              aria-label="FormUp"
+              class="c9"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 15-6-6-6 6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+          <button
+            aria-label="1 alpha move down"
+            class="c10"
+            id="alphaMoveDown"
+            tabindex="0"
+            type="button"
+          >
+            <svg
+              aria-label="FormDown"
+              class="c9"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 9-6 6-6-6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </div>
+      </li>
+      <li
+        class="c11 c3"
+        draggable="true"
       >
-        <button
-          aria-label="1 alpha move up"
-          class="c8"
-          disabled=""
-          id="alphaMoveUp"
-          tabindex="-1"
-          type="button"
+        <div
+          class="c4"
         >
-          <svg
-            aria-label="FormUp"
-            class="c9"
-            viewBox="0 0 24 24"
+          <span
+            class="c5"
           >
-            <path
-              d="m18 15-6-6-6 6"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-        <button
-          aria-label="1 alpha move down"
-          class="c10"
-          id="alphaMoveDown"
-          tabindex="-1"
-          type="button"
+            beta
+          </span>
+        </div>
+        <div
+          class="c6"
+        />
+        <div
+          class="c7"
         >
-          <svg
-            aria-label="FormDown"
-            class="c9"
-            viewBox="0 0 24 24"
+          <button
+            aria-label="2 beta move up"
+            class="c12"
+            id="betaMoveUp"
+            tabindex="-1"
+            type="button"
           >
-            <path
-              d="m18 9-6 6-6-6"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-      </div>
-    </li>
-    <li
-      class="c11 c3"
-      draggable="true"
+            <svg
+              aria-label="FormUp"
+              class="c9"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 15-6-6-6 6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+          <button
+            aria-label="2 beta move down"
+            class="c8"
+            disabled=""
+            id="betaMoveDown"
+            tabindex="-1"
+            type="button"
+          >
+            <svg
+              aria-label="FormDown"
+              class="c9"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 9-6 6-6-6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </div>
+      </li>
+    </ul>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`List onOrder with no-index Keyboard move down 3`] = `
+<DocumentFragment>
+  .c9 {
+  display: inline-block;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #666666;
+  stroke: #666666;
+}
+
+.c9 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c9 *:not([stroke])[fill='none'] {
+  stroke-width: 0;
+}
+
+.c9 *[stroke*='#'],
+.c9 *[STROKE*='#'] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c9 *[fill-rule],
+.c9 *[FILL-RULE],
+.c9 *[fill*='#'],
+.c9 *[FILL*='#'] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c2 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: center;
+  border-top: solid 1px rgba(0, 0, 0, 0.33);
+  border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  flex: 0 0 auto;
+  padding-left: 24px;
+  padding-right: 24px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+
+.c4 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  flex: 1 1;
+}
+
+.c7 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  justify-content: flex-end;
+}
+
+.c11 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: center;
+  border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  flex: 0 0 auto;
+  padding-left: 24px;
+  padding-right: 24px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+
+.c6 {
+  flex: 0 0 auto;
+  align-self: stretch;
+  width: 24px;
+}
+
+.c5 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c8 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  opacity: 0.3;
+  cursor: default;
+  line-height: 0;
+  padding: 12px;
+}
+
+.c8:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus >circle,
+.c8:focus >ellipse,
+.c8:focus >line,
+.c8:focus >path,
+.c8:focus >polygon,
+.c8:focus >polyline,
+.c8:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c8:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c8:focus:not(:focus-visible) >circle,
+.c8:focus:not(:focus-visible) >ellipse,
+.c8:focus:not(:focus-visible) >line,
+.c8:focus:not(:focus-visible) >path,
+.c8:focus:not(:focus-visible) >polygon,
+.c8:focus:not(:focus-visible) >polyline,
+.c8:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c8:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c10 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  line-height: 0;
+  padding: 12px;
+}
+
+.c10:hover {
+  background-color: rgba(221, 221, 221, 0.4);
+  color: #000000;
+}
+
+.c10:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus >circle,
+.c10:focus >ellipse,
+.c10:focus >line,
+.c10:focus >path,
+.c10:focus >polygon,
+.c10:focus >polyline,
+.c10:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c10:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c10:focus:not(:focus-visible) >circle,
+.c10:focus:not(:focus-visible) >ellipse,
+.c10:focus:not(:focus-visible) >line,
+.c10:focus:not(:focus-visible) >path,
+.c10:focus:not(:focus-visible) >polygon,
+.c10:focus:not(:focus-visible) >polyline,
+.c10:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c10:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c12 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  background-color: rgba(221, 221, 221, 0.4);
+  color: #000000;
+  line-height: 0;
+  padding: 12px;
+}
+
+.c12:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c12:focus >circle,
+.c12:focus >ellipse,
+.c12:focus >line,
+.c12:focus >path,
+.c12:focus >polygon,
+.c12:focus >polyline,
+.c12:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c12:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c12:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c12:focus:not(:focus-visible) >circle,
+.c12:focus:not(:focus-visible) >ellipse,
+.c12:focus:not(:focus-visible) >line,
+.c12:focus:not(:focus-visible) >path,
+.c12:focus:not(:focus-visible) >polygon,
+.c12:focus:not(:focus-visible) >polyline,
+.c12:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c12:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c1 {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.c3 {
+  cursor: move;
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    border-top: solid 1px rgba(0, 0, 0, 0.33);
+    border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c11 {
+    border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c11 {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c11 {
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c6 {
+    width: 12px;
+  }
+}
+
+<div
+    class="c0"
+  >
+    <ul
+      class="c1"
+      role="list"
     >
-      <div
-        class="c4"
+      <li
+        class="c2 c3"
+        draggable="true"
       >
-        <span
-          class="c5"
+        <div
+          class="c4"
         >
-          beta
-        </span>
-      </div>
-      <div
-        class="c6"
-      />
-      <div
-        class="c7"
+          <span
+            class="c5"
+          >
+            beta
+          </span>
+        </div>
+        <div
+          class="c6"
+        />
+        <div
+          class="c7"
+        >
+          <button
+            aria-label="1 beta move up"
+            class="c8"
+            disabled=""
+            id="betaMoveUp"
+            tabindex="-1"
+            type="button"
+          >
+            <svg
+              aria-label="FormUp"
+              class="c9"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 15-6-6-6 6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+          <button
+            aria-label="1 beta move down"
+            class="c10"
+            id="betaMoveDown"
+            tabindex="-1"
+            type="button"
+          >
+            <svg
+              aria-label="FormDown"
+              class="c9"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 9-6 6-6-6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </div>
+      </li>
+      <li
+        class="c11 c3"
+        draggable="true"
       >
-        <button
-          aria-label="2 beta move up"
-          class="c10"
-          id="betaMoveUp"
-          tabindex="-1"
-          type="button"
+        <div
+          class="c4"
         >
-          <svg
-            aria-label="FormUp"
-            class="c9"
-            viewBox="0 0 24 24"
+          <span
+            class="c5"
           >
-            <path
-              d="m18 15-6-6-6 6"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-        <button
-          aria-label="2 beta move down"
-          class="c8"
-          disabled=""
-          id="betaMoveDown"
-          tabindex="-1"
-          type="button"
+            alpha
+          </span>
+        </div>
+        <div
+          class="c6"
+        />
+        <div
+          class="c7"
         >
-          <svg
-            aria-label="FormDown"
-            class="c9"
-            viewBox="0 0 24 24"
+          <button
+            aria-label="2 alpha move up"
+            class="c12"
+            id="alphaMoveUp"
+            tabindex="0"
+            type="button"
           >
-            <path
-              d="m18 9-6 6-6-6"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-      </div>
-    </li>
-  </ul>
-</div>
+            <svg
+              aria-label="FormUp"
+              class="c9"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 15-6-6-6 6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+          <button
+            aria-label="2 alpha move down"
+            class="c8"
+            disabled=""
+            id="alphaMoveDown"
+            tabindex="-1"
+            type="button"
+          >
+            <svg
+              aria-label="FormDown"
+              class="c9"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 9-6 6-6-6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </div>
+      </li>
+    </ul>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`List onOrder with no-index Keyboard move up 1`] = `
+<DocumentFragment>
+  .c9 {
+  display: inline-block;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #666666;
+  stroke: #666666;
+}
+
+.c9 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c9 *:not([stroke])[fill='none'] {
+  stroke-width: 0;
+}
+
+.c9 *[stroke*='#'],
+.c9 *[STROKE*='#'] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c9 *[fill-rule],
+.c9 *[FILL-RULE],
+.c9 *[fill*='#'],
+.c9 *[FILL*='#'] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c2 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: center;
+  border-top: solid 1px rgba(0, 0, 0, 0.33);
+  border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  flex: 0 0 auto;
+  padding-left: 24px;
+  padding-right: 24px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+
+.c4 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  flex: 1 1;
+}
+
+.c7 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  justify-content: flex-end;
+}
+
+.c11 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: center;
+  border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  flex: 0 0 auto;
+  padding-left: 24px;
+  padding-right: 24px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+
+.c6 {
+  flex: 0 0 auto;
+  align-self: stretch;
+  width: 24px;
+}
+
+.c5 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c8 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  opacity: 0.3;
+  cursor: default;
+  line-height: 0;
+  padding: 12px;
+}
+
+.c8:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus >circle,
+.c8:focus >ellipse,
+.c8:focus >line,
+.c8:focus >path,
+.c8:focus >polygon,
+.c8:focus >polyline,
+.c8:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c8:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c8:focus:not(:focus-visible) >circle,
+.c8:focus:not(:focus-visible) >ellipse,
+.c8:focus:not(:focus-visible) >line,
+.c8:focus:not(:focus-visible) >path,
+.c8:focus:not(:focus-visible) >polygon,
+.c8:focus:not(:focus-visible) >polyline,
+.c8:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c8:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c10 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  line-height: 0;
+  padding: 12px;
+}
+
+.c10:hover {
+  background-color: rgba(221, 221, 221, 0.4);
+  color: #000000;
+}
+
+.c10:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus >circle,
+.c10:focus >ellipse,
+.c10:focus >line,
+.c10:focus >path,
+.c10:focus >polygon,
+.c10:focus >polyline,
+.c10:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c10:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c10:focus:not(:focus-visible) >circle,
+.c10:focus:not(:focus-visible) >ellipse,
+.c10:focus:not(:focus-visible) >line,
+.c10:focus:not(:focus-visible) >path,
+.c10:focus:not(:focus-visible) >polygon,
+.c10:focus:not(:focus-visible) >polyline,
+.c10:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c10:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c1 {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.c3 {
+  cursor: move;
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    border-top: solid 1px rgba(0, 0, 0, 0.33);
+    border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c11 {
+    border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c11 {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c11 {
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c6 {
+    width: 12px;
+  }
+}
+
+<div
+    class="c0"
+  >
+    <ul
+      class="c1"
+      role="list"
+    >
+      <li
+        class="c2 c3"
+        draggable="true"
+      >
+        <div
+          class="c4"
+        >
+          <span
+            class="c5"
+          >
+            alpha
+          </span>
+        </div>
+        <div
+          class="c6"
+        />
+        <div
+          class="c7"
+        >
+          <button
+            aria-label="1 alpha move up"
+            class="c8"
+            disabled=""
+            id="alphaMoveUp"
+            tabindex="-1"
+            type="button"
+          >
+            <svg
+              aria-label="FormUp"
+              class="c9"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 15-6-6-6 6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+          <button
+            aria-label="1 alpha move down"
+            class="c10"
+            id="alphaMoveDown"
+            tabindex="0"
+            type="button"
+          >
+            <svg
+              aria-label="FormDown"
+              class="c9"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 9-6 6-6-6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </div>
+      </li>
+      <li
+        class="c11 c3"
+        draggable="true"
+      >
+        <div
+          class="c4"
+        >
+          <span
+            class="c5"
+          >
+            beta
+          </span>
+        </div>
+        <div
+          class="c6"
+        />
+        <div
+          class="c7"
+        >
+          <button
+            aria-label="2 beta move up"
+            class="c10"
+            id="betaMoveUp"
+            tabindex="-1"
+            type="button"
+          >
+            <svg
+              aria-label="FormUp"
+              class="c9"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 15-6-6-6 6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+          <button
+            aria-label="2 beta move down"
+            class="c8"
+            disabled=""
+            id="betaMoveDown"
+            tabindex="-1"
+            type="button"
+          >
+            <svg
+              aria-label="FormDown"
+              class="c9"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 9-6 6-6-6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </div>
+      </li>
+    </ul>
+  </div>
+</DocumentFragment>
 `;
 
 exports[`List onOrder with no-index Keyboard move up 2`] = `
+<DocumentFragment>
+  .c9 {
+  display: inline-block;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #666666;
+  stroke: #666666;
+}
+
+.c9 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c9 *:not([stroke])[fill='none'] {
+  stroke-width: 0;
+}
+
+.c9 *[stroke*='#'],
+.c9 *[STROKE*='#'] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c9 *[fill-rule],
+.c9 *[FILL-RULE],
+.c9 *[fill*='#'],
+.c9 *[FILL*='#'] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c2 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: center;
+  border-top: solid 1px rgba(0, 0, 0, 0.33);
+  border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  flex: 0 0 auto;
+  padding-left: 24px;
+  padding-right: 24px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+
+.c4 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  flex: 1 1;
+}
+
+.c7 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  justify-content: flex-end;
+}
+
+.c11 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: center;
+  border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  flex: 0 0 auto;
+  padding-left: 24px;
+  padding-right: 24px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+
+.c6 {
+  flex: 0 0 auto;
+  align-self: stretch;
+  width: 24px;
+}
+
+.c5 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c8 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  opacity: 0.3;
+  cursor: default;
+  line-height: 0;
+  padding: 12px;
+}
+
+.c8:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus >circle,
+.c8:focus >ellipse,
+.c8:focus >line,
+.c8:focus >path,
+.c8:focus >polygon,
+.c8:focus >polyline,
+.c8:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c8:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c8:focus:not(:focus-visible) >circle,
+.c8:focus:not(:focus-visible) >ellipse,
+.c8:focus:not(:focus-visible) >line,
+.c8:focus:not(:focus-visible) >path,
+.c8:focus:not(:focus-visible) >polygon,
+.c8:focus:not(:focus-visible) >polyline,
+.c8:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c8:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c12 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  line-height: 0;
+  padding: 12px;
+}
+
+.c12:hover {
+  background-color: rgba(221, 221, 221, 0.4);
+  color: #000000;
+}
+
+.c12:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c12:focus >circle,
+.c12:focus >ellipse,
+.c12:focus >line,
+.c12:focus >path,
+.c12:focus >polygon,
+.c12:focus >polyline,
+.c12:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c12:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c12:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c12:focus:not(:focus-visible) >circle,
+.c12:focus:not(:focus-visible) >ellipse,
+.c12:focus:not(:focus-visible) >line,
+.c12:focus:not(:focus-visible) >path,
+.c12:focus:not(:focus-visible) >polygon,
+.c12:focus:not(:focus-visible) >polyline,
+.c12:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c12:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c10 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  background-color: rgba(221, 221, 221, 0.4);
+  color: #000000;
+  line-height: 0;
+  padding: 12px;
+}
+
+.c10:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus >circle,
+.c10:focus >ellipse,
+.c10:focus >line,
+.c10:focus >path,
+.c10:focus >polygon,
+.c10:focus >polyline,
+.c10:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c10:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c10:focus:not(:focus-visible) >circle,
+.c10:focus:not(:focus-visible) >ellipse,
+.c10:focus:not(:focus-visible) >line,
+.c10:focus:not(:focus-visible) >path,
+.c10:focus:not(:focus-visible) >polygon,
+.c10:focus:not(:focus-visible) >polyline,
+.c10:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c10:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c1 {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.c3 {
+  cursor: move;
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    border-top: solid 1px rgba(0, 0, 0, 0.33);
+    border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c11 {
+    border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c11 {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c11 {
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c6 {
+    width: 12px;
+  }
+}
+
 <div
-  class="StyledGrommet-sc-19lkkz7-0 cBoJUe"
->
-  <ul
-    aria-activedescendant="betaMoveUp"
-    class="List__StyledList-sc-130gdqg-0 dHNMqI"
-    role="list"
-    tabindex="0"
+    class="c0"
   >
-    <li
-      class="StyledBox-sc-13pk1d4-0 geglev List__StyledItem-sc-130gdqg-1 bIUWQJ"
-      draggable="true"
+    <ul
+      class="c1"
+      role="list"
     >
-      <div
-        class="StyledBox-sc-13pk1d4-0 jNsTaV"
+      <li
+        class="c2 c3"
+        draggable="true"
       >
-        <span
-          class="StyledText-sc-1sadyjn-0 cUpCuS"
+        <div
+          class="c4"
         >
-          alpha
-        </span>
-      </div>
-      <div
-        class="StyledBox__StyledBoxGap-sc-13pk1d4-1 iGPQzj"
-      />
-      <div
-        class="StyledBox-sc-13pk1d4-0 hKXGyN"
+          <span
+            class="c5"
+          >
+            alpha
+          </span>
+        </div>
+        <div
+          class="c6"
+        />
+        <div
+          class="c7"
+        >
+          <button
+            aria-label="1 alpha move up"
+            class="c8"
+            disabled=""
+            id="alphaMoveUp"
+            tabindex="-1"
+            type="button"
+          >
+            <svg
+              aria-label="FormUp"
+              class="c9"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 15-6-6-6 6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+          <button
+            aria-label="1 alpha move down"
+            class="c10"
+            id="alphaMoveDown"
+            tabindex="0"
+            type="button"
+          >
+            <svg
+              aria-label="FormDown"
+              class="c9"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 9-6 6-6-6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </div>
+      </li>
+      <li
+        class="c11 c3"
+        draggable="true"
       >
-        <button
-          aria-label="1 alpha move up"
-          class="StyledButton-sc-323bzc-0 fVKxFa"
-          disabled=""
-          id="alphaMoveUp"
-          tabindex="-1"
-          type="button"
+        <div
+          class="c4"
         >
-          <svg
-            aria-label="FormUp"
-            class="StyledIcon-sc-ofa7kd-0 jCZnaS"
-            viewBox="0 0 24 24"
+          <span
+            class="c5"
           >
-            <path
-              d="m18 15-6-6-6 6"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-        <button
-          aria-label="1 alpha move down"
-          class="StyledButton-sc-323bzc-0 eYvQIM"
-          id="alphaMoveDown"
-          tabindex="-1"
-          type="button"
+            beta
+          </span>
+        </div>
+        <div
+          class="c6"
+        />
+        <div
+          class="c7"
         >
-          <svg
-            aria-label="FormDown"
-            class="StyledIcon-sc-ofa7kd-0 jCZnaS"
-            viewBox="0 0 24 24"
+          <button
+            aria-label="2 beta move up"
+            class="c12"
+            id="betaMoveUp"
+            tabindex="-1"
+            type="button"
           >
-            <path
-              d="m18 9-6 6-6-6"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-      </div>
-    </li>
-    <li
-      class="StyledBox-sc-13pk1d4-0 jBetvR List__StyledItem-sc-130gdqg-1 bIUWQJ"
-      draggable="true"
-    >
-      <div
-        class="StyledBox-sc-13pk1d4-0 jNsTaV"
-      >
-        <span
-          class="StyledText-sc-1sadyjn-0 cUpCuS"
-        >
-          beta
-        </span>
-      </div>
-      <div
-        class="StyledBox__StyledBoxGap-sc-13pk1d4-1 iGPQzj"
-      />
-      <div
-        class="StyledBox-sc-13pk1d4-0 hKXGyN"
-      >
-        <button
-          aria-label="2 beta move up"
-          class="StyledButton-sc-323bzc-0 hpYwyU"
-          id="betaMoveUp"
-          tabindex="-1"
-          type="button"
-        >
-          <svg
-            aria-label="FormUp"
-            class="StyledIcon-sc-ofa7kd-0 jCZnaS"
-            viewBox="0 0 24 24"
+            <svg
+              aria-label="FormUp"
+              class="c9"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 15-6-6-6 6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+          <button
+            aria-label="2 beta move down"
+            class="c8"
+            disabled=""
+            id="betaMoveDown"
+            tabindex="-1"
+            type="button"
           >
-            <path
-              d="m18 15-6-6-6 6"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-        <button
-          aria-label="2 beta move down"
-          class="StyledButton-sc-323bzc-0 fVKxFa"
-          disabled=""
-          id="betaMoveDown"
-          tabindex="-1"
-          type="button"
-        >
-          <svg
-            aria-label="FormDown"
-            class="StyledIcon-sc-ofa7kd-0 jCZnaS"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="m18 9-6 6-6-6"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-      </div>
-    </li>
-  </ul>
-</div>
+            <svg
+              aria-label="FormDown"
+              class="c9"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 9-6 6-6-6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </div>
+      </li>
+    </ul>
+  </div>
+</DocumentFragment>
 `;
 
 exports[`List onOrder with no-index Keyboard move up 3`] = `
+<DocumentFragment>
+  .c9 {
+  display: inline-block;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: #666666;
+  stroke: #666666;
+}
+
+.c9 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c9 *:not([stroke])[fill='none'] {
+  stroke-width: 0;
+}
+
+.c9 *[stroke*='#'],
+.c9 *[STROKE*='#'] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c9 *[fill-rule],
+.c9 *[FILL-RULE],
+.c9 *[fill*='#'],
+.c9 *[FILL*='#'] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c2 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: center;
+  border-top: solid 1px rgba(0, 0, 0, 0.33);
+  border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  flex: 0 0 auto;
+  padding-left: 24px;
+  padding-right: 24px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+
+.c4 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  flex: 1 1;
+}
+
+.c7 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  justify-content: flex-end;
+}
+
+.c11 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: center;
+  border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  flex: 0 0 auto;
+  padding-left: 24px;
+  padding-right: 24px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+
+.c6 {
+  flex: 0 0 auto;
+  align-self: stretch;
+  width: 24px;
+}
+
+.c5 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c8 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  opacity: 0.3;
+  cursor: default;
+  line-height: 0;
+  padding: 12px;
+}
+
+.c8:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus >circle,
+.c8:focus >ellipse,
+.c8:focus >line,
+.c8:focus >path,
+.c8:focus >polygon,
+.c8:focus >polyline,
+.c8:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c8:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c8:focus:not(:focus-visible) >circle,
+.c8:focus:not(:focus-visible) >ellipse,
+.c8:focus:not(:focus-visible) >line,
+.c8:focus:not(:focus-visible) >path,
+.c8:focus:not(:focus-visible) >polygon,
+.c8:focus:not(:focus-visible) >polyline,
+.c8:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c8:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c10 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  line-height: 0;
+  padding: 12px;
+}
+
+.c10:hover {
+  background-color: rgba(221, 221, 221, 0.4);
+  color: #000000;
+}
+
+.c10:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus >circle,
+.c10:focus >ellipse,
+.c10:focus >line,
+.c10:focus >path,
+.c10:focus >polygon,
+.c10:focus >polyline,
+.c10:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c10:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c10:focus:not(:focus-visible) >circle,
+.c10:focus:not(:focus-visible) >ellipse,
+.c10:focus:not(:focus-visible) >line,
+.c10:focus:not(:focus-visible) >path,
+.c10:focus:not(:focus-visible) >polygon,
+.c10:focus:not(:focus-visible) >polyline,
+.c10:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c10:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c12 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+  background-color: rgba(221, 221, 221, 0.4);
+  color: #000000;
+  line-height: 0;
+  padding: 12px;
+}
+
+.c12:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c12:focus >circle,
+.c12:focus >ellipse,
+.c12:focus >line,
+.c12:focus >path,
+.c12:focus >polygon,
+.c12:focus >polyline,
+.c12:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c12:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c12:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c12:focus:not(:focus-visible) >circle,
+.c12:focus:not(:focus-visible) >ellipse,
+.c12:focus:not(:focus-visible) >line,
+.c12:focus:not(:focus-visible) >path,
+.c12:focus:not(:focus-visible) >polygon,
+.c12:focus:not(:focus-visible) >polyline,
+.c12:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c12:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c1 {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.c3 {
+  cursor: move;
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    border-top: solid 1px rgba(0, 0, 0, 0.33);
+    border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c11 {
+    border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c11 {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c11 {
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c6 {
+    width: 12px;
+  }
+}
+
 <div
-  class="StyledGrommet-sc-19lkkz7-0 cBoJUe"
->
-  <ul
-    aria-activedescendant="betaMoveDown"
-    class="List__StyledList-sc-130gdqg-0 dHNMqI"
-    role="list"
-    tabindex="0"
+    class="c0"
   >
-    <li
-      class="StyledBox-sc-13pk1d4-0 geglev List__StyledItem-sc-130gdqg-1 bIUWQJ"
-      draggable="true"
+    <ul
+      class="c1"
+      role="list"
     >
-      <div
-        class="StyledBox-sc-13pk1d4-0 jNsTaV"
+      <li
+        class="c2 c3"
+        draggable="true"
       >
-        <span
-          class="StyledText-sc-1sadyjn-0 cUpCuS"
+        <div
+          class="c4"
         >
-          beta
-        </span>
-      </div>
-      <div
-        class="StyledBox__StyledBoxGap-sc-13pk1d4-1 iGPQzj"
-      />
-      <div
-        class="StyledBox-sc-13pk1d4-0 hKXGyN"
+          <span
+            class="c5"
+          >
+            beta
+          </span>
+        </div>
+        <div
+          class="c6"
+        />
+        <div
+          class="c7"
+        >
+          <button
+            aria-label="1 beta move up"
+            class="c8"
+            disabled=""
+            id="betaMoveUp"
+            tabindex="-1"
+            type="button"
+          >
+            <svg
+              aria-label="FormUp"
+              class="c9"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 15-6-6-6 6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+          <button
+            aria-label="1 beta move down"
+            class="c10"
+            id="betaMoveDown"
+            tabindex="-1"
+            type="button"
+          >
+            <svg
+              aria-label="FormDown"
+              class="c9"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 9-6 6-6-6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </div>
+      </li>
+      <li
+        class="c11 c3"
+        draggable="true"
       >
-        <button
-          aria-label="1 beta move up"
-          class="StyledButton-sc-323bzc-0 fVKxFa"
-          disabled=""
-          id="betaMoveUp"
-          tabindex="-1"
-          type="button"
+        <div
+          class="c4"
         >
-          <svg
-            aria-label="FormUp"
-            class="StyledIcon-sc-ofa7kd-0 jCZnaS"
-            viewBox="0 0 24 24"
+          <span
+            class="c5"
           >
-            <path
-              d="m18 15-6-6-6 6"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-        <button
-          aria-label="1 beta move down"
-          class="StyledButton-sc-323bzc-0 hpYwyU"
-          id="betaMoveDown"
-          tabindex="-1"
-          type="button"
+            alpha
+          </span>
+        </div>
+        <div
+          class="c6"
+        />
+        <div
+          class="c7"
         >
-          <svg
-            aria-label="FormDown"
-            class="StyledIcon-sc-ofa7kd-0 jCZnaS"
-            viewBox="0 0 24 24"
+          <button
+            aria-label="2 alpha move up"
+            class="c12"
+            id="alphaMoveUp"
+            tabindex="0"
+            type="button"
           >
-            <path
-              d="m18 9-6 6-6-6"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-      </div>
-    </li>
-    <li
-      class="StyledBox-sc-13pk1d4-0 jBetvR List__StyledItem-sc-130gdqg-1 bIUWQJ"
-      draggable="true"
-    >
-      <div
-        class="StyledBox-sc-13pk1d4-0 jNsTaV"
-      >
-        <span
-          class="StyledText-sc-1sadyjn-0 cUpCuS"
-        >
-          alpha
-        </span>
-      </div>
-      <div
-        class="StyledBox__StyledBoxGap-sc-13pk1d4-1 iGPQzj"
-      />
-      <div
-        class="StyledBox-sc-13pk1d4-0 hKXGyN"
-      >
-        <button
-          aria-label="2 alpha move up"
-          class="StyledButton-sc-323bzc-0 eYvQIM"
-          id="alphaMoveUp"
-          tabindex="-1"
-          type="button"
-        >
-          <svg
-            aria-label="FormUp"
-            class="StyledIcon-sc-ofa7kd-0 jCZnaS"
-            viewBox="0 0 24 24"
+            <svg
+              aria-label="FormUp"
+              class="c9"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 15-6-6-6 6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+          <button
+            aria-label="2 alpha move down"
+            class="c8"
+            disabled=""
+            id="alphaMoveDown"
+            tabindex="-1"
+            type="button"
           >
-            <path
-              d="m18 15-6-6-6 6"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-        <button
-          aria-label="2 alpha move down"
-          class="StyledButton-sc-323bzc-0 fVKxFa"
-          disabled=""
-          id="alphaMoveDown"
-          tabindex="-1"
-          type="button"
-        >
-          <svg
-            aria-label="FormDown"
-            class="StyledIcon-sc-ofa7kd-0 jCZnaS"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="m18 9-6 6-6-6"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-      </div>
-    </li>
-  </ul>
-</div>
+            <svg
+              aria-label="FormDown"
+              class="c9"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m18 9-6 6-6-6"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </div>
+      </li>
+    </ul>
+  </div>
+</DocumentFragment>
 `;
 
 exports[`List onOrder with no-index Mouse move down 1`] = `
@@ -17994,6 +21049,26 @@ exports[`List onOrder with no-index Mouse move down 1`] = `
   padding: 12px;
 }
 
+.c8:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus >circle,
+.c8:focus >ellipse,
+.c8:focus >line,
+.c8:focus >path,
+.c8:focus >polygon,
+.c8:focus >polyline,
+.c8:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus ::-moz-focus-inner {
+  border: 0;
+}
+
 .c8:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -18038,6 +21113,26 @@ exports[`List onOrder with no-index Mouse move down 1`] = `
   color: #000000;
 }
 
+.c10:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus >circle,
+.c10:focus >ellipse,
+.c10:focus >line,
+.c10:focus >path,
+.c10:focus >polygon,
+.c10:focus >polyline,
+.c10:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus ::-moz-focus-inner {
+  border: 0;
+}
+
 .c10:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -18064,16 +21159,8 @@ exports[`List onOrder with no-index Mouse move down 1`] = `
   padding: 0;
 }
 
-.c1:focus {
-  outline: 2px solid #6FFFB0;
-}
-
 .c3 {
   cursor: move;
-}
-
-.c3:focus {
-  outline: none;
 }
 
 @media only screen and (max-width: 768px) {
@@ -18129,7 +21216,6 @@ exports[`List onOrder with no-index Mouse move down 1`] = `
   <ul
     class="c1"
     role="list"
-    tabindex="0"
   >
     <li
       class="c2 c3"
@@ -18175,7 +21261,7 @@ exports[`List onOrder with no-index Mouse move down 1`] = `
           aria-label="1 alpha move down"
           class="c10"
           id="alphaMoveDown"
-          tabindex="-1"
+          tabindex="0"
           type="button"
         >
           <svg
@@ -18264,12 +21350,11 @@ exports[`List onOrder with no-index Mouse move down 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 cBoJUe"
 >
   <ul
-    class="List__StyledList-sc-130gdqg-0 dHNMqI"
+    class="List__StyledList-sc-130gdqg-0 gjWLKL"
     role="list"
-    tabindex="0"
   >
     <li
-      class="StyledBox-sc-13pk1d4-0 geglev List__StyledItem-sc-130gdqg-1 bIUWQJ"
+      class="StyledBox-sc-13pk1d4-0 geglev List__StyledItem-sc-130gdqg-1 bvxxXX"
       draggable="true"
     >
       <div
@@ -18289,7 +21374,7 @@ exports[`List onOrder with no-index Mouse move down 2`] = `
       >
         <button
           aria-label="1 beta move up"
-          class="StyledButton-sc-323bzc-0 fVKxFa"
+          class="StyledButton-sc-323bzc-0 ciYqzT"
           disabled=""
           id="betaMoveUp"
           tabindex="-1"
@@ -18310,7 +21395,7 @@ exports[`List onOrder with no-index Mouse move down 2`] = `
         </button>
         <button
           aria-label="1 beta move down"
-          class="StyledButton-sc-323bzc-0 eYvQIM"
+          class="StyledButton-sc-323bzc-0 hzRFzp"
           id="betaMoveDown"
           tabindex="-1"
           type="button"
@@ -18331,7 +21416,7 @@ exports[`List onOrder with no-index Mouse move down 2`] = `
       </div>
     </li>
     <li
-      class="StyledBox-sc-13pk1d4-0 jBetvR List__StyledItem-sc-130gdqg-1 bIUWQJ"
+      class="StyledBox-sc-13pk1d4-0 jBetvR List__StyledItem-sc-130gdqg-1 bvxxXX"
       draggable="true"
     >
       <div
@@ -18351,7 +21436,7 @@ exports[`List onOrder with no-index Mouse move down 2`] = `
       >
         <button
           aria-label="2 alpha move up"
-          class="StyledButton-sc-323bzc-0 eYvQIM"
+          class="StyledButton-sc-323bzc-0 hzRFzp"
           id="alphaMoveUp"
           tabindex="-1"
           type="button"
@@ -18371,7 +21456,7 @@ exports[`List onOrder with no-index Mouse move down 2`] = `
         </button>
         <button
           aria-label="2 alpha move down"
-          class="StyledButton-sc-323bzc-0 fVKxFa"
+          class="StyledButton-sc-323bzc-0 ciYqzT"
           disabled=""
           id="alphaMoveDown"
           tabindex="-1"
@@ -18421,7 +21506,7 @@ exports[`List pad object 1`] = `
   padding-right: 48px;
 }
 
-.c4 {
+.c3 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -18440,10 +21525,6 @@ exports[`List pad object 1`] = `
   padding: 0;
 }
 
-.c3:focus {
-  outline: none;
-}
-
 @media only screen and (max-width: 768px) {
   .c2 {
     border-top: solid 1px rgba(0, 0, 0, 0.33);
@@ -18459,13 +21540,13 @@ exports[`List pad object 1`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c4 {
+  .c3 {
     border-bottom: solid 1px rgba(0, 0, 0, 0.33);
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c4 {
+  .c3 {
     padding-left: 24px;
     padding-right: 24px;
   }
@@ -18479,12 +21560,12 @@ exports[`List pad object 1`] = `
     role="list"
   >
     <li
-      class="c2 c3"
+      class="c2 "
     >
       one
     </li>
     <li
-      class="c4 c3"
+      class="c3 "
     >
       two
     </li>
@@ -18516,7 +21597,7 @@ exports[`List pad string 1`] = `
   padding: 48px;
 }
 
-.c4 {
+.c3 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -18534,10 +21615,6 @@ exports[`List pad string 1`] = `
   padding: 0;
 }
 
-.c3:focus {
-  outline: none;
-}
-
 @media only screen and (max-width: 768px) {
   .c2 {
     border-top: solid 1px rgba(0, 0, 0, 0.33);
@@ -18552,13 +21629,13 @@ exports[`List pad string 1`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c4 {
+  .c3 {
     border-bottom: solid 1px rgba(0, 0, 0, 0.33);
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c4 {
+  .c3 {
     padding: 24px;
   }
 }
@@ -18571,12 +21648,12 @@ exports[`List pad string 1`] = `
     role="list"
   >
     <li
-      class="c2 c3"
+      class="c2 "
     >
       one
     </li>
     <li
-      class="c4 c3"
+      class="c3 "
     >
       two
     </li>
@@ -18684,7 +21761,7 @@ exports[`List pinned Pinned items should not be allowed to be re-ordered 1`] = `
   padding-bottom: 12px;
 }
 
-.c13 {
+.c12 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -18696,7 +21773,7 @@ exports[`List pinned Pinned items should not be allowed to be re-ordered 1`] = `
   padding: 12px;
 }
 
-.c14 {
+.c13 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -18744,6 +21821,26 @@ exports[`List pinned Pinned items should not be allowed to be re-ordered 1`] = `
   padding: 12px;
 }
 
+.c8:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus >circle,
+.c8:focus >ellipse,
+.c8:focus >line,
+.c8:focus >path,
+.c8:focus >polygon,
+.c8:focus >polyline,
+.c8:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus ::-moz-focus-inner {
+  border: 0;
+}
+
 .c8:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -18788,6 +21885,26 @@ exports[`List pinned Pinned items should not be allowed to be re-ordered 1`] = `
   color: #000000;
 }
 
+.c10:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus >circle,
+.c10:focus >ellipse,
+.c10:focus >line,
+.c10:focus >path,
+.c10:focus >polygon,
+.c10:focus >polyline,
+.c10:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus ::-moz-focus-inner {
+  border: 0;
+}
+
 .c10:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -18814,20 +21931,8 @@ exports[`List pinned Pinned items should not be allowed to be re-ordered 1`] = `
   padding: 0;
 }
 
-.c1:focus {
-  outline: 2px solid #6FFFB0;
-}
-
 .c3 {
   cursor: move;
-}
-
-.c3:focus {
-  outline: none;
-}
-
-.c12:focus {
-  outline: none;
 }
 
 @media only screen and (max-width: 768px) {
@@ -18872,26 +21977,26 @@ exports[`List pinned Pinned items should not be allowed to be re-ordered 1`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c13 {
+  .c12 {
     padding: 6px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c14 {
+  .c13 {
     border-bottom: solid 1px rgba(0, 0, 0, 0.33);
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c14 {
+  .c13 {
     padding-left: 12px;
     padding-right: 12px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c14 {
+  .c13 {
     padding-top: 6px;
     padding-bottom: 6px;
   }
@@ -18909,7 +22014,6 @@ exports[`List pinned Pinned items should not be allowed to be re-ordered 1`] = `
     <ul
       class="c1"
       role="list"
-      tabindex="0"
     >
       <li
         class="c2 c3"
@@ -18959,7 +22063,7 @@ exports[`List pinned Pinned items should not be allowed to be re-ordered 1`] = `
             aria-label="1 Boise move down"
             class="c10"
             id="BoiseMoveDown"
-            tabindex="-1"
+            tabindex="0"
             type="button"
           >
             <svg
@@ -18978,7 +22082,7 @@ exports[`List pinned Pinned items should not be allowed to be re-ordered 1`] = `
         </div>
       </li>
       <li
-        class="c11 c12"
+        class="c11 "
       >
         <span
           class="c4"
@@ -18997,7 +22101,7 @@ exports[`List pinned Pinned items should not be allowed to be re-ordered 1`] = `
           class="c5"
         />
         <div
-          class="c13"
+          class="c12"
         >
           <svg
             aria-label="Item pinned, order cannot be changed."
@@ -19014,7 +22118,7 @@ exports[`List pinned Pinned items should not be allowed to be re-ordered 1`] = `
         </div>
       </li>
       <li
-        class="c14 c3"
+        class="c13 c3"
         draggable="true"
       >
         <span
@@ -19079,7 +22183,7 @@ exports[`List pinned Pinned items should not be allowed to be re-ordered 1`] = `
         </div>
       </li>
       <li
-        class="c11 c12"
+        class="c11 "
       >
         <span
           class="c4"
@@ -19098,7 +22202,7 @@ exports[`List pinned Pinned items should not be allowed to be re-ordered 1`] = `
           class="c5"
         />
         <div
-          class="c13"
+          class="c12"
         >
           <svg
             aria-label="Item pinned, order cannot be changed."
@@ -19115,7 +22219,7 @@ exports[`List pinned Pinned items should not be allowed to be re-ordered 1`] = `
         </div>
       </li>
       <li
-        class="c14 c3"
+        class="c13 c3"
         draggable="true"
       >
         <span
@@ -19285,7 +22389,7 @@ exports[`List pinned Pinned items should not be allowed to be re-ordered 2`] = `
   padding-bottom: 12px;
 }
 
-.c13 {
+.c12 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -19297,7 +22401,7 @@ exports[`List pinned Pinned items should not be allowed to be re-ordered 2`] = `
   padding: 12px;
 }
 
-.c14 {
+.c13 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -19345,6 +22449,26 @@ exports[`List pinned Pinned items should not be allowed to be re-ordered 2`] = `
   padding: 12px;
 }
 
+.c8:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus >circle,
+.c8:focus >ellipse,
+.c8:focus >line,
+.c8:focus >path,
+.c8:focus >polygon,
+.c8:focus >polyline,
+.c8:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus ::-moz-focus-inner {
+  border: 0;
+}
+
 .c8:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -19389,6 +22513,26 @@ exports[`List pinned Pinned items should not be allowed to be re-ordered 2`] = `
   color: #000000;
 }
 
+.c10:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus >circle,
+.c10:focus >ellipse,
+.c10:focus >line,
+.c10:focus >path,
+.c10:focus >polygon,
+.c10:focus >polyline,
+.c10:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus ::-moz-focus-inner {
+  border: 0;
+}
+
 .c10:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -19409,7 +22553,7 @@ exports[`List pinned Pinned items should not be allowed to be re-ordered 2`] = `
   border: 0;
 }
 
-.c16 {
+.c14 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -19430,67 +22574,43 @@ exports[`List pinned Pinned items should not be allowed to be re-ordered 2`] = `
   padding: 12px;
 }
 
-.c16:hover {
-  background-color: rgba(221, 221, 221, 0.4);
-  color: #000000;
-}
-
-.c16:focus:not(:focus-visible) {
+.c14:focus {
   outline: none;
-  box-shadow: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c16:focus:not(:focus-visible) >circle,
-.c16:focus:not(:focus-visible) >ellipse,
-.c16:focus:not(:focus-visible) >line,
-.c16:focus:not(:focus-visible) >path,
-.c16:focus:not(:focus-visible) >polygon,
-.c16:focus:not(:focus-visible) >polyline,
-.c16:focus:not(:focus-visible) >rect {
+.c14:focus >circle,
+.c14:focus >ellipse,
+.c14:focus >line,
+.c14:focus >path,
+.c14:focus >polygon,
+.c14:focus >polyline,
+.c14:focus >rect {
   outline: none;
-  box-shadow: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c16:focus:not(:focus-visible) ::-moz-focus-inner {
+.c14:focus ::-moz-focus-inner {
   border: 0;
 }
 
-.c15 {
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-  font: inherit;
-  text-decoration: none;
-  margin: 0;
-  background: transparent;
-  overflow: visible;
-  text-transform: none;
-  color: inherit;
-  outline: none;
-  border: none;
-  padding: 0;
-  text-align: inherit;
-  line-height: 0;
-  padding: 12px;
-}
-
-.c15:focus:not(:focus-visible) {
+.c14:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c15:focus:not(:focus-visible) >circle,
-.c15:focus:not(:focus-visible) >ellipse,
-.c15:focus:not(:focus-visible) >line,
-.c15:focus:not(:focus-visible) >path,
-.c15:focus:not(:focus-visible) >polygon,
-.c15:focus:not(:focus-visible) >polyline,
-.c15:focus:not(:focus-visible) >rect {
+.c14:focus:not(:focus-visible) >circle,
+.c14:focus:not(:focus-visible) >ellipse,
+.c14:focus:not(:focus-visible) >line,
+.c14:focus:not(:focus-visible) >path,
+.c14:focus:not(:focus-visible) >polygon,
+.c14:focus:not(:focus-visible) >polyline,
+.c14:focus:not(:focus-visible) >rect {
   outline: none;
   box-shadow: none;
 }
 
-.c15:focus:not(:focus-visible) ::-moz-focus-inner {
+.c14:focus:not(:focus-visible) ::-moz-focus-inner {
   border: 0;
 }
 
@@ -19500,20 +22620,8 @@ exports[`List pinned Pinned items should not be allowed to be re-ordered 2`] = `
   padding: 0;
 }
 
-.c1:focus {
-  outline: 2px solid #6FFFB0;
-}
-
 .c3 {
   cursor: move;
-}
-
-.c3:focus {
-  outline: none;
-}
-
-.c12:focus {
-  outline: none;
 }
 
 @media only screen and (max-width: 768px) {
@@ -19558,26 +22666,26 @@ exports[`List pinned Pinned items should not be allowed to be re-ordered 2`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c13 {
+  .c12 {
     padding: 6px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c14 {
+  .c13 {
     border-bottom: solid 1px rgba(0, 0, 0, 0.33);
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c14 {
+  .c13 {
     padding-left: 12px;
     padding-right: 12px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c14 {
+  .c13 {
     padding-top: 6px;
     padding-bottom: 6px;
   }
@@ -19593,10 +22701,8 @@ exports[`List pinned Pinned items should not be allowed to be re-ordered 2`] = `
     class="c0"
   >
     <ul
-      aria-activedescendant="Los GatosMoveUp"
       class="c1"
       role="list"
-      tabindex="0"
     >
       <li
         class="c2 c3"
@@ -19665,7 +22771,7 @@ exports[`List pinned Pinned items should not be allowed to be re-ordered 2`] = `
         </div>
       </li>
       <li
-        class="c11 c12"
+        class="c11 "
       >
         <span
           class="c4"
@@ -19684,7 +22790,7 @@ exports[`List pinned Pinned items should not be allowed to be re-ordered 2`] = `
           class="c5"
         />
         <div
-          class="c13"
+          class="c12"
         >
           <svg
             aria-label="Item pinned, order cannot be changed."
@@ -19701,7 +22807,7 @@ exports[`List pinned Pinned items should not be allowed to be re-ordered 2`] = `
         </div>
       </li>
       <li
-        class="c14 c3"
+        class="c13 c3"
         draggable="true"
       >
         <span
@@ -19725,7 +22831,7 @@ exports[`List pinned Pinned items should not be allowed to be re-ordered 2`] = `
         >
           <button
             aria-label="2 San Francisco move up"
-            class="c15"
+            class="c10"
             id="San FranciscoMoveUp"
             tabindex="-1"
             type="button"
@@ -19766,7 +22872,7 @@ exports[`List pinned Pinned items should not be allowed to be re-ordered 2`] = `
         </div>
       </li>
       <li
-        class="c11 c12"
+        class="c11 "
       >
         <span
           class="c4"
@@ -19785,7 +22891,7 @@ exports[`List pinned Pinned items should not be allowed to be re-ordered 2`] = `
           class="c5"
         />
         <div
-          class="c13"
+          class="c12"
         >
           <svg
             aria-label="Item pinned, order cannot be changed."
@@ -19802,7 +22908,7 @@ exports[`List pinned Pinned items should not be allowed to be re-ordered 2`] = `
         </div>
       </li>
       <li
-        class="c14 c3"
+        class="c13 c3"
         draggable="true"
       >
         <span
@@ -19826,9 +22932,9 @@ exports[`List pinned Pinned items should not be allowed to be re-ordered 2`] = `
         >
           <button
             aria-label="3 Los Gatos move up"
-            class="c16"
+            class="c14"
             id="Los GatosMoveUp"
-            tabindex="-1"
+            tabindex="0"
             type="button"
           >
             <svg
@@ -19874,7 +22980,7 @@ exports[`List pinned Pinned items should not be allowed to be re-ordered 2`] = `
 
 exports[`List pinned Should apply pinned styling to items 1`] = `
 <DocumentFragment>
-  .c8 {
+  .c7 {
   display: inline-block;
   flex: 0 0 auto;
   width: 24px;
@@ -19883,25 +22989,25 @@ exports[`List pinned Should apply pinned styling to items 1`] = `
   stroke: #666666;
 }
 
-.c8 g {
+.c7 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c8 *:not([stroke])[fill='none'] {
+.c7 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c8 *[stroke*='#'],
-.c8 *[STROKE*='#'] {
+.c7 *[stroke*='#'],
+.c7 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c8 *[fill-rule],
-.c8 *[FILL-RULE],
-.c8 *[fill*='#'],
-.c8 *[FILL*='#'] {
+.c7 *[fill-rule],
+.c7 *[FILL-RULE],
+.c7 *[fill*='#'],
+.c7 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -19932,7 +23038,7 @@ exports[`List pinned Should apply pinned styling to items 1`] = `
   padding-bottom: 12px;
 }
 
-.c4 {
+.c3 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -19950,7 +23056,7 @@ exports[`List pinned Should apply pinned styling to items 1`] = `
   padding-bottom: 12px;
 }
 
-.c5 {
+.c4 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -19960,7 +23066,7 @@ exports[`List pinned Should apply pinned styling to items 1`] = `
   flex: 1 1;
 }
 
-.c7 {
+.c6 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -19972,7 +23078,7 @@ exports[`List pinned Should apply pinned styling to items 1`] = `
   padding: 12px;
 }
 
-.c9 {
+.c8 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -19987,7 +23093,7 @@ exports[`List pinned Should apply pinned styling to items 1`] = `
   padding-bottom: 12px;
 }
 
-.c6 {
+.c5 {
   flex: 0 0 auto;
   align-self: stretch;
   width: 24px;
@@ -19997,10 +23103,6 @@ exports[`List pinned Should apply pinned styling to items 1`] = `
   list-style: none;
   margin: 0;
   padding: 0;
-}
-
-.c3:focus {
-  outline: none;
 }
 
 @media only screen and (max-width: 768px) {
@@ -20025,46 +23127,20 @@ exports[`List pinned Should apply pinned styling to items 1`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c4 {
+  .c3 {
     border-bottom: solid 1px rgba(0, 0, 0, 0.33);
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c4 {
+  .c3 {
     padding-left: 12px;
     padding-right: 12px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c4 {
-    padding-top: 6px;
-    padding-bottom: 6px;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c7 {
-    padding: 6px;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c9 {
-    border-bottom: solid 1px rgba(0, 0, 0, 0.33);
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c9 {
-    padding-left: 12px;
-    padding-right: 12px;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c9 {
+  .c3 {
     padding-top: 6px;
     padding-bottom: 6px;
   }
@@ -20072,6 +23148,32 @@ exports[`List pinned Should apply pinned styling to items 1`] = `
 
 @media only screen and (max-width: 768px) {
   .c6 {
+    padding: 6px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c8 {
+    border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c8 {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c8 {
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c5 {
     width: 12px;
   }
 }
@@ -20084,27 +23186,27 @@ exports[`List pinned Should apply pinned styling to items 1`] = `
       role="list"
     >
       <li
-        class="c2 c3"
+        class="c2 "
       >
         Boise
       </li>
       <li
-        class="c4 c3"
+        class="c3 "
       >
         <div
-          class="c5"
+          class="c4"
         >
           Fort Collins
         </div>
         <div
-          class="c6"
+          class="c5"
         />
         <div
-          class="c7"
+          class="c6"
         >
           <svg
             aria-label="Item pinned, order cannot be changed."
-            class="c8"
+            class="c7"
             viewBox="0 0 24 24"
           >
             <path
@@ -20117,27 +23219,27 @@ exports[`List pinned Should apply pinned styling to items 1`] = `
         </div>
       </li>
       <li
-        class="c9 c3"
+        class="c8 "
       >
         Los Gatos
       </li>
       <li
-        class="c4 c3"
+        class="c3 "
       >
         <div
-          class="c5"
+          class="c4"
         >
           Palo Alto
         </div>
         <div
-          class="c6"
+          class="c5"
         />
         <div
-          class="c7"
+          class="c6"
         >
           <svg
             aria-label="Item pinned, order cannot be changed."
-            class="c8"
+            class="c7"
             viewBox="0 0 24 24"
           >
             <path
@@ -20150,7 +23252,7 @@ exports[`List pinned Should apply pinned styling to items 1`] = `
         </div>
       </li>
       <li
-        class="c9 c3"
+        class="c8 "
       >
         San Francisco
       </li>
@@ -20161,7 +23263,7 @@ exports[`List pinned Should apply pinned styling to items 1`] = `
 
 exports[`List pinned Should apply pinned styling to items when data are children 1`] = `
 <DocumentFragment>
-  .c10 {
+  .c9 {
   display: inline-block;
   flex: 0 0 auto;
   width: 24px;
@@ -20170,25 +23272,25 @@ exports[`List pinned Should apply pinned styling to items when data are children
   stroke: #666666;
 }
 
-.c10 g {
+.c9 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c10 *:not([stroke])[fill='none'] {
+.c9 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c10 *[stroke*='#'],
-.c10 *[STROKE*='#'] {
+.c9 *[stroke*='#'],
+.c9 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c10 *[fill-rule],
-.c10 *[FILL-RULE],
-.c10 *[fill*='#'],
-.c10 *[FILL*='#'] {
+.c9 *[fill-rule],
+.c9 *[FILL-RULE],
+.c9 *[fill*='#'],
+.c9 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -20219,7 +23321,7 @@ exports[`List pinned Should apply pinned styling to items when data are children
   padding-bottom: 12px;
 }
 
-.c4 {
+.c3 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -20228,7 +23330,7 @@ exports[`List pinned Should apply pinned styling to items when data are children
   flex-direction: column;
 }
 
-.c6 {
+.c5 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -20246,7 +23348,7 @@ exports[`List pinned Should apply pinned styling to items when data are children
   padding-bottom: 12px;
 }
 
-.c7 {
+.c6 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -20256,7 +23358,7 @@ exports[`List pinned Should apply pinned styling to items when data are children
   flex: 1 1;
 }
 
-.c9 {
+.c8 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -20268,7 +23370,7 @@ exports[`List pinned Should apply pinned styling to items when data are children
   padding: 12px;
 }
 
-.c11 {
+.c10 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -20283,13 +23385,13 @@ exports[`List pinned Should apply pinned styling to items when data are children
   padding-bottom: 12px;
 }
 
-.c8 {
+.c7 {
   flex: 0 0 auto;
   align-self: stretch;
   width: 24px;
 }
 
-.c5 {
+.c4 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
@@ -20301,10 +23403,6 @@ exports[`List pinned Should apply pinned styling to items when data are children
   padding: 0;
 }
 
-.c3:focus {
-  outline: none;
-}
-
 @media only screen and (max-width: 768px) {
   .c2 {
     border-top: solid 1px rgba(0, 0, 0, 0.33);
@@ -20327,46 +23425,20 @@ exports[`List pinned Should apply pinned styling to items when data are children
 }
 
 @media only screen and (max-width: 768px) {
-  .c6 {
+  .c5 {
     border-bottom: solid 1px rgba(0, 0, 0, 0.33);
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c6 {
+  .c5 {
     padding-left: 12px;
     padding-right: 12px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c6 {
-    padding-top: 6px;
-    padding-bottom: 6px;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c9 {
-    padding: 6px;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c11 {
-    border-bottom: solid 1px rgba(0, 0, 0, 0.33);
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c11 {
-    padding-left: 12px;
-    padding-right: 12px;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c11 {
+  .c5 {
     padding-top: 6px;
     padding-bottom: 6px;
   }
@@ -20374,6 +23446,32 @@ exports[`List pinned Should apply pinned styling to items when data are children
 
 @media only screen and (max-width: 768px) {
   .c8 {
+    padding: 6px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c10 {
+    border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c10 {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c10 {
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c7 {
     width: 12px;
   }
 }
@@ -20386,43 +23484,43 @@ exports[`List pinned Should apply pinned styling to items when data are children
       role="list"
     >
       <li
-        class="c2 c3"
+        class="c2 "
       >
         <div
-          class="c4"
+          class="c3"
         >
           <span
-            class="c5"
+            class="c4"
           >
             Boise
           </span>
         </div>
       </li>
       <li
-        class="c6 c3"
+        class="c5 "
       >
         <div
-          class="c7"
+          class="c6"
         >
           <div
-            class="c4"
+            class="c3"
           >
             <span
-              class="c5"
+              class="c4"
             >
               Fort Collins
             </span>
           </div>
         </div>
         <div
-          class="c8"
+          class="c7"
         />
         <div
-          class="c9"
+          class="c8"
         >
           <svg
             aria-label="Item pinned, order cannot be changed."
-            class="c10"
+            class="c9"
             viewBox="0 0 24 24"
           >
             <path
@@ -20435,43 +23533,43 @@ exports[`List pinned Should apply pinned styling to items when data are children
         </div>
       </li>
       <li
-        class="c11 c3"
+        class="c10 "
       >
         <div
-          class="c4"
+          class="c3"
         >
           <span
-            class="c5"
+            class="c4"
           >
             Los Gatos
           </span>
         </div>
       </li>
       <li
-        class="c6 c3"
+        class="c5 "
       >
         <div
-          class="c7"
+          class="c6"
         >
           <div
-            class="c4"
+            class="c3"
           >
             <span
-              class="c5"
+              class="c4"
             >
               Palo Alto
             </span>
           </div>
         </div>
         <div
-          class="c8"
+          class="c7"
         />
         <div
-          class="c9"
+          class="c8"
         >
           <svg
             aria-label="Item pinned, order cannot be changed."
-            class="c10"
+            class="c9"
             viewBox="0 0 24 24"
           >
             <path
@@ -20484,13 +23582,13 @@ exports[`List pinned Should apply pinned styling to items when data are children
         </div>
       </li>
       <li
-        class="c11 c3"
+        class="c10 "
       >
         <div
-          class="c4"
+          class="c3"
         >
           <span
-            class="c5"
+            class="c4"
           >
             San Francisco
           </span>
@@ -20503,7 +23601,7 @@ exports[`List pinned Should apply pinned styling to items when data are children
 
 exports[`List pinned Should apply pinned styling to items when data are objects 1`] = `
 <DocumentFragment>
-  .c8 {
+  .c7 {
   display: inline-block;
   flex: 0 0 auto;
   width: 24px;
@@ -20512,25 +23610,25 @@ exports[`List pinned Should apply pinned styling to items when data are objects 
   stroke: #666666;
 }
 
-.c8 g {
+.c7 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c8 *:not([stroke])[fill='none'] {
+.c7 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c8 *[stroke*='#'],
-.c8 *[STROKE*='#'] {
+.c7 *[stroke*='#'],
+.c7 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c8 *[fill-rule],
-.c8 *[FILL-RULE],
-.c8 *[fill*='#'],
-.c8 *[FILL*='#'] {
+.c7 *[fill-rule],
+.c7 *[FILL-RULE],
+.c7 *[fill*='#'],
+.c7 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -20561,7 +23659,7 @@ exports[`List pinned Should apply pinned styling to items when data are objects 
   padding-bottom: 12px;
 }
 
-.c4 {
+.c3 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -20579,7 +23677,7 @@ exports[`List pinned Should apply pinned styling to items when data are objects 
   padding-bottom: 12px;
 }
 
-.c5 {
+.c4 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -20589,7 +23687,7 @@ exports[`List pinned Should apply pinned styling to items when data are objects 
   flex: 1 1;
 }
 
-.c7 {
+.c6 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -20601,7 +23699,7 @@ exports[`List pinned Should apply pinned styling to items when data are objects 
   padding: 12px;
 }
 
-.c9 {
+.c8 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -20616,7 +23714,7 @@ exports[`List pinned Should apply pinned styling to items when data are objects 
   padding-bottom: 12px;
 }
 
-.c6 {
+.c5 {
   flex: 0 0 auto;
   align-self: stretch;
   width: 24px;
@@ -20626,10 +23724,6 @@ exports[`List pinned Should apply pinned styling to items when data are objects 
   list-style: none;
   margin: 0;
   padding: 0;
-}
-
-.c3:focus {
-  outline: none;
 }
 
 @media only screen and (max-width: 768px) {
@@ -20654,46 +23748,20 @@ exports[`List pinned Should apply pinned styling to items when data are objects 
 }
 
 @media only screen and (max-width: 768px) {
-  .c4 {
+  .c3 {
     border-bottom: solid 1px rgba(0, 0, 0, 0.33);
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c4 {
+  .c3 {
     padding-left: 12px;
     padding-right: 12px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c4 {
-    padding-top: 6px;
-    padding-bottom: 6px;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c7 {
-    padding: 6px;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c9 {
-    border-bottom: solid 1px rgba(0, 0, 0, 0.33);
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c9 {
-    padding-left: 12px;
-    padding-right: 12px;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c9 {
+  .c3 {
     padding-top: 6px;
     padding-bottom: 6px;
   }
@@ -20701,6 +23769,32 @@ exports[`List pinned Should apply pinned styling to items when data are objects 
 
 @media only screen and (max-width: 768px) {
   .c6 {
+    padding: 6px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c8 {
+    border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c8 {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c8 {
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c5 {
     width: 12px;
   }
 }
@@ -20713,27 +23807,27 @@ exports[`List pinned Should apply pinned styling to items when data are objects 
       role="list"
     >
       <li
-        class="c2 c3"
+        class="c2 "
       >
         Boise
       </li>
       <li
-        class="c4 c3"
+        class="c3 "
       >
         <div
-          class="c5"
+          class="c4"
         >
           Fort Collins
         </div>
         <div
-          class="c6"
+          class="c5"
         />
         <div
-          class="c7"
+          class="c6"
         >
           <svg
             aria-label="Item pinned, order cannot be changed."
-            class="c8"
+            class="c7"
             viewBox="0 0 24 24"
           >
             <path
@@ -20746,27 +23840,27 @@ exports[`List pinned Should apply pinned styling to items when data are objects 
         </div>
       </li>
       <li
-        class="c9 c3"
+        class="c8 "
       >
         Los Gatos
       </li>
       <li
-        class="c4 c3"
+        class="c3 "
       >
         <div
-          class="c5"
+          class="c4"
         >
           Palo Alto
         </div>
         <div
-          class="c6"
+          class="c5"
         />
         <div
-          class="c7"
+          class="c6"
         >
           <svg
             aria-label="Item pinned, order cannot be changed."
-            class="c8"
+            class="c7"
             viewBox="0 0 24 24"
           >
             <path
@@ -20779,7 +23873,7 @@ exports[`List pinned Should apply pinned styling to items when data are objects 
         </div>
       </li>
       <li
-        class="c9 c3"
+        class="c8 "
       >
         San Francisco
       </li>
@@ -20822,7 +23916,7 @@ exports[`List pinned should apply pinned object styling to items when data are o
   stroke: none;
 }
 
-.c15 {
+.c14 {
   display: inline-block;
   flex: 0 0 auto;
   width: 24px;
@@ -20831,25 +23925,25 @@ exports[`List pinned should apply pinned object styling to items when data are o
   stroke: blue;
 }
 
-.c15 g {
+.c14 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c15 *:not([stroke])[fill='none'] {
+.c14 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c15 *[stroke*='#'],
-.c15 *[STROKE*='#'] {
+.c14 *[stroke*='#'],
+.c14 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c15 *[fill-rule],
-.c15 *[FILL-RULE],
-.c15 *[fill*='#'],
-.c15 *[FILL*='#'] {
+.c14 *[fill-rule],
+.c14 *[FILL-RULE],
+.c14 *[fill*='#'],
+.c14 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -20919,7 +24013,7 @@ exports[`List pinned should apply pinned object styling to items when data are o
   padding-bottom: 12px;
 }
 
-.c14 {
+.c13 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -20931,7 +24025,7 @@ exports[`List pinned should apply pinned object styling to items when data are o
   padding: 12px;
 }
 
-.c16 {
+.c15 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -20958,7 +24052,7 @@ exports[`List pinned should apply pinned object styling to items when data are o
   line-height: 24px;
 }
 
-.c13 {
+.c12 {
   font-size: 18px;
   line-height: 24px;
   color: blue;
@@ -20983,6 +24077,26 @@ exports[`List pinned should apply pinned object styling to items when data are o
   cursor: default;
   line-height: 0;
   padding: 12px;
+}
+
+.c8:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus >circle,
+.c8:focus >ellipse,
+.c8:focus >line,
+.c8:focus >path,
+.c8:focus >polygon,
+.c8:focus >polyline,
+.c8:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus ::-moz-focus-inner {
+  border: 0;
 }
 
 .c8:focus:not(:focus-visible) {
@@ -21029,6 +24143,26 @@ exports[`List pinned should apply pinned object styling to items when data are o
   color: #000000;
 }
 
+.c10:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus >circle,
+.c10:focus >ellipse,
+.c10:focus >line,
+.c10:focus >path,
+.c10:focus >polygon,
+.c10:focus >polyline,
+.c10:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus ::-moz-focus-inner {
+  border: 0;
+}
+
 .c10:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -21055,20 +24189,8 @@ exports[`List pinned should apply pinned object styling to items when data are o
   padding: 0;
 }
 
-.c1:focus {
-  outline: 2px solid #6FFFB0;
-}
-
 .c3 {
   cursor: move;
-}
-
-.c3:focus {
-  outline: none;
-}
-
-.c12:focus {
-  outline: none;
 }
 
 @media only screen and (max-width: 768px) {
@@ -21113,26 +24235,26 @@ exports[`List pinned should apply pinned object styling to items when data are o
 }
 
 @media only screen and (max-width: 768px) {
-  .c14 {
+  .c13 {
     padding: 6px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c16 {
+  .c15 {
     border-bottom: solid 1px rgba(0, 0, 0, 0.33);
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c16 {
+  .c15 {
     padding-left: 12px;
     padding-right: 12px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c16 {
+  .c15 {
     padding-top: 6px;
     padding-bottom: 6px;
   }
@@ -21150,7 +24272,6 @@ exports[`List pinned should apply pinned object styling to items when data are o
     <ul
       class="c1"
       role="list"
-      tabindex="0"
     >
       <li
         class="c2 c3"
@@ -21200,7 +24321,7 @@ exports[`List pinned should apply pinned object styling to items when data are o
             aria-label="1 Boise move down"
             class="c10"
             id="BoiseMoveDown"
-            tabindex="-1"
+            tabindex="0"
             type="button"
           >
             <svg
@@ -21219,10 +24340,10 @@ exports[`List pinned should apply pinned object styling to items when data are o
         </div>
       </li>
       <li
-        class="c11 c12"
+        class="c11 "
       >
         <span
-          class="c13"
+          class="c12"
         >
           2
         </span>
@@ -21233,7 +24354,7 @@ exports[`List pinned should apply pinned object styling to items when data are o
           class="c6"
         >
           <span
-            class="c13"
+            class="c12"
           >
             Fort Collins
           </span>
@@ -21242,11 +24363,11 @@ exports[`List pinned should apply pinned object styling to items when data are o
           class="c5"
         />
         <div
-          class="c14"
+          class="c13"
         >
           <svg
             aria-label="Item pinned, order cannot be changed."
-            class="c15"
+            class="c14"
             viewBox="0 0 24 24"
           >
             <path
@@ -21259,7 +24380,7 @@ exports[`List pinned should apply pinned object styling to items when data are o
         </div>
       </li>
       <li
-        class="c16 c3"
+        class="c15 c3"
         draggable="true"
       >
         <span
@@ -21324,10 +24445,10 @@ exports[`List pinned should apply pinned object styling to items when data are o
         </div>
       </li>
       <li
-        class="c11 c12"
+        class="c11 "
       >
         <span
-          class="c13"
+          class="c12"
         >
           4
         </span>
@@ -21338,7 +24459,7 @@ exports[`List pinned should apply pinned object styling to items when data are o
           class="c6"
         >
           <span
-            class="c13"
+            class="c12"
           >
             Palo Alto
           </span>
@@ -21347,11 +24468,11 @@ exports[`List pinned should apply pinned object styling to items when data are o
           class="c5"
         />
         <div
-          class="c14"
+          class="c13"
         >
           <svg
             aria-label="Item pinned, order cannot be changed."
-            class="c15"
+            class="c14"
             viewBox="0 0 24 24"
           >
             <path
@@ -21364,7 +24485,7 @@ exports[`List pinned should apply pinned object styling to items when data are o
         </div>
       </li>
       <li
-        class="c16 c3"
+        class="c15 c3"
         draggable="true"
       >
         <span
@@ -21468,7 +24589,7 @@ exports[`List pinned should apply pinned object styling to items when data are s
   stroke: none;
 }
 
-.c15 {
+.c14 {
   display: inline-block;
   flex: 0 0 auto;
   width: 24px;
@@ -21477,25 +24598,25 @@ exports[`List pinned should apply pinned object styling to items when data are s
   stroke: blue;
 }
 
-.c15 g {
+.c14 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c15 *:not([stroke])[fill='none'] {
+.c14 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c15 *[stroke*='#'],
-.c15 *[STROKE*='#'] {
+.c14 *[stroke*='#'],
+.c14 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c15 *[fill-rule],
-.c15 *[FILL-RULE],
-.c15 *[fill*='#'],
-.c15 *[FILL*='#'] {
+.c14 *[fill-rule],
+.c14 *[FILL-RULE],
+.c14 *[fill*='#'],
+.c14 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -21565,7 +24686,7 @@ exports[`List pinned should apply pinned object styling to items when data are s
   padding-bottom: 12px;
 }
 
-.c14 {
+.c13 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -21577,7 +24698,7 @@ exports[`List pinned should apply pinned object styling to items when data are s
   padding: 12px;
 }
 
-.c16 {
+.c15 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -21604,7 +24725,7 @@ exports[`List pinned should apply pinned object styling to items when data are s
   line-height: 24px;
 }
 
-.c13 {
+.c12 {
   font-size: 18px;
   line-height: 24px;
   color: blue;
@@ -21629,6 +24750,26 @@ exports[`List pinned should apply pinned object styling to items when data are s
   cursor: default;
   line-height: 0;
   padding: 12px;
+}
+
+.c8:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus >circle,
+.c8:focus >ellipse,
+.c8:focus >line,
+.c8:focus >path,
+.c8:focus >polygon,
+.c8:focus >polyline,
+.c8:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus ::-moz-focus-inner {
+  border: 0;
 }
 
 .c8:focus:not(:focus-visible) {
@@ -21675,6 +24816,26 @@ exports[`List pinned should apply pinned object styling to items when data are s
   color: #000000;
 }
 
+.c10:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus >circle,
+.c10:focus >ellipse,
+.c10:focus >line,
+.c10:focus >path,
+.c10:focus >polygon,
+.c10:focus >polyline,
+.c10:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus ::-moz-focus-inner {
+  border: 0;
+}
+
 .c10:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -21701,20 +24862,8 @@ exports[`List pinned should apply pinned object styling to items when data are s
   padding: 0;
 }
 
-.c1:focus {
-  outline: 2px solid #6FFFB0;
-}
-
 .c3 {
   cursor: move;
-}
-
-.c3:focus {
-  outline: none;
-}
-
-.c12:focus {
-  outline: none;
 }
 
 @media only screen and (max-width: 768px) {
@@ -21759,26 +24908,26 @@ exports[`List pinned should apply pinned object styling to items when data are s
 }
 
 @media only screen and (max-width: 768px) {
-  .c14 {
+  .c13 {
     padding: 6px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c16 {
+  .c15 {
     border-bottom: solid 1px rgba(0, 0, 0, 0.33);
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c16 {
+  .c15 {
     padding-left: 12px;
     padding-right: 12px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c16 {
+  .c15 {
     padding-top: 6px;
     padding-bottom: 6px;
   }
@@ -21796,7 +24945,6 @@ exports[`List pinned should apply pinned object styling to items when data are s
     <ul
       class="c1"
       role="list"
-      tabindex="0"
     >
       <li
         class="c2 c3"
@@ -21846,7 +24994,7 @@ exports[`List pinned should apply pinned object styling to items when data are s
             aria-label="1 Boise move down"
             class="c10"
             id="BoiseMoveDown"
-            tabindex="-1"
+            tabindex="0"
             type="button"
           >
             <svg
@@ -21865,10 +25013,10 @@ exports[`List pinned should apply pinned object styling to items when data are s
         </div>
       </li>
       <li
-        class="c11 c12"
+        class="c11 "
       >
         <span
-          class="c13"
+          class="c12"
         >
           2
         </span>
@@ -21879,7 +25027,7 @@ exports[`List pinned should apply pinned object styling to items when data are s
           class="c6"
         >
           <span
-            class="c13"
+            class="c12"
           >
             Fort Collins
           </span>
@@ -21888,11 +25036,11 @@ exports[`List pinned should apply pinned object styling to items when data are s
           class="c5"
         />
         <div
-          class="c14"
+          class="c13"
         >
           <svg
             aria-label="Item pinned, order cannot be changed."
-            class="c15"
+            class="c14"
             viewBox="0 0 24 24"
           >
             <path
@@ -21905,7 +25053,7 @@ exports[`List pinned should apply pinned object styling to items when data are s
         </div>
       </li>
       <li
-        class="c16 c3"
+        class="c15 c3"
         draggable="true"
       >
         <span
@@ -21970,10 +25118,10 @@ exports[`List pinned should apply pinned object styling to items when data are s
         </div>
       </li>
       <li
-        class="c11 c12"
+        class="c11 "
       >
         <span
-          class="c13"
+          class="c12"
         >
           4
         </span>
@@ -21984,7 +25132,7 @@ exports[`List pinned should apply pinned object styling to items when data are s
           class="c6"
         >
           <span
-            class="c13"
+            class="c12"
           >
             Palo Alto
           </span>
@@ -21993,11 +25141,11 @@ exports[`List pinned should apply pinned object styling to items when data are s
           class="c5"
         />
         <div
-          class="c14"
+          class="c13"
         >
           <svg
             aria-label="Item pinned, order cannot be changed."
-            class="c15"
+            class="c14"
             viewBox="0 0 24 24"
           >
             <path
@@ -22010,7 +25158,7 @@ exports[`List pinned should apply pinned object styling to items when data are s
         </div>
       </li>
       <li
-        class="c16 c3"
+        class="c15 c3"
         draggable="true"
       >
         <span
@@ -22082,7 +25230,7 @@ exports[`List pinned should apply pinned object styling to items when data are s
 
 exports[`List pinned should apply pinned.color styling to primaryKey and secondaryKey when they are strings 1`] = `
 <DocumentFragment>
-  .c12 {
+  .c11 {
   display: inline-block;
   flex: 0 0 auto;
   width: 24px;
@@ -22091,25 +25239,25 @@ exports[`List pinned should apply pinned.color styling to primaryKey and seconda
   stroke: blue;
 }
 
-.c12 g {
+.c11 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c12 *:not([stroke])[fill='none'] {
+.c11 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c12 *[stroke*='#'],
-.c12 *[STROKE*='#'] {
+.c11 *[stroke*='#'],
+.c11 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c12 *[fill-rule],
-.c12 *[FILL-RULE],
-.c12 *[fill*='#'],
-.c12 *[FILL*='#'] {
+.c11 *[fill-rule],
+.c11 *[FILL-RULE],
+.c11 *[fill*='#'],
+.c11 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -22142,7 +25290,7 @@ exports[`List pinned should apply pinned.color styling to primaryKey and seconda
   padding-bottom: 12px;
 }
 
-.c7 {
+.c6 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -22159,7 +25307,7 @@ exports[`List pinned should apply pinned.color styling to primaryKey and seconda
   padding-bottom: 12px;
 }
 
-.c8 {
+.c7 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -22169,7 +25317,7 @@ exports[`List pinned should apply pinned.color styling to primaryKey and seconda
   flex: 1 1;
 }
 
-.c11 {
+.c10 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -22181,7 +25329,7 @@ exports[`List pinned should apply pinned.color styling to primaryKey and seconda
   padding: 12px;
 }
 
-.c13 {
+.c12 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -22198,31 +25346,31 @@ exports[`List pinned should apply pinned.color styling to primaryKey and seconda
   padding-bottom: 12px;
 }
 
-.c5 {
+.c4 {
   flex: 0 0 auto;
   align-self: stretch;
   width: 24px;
 }
 
-.c4 {
+.c3 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
 }
 
-.c6 {
+.c5 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c9 {
+.c8 {
   font-size: 18px;
   line-height: 24px;
   color: blue;
   font-weight: bold;
 }
 
-.c10 {
+.c9 {
   font-size: 18px;
   line-height: 24px;
   color: blue;
@@ -22232,10 +25380,6 @@ exports[`List pinned should apply pinned.color styling to primaryKey and seconda
   list-style: none;
   margin: 0;
   padding: 0;
-}
-
-.c3:focus {
-  outline: none;
 }
 
 @media only screen and (max-width: 768px) {
@@ -22260,53 +25404,53 @@ exports[`List pinned should apply pinned.color styling to primaryKey and seconda
 }
 
 @media only screen and (max-width: 768px) {
-  .c7 {
+  .c6 {
     border-bottom: solid 1px rgba(0, 0, 0, 0.33);
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c7 {
+  .c6 {
     padding-left: 12px;
     padding-right: 12px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c7 {
+  .c6 {
     padding-top: 6px;
     padding-bottom: 6px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c11 {
+  .c10 {
     padding: 6px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c13 {
+  .c12 {
     border-bottom: solid 1px rgba(0, 0, 0, 0.33);
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c13 {
+  .c12 {
     padding-left: 12px;
     padding-right: 12px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c13 {
+  .c12 {
     padding-top: 6px;
     padding-bottom: 6px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c5 {
+  .c4 {
     width: 12px;
   }
 }
@@ -22319,48 +25463,48 @@ exports[`List pinned should apply pinned.color styling to primaryKey and seconda
       role="list"
     >
       <li
-        class="c2 c3"
+        class="c2 "
       >
         <span
-          class="c4"
+          class="c3"
         >
           Boise
         </span>
         <div
-          class="c5"
+          class="c4"
         />
         <span
-          class="c6"
+          class="c5"
         >
           Idaho
         </span>
       </li>
       <li
-        class="c7 c3"
+        class="c6 "
       >
         <div
-          class="c8"
+          class="c7"
         >
           <span
-            class="c9"
+            class="c8"
           >
             Fort Collins
           </span>
           <span
-            class="c10"
+            class="c9"
           >
             Colorado
           </span>
         </div>
         <div
-          class="c5"
+          class="c4"
         />
         <div
-          class="c11"
+          class="c10"
         >
           <svg
             aria-label="Item pinned, order cannot be changed."
-            class="c12"
+            class="c11"
             viewBox="0 0 24 24"
           >
             <path
@@ -22373,48 +25517,48 @@ exports[`List pinned should apply pinned.color styling to primaryKey and seconda
         </div>
       </li>
       <li
-        class="c13 c3"
+        class="c12 "
       >
         <span
-          class="c4"
+          class="c3"
         >
           Los Gatos
         </span>
         <div
-          class="c5"
+          class="c4"
         />
         <span
-          class="c6"
+          class="c5"
         >
           California
         </span>
       </li>
       <li
-        class="c7 c3"
+        class="c6 "
       >
         <div
-          class="c8"
+          class="c7"
         >
           <span
-            class="c9"
+            class="c8"
           >
             Palo Alto
           </span>
           <span
-            class="c10"
+            class="c9"
           >
             California
           </span>
         </div>
         <div
-          class="c5"
+          class="c4"
         />
         <div
-          class="c11"
+          class="c10"
         >
           <svg
             aria-label="Item pinned, order cannot be changed."
-            class="c12"
+            class="c11"
             viewBox="0 0 24 24"
           >
             <path
@@ -22427,18 +25571,18 @@ exports[`List pinned should apply pinned.color styling to primaryKey and seconda
         </div>
       </li>
       <li
-        class="c13 c3"
+        class="c12 "
       >
         <span
-          class="c4"
+          class="c3"
         >
           San Francisco
         </span>
         <div
-          class="c5"
+          class="c4"
         />
         <span
-          class="c6"
+          class="c5"
         >
           California
         </span>
@@ -22450,13 +25594,309 @@ exports[`List pinned should apply pinned.color styling to primaryKey and seconda
 
 exports[`List pinned should apply pinned.icon but not pinned.color if icon color prop is specified 1`] = `
 <DocumentFragment>
-  .c9 {
+  .c8 {
   display: inline-block;
   flex: 0 0 auto;
   width: 24px;
   height: 24px;
   fill: pink;
   stroke: pink;
+}
+
+.c8 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c8 *:not([stroke])[fill='none'] {
+  stroke-width: 0;
+}
+
+.c8 *[stroke*='#'],
+.c8 *[STROKE*='#'] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c8 *[fill-rule],
+.c8 *[FILL-RULE],
+.c8 *[fill*='#'],
+.c8 *[FILL*='#'] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c2 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border-top: solid 1px rgba(0, 0, 0, 0.33);
+  border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  flex: 0 0 auto;
+  padding-left: 24px;
+  padding-right: 24px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+
+.c3 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: center;
+  background: green;
+  border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  flex: 0 0 auto;
+  padding-left: 24px;
+  padding-right: 24px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+
+.c4 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  flex: 1 1;
+}
+
+.c7 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  justify-content: flex-end;
+  padding: 12px;
+}
+
+.c9 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  flex: 0 0 auto;
+  padding-left: 24px;
+  padding-right: 24px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+
+.c6 {
+  flex: 0 0 auto;
+  align-self: stretch;
+  width: 24px;
+}
+
+.c5 {
+  font-size: 18px;
+  line-height: 24px;
+  color: blue;
+}
+
+.c1 {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    border-top: solid 1px rgba(0, 0, 0, 0.33);
+    border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c3 {
+    border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c3 {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c3 {
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c7 {
+    padding: 6px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c9 {
+    border-bottom: solid 1px rgba(0, 0, 0, 0.33);
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c9 {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c9 {
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c6 {
+    width: 12px;
+  }
+}
+
+<div
+    class="c0"
+  >
+    <ul
+      class="c1"
+      role="list"
+    >
+      <li
+        class="c2 "
+      >
+        Boise
+      </li>
+      <li
+        class="c3 "
+      >
+        <div
+          class="c4"
+        >
+          <span
+            class="c5"
+          >
+            Fort Collins
+          </span>
+        </div>
+        <div
+          class="c6"
+        />
+        <div
+          class="c7"
+        >
+          <svg
+            aria-label="Item pinned, order cannot be changed."
+            class="c8"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M19 23V11H5v12h14zm-7-8v4m5-8V7c0-3 0-6-5-6S7 4 7 7v4"
+              fill="none"
+              stroke="#000"
+              stroke-width="2"
+            />
+          </svg>
+        </div>
+      </li>
+      <li
+        class="c9 "
+      >
+        Los Gatos
+      </li>
+      <li
+        class="c3 "
+      >
+        <div
+          class="c4"
+        >
+          <span
+            class="c5"
+          >
+            Palo Alto
+          </span>
+        </div>
+        <div
+          class="c6"
+        />
+        <div
+          class="c7"
+        >
+          <svg
+            aria-label="Item pinned, order cannot be changed."
+            class="c8"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M19 23V11H5v12h14zm-7-8v4m5-8V7c0-3 0-6-5-6S7 4 7 7v4"
+              fill="none"
+              stroke="#000"
+              stroke-width="2"
+            />
+          </svg>
+        </div>
+      </li>
+      <li
+        class="c9 "
+      >
+        San Francisco
+      </li>
+    </ul>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`List pinned should not apply pinned.color to primaryKey and secondaryKey when they are custom render functions 1`] = `
+<DocumentFragment>
+  .c9 {
+  display: inline-block;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: blue;
+  stroke: blue;
 }
 
 .c9 g {
@@ -22496,19 +25936,21 @@ exports[`List pinned should apply pinned.icon but not pinned.color if icon color
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  align-items: center;
   border-top: solid 1px rgba(0, 0, 0, 0.33);
   border-bottom: solid 1px rgba(0, 0, 0, 0.33);
   min-width: 0;
   min-height: 0;
-  flex-direction: column;
+  flex-direction: row;
   flex: 0 0 auto;
+  justify-content: space-between;
   padding-left: 24px;
   padding-right: 24px;
   padding-top: 12px;
   padding-bottom: 12px;
 }
 
-.c4 {
+.c6 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -22525,7 +25967,7 @@ exports[`List pinned should apply pinned.icon but not pinned.color if icon color
   padding-bottom: 12px;
 }
 
-.c5 {
+.c7 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -22551,37 +25993,41 @@ exports[`List pinned should apply pinned.icon but not pinned.color if icon color
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
+  align-items: center;
   border-bottom: solid 1px rgba(0, 0, 0, 0.33);
   min-width: 0;
   min-height: 0;
-  flex-direction: column;
+  flex-direction: row;
   flex: 0 0 auto;
+  justify-content: space-between;
   padding-left: 24px;
   padding-right: 24px;
   padding-top: 12px;
   padding-bottom: 12px;
 }
 
-.c7 {
+.c4 {
   flex: 0 0 auto;
   align-self: stretch;
   width: 24px;
 }
 
-.c6 {
+.c3 {
   font-size: 18px;
   line-height: 24px;
-  color: blue;
+  color: red;
+}
+
+.c5 {
+  font-size: 18px;
+  line-height: 24px;
+  color: pink;
 }
 
 .c1 {
   list-style: none;
   margin: 0;
   padding: 0;
-}
-
-.c3:focus {
-  outline: none;
 }
 
 @media only screen and (max-width: 768px) {
@@ -22606,20 +26052,20 @@ exports[`List pinned should apply pinned.icon but not pinned.color if icon color
 }
 
 @media only screen and (max-width: 768px) {
-  .c4 {
+  .c6 {
     border-bottom: solid 1px rgba(0, 0, 0, 0.33);
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c4 {
+  .c6 {
     padding-left: 12px;
     padding-right: 12px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c4 {
+  .c6 {
     padding-top: 6px;
     padding-bottom: 6px;
   }
@@ -22652,7 +26098,7 @@ exports[`List pinned should apply pinned.icon but not pinned.color if icon color
 }
 
 @media only screen and (max-width: 768px) {
-  .c7 {
+  .c4 {
     width: 12px;
   }
 }
@@ -22665,358 +26111,48 @@ exports[`List pinned should apply pinned.icon but not pinned.color if icon color
       role="list"
     >
       <li
-        class="c2 c3"
-      >
-        Boise
-      </li>
-      <li
-        class="c4 c3"
-      >
-        <div
-          class="c5"
-        >
-          <span
-            class="c6"
-          >
-            Fort Collins
-          </span>
-        </div>
-        <div
-          class="c7"
-        />
-        <div
-          class="c8"
-        >
-          <svg
-            aria-label="Item pinned, order cannot be changed."
-            class="c9"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M19 23V11H5v12h14zm-7-8v4m5-8V7c0-3 0-6-5-6S7 4 7 7v4"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </div>
-      </li>
-      <li
-        class="c10 c3"
-      >
-        Los Gatos
-      </li>
-      <li
-        class="c4 c3"
-      >
-        <div
-          class="c5"
-        >
-          <span
-            class="c6"
-          >
-            Palo Alto
-          </span>
-        </div>
-        <div
-          class="c7"
-        />
-        <div
-          class="c8"
-        >
-          <svg
-            aria-label="Item pinned, order cannot be changed."
-            class="c9"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M19 23V11H5v12h14zm-7-8v4m5-8V7c0-3 0-6-5-6S7 4 7 7v4"
-              fill="none"
-              stroke="#000"
-              stroke-width="2"
-            />
-          </svg>
-        </div>
-      </li>
-      <li
-        class="c10 c3"
-      >
-        San Francisco
-      </li>
-    </ul>
-  </div>
-</DocumentFragment>
-`;
-
-exports[`List pinned should not apply pinned.color to primaryKey and secondaryKey when they are custom render functions 1`] = `
-<DocumentFragment>
-  .c10 {
-  display: inline-block;
-  flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
-  fill: blue;
-  stroke: blue;
-}
-
-.c10 g {
-  fill: inherit;
-  stroke: inherit;
-}
-
-.c10 *:not([stroke])[fill='none'] {
-  stroke-width: 0;
-}
-
-.c10 *[stroke*='#'],
-.c10 *[STROKE*='#'] {
-  stroke: inherit;
-  fill: none;
-}
-
-.c10 *[fill-rule],
-.c10 *[FILL-RULE],
-.c10 *[fill*='#'],
-.c10 *[FILL*='#'] {
-  fill: inherit;
-  stroke: none;
-}
-
-.c0 {
-  font-size: 18px;
-  line-height: 24px;
-  box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
-.c2 {
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  align-items: center;
-  border-top: solid 1px rgba(0, 0, 0, 0.33);
-  border-bottom: solid 1px rgba(0, 0, 0, 0.33);
-  min-width: 0;
-  min-height: 0;
-  flex-direction: row;
-  flex: 0 0 auto;
-  justify-content: space-between;
-  padding-left: 24px;
-  padding-right: 24px;
-  padding-top: 12px;
-  padding-bottom: 12px;
-}
-
-.c7 {
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  align-items: center;
-  background: green;
-  border-bottom: solid 1px rgba(0, 0, 0, 0.33);
-  min-width: 0;
-  min-height: 0;
-  flex-direction: row;
-  flex: 0 0 auto;
-  padding-left: 24px;
-  padding-right: 24px;
-  padding-top: 12px;
-  padding-bottom: 12px;
-}
-
-.c8 {
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  min-width: 0;
-  min-height: 0;
-  flex-direction: column;
-  flex: 1 1;
-}
-
-.c9 {
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  align-items: center;
-  min-width: 0;
-  min-height: 0;
-  flex-direction: row;
-  justify-content: flex-end;
-  padding: 12px;
-}
-
-.c11 {
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  align-items: center;
-  border-bottom: solid 1px rgba(0, 0, 0, 0.33);
-  min-width: 0;
-  min-height: 0;
-  flex-direction: row;
-  flex: 0 0 auto;
-  justify-content: space-between;
-  padding-left: 24px;
-  padding-right: 24px;
-  padding-top: 12px;
-  padding-bottom: 12px;
-}
-
-.c5 {
-  flex: 0 0 auto;
-  align-self: stretch;
-  width: 24px;
-}
-
-.c4 {
-  font-size: 18px;
-  line-height: 24px;
-  color: red;
-}
-
-.c6 {
-  font-size: 18px;
-  line-height: 24px;
-  color: pink;
-}
-
-.c1 {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-
-.c3:focus {
-  outline: none;
-}
-
-@media only screen and (max-width: 768px) {
-  .c2 {
-    border-top: solid 1px rgba(0, 0, 0, 0.33);
-    border-bottom: solid 1px rgba(0, 0, 0, 0.33);
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c2 {
-    padding-left: 12px;
-    padding-right: 12px;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c2 {
-    padding-top: 6px;
-    padding-bottom: 6px;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c7 {
-    border-bottom: solid 1px rgba(0, 0, 0, 0.33);
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c7 {
-    padding-left: 12px;
-    padding-right: 12px;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c7 {
-    padding-top: 6px;
-    padding-bottom: 6px;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c9 {
-    padding: 6px;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c11 {
-    border-bottom: solid 1px rgba(0, 0, 0, 0.33);
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c11 {
-    padding-left: 12px;
-    padding-right: 12px;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c11 {
-    padding-top: 6px;
-    padding-bottom: 6px;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c5 {
-    width: 12px;
-  }
-}
-
-<div
-    class="c0"
-  >
-    <ul
-      class="c1"
-      role="list"
-    >
-      <li
-        class="c2 c3"
+        class="c2 "
       >
         <span
-          class="c4"
+          class="c3"
         >
           Boise
         </span>
         <div
-          class="c5"
+          class="c4"
         />
         <span
-          class="c6"
+          class="c5"
         >
           Idaho
         </span>
       </li>
       <li
-        class="c7 c3"
+        class="c6 "
       >
         <div
-          class="c8"
+          class="c7"
         >
           <span
-            class="c4"
+            class="c3"
           >
             Fort Collins
           </span>
           <span
-            class="c6"
+            class="c5"
           >
             Colorado
           </span>
         </div>
         <div
-          class="c5"
+          class="c4"
         />
         <div
-          class="c9"
+          class="c8"
         >
           <svg
             aria-label="Item pinned, order cannot be changed."
-            class="c10"
+            class="c9"
             viewBox="0 0 24 24"
           >
             <path
@@ -23029,48 +26165,48 @@ exports[`List pinned should not apply pinned.color to primaryKey and secondaryKe
         </div>
       </li>
       <li
-        class="c11 c3"
+        class="c10 "
       >
         <span
-          class="c4"
+          class="c3"
         >
           Los Gatos
         </span>
         <div
-          class="c5"
+          class="c4"
         />
         <span
-          class="c6"
+          class="c5"
         >
           California
         </span>
       </li>
       <li
-        class="c7 c3"
+        class="c6 "
       >
         <div
-          class="c8"
+          class="c7"
         >
           <span
-            class="c4"
+            class="c3"
           >
             Palo Alto
           </span>
           <span
-            class="c6"
+            class="c5"
           >
             California
           </span>
         </div>
         <div
-          class="c5"
+          class="c4"
         />
         <div
-          class="c9"
+          class="c8"
         >
           <svg
             aria-label="Item pinned, order cannot be changed."
-            class="c10"
+            class="c9"
             viewBox="0 0 24 24"
           >
             <path
@@ -23083,18 +26219,18 @@ exports[`List pinned should not apply pinned.color to primaryKey and secondaryKe
         </div>
       </li>
       <li
-        class="c11 c3"
+        class="c10 "
       >
         <span
-          class="c4"
+          class="c3"
         >
           San Francisco
         </span>
         <div
-          class="c5"
+          class="c4"
         />
         <span
-          class="c6"
+          class="c5"
         >
           California
         </span>
@@ -23131,7 +26267,7 @@ exports[`List primaryKey 1`] = `
   padding-bottom: 12px;
 }
 
-.c5 {
+.c4 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -23146,7 +26282,7 @@ exports[`List primaryKey 1`] = `
   padding-bottom: 12px;
 }
 
-.c4 {
+.c3 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
@@ -23156,10 +26292,6 @@ exports[`List primaryKey 1`] = `
   list-style: none;
   margin: 0;
   padding: 0;
-}
-
-.c3:focus {
-  outline: none;
 }
 
 @media only screen and (max-width: 768px) {
@@ -23184,20 +26316,20 @@ exports[`List primaryKey 1`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c5 {
+  .c4 {
     border-bottom: solid 1px rgba(0, 0, 0, 0.33);
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c5 {
+  .c4 {
     padding-left: 12px;
     padding-right: 12px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c5 {
+  .c4 {
     padding-top: 6px;
     padding-bottom: 6px;
   }
@@ -23211,19 +26343,19 @@ exports[`List primaryKey 1`] = `
     role="list"
   >
     <li
-      class="c2 c3"
+      class="c2 "
     >
       <span
-        class="c4"
+        class="c3"
       >
         one
       </span>
     </li>
     <li
-      class="c5 c3"
+      class="c4 "
     >
       <span
-        class="c4"
+        class="c3"
       >
         two
       </span>
@@ -23332,7 +26464,7 @@ exports[`List prop messages 1`] = `
   padding-bottom: 12px;
 }
 
-.c13 {
+.c12 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -23344,7 +26476,7 @@ exports[`List prop messages 1`] = `
   padding: 12px;
 }
 
-.c14 {
+.c13 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -23392,6 +26524,26 @@ exports[`List prop messages 1`] = `
   padding: 12px;
 }
 
+.c8:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus >circle,
+.c8:focus >ellipse,
+.c8:focus >line,
+.c8:focus >path,
+.c8:focus >polygon,
+.c8:focus >polyline,
+.c8:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c8:focus ::-moz-focus-inner {
+  border: 0;
+}
+
 .c8:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -23436,6 +26588,26 @@ exports[`List prop messages 1`] = `
   color: #000000;
 }
 
+.c10:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus >circle,
+.c10:focus >ellipse,
+.c10:focus >line,
+.c10:focus >path,
+.c10:focus >polygon,
+.c10:focus >polyline,
+.c10:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c10:focus ::-moz-focus-inner {
+  border: 0;
+}
+
 .c10:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -23462,20 +26634,8 @@ exports[`List prop messages 1`] = `
   padding: 0;
 }
 
-.c1:focus {
-  outline: 2px solid #6FFFB0;
-}
-
 .c3 {
   cursor: move;
-}
-
-.c3:focus {
-  outline: none;
-}
-
-.c12:focus {
-  outline: none;
 }
 
 @media only screen and (max-width: 768px) {
@@ -23520,26 +26680,26 @@ exports[`List prop messages 1`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c13 {
+  .c12 {
     padding: 6px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c14 {
+  .c13 {
     border-bottom: solid 1px rgba(0, 0, 0, 0.33);
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c14 {
+  .c13 {
     padding-left: 12px;
     padding-right: 12px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c14 {
+  .c13 {
     padding-top: 6px;
     padding-bottom: 6px;
   }
@@ -23557,7 +26717,6 @@ exports[`List prop messages 1`] = `
     <ul
       class="c1"
       role="list"
-      tabindex="0"
     >
       <li
         class="c2 c3"
@@ -23607,7 +26766,7 @@ exports[`List prop messages 1`] = `
             aria-label="1 Colorado move down"
             class="c10"
             id="ColoradoMoveDown"
-            tabindex="-1"
+            tabindex="0"
             type="button"
           >
             <svg
@@ -23626,7 +26785,7 @@ exports[`List prop messages 1`] = `
         </div>
       </li>
       <li
-        class="c11 c12"
+        class="c11 "
       >
         <span
           class="c4"
@@ -23645,7 +26804,7 @@ exports[`List prop messages 1`] = `
           class="c5"
         />
         <div
-          class="c13"
+          class="c12"
         >
           <svg
             aria-label="Item locked."
@@ -23662,7 +26821,7 @@ exports[`List prop messages 1`] = `
         </div>
       </li>
       <li
-        class="c14 c3"
+        class="c13 c3"
         draggable="true"
       >
         <span
@@ -23759,7 +26918,7 @@ exports[`List renders a11yTitle and aria-label 1`] = `
   padding-bottom: 12px;
 }
 
-.c4 {
+.c3 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -23778,10 +26937,6 @@ exports[`List renders a11yTitle and aria-label 1`] = `
   list-style: none;
   margin: 0;
   padding: 0;
-}
-
-.c3:focus {
-  outline: none;
 }
 
 @media only screen and (max-width: 768px) {
@@ -23806,20 +26961,20 @@ exports[`List renders a11yTitle and aria-label 1`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c4 {
+  .c3 {
     border-bottom: solid 1px rgba(0, 0, 0, 0.33);
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c4 {
+  .c3 {
     padding-left: 12px;
     padding-right: 12px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c4 {
+  .c3 {
     padding-top: 6px;
     padding-bottom: 6px;
   }
@@ -23835,12 +26990,12 @@ exports[`List renders a11yTitle and aria-label 1`] = `
       role="list"
     >
       <li
-        class="c2 c3"
+        class="c2 "
       >
         alpha
       </li>
       <li
-        class="c4 c3"
+        class="c3 "
       >
         beta
       </li>
@@ -23851,12 +27006,12 @@ exports[`List renders a11yTitle and aria-label 1`] = `
       role="list"
     >
       <li
-        class="c2 c3"
+        class="c2 "
       >
         alpha
       </li>
       <li
-        class="c4 c3"
+        class="c3 "
       >
         beta
       </li>
@@ -23893,7 +27048,7 @@ exports[`List renders custom theme for primaryKey 1`] = `
   padding-bottom: 12px;
 }
 
-.c5 {
+.c4 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -23908,7 +27063,7 @@ exports[`List renders custom theme for primaryKey 1`] = `
   padding-bottom: 12px;
 }
 
-.c4 {
+.c3 {
   font-size: 18px;
   line-height: 24px;
   color: #7D4CDB;
@@ -23919,10 +27074,6 @@ exports[`List renders custom theme for primaryKey 1`] = `
   list-style: none;
   margin: 0;
   padding: 0;
-}
-
-.c3:focus {
-  outline: none;
 }
 
 @media only screen and (max-width: 768px) {
@@ -23947,20 +27098,20 @@ exports[`List renders custom theme for primaryKey 1`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c5 {
+  .c4 {
     border-bottom: solid 1px rgba(0, 0, 0, 0.33);
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c5 {
+  .c4 {
     padding-left: 12px;
     padding-right: 12px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c5 {
+  .c4 {
     padding-top: 6px;
     padding-bottom: 6px;
   }
@@ -23974,19 +27125,19 @@ exports[`List renders custom theme for primaryKey 1`] = `
       role="list"
     >
       <li
-        class="c2 c3"
+        class="c2 "
       >
         <span
-          class="c4"
+          class="c3"
         >
           one
         </span>
       </li>
       <li
-        class="c5 c3"
+        class="c4 "
       >
         <span
-          class="c4"
+          class="c3"
         >
           two
         </span>
@@ -24013,7 +27164,7 @@ exports[`List renders outside grommet wrapper 1`] = `
   padding-bottom: 12px;
 }
 
-.c3 {
+.c2 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -24032,10 +27183,6 @@ exports[`List renders outside grommet wrapper 1`] = `
   list-style: none;
   margin: 0;
   padding: 0;
-}
-
-.c2:focus {
-  outline: none;
 }
 
 @media only screen and (max-width: 768px) {
@@ -24060,20 +27207,20 @@ exports[`List renders outside grommet wrapper 1`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c3 {
+  .c2 {
     border-bottom: solid 1px rgba(0, 0, 0, 0.33);
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c3 {
+  .c2 {
     padding-left: 12px;
     padding-right: 12px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c3 {
+  .c2 {
     padding-top: 6px;
     padding-bottom: 6px;
   }
@@ -24085,12 +27232,12 @@ exports[`List renders outside grommet wrapper 1`] = `
   role="list"
 >
   <li
-    class="c1 c2"
+    class="c1 "
   >
     alpha
   </li>
   <li
-    class="c3 c2"
+    class="c2 "
   >
     beta
   </li>
@@ -24126,7 +27273,7 @@ exports[`List secondaryKey 1`] = `
   padding-bottom: 12px;
 }
 
-.c7 {
+.c6 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -24143,19 +27290,19 @@ exports[`List secondaryKey 1`] = `
   padding-bottom: 12px;
 }
 
-.c5 {
+.c4 {
   flex: 0 0 auto;
   align-self: stretch;
   width: 24px;
 }
 
-.c4 {
+.c3 {
   font-size: 18px;
   line-height: 24px;
   font-weight: bold;
 }
 
-.c6 {
+.c5 {
   font-size: 18px;
   line-height: 24px;
 }
@@ -24164,10 +27311,6 @@ exports[`List secondaryKey 1`] = `
   list-style: none;
   margin: 0;
   padding: 0;
-}
-
-.c3:focus {
-  outline: none;
 }
 
 @media only screen and (max-width: 768px) {
@@ -24192,27 +27335,27 @@ exports[`List secondaryKey 1`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c7 {
+  .c6 {
     border-bottom: solid 1px rgba(0, 0, 0, 0.33);
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c7 {
+  .c6 {
     padding-left: 12px;
     padding-right: 12px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c7 {
+  .c6 {
     padding-top: 6px;
     padding-bottom: 6px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c5 {
+  .c4 {
     width: 12px;
   }
 }
@@ -24225,35 +27368,35 @@ exports[`List secondaryKey 1`] = `
     role="list"
   >
     <li
-      class="c2 c3"
+      class="c2 "
     >
       <span
-        class="c4"
+        class="c3"
       >
         one
       </span>
       <div
-        class="c5"
+        class="c4"
       />
       <span
-        class="c6"
+        class="c5"
       >
         1
       </span>
     </li>
     <li
-      class="c7 c3"
+      class="c6 "
     >
       <span
-        class="c4"
+        class="c3"
       >
         two
       </span>
       <div
-        class="c5"
+        class="c4"
       />
       <span
-        class="c6"
+        class="c5"
       >
         2
       </span>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

This follows generally the same approach as https://github.com/grommet/grommet/pull/7682 with regards to making the mouse and keyboard navigation more independent and aligned to the WCAG APG pattern.

That said it also retains backwards compatible behavior for how `onActive` is documented on List component/how `active` would be passed to List with children. This required introducing a new state variable internal to List (`focused`, `setFocused`) to manage DOM focus.

#### Where should the reviewer start?
List.js

#### What testing has been done on this PR?
Various list storybook examples


https://github.com/user-attachments/assets/4897762d-756e-4770-9101-97c92084b825


https://github.com/user-attachments/assets/8b41cd5a-b61e-40ea-ad61-03ee99ca89b5


https://github.com/user-attachments/assets/707c7880-4038-4f7c-bab2-f8c12fb48838

#### How should this be manually tested?

Storybook examples or locally.

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

Closes #7648 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.
