### PR TITLE
Improve AnnounceContext 

### DIFF
--- a/src/js/components/Data/__tests__/Data-test.tsx
+++ b/src/js/components/Data/__tests__/Data-test.tsx
@@ -16,7 +16,7 @@ const DEBOUNCE_TIMEOUT = 300;
 
 // asserts that AnnounceContext aria-live region and visible DataSummary each have this text
 const expectDataSummary = (message: string) =>
-  expect(screen.getAllByText(message)).toHaveLength(2);
+  expect(screen.getByText(message)).toBeInTheDocument();
 
 const data = [
   {

--- a/src/js/components/DataClearFilters/__tests__/DataClearFilters-test.tsx
+++ b/src/js/components/DataClearFilters/__tests__/DataClearFilters-test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import 'jest-styled-components';
 import { Data, View } from '../../Data';
 import { Grommet } from '../../Grommet';
@@ -8,7 +9,7 @@ import { DataSummary } from '../../DataSummary';
 
 // asserts that AnnounceContext aria-live region and visible DataSummary each have this text
 const expectDataSummary = (message: string) =>
-  expect(screen.getAllByText(message)).toHaveLength(2);
+  expect(screen.getByText(message)).toBeInTheDocument();
 
 const data = [
   {

--- a/src/js/components/DataSummary/__tests__/DataSummary-test.tsx
+++ b/src/js/components/DataSummary/__tests__/DataSummary-test.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import 'jest-styled-components';
 
 import { Data } from '../../Data';
@@ -10,7 +11,7 @@ import { DataSummary } from '..';
 
 // asserts that AnnounceContext aria-live region and visible DataSummary each have this text
 const expectDataSummary = (message: string) =>
-  expect(screen.getAllByText(message)).toHaveLength(2);
+  expect(screen.getByText(message)).toBeInTheDocument();
 
 const data = [{ name: 'a' }, { name: 'b' }];
 

--- a/src/js/components/Grommet/__tests__/Grommet-test.js
+++ b/src/js/components/Grommet/__tests__/Grommet-test.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import '@testing-library/jest-dom';
 import 'jest-styled-components';
 
 import { hpe as hpeTheme } from 'grommet-theme-hpe';
@@ -62,9 +61,7 @@ describe('Grommet', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test('announce', () => {
-    jest.useFakeTimers();
-
+  test('announce', (done) => {
     const { container } = render(
       <Grommet>
         <AnnounceContext.Consumer>
@@ -75,26 +72,18 @@ describe('Grommet', () => {
 
     expect(container.firstChild).toMatchSnapshot();
 
-    // Check that announcer element is created
-    const announcer = document.body.querySelector(
-      '#grommet-announcer[aria-live]',
-    );
-    expect(announcer).toBeInTheDocument();
-    expect(announcer).toMatchSnapshot();
+    // no style, no need for expectPortal
+    expect(
+      document.body.querySelector('#grommet-announcer[aria-live]'),
+    ).toMatchSnapshot();
 
-    jest.advanceTimersByTime(100);
-
-    // The message should now be announced
-    expect(announcer.textContent).toBe('hello');
-    expect(announcer.getAttribute('aria-live')).toBe('assertive');
-
-    // Fast-forward past the timeout
-    jest.advanceTimersByTime(500);
-
-    // The announcer should be cleared
-    expect(announcer.textContent).toBe('');
-
-    jest.useRealTimers();
+    setTimeout(() => {
+      // should clear the aria-live container
+      expect(
+        document.body.querySelector('#grommet-announcer[aria-live]'),
+      ).toMatchSnapshot();
+      done();
+    }, 600); // wait the aria-live container to clear
   });
 
   test('messages', () => {

--- a/src/js/components/Grommet/__tests__/Grommet-test.js
+++ b/src/js/components/Grommet/__tests__/Grommet-test.js
@@ -61,7 +61,9 @@ describe('Grommet', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test('announce', (done) => {
+  test('announce', () => {
+    jest.useFakeTimers();
+
     const { container } = render(
       <Grommet>
         <AnnounceContext.Consumer>
@@ -72,18 +74,25 @@ describe('Grommet', () => {
 
     expect(container.firstChild).toMatchSnapshot();
 
-    // no style, no need for expectPortal
-    expect(
-      document.body.querySelector('#grommet-announcer[aria-live]'),
-    ).toMatchSnapshot();
+    // Test announcer element properties
+    const announcer = document.body.querySelector(
+      '#grommet-announcer[aria-live]',
+    );
+    expect(announcer).toBeTruthy();
+    expect(announcer.getAttribute('aria-live')).toBe('assertive');
+    expect(announcer.getAttribute('aria-atomic')).toBe('true');
+    expect(announcer.id).toBe('grommet-announcer');
 
-    setTimeout(() => {
-      // should clear the aria-live container
-      expect(
-        document.body.querySelector('#grommet-announcer[aria-live]'),
-      ).toMatchSnapshot();
-      done();
-    }, 600); // wait the aria-live container to clear
+    jest.advanceTimersByTime(150);
+
+    // Now check that the message is announced
+    expect(announcer.textContent).toBe('hello');
+    jest.advanceTimersByTime(600);
+
+    // Check that content is cleared
+    expect(announcer.textContent).toBe('');
+
+    jest.useRealTimers();
   });
 
   test('messages', () => {

--- a/src/js/components/Grommet/__tests__/Grommet-test.js
+++ b/src/js/components/Grommet/__tests__/Grommet-test.js
@@ -78,9 +78,10 @@ describe('Grommet', () => {
 
     setTimeout(() => {
       // should clear the aria-live container
-      expect(
-        document.body.querySelector('#grommet-announcer[aria-live]'),
-      ).toMatchSnapshot();
+      const announcer = document.body.querySelector(
+        '#grommet-announcer[aria-live]',
+      );
+      expect(announcer.textContent).toBe('hello');
       done();
     }, 600); // wait the aria-live container to clear
   });

--- a/src/js/components/Grommet/__tests__/__snapshots__/Grommet-test.js.snap
+++ b/src/js/components/Grommet/__tests__/__snapshots__/Grommet-test.js.snap
@@ -20,31 +20,6 @@ exports[`Grommet announce 1`] = `
 </div>
 `;
 
-exports[`Grommet announce 2`] = `
-<div
-  aria-atomic="true"
-  aria-live="assertive"
-  data-initial-announce-timeout-id="rAF"
-  data-raf-id="1"
-  id="grommet-announcer"
-  style="position: absolute; left: -9999px; height: 1px; width: 1px; overflow: hidden;"
->
-   
-</div>
-`;
-
-exports[`Grommet announce 3`] = `
-<div
-  aria-atomic="true"
-  aria-live="assertive"
-  data-timeout-id="39"
-  id="grommet-announcer"
-  style="position: absolute; left: -9999px; height: 1px; width: 1px; overflow: hidden;"
->
-  hello
-</div>
-`;
-
 exports[`Grommet background 1`] = `
 .c0 {
   font-size: 18px;

--- a/src/js/components/Grommet/__tests__/__snapshots__/Grommet-test.js.snap
+++ b/src/js/components/Grommet/__tests__/__snapshots__/Grommet-test.js.snap
@@ -24,7 +24,7 @@ exports[`Grommet announce 2`] = `
 <div
   aria-atomic="true"
   aria-live="assertive"
-  data-initial-announce-timeout-id="38"
+  data-initial-announce-timeout-id="1000000000000"
   id="grommet-announcer"
   style="position: absolute; left: -9999px; height: 1px; width: 1px; overflow: hidden;"
 >

--- a/src/js/components/Grommet/__tests__/__snapshots__/Grommet-test.js.snap
+++ b/src/js/components/Grommet/__tests__/__snapshots__/Grommet-test.js.snap
@@ -32,18 +32,6 @@ exports[`Grommet announce 2`] = `
 </div>
 `;
 
-exports[`Grommet announce 3`] = `
-<div
-  aria-atomic="true"
-  aria-live="assertive"
-  data-timeout-id="40"
-  id="grommet-announcer"
-  style="position: absolute; left: -9999px; height: 1px; width: 1px; overflow: hidden;"
->
-  hello
-</div>
-`;
-
 exports[`Grommet background 1`] = `
 .c0 {
   font-size: 18px;

--- a/src/js/components/Grommet/__tests__/__snapshots__/Grommet-test.js.snap
+++ b/src/js/components/Grommet/__tests__/__snapshots__/Grommet-test.js.snap
@@ -22,20 +22,26 @@ exports[`Grommet announce 1`] = `
 
 exports[`Grommet announce 2`] = `
 <div
+  aria-atomic="true"
   aria-live="assertive"
+  data-initial-announce-timeout-id="38"
   id="grommet-announcer"
-  style="left: -100%; right: 100%; position: fixed; z-index: -1;"
+  style="position: absolute; left: -9999px; height: 1px; width: 1px; overflow: hidden;"
 >
-  hello
+   
 </div>
 `;
 
 exports[`Grommet announce 3`] = `
 <div
+  aria-atomic="true"
   aria-live="assertive"
+  data-timeout-id="40"
   id="grommet-announcer"
-  style="left: -100%; right: 100%; position: fixed; z-index: -1;"
-/>
+  style="position: absolute; left: -9999px; height: 1px; width: 1px; overflow: hidden;"
+>
+  hello
+</div>
 `;
 
 exports[`Grommet background 1`] = `

--- a/src/js/components/Grommet/__tests__/__snapshots__/Grommet-test.js.snap
+++ b/src/js/components/Grommet/__tests__/__snapshots__/Grommet-test.js.snap
@@ -24,11 +24,24 @@ exports[`Grommet announce 2`] = `
 <div
   aria-atomic="true"
   aria-live="assertive"
-  data-initial-announce-timeout-id="1000000000000"
+  data-initial-announce-timeout-id="rAF"
+  data-raf-id="1"
   id="grommet-announcer"
   style="position: absolute; left: -9999px; height: 1px; width: 1px; overflow: hidden;"
 >
    
+</div>
+`;
+
+exports[`Grommet announce 3`] = `
+<div
+  aria-atomic="true"
+  aria-live="assertive"
+  data-timeout-id="39"
+  id="grommet-announcer"
+  style="position: absolute; left: -9999px; height: 1px; width: 1px; overflow: hidden;"
+>
+  hello
 </div>
 `;
 

--- a/src/js/components/Notification/Notification.js
+++ b/src/js/components/Notification/Notification.js
@@ -1,10 +1,10 @@
 import React, {
   useCallback,
+  useContext,
   useEffect,
   useState,
   useMemo,
   Fragment,
-  useContext,
 } from 'react';
 import styled from 'styled-components';
 
@@ -18,6 +18,7 @@ import { MessageContext } from '../../contexts/MessageContext';
 
 import { NotificationType } from './propTypes';
 import { useThemeValue } from '../../utils/useThemeValue';
+import { AnnounceContext } from '../../contexts/AnnounceContext';
 
 const Message = ({ fill, direction, ...rest }) =>
   direction === 'row' ? (
@@ -89,6 +90,7 @@ const Notification = ({
   const [visible, setVisible] = useState(true);
   const { format } = useContext(MessageContext);
   const position = useMemo(() => (toast && toast?.position) || 'top', [toast]);
+  const announce = useContext(AnnounceContext);
 
   const close = useCallback(
     (event) => {
@@ -97,6 +99,15 @@ const Notification = ({
     },
     [onClose],
   );
+
+  useEffect(() => {
+    if (visible && toast) {
+      const announceText =
+        typeof messageProp === 'string' ? `${title}. ${messageProp}` : title;
+
+      announce(announceText, 'polite');
+    }
+  }, [announce, visible, toast, messageProp, title]);
 
   useEffect(() => {
     if (autoClose) {
@@ -259,7 +270,7 @@ const Notification = ({
     content = visible && (
       <Layer
         {...theme.notification.toast.layer}
-        role="log"
+        role="status"
         modal={false}
         onEsc={onClose}
         id={id}

--- a/src/js/components/Notification/__tests__/__snapshots__/Notification-test.tsx.snap
+++ b/src/js/components/Notification/__tests__/__snapshots__/Notification-test.tsx.snap
@@ -1965,7 +1965,7 @@ exports[`Notification position bottom 1`] = `
     class="c1"
     data-g-portal-id="0"
     id="position-test"
-    role="log"
+    role="status"
   >
     <div
       class="c2"
@@ -2220,7 +2220,7 @@ exports[`Notification position bottom-left 1`] = `
     class="c1"
     data-g-portal-id="0"
     id="position-test"
-    role="log"
+    role="status"
   >
     <div
       class="c2"
@@ -2475,7 +2475,7 @@ exports[`Notification position bottom-right 1`] = `
     class="c1"
     data-g-portal-id="0"
     id="position-test"
-    role="log"
+    role="status"
   >
     <div
       class="c2"
@@ -2730,7 +2730,7 @@ exports[`Notification position center 1`] = `
     class="c1"
     data-g-portal-id="0"
     id="position-test"
-    role="log"
+    role="status"
   >
     <div
       class="c2"
@@ -2985,7 +2985,7 @@ exports[`Notification position end 1`] = `
     class="c1"
     data-g-portal-id="0"
     id="position-test"
-    role="log"
+    role="status"
   >
     <div
       class="c2"
@@ -3240,7 +3240,7 @@ exports[`Notification position left 1`] = `
     class="c1"
     data-g-portal-id="0"
     id="position-test"
-    role="log"
+    role="status"
   >
     <div
       class="c2"
@@ -3495,7 +3495,7 @@ exports[`Notification position right 1`] = `
     class="c1"
     data-g-portal-id="0"
     id="position-test"
-    role="log"
+    role="status"
   >
     <div
       class="c2"
@@ -3750,7 +3750,7 @@ exports[`Notification position start 1`] = `
     class="c1"
     data-g-portal-id="0"
     id="position-test"
-    role="log"
+    role="status"
   >
     <div
       class="c2"
@@ -4005,7 +4005,7 @@ exports[`Notification position top 1`] = `
     class="c1"
     data-g-portal-id="0"
     id="position-test"
-    role="log"
+    role="status"
   >
     <div
       class="c2"
@@ -4260,7 +4260,7 @@ exports[`Notification position top-left 1`] = `
     class="c1"
     data-g-portal-id="0"
     id="position-test"
-    role="log"
+    role="status"
   >
     <div
       class="c2"
@@ -4515,7 +4515,7 @@ exports[`Notification position top-right 1`] = `
     class="c1"
     data-g-portal-id="0"
     id="position-test"
-    role="log"
+    role="status"
   >
     <div
       class="c2"

--- a/src/js/contexts/AnnounceContext/AnnounceContext.js
+++ b/src/js/contexts/AnnounceContext/AnnounceContext.js
@@ -7,7 +7,7 @@ import { AnnounceContextPropTypes } from './propTypes';
  */
 const createAnnouncer = () => {
   const announcer = document.createElement('div');
-  announcer.id = 'grommet-announcer';
+  announcer.setAttribute('id', 'grommet-announcer');
   announcer.setAttribute('aria-live', 'polite');
   announcer.setAttribute('aria-atomic', 'true');
 
@@ -19,7 +19,6 @@ const createAnnouncer = () => {
   announcer.style.overflow = 'hidden';
 
   // Add to DOM at the beginning of body for best screen reader support
-  document.body.appendChild(announcer);
   document.body.insertBefore(announcer, document.body.firstChild);
 
   return announcer;

--- a/src/js/contexts/AnnounceContext/AnnounceContext.js
+++ b/src/js/contexts/AnnounceContext/AnnounceContext.js
@@ -51,33 +51,39 @@ export const AnnounceContext = React.createContext(
     announcer.offsetWidth;
 
     // Delay before announcing to ensure screen readers are ready
-    const announceDelay = 100;
+    const announceStartTime = performance.now();
 
-    const initialAnnounceTimeout = setTimeout(() => {
-      // Set the actual message to be announced
-      announcer.textContent = message;
+    const checkAnnounceDelay = () => {
+      const currentTime = performance.now();
+      if (currentTime - announceStartTime >= 100) {
+        // Set the actual message to be announced
+        announcer.textContent = message;
 
-      // Set timeout to clear the message (if timeout > 0)
-      if (timeout > 0) {
-        const clearAnnounceTimeout = setTimeout(() => {
-          announcer.textContent = '';
+        // Set timeout to clear the message (if timeout > 0)
+        if (timeout > 0) {
+          const clearAnnounceTimeout = setTimeout(() => {
+            announcer.textContent = '';
+            delete announcer.dataset.timeoutId;
+          }, timeout);
+
+          // Store timeout ID for potential cleanup
+          announcer.dataset.timeoutId = clearAnnounceTimeout.toString();
+        } else {
+          // No auto-clear if timeout is 0
           delete announcer.dataset.timeoutId;
-        }, timeout);
+        }
 
-        // Store timeout ID for potential cleanup
-        announcer.dataset.timeoutId = clearAnnounceTimeout.toString();
+        // Clean up initial timeout reference
+        delete announcer.dataset.initialAnnounceTimeoutId;
       } else {
-        // No auto-clear if timeout is 0
-        delete announcer.dataset.timeoutId;
+        requestAnimationFrame(checkAnnounceDelay);
       }
+    };
 
-      // Clean up initial timeout reference
-      delete announcer.dataset.initialAnnounceTimeoutId;
-    }, announceDelay);
+    requestAnimationFrame(checkAnnounceDelay);
 
     // helps avoid multiple announcements stacking up
-    announcer.dataset.initialAnnounceTimeoutId =
-      initialAnnounceTimeout.toString();
+    announcer.dataset.initialAnnounceTimeoutId = 'rAF';
   },
 );
 

--- a/src/js/contexts/AnnounceContext/AnnounceContext.js
+++ b/src/js/contexts/AnnounceContext/AnnounceContext.js
@@ -7,7 +7,7 @@ import { AnnounceContextPropTypes } from './propTypes';
  */
 const createAnnouncer = () => {
   const announcer = document.createElement('div');
-  announcer.setAttribute('id', 'grommet-announcer');
+  announcer.id = 'grommet-announcer';
   announcer.setAttribute('aria-live', 'polite');
   announcer.setAttribute('aria-atomic', 'true');
 

--- a/src/js/contexts/AnnounceContext/AnnounceContext.js
+++ b/src/js/contexts/AnnounceContext/AnnounceContext.js
@@ -3,11 +3,15 @@ import { AnnounceContextPropTypes } from './propTypes';
 
 const createAnnouncer = () => {
   const announcer = document.createElement('div');
-  announcer.id = 'grommet-announcer';
-  announcer.style.left = '-100%';
-  announcer.style.right = '100%';
-  announcer.style.position = 'fixed';
-  announcer.style['z-index'] = '-1';
+  announcer.setAttribute('id', 'grommet-announcer');
+  announcer.setAttribute('aria-live', 'polite');
+  announcer.setAttribute('aria-atomic', 'true');
+  announcer.style.position = 'absolute';
+  announcer.style.left = '-9999px';
+  announcer.style.height = '1px';
+  announcer.style.width = '1px';
+  announcer.style.overflow = 'hidden';
+  document.body.appendChild(announcer);
 
   document.body.insertBefore(announcer, document.body.firstChild);
 
@@ -16,18 +20,48 @@ const createAnnouncer = () => {
 
 export const AnnounceContext = React.createContext(
   (message, mode = 'polite', timeout = 500) => {
-    // we only create a new container if we don't have one already
-    // we create a separate node so that grommet does not set aria-hidden to it
     const announcer =
-      document.body.querySelector(`#grommet-announcer[aria-live]`) ||
-      createAnnouncer();
+      document.body.querySelector('#grommet-announcer') || createAnnouncer();
 
-    announcer.setAttribute('aria-live', 'off');
-    announcer.innerHTML = message;
+    // Set aria-live for the upcoming message, in case it changes mode
     announcer.setAttribute('aria-live', mode);
-    setTimeout(() => {
-      announcer.innerHTML = '';
-    }, timeout);
+    announcer.textContent = '';
+
+    announcer.textContent = '\u00A0';
+
+    // Force a DOM reflow. This makes the browser immediately apply the DOM changes
+    // which can help screen readers detect the change more reliably.
+    void announcer.offsetWidth;
+
+    // Set a short delay before placing the actual message.
+    const announceDelay = 100;
+
+    const initialAnnounceTimeout = setTimeout(() => {
+      announcer.textContent = message;
+
+      // 4. Set a timeout to clear the message after the specified duration (if timeout > 0)
+      if (timeout > 0) {
+        const clearAnnounceTimeout = setTimeout(() => {
+          announcer.textContent = ''; // Clear the message after its display duration
+          delete announcer.dataset.timeoutId; // Remove the stored timeout ID
+        }, timeout);
+
+        // Store the ID of this *clear* timeout. This allows us to cancel it
+        // if a new announcement comes in before this one is cleared.
+        announcer.dataset.timeoutId = clearAnnounceTimeout.toString();
+      } else {
+        // If timeout is 0, the message should persist indefinitely until
+        // a new announcement occurs. Ensure no stale timeout ID.
+        delete announcer.dataset.timeoutId;
+      }
+      // Clean up the initial timeout ID once the message has been set
+      delete announcer.dataset.initialAnnounceTimeoutId;
+    }, announceDelay);
+
+    // Store the ID for the initial announce delay, in case it needs to be cancelled
+    // if a new message is triggered extremely quickly (e.g., within announceDelay).
+    announcer.dataset.initialAnnounceTimeoutId =
+      initialAnnounceTimeout.toString();
   },
 );
 

--- a/src/js/contexts/AnnounceContext/AnnounceContext.js
+++ b/src/js/contexts/AnnounceContext/AnnounceContext.js
@@ -41,7 +41,6 @@ export const AnnounceContext = React.createContext(
       announcer.textContent = message;
 
       // Set a timeout to clear the message after the specified duration
-      // (if timeout > 0)
       if (timeout > 0) {
         const clearAnnounceTimeout = setTimeout(() => {
           announcer.textContent = ''; // Clear the message after display

--- a/src/js/contexts/AnnounceContext/AnnounceContext.js
+++ b/src/js/contexts/AnnounceContext/AnnounceContext.js
@@ -29,9 +29,10 @@ export const AnnounceContext = React.createContext(
 
     announcer.textContent = '\u00A0';
 
-    // Force a DOM reflow. This makes the browser immediately apply the DOM changes
-    // which can help screen readers detect the change more reliably.
-    void announcer.offsetWidth;
+    // Force a DOM reflow. This makes the browser immediately apply the DOM
+    // changes which can help screen readers detect the change more reliably.
+    // eslint-disable-next-line no-unused-expressions
+    announcer.offsetWidth;
 
     // Set a short delay before placing the actual message.
     const announceDelay = 100;
@@ -39,11 +40,12 @@ export const AnnounceContext = React.createContext(
     const initialAnnounceTimeout = setTimeout(() => {
       announcer.textContent = message;
 
-      // 4. Set a timeout to clear the message after the specified duration (if timeout > 0)
+      // Set a timeout to clear the message after the specified duration
+      // (if timeout > 0)
       if (timeout > 0) {
         const clearAnnounceTimeout = setTimeout(() => {
-          announcer.textContent = ''; // Clear the message after its display duration
-          delete announcer.dataset.timeoutId; // Remove the stored timeout ID
+          announcer.textContent = ''; // Clear the message after display
+          delete announcer.dataset.timeoutId; // Remove stored timeout ID
         }, timeout);
 
         // Store the ID of this *clear* timeout. This allows us to cancel it
@@ -58,8 +60,9 @@ export const AnnounceContext = React.createContext(
       delete announcer.dataset.initialAnnounceTimeoutId;
     }, announceDelay);
 
-    // Store the ID for the initial announce delay, in case it needs to be cancelled
-    // if a new message is triggered extremely quickly (e.g., within announceDelay).
+    // Store the ID for the initial announce delay, in case it needs to be
+    // cancelled if a new message is triggered extremely quickly
+    // (e.g., within announceDelay).
     announcer.dataset.initialAnnounceTimeoutId =
       initialAnnounceTimeout.toString();
   },


### PR DESCRIPTION
#### What does this PR do?
Improves the reliability and accessibility of the AnnounceContext utility in Grommet, which is used to trigger screen reader announcements. 
The previous implementation had structural and timing issues that caused announcements to be missed or inconsistently read by screen readers.

**Key improvements:**
1. Replaces innerHTML with textContent to avoid parsing and ensure clean text announcements.

2. Renders a persistently hidden live region using visually hidden styles that are more widely recognized by screen readers.

3. Adds aria-atomic="true" to ensure the entire message is read.

4. Forces a DOM reflow (offsetWidth) and uses a short timeout before setting the message content, which helps screen readers recognize announcements—especially when using aria-live="polite".

#### Where should the reviewer start?
AnnounceContext.js

#### What testing has been done?
Manual testing in Storybook using macOS VoiceOver

#### Any background context?
The previous implementation:

inserted a live region with z-index: -1, which some screen readers ignored

Used innerHTML instead of textContent, which is not recommended for screen readers

**Resources:**

https://css-tricks.com/inclusively-hidden/

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-atomic

https://stackoverflow.com/questions/75520027/using-a-separate-status-div-with-aria-live-assertive-to-handle-toast-message

https://github.com/nvaccess/nvda/issues/7996

So with the AnnounceContext the story is rendered inside an iframe in the storybook.
There are known issues with `aria-live` and iframes suck that can result in messages being read twice or inconsistently.

While `aria-live="polite"` is designed to announce dynamic content changes without interrupting the user's current task, issues can arise when implementing it within an iframe, especially with VoiceOver. 

https://stackoverflow.com/questions/61244988/aria-live-content-read-twice-by-mac-chrome-voiceover#:~:text=According%20to%20a%20bug%20report%2C%20VoiceOver%20duplicates,in%20iframe**%20Aria%2Dlive%20reads%20content%20only%20once

While testing this open a new window so that the example is rendered without iframe

#### Related issues?
Related to #7607

#### Do the Grommet docs need to be updated?
No

#### Should this PR be mentioned in release notes?
Yes

#### Is this change backwards compatible?
Yes