### PR TITLE
Fix incorrect formatting of video time

### DIFF
--- a/src/js/components/Video/Video.js
+++ b/src/js/components/Video/Video.js
@@ -33,7 +33,7 @@ import { useThemeValue } from '../../utils/useThemeValue';
 const VOLUME_STEP = 0.166667;
 
 const formatTime = (time) => {
-  let minutes = Math.round(time / 60);
+  let minutes = Math.trunc(time / 60);
   if (minutes < 10) {
     minutes = `0${minutes}`;
   }


### PR DESCRIPTION

#### What does this PR do?
This fixes the formatting of the current/total minutes display to truncate the number of minutes rather than accidentally rounding it (it shouldn't round because it displays the seconds too.)

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?
You can see the issue with [this story](https://storybook.grommet.io/?path=/story/media-video-theater-mode--customizable-controls&globals=theme:hpe)

It's easier to see with a longer video like https://pavo.common.cloud.hpe.com/whatsnew/9731e661-5b03-4763-9fd9-2280b6ac87fb/whats-new-og-iam-rough-draft-80percent.mp4. If you hover along the scrubber line you can see at any intervals between 30-59 seconds it makes the minute digit too high

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Fixes #7689 

#### Screenshots (if appropriate)
Issue:
![image](https://github.com/user-attachments/assets/a5c6d47a-8824-4b4b-9438-fc0a1156ed9c)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
Yes

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible