### PR TITLE
fix header text overlap with searchbuton

### DIFF
--- a/src/js/components/DataTable/Header.js
+++ b/src/js/components/DataTable/Header.js
@@ -410,7 +410,7 @@ const Header = forwardRef(
               // from automatically filling the vertical space.
               content = (
                 <Box
-                  flex="grow"
+                  flex={onResize || search ? { grow: 1, shrink: 1 } : 'grow'}
                   fill={onResize || search ? 'vertical' : false}
                   justify={(!align && 'center') || align}
                 >

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.tsx.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.tsx.snap
@@ -3461,7 +3461,7 @@ exports[`DataTable custom theme 1`] = `
   min-width: 0;
   min-height: 0;
   flex-direction: column;
-  flex: 1 0 auto;
+  flex: 1 1 auto;
   height: 100%;
   justify-content: center;
 }
@@ -4062,7 +4062,7 @@ exports[`DataTable custom theme 2`] = `
             style="position: relative;"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 kuLnal"
+              class="StyledBox-sc-13pk1d4-0 doOSIY"
             >
               <button
                 class="StyledButton-sc-323bzc-0 hHREQh Header__StyledHeaderCellButton-sc-1baku5q-0 kFaTHr"
@@ -20880,7 +20880,7 @@ exports[`DataTable resizeable 1`] = `
   min-width: 0;
   min-height: 0;
   flex-direction: column;
-  flex: 1 0 auto;
+  flex: 1 1 auto;
   height: 100%;
   justify-content: center;
 }
@@ -23591,7 +23591,7 @@ exports[`DataTable search 1`] = `
   min-width: 0;
   min-height: 0;
   flex-direction: column;
-  flex: 1 0 auto;
+  flex: 1 1 auto;
   height: 100%;
   justify-content: center;
 }
@@ -23913,7 +23913,7 @@ exports[`DataTable search 2`] = `
             class="StyledBox-sc-13pk1d4-0 bdQsBF"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 kuLnal"
+              class="StyledBox-sc-13pk1d4-0 doOSIY"
             >
               <span
                 class="StyledText-sc-1sadyjn-0 ldA-DUE"


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
- fixes dataTable header text overlap with search button
- closes #7630    

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?
- Visit the story https://storybook.grommet.io/?path=/story/visualizations-datatable-tunable--tunable-data-table
- resize any of the columns, the heading text does not overlap the search button in the header

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
