### PR TITLE
AnnounceContext -- ensure "polite" mode is announced

### DIFF
--- a/src/js/components/Data/__tests__/Data-test.tsx
+++ b/src/js/components/Data/__tests__/Data-test.tsx
@@ -14,9 +14,10 @@ import { Data } from '..';
 import { createPortal, expectPortal } from '../../../utils/portal';
 const DEBOUNCE_TIMEOUT = 300;
 
-// asserts that AnnounceContext aria-live region and visible DataSummary each have this text
+// asserts that DataSummary has text. Previously this was set to 2 to include AnnounceContext
+// but that is no longer the case with improvments to AnnounceContext in "polite" mode.
 const expectDataSummary = (message: string) =>
-  expect(screen.getAllByText(message)).toHaveLength(2);
+  expect(screen.getAllByText(message)).toHaveLength(1);
 
 const data = [
   {

--- a/src/js/components/DataClearFilters/__tests__/DataClearFilters-test.tsx
+++ b/src/js/components/DataClearFilters/__tests__/DataClearFilters-test.tsx
@@ -6,9 +6,10 @@ import { Grommet } from '../../Grommet';
 import { DataClearFilters } from '..';
 import { DataSummary } from '../../DataSummary';
 
-// asserts that AnnounceContext aria-live region and visible DataSummary each have this text
+// asserts that DataSummary has text. Previously this was set to 2 to include AnnounceContext
+// but that is no longer the case with improvments to AnnounceContext in "polite" mode.
 const expectDataSummary = (message: string) =>
-  expect(screen.getAllByText(message)).toHaveLength(2);
+  expect(screen.getAllByText(message)).toHaveLength(1);
 
 const data = [
   {

--- a/src/js/components/DataSummary/__tests__/DataSummary-test.tsx
+++ b/src/js/components/DataSummary/__tests__/DataSummary-test.tsx
@@ -8,9 +8,10 @@ import { DataTable } from '../../DataTable';
 import { Grommet } from '../../Grommet';
 import { DataSummary } from '..';
 
-// asserts that AnnounceContext aria-live region and visible DataSummary each have this text
+// asserts that DataSummary has text. Previously this was set to 2 to include AnnounceContext
+// but that is no longer the case with improvments to AnnounceContext in "polite" mode.
 const expectDataSummary = (message: string) =>
-  expect(screen.getAllByText(message)).toHaveLength(2);
+  expect(screen.getAllByText(message)).toHaveLength(1);
 
 const data = [{ name: 'a' }, { name: 'b' }];
 

--- a/src/js/components/Grommet/__tests__/__snapshots__/Grommet-test.js.snap
+++ b/src/js/components/Grommet/__tests__/__snapshots__/Grommet-test.js.snap
@@ -22,6 +22,7 @@ exports[`Grommet announce 1`] = `
 
 exports[`Grommet announce 2`] = `
 <div
+  aria-atomic="true"
   aria-live="assertive"
   id="grommet-announcer"
   style="left: -100%; right: 100%; position: fixed; z-index: -1;"
@@ -32,6 +33,7 @@ exports[`Grommet announce 2`] = `
 
 exports[`Grommet announce 3`] = `
 <div
+  aria-atomic="true"
   aria-live="assertive"
   id="grommet-announcer"
   style="left: -100%; right: 100%; position: fixed; z-index: -1;"

--- a/src/js/components/Notification/Notification.js
+++ b/src/js/components/Notification/Notification.js
@@ -14,6 +14,8 @@ import { Button } from '../Button';
 import { Layer } from '../Layer';
 import { Paragraph } from '../Paragraph';
 import { Text } from '../Text';
+// eslint-disable-next-line max-len
+import { AnnounceContext } from '../../contexts/AnnounceContext/AnnounceContext';
 import { MessageContext } from '../../contexts/MessageContext';
 
 import { NotificationType } from './propTypes';
@@ -90,6 +92,29 @@ const Notification = ({
   const { format } = useContext(MessageContext);
   const position = useMemo(() => (toast && toast?.position) || 'top', [toast]);
 
+  const announce = useContext(AnnounceContext);
+  useEffect(() => {
+    if (visible && toast) {
+      const announceText =
+        typeof messageProp === 'string' ? `${title}. ${messageProp}` : title;
+
+      announce(
+        announceText,
+        'polite',
+        time || theme.notification.toast.time || theme.notification.time,
+      );
+    }
+  }, [
+    announce,
+    visible,
+    toast,
+    messageProp,
+    title,
+    theme.notification.toast.time,
+    theme.notification.time,
+    time,
+  ]);
+
   const close = useCallback(
     (event) => {
       setVisible(false);
@@ -97,7 +122,6 @@ const Notification = ({
     },
     [onClose],
   );
-
   useEffect(() => {
     if (autoClose) {
       const timer = setTimeout(
@@ -259,7 +283,7 @@ const Notification = ({
     content = visible && (
       <Layer
         {...theme.notification.toast.layer}
-        role="log"
+        role="status"
         modal={false}
         onEsc={onClose}
         id={id}

--- a/src/js/components/Notification/__tests__/__snapshots__/Notification-test.tsx.snap
+++ b/src/js/components/Notification/__tests__/__snapshots__/Notification-test.tsx.snap
@@ -1965,7 +1965,7 @@ exports[`Notification position bottom 1`] = `
     class="c1"
     data-g-portal-id="0"
     id="position-test"
-    role="log"
+    role="status"
   >
     <div
       class="c2"
@@ -2220,7 +2220,7 @@ exports[`Notification position bottom-left 1`] = `
     class="c1"
     data-g-portal-id="0"
     id="position-test"
-    role="log"
+    role="status"
   >
     <div
       class="c2"
@@ -2475,7 +2475,7 @@ exports[`Notification position bottom-right 1`] = `
     class="c1"
     data-g-portal-id="0"
     id="position-test"
-    role="log"
+    role="status"
   >
     <div
       class="c2"
@@ -2730,7 +2730,7 @@ exports[`Notification position center 1`] = `
     class="c1"
     data-g-portal-id="0"
     id="position-test"
-    role="log"
+    role="status"
   >
     <div
       class="c2"
@@ -2985,7 +2985,7 @@ exports[`Notification position end 1`] = `
     class="c1"
     data-g-portal-id="0"
     id="position-test"
-    role="log"
+    role="status"
   >
     <div
       class="c2"
@@ -3240,7 +3240,7 @@ exports[`Notification position left 1`] = `
     class="c1"
     data-g-portal-id="0"
     id="position-test"
-    role="log"
+    role="status"
   >
     <div
       class="c2"
@@ -3495,7 +3495,7 @@ exports[`Notification position right 1`] = `
     class="c1"
     data-g-portal-id="0"
     id="position-test"
-    role="log"
+    role="status"
   >
     <div
       class="c2"
@@ -3750,7 +3750,7 @@ exports[`Notification position start 1`] = `
     class="c1"
     data-g-portal-id="0"
     id="position-test"
-    role="log"
+    role="status"
   >
     <div
       class="c2"
@@ -4005,7 +4005,7 @@ exports[`Notification position top 1`] = `
     class="c1"
     data-g-portal-id="0"
     id="position-test"
-    role="log"
+    role="status"
   >
     <div
       class="c2"
@@ -4260,7 +4260,7 @@ exports[`Notification position top-left 1`] = `
     class="c1"
     data-g-portal-id="0"
     id="position-test"
-    role="log"
+    role="status"
   >
     <div
       class="c2"
@@ -4515,7 +4515,7 @@ exports[`Notification position top-right 1`] = `
     class="c1"
     data-g-portal-id="0"
     id="position-test"
-    role="log"
+    role="status"
   >
     <div
       class="c2"

--- a/src/js/contexts/AnnounceContext/AnnounceContext.js
+++ b/src/js/contexts/AnnounceContext/AnnounceContext.js
@@ -1,9 +1,13 @@
 import React from 'react';
 import { AnnounceContextPropTypes } from './propTypes';
 
+const DEFAULT_MODE = 'polite';
+
 const createAnnouncer = () => {
   const announcer = document.createElement('div');
   announcer.id = 'grommet-announcer';
+  announcer.setAttribute('aria-live', DEFAULT_MODE);
+  announcer.setAttribute('aria-atomic', 'true');
   announcer.style.left = '-100%';
   announcer.style.right = '100%';
   announcer.style.position = 'fixed';
@@ -14,19 +18,33 @@ const createAnnouncer = () => {
   return announcer;
 };
 
+let announceCounter = 0; // Counter to ensure unique announcements
+
 export const AnnounceContext = React.createContext(
-  (message, mode = 'polite', timeout = 500) => {
+  (message, mode = DEFAULT_MODE, timeout = 500) => {
     // we only create a new container if we don't have one already
     // we create a separate node so that grommet does not set aria-hidden to it
     const announcer =
       document.body.querySelector(`#grommet-announcer[aria-live]`) ||
       createAnnouncer();
 
-    announcer.setAttribute('aria-live', 'off');
-    announcer.innerHTML = message;
     announcer.setAttribute('aria-live', mode);
+    if (mode === 'polite') {
+      // using setTimeout for polite mode pushes to next event loop tick,
+      // giving time for the browser to process the change
+      setTimeout(() => {
+        const invisibleChars = ['\u200B', '\uFEFF', '\u200C', '\u200D'];
+        const uniqueChar =
+          invisibleChars[announceCounter % invisibleChars.length];
+        announceCounter += 1; // Increment the counter for the next call
+        // set the message with a unique invisible character to ensure
+        // it is registered as different by screen readers
+        announcer.textContent = `${message}${uniqueChar}`;
+      }, 0);
+    } else announcer.textContent = message;
+    // clear the message after the specified timeout
     setTimeout(() => {
-      announcer.innerHTML = '';
+      announcer.textContent = '';
     }, timeout);
   },
 );


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Exploring a slightly alternate approach to https://github.com/grommet/grommet/pull/7701

Similar goal of ensure the browser has time to register "polite" mode and that if someone interacts with the same control again that it will announce again by registering it as unique.

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
