### PR TITLE
DataTable - Ensure onEsc from header search returns focus to search button

### DIFF
--- a/src/js/components/DataTable/Searcher.js
+++ b/src/js/components/DataTable/Searcher.js
@@ -13,6 +13,7 @@ import { useThemeValue } from '../../utils/useThemeValue';
 const Searcher = ({ filtering, filters, onFilter, onFiltering, property }) => {
   const { theme } = useThemeValue();
   const inputRef = useRef();
+  const buttonRef = useRef();
   const needsFocus = filtering === property;
 
   useEffect(() => {
@@ -22,7 +23,20 @@ const Searcher = ({ filtering, filters, onFilter, onFiltering, property }) => {
   }, [needsFocus, inputRef]);
 
   return filtering === property ? (
-    <Keyboard onEsc={() => onFiltering(undefined)}>
+    <Keyboard
+      onEsc={() => {
+        onFiltering(undefined);
+        // Focus the button after closing the search
+        // setTimeout with 0 delay pushes the focus operation to the
+        // next round of the event loop, which happens after React has
+        // updated the DOM with the button element
+        setTimeout(() => {
+          if (buttonRef.current) {
+            buttonRef.current.focus();
+          }
+        }, 0);
+      }}
+    >
       <Box width={{ min: 'xsmall' }} flex pad={{ horizontal: 'small' }}>
         <TextInput
           name={`search-${property}`}
@@ -47,6 +61,7 @@ const Searcher = ({ filtering, filters, onFilter, onFiltering, property }) => {
         </Box>
       ) : null}
       <Button
+        ref={buttonRef}
         a11yTitle={`Open search by ${property}`}
         icon={
           <FormSearch


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Ensures that focus is returned to header search button when `onEsc` is used to close header cell search input.

#### Where should the reviewer start?
src/js/components/DataTable/Searcher.js

#### What testing has been done on this PR?
Locally in storybook.

#### How should this be manually tested?
Storybook.

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #7691 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
Yes.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.