### PR TITLE
DataTable – Add `messages` support for when number of rows change

### DIFF
--- a/src/js/components/DataTable/index.d.ts
+++ b/src/js/components/DataTable/index.d.ts
@@ -49,6 +49,13 @@ export interface ColumnConfig<TRowType> {
   aggregate?: 'avg' | 'max' | 'min' | 'sum';
   footer?: React.ReactNode | { aggregate?: boolean };
   header?: string | React.ReactNode | { aggregate?: boolean };
+  messages?: {
+    rows?: string;
+    rowsSingle?: string;
+    rowsChanged?: string;
+    total?: string;
+    totalSingle?: string;
+  };
   pin?: boolean;
   plain?: boolean;
   primary?: boolean;

--- a/src/js/components/DataTable/propTypes.js
+++ b/src/js/components/DataTable/propTypes.js
@@ -128,6 +128,13 @@ if (process.env.NODE_ENV !== 'production') {
         onSelect: PropTypes.func,
       }),
     ]),
+    messages: PropTypes.shape({
+      rows: PropTypes.string,
+      rowsSingle: PropTypes.string,
+      rowsChanged: PropTypes.string,
+      total: PropTypes.string,
+      totalSingle: PropTypes.string,
+    }),
     onClickRow: PropTypes.oneOfType([
       PropTypes.func,
       PropTypes.oneOf(['select']),

--- a/src/js/components/Grommet/index.d.ts
+++ b/src/js/components/Grommet/index.d.ts
@@ -77,6 +77,13 @@ export interface GrommetProps {
         total?: string;
         totalSingle?: string;
       };
+      dataTable?: {
+        rows?: string;
+        rowsSingle?: string;
+        rowsChanged?: string;
+        total?: string;
+        totalSingle?: string;
+      };
       dataTableColumns?: {
         open?: string;
         order?: string;

--- a/src/js/components/Grommet/propTypes.js
+++ b/src/js/components/Grommet/propTypes.js
@@ -76,6 +76,13 @@ if (process.env.NODE_ENV !== 'production') {
           total: PropTypes.string,
           totalSingle: PropTypes.string,
         }),
+        dataTable: PropTypes.shape({
+          rows: PropTypes.string,
+          rowsSingle: PropTypes.string,
+          rowsChanged: PropTypes.string,
+          total: PropTypes.string,
+          totalSingle: PropTypes.string,
+        }),
         dataTableColumns: PropTypes.shape({
           open: PropTypes.string,
           order: PropTypes.string,

--- a/src/js/languages/default.json
+++ b/src/js/languages/default.json
@@ -55,6 +55,13 @@
     "total": "{total} {items}",
     "totalSingle": "{total} {items}"
   },
+  "dataTable": {
+    "rows": "rows",
+    "rowsSingle": "row",
+    "rowsChanged": "Number of rows changed",
+    "total": "{total} {rows}",
+    "totalSingle": "{total} {rows}"
+  },
   "dataTableColumns": {
     "open": "Open column selector",
     "order": "Order columns",


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

This PR adds screen reader announcement for when DataTable row amount changes (for example as a result of using search in header cell or expand/collapse).

The announcement only runs if DataTable is outside of DataContext (because Data already has its own similar announcement, so avoid redundant/cluttering announcements).

If the adjustedData is < one page, DataTable will announce the specific amount of rows. If it's greater than a page, it'll use a generic message (this handles cases like InfiniteScroll / API calls that won't necessarily be calling all the data).

#### Where should the reviewer start?
src/js/components/DataTable/DataTable.js

#### What testing has been done on this PR?
Locally


https://github.com/user-attachments/assets/89f7e59f-d1dd-4eae-84f5-9564239b1146


https://github.com/user-attachments/assets/6a11cebe-594d-4572-86fb-e5ad3259341d


#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
src/js/components/DataTable/DataTable.js

#### What are the relevant issues?
Related to #7657 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Yes.

#### Should this PR be mentioned in the release notes?
Yes.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.