### PR TITLE
switch to available star wars api

### DIFF
--- a/src/js/components/Data/stories/StarWars.stories.js
+++ b/src/js/components/Data/stories/StarWars.stories.js
@@ -1,23 +1,17 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Box, Data, List, Pagination } from 'grommet';
 
 // Uses the StarWars API for starships, see https://swapi.dev
 
-const step = 10; // default for https://swapi.dev
+// const step = 10; // default for https://swapi.dev
 
-const fetchData = async (view, signal) => {
-  const params = {};
-  if (view.search) params.search = view.search;
-  if (view.page) params.page = view.page;
-  const url = `https://swapi.dev/api/starships?${Object.keys(params)
-    .map((k) => `${k}=${params[k]}`)
-    .join('&')}`;
+const fetchData = async () => {
+  const url = `https://swapi.info/api/starships`;
   return fetch(url, {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',
     },
-    signal,
   })
     .then((response) => response.json())
     .catch((err) => {
@@ -29,37 +23,24 @@ const fetchData = async (view, signal) => {
 export const StarWars = () => {
   const [result, setResult] = useState({});
   const [total, setTotal] = useState(0);
-  const [view, setView] = useState({ search: '', step });
-  const abortRef = useRef();
 
   useEffect(() => {
-    // This API is a bit slow, abort any uncompleted requests.
-    abortRef?.current?.abort();
-    abortRef.current = new AbortController();
-    fetchData(view, abortRef.current.signal).then(({ count, results }) => {
+    fetchData().then((results) => {
       if (results) {
         // The API doesn't provide a non-filtered total, so we rely on the
         // first call having no filtering telling us the total.
-        setTotal((prevTotal) => Math.max(prevTotal, count));
-        setResult({ data: results, filteredTotal: count });
-        abortRef.current = undefined;
+        setTotal((prevTotal) => Math.max(prevTotal, results.length));
+        setResult({ data: results, filteredTotal: results.length });
       }
     });
-  }, [view]);
+  }, []);
 
   return (
     // Uncomment <Grommet> lines when using outside of storybook
     // <Grommet theme={...}>
 
     <Box skeleton={!result.data} width="large" pad="large">
-      <Data
-        data={result.data}
-        total={total}
-        filteredTotal={result.filteredTotal}
-        view={view}
-        onView={setView}
-        toolbar="search"
-      >
+      <Data data={result.data} total={total} toolbar="search">
         <List primaryKey="name" secondaryKey="starship_class" />
         <Pagination />
       </Data>

--- a/src/js/components/Data/stories/StarWars.stories.js
+++ b/src/js/components/Data/stories/StarWars.stories.js
@@ -1,9 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Box, Data, List, Pagination } from 'grommet';
 
-// Uses the StarWars API for starships, see https://swapi.dev
-
-// const step = 10; // default for https://swapi.dev
+// Uses the StarWars API for starships, see https://swapi.info
 
 const fetchData = async () => {
   const url = `https://swapi.info/api/starships`;

--- a/src/js/components/DataTable/stories/rowDetails.stories.js
+++ b/src/js/components/DataTable/stories/rowDetails.stories.js
@@ -75,16 +75,12 @@ export const RowDetails = () => {
   const [expand, setExpand] = useState(['Y-wing']);
 
   useEffect(() => {
-    // This API is a bit slow, abort any uncompleted requests.
-    // abortRef?.current?.abort();
-    // abortRef.current = new AbortController();
-    fetchData(/* view, abortRef.current.signal */).then((results) => {
+    fetchData().then((results) => {
       if (results) {
         // The API doesn't provide a non-filtered total, so we rely on the
         // first call having no filtering telling us the total.
         setTotal((prevTotal) => Math.max(prevTotal, results.length));
         setResult({ data: results });
-        // abortRef.current = undefined;
       }
     });
   }, []);

--- a/src/js/components/DataTable/stories/rowDetails.stories.js
+++ b/src/js/components/DataTable/stories/rowDetails.stories.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import {
   Box,
   Data,
@@ -9,23 +9,17 @@ import {
   Text,
 } from 'grommet';
 
-// Uses the StarWars API for starships, see https://swapi.dev
+// Uses the StarWars API for starships, see https://swapi.info
 
-const step = 10; // default for https://swapi.dev
+// const step = 10; // default for https://swapi.dev
 
-const fetchData = async (view, signal) => {
-  const params = {};
-  if (view.search) params.search = view.search;
-  if (view.page) params.page = view.page;
-  const url = `https://swapi.dev/api/starships?${Object.keys(params)
-    .map((k) => `${k}=${params[k]}`)
-    .join('&')}`;
+const fetchData = async () => {
+  const url = `https://swapi.info/api/starships`;
   return fetch(url, {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',
     },
-    signal,
   })
     .then((response) => response.json())
     .catch((err) => {
@@ -80,24 +74,22 @@ const ShipProperties = ({ ship }) => (
 export const RowDetails = () => {
   const [result, setResult] = useState({});
   const [total, setTotal] = useState(0);
-  const [view, setView] = useState({ search: '', step });
-  const abortRef = useRef();
   const [expand, setExpand] = useState(['Y-wing']);
 
   useEffect(() => {
     // This API is a bit slow, abort any uncompleted requests.
-    abortRef?.current?.abort();
-    abortRef.current = new AbortController();
-    fetchData(view, abortRef.current.signal).then(({ count, results }) => {
+    // abortRef?.current?.abort();
+    // abortRef.current = new AbortController();
+    fetchData(/* view, abortRef.current.signal */).then((results) => {
       if (results) {
         // The API doesn't provide a non-filtered total, so we rely on the
         // first call having no filtering telling us the total.
-        setTotal((prevTotal) => Math.max(prevTotal, count));
-        setResult({ data: results, filteredTotal: count });
-        abortRef.current = undefined;
+        setTotal((prevTotal) => Math.max(prevTotal, results.length));
+        setResult({ data: results });
+        // abortRef.current = undefined;
       }
     });
-  }, [view]);
+  }, []);
 
   const rowDetails = useMemo(
     () => ({
@@ -113,14 +105,7 @@ export const RowDetails = () => {
     // <Grommet theme={...}>
 
     <Box skeleton={!result.data} width="large" pad="large">
-      <Data
-        data={result.data}
-        total={total}
-        filteredTotal={result.filteredTotal}
-        view={view}
-        onView={setView}
-        toolbar="search"
-      >
+      <Data data={result.data} total={total} toolbar="search">
         <DataTable
           columns={[
             {

--- a/src/js/components/DataTable/stories/rowDetails.stories.js
+++ b/src/js/components/DataTable/stories/rowDetails.stories.js
@@ -11,8 +11,6 @@ import {
 
 // Uses the StarWars API for starships, see https://swapi.info
 
-// const step = 10; // default for https://swapi.dev
-
 const fetchData = async () => {
   const url = `https://swapi.info/api/starships`;
   return fetch(url, {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR switches the two stories that use the StarWars api to use a more supported one.

The original `https://swapi.dev` we originally used no longer maintained and has an invalid certificate, preventing it from working in storybook. There is a `https://swapi.info` version of the API now available that is more supported. Unfortunately it doesn't support search or pagination. The examples still to search and pagination locally.

#### Where should the reviewer start?
Storybook->Data->Data->StarWars

Storybook->Visualizations->DataTable->rowDetails


#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible