### PR TITLE
Prevent umounting of Accordion and Collapsible content

### DIFF
--- a/src/js/components/Accordion/Accordion.js
+++ b/src/js/components/Accordion/Accordion.js
@@ -16,6 +16,7 @@ const Accordion = forwardRef(
       level,
       multiple,
       onActive,
+      keepMount,
       ...rest
     },
     ref,
@@ -60,9 +61,10 @@ const Accordion = forwardRef(
           animate,
           level,
           onPanelChange: () => onPanelChange(index),
+          keepMount,
         };
       },
-      [activeIndexes, animate, level, multiple, onActive],
+      [activeIndexes, animate, keepMount, level, multiple, onActive],
     );
 
     return (

--- a/src/js/components/Accordion/__tests__/Accordion-test.tsx
+++ b/src/js/components/Accordion/__tests__/Accordion-test.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import 'jest-styled-components';
 import 'jest-axe/extend-expect';
 import 'regenerator-runtime/runtime';
+import '@testing-library/jest-dom';
 
 import { axe } from 'jest-axe';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { Accordion, AccordionPanel, Box, Grommet } from '../..';
@@ -407,5 +408,70 @@ describe('Accordion', () => {
     ).toBeTruthy();
 
     expect(asFragment()).toMatchSnapshot();
+  });
+
+  test('should keep mount panels content', () => {
+    const Test = () => {
+      const [activeIndex, setActiveIndex] = useState([0]);
+
+      return (
+        <Accordion
+          level={2}
+          keepMount
+          activeIndex={activeIndex}
+          onActive={setActiveIndex}
+        >
+          <AccordionPanel label="Panel" data-testid="panel">
+            <div data-testid="panel-body">Panel body</div>
+          </AccordionPanel>
+        </Accordion>
+      );
+    };
+
+    render(
+      <Grommet>
+        <Test />
+      </Grommet>,
+    );
+
+    const panelBody = screen.getByTestId('panel-body');
+    expect(panelBody).toBeInTheDocument();
+
+    const accordionPanel = screen.getByTestId('panel');
+    fireEvent.click(accordionPanel);
+    expect(panelBody).toBeInTheDocument();
+  });
+
+  test('should keep mount panels content (animate=false)', () => {
+    const Test = () => {
+      const [activeIndex, setActiveIndex] = useState([0]);
+
+      return (
+        <Accordion
+          level={2}
+          keepMount
+          animate={false}
+          activeIndex={activeIndex}
+          onActive={setActiveIndex}
+        >
+          <AccordionPanel label="Panel" data-testid="panel">
+            <div data-testid="panel-body">Panel body</div>
+          </AccordionPanel>
+        </Accordion>
+      );
+    };
+
+    render(
+      <Grommet>
+        <Test />
+      </Grommet>,
+    );
+
+    const panelBody = screen.getByTestId('panel-body');
+    expect(panelBody).toBeInTheDocument();
+
+    const accordionPanel = screen.getByTestId('panel');
+    fireEvent.click(accordionPanel);
+    expect(panelBody).toBeInTheDocument();
   });
 });

--- a/src/js/components/Accordion/index.d.ts
+++ b/src/js/components/Accordion/index.d.ts
@@ -9,6 +9,7 @@ export interface AccordionProps {
   onActive?: (activeIndexes: number[]) => void;
   multiple?: boolean;
   messages?: { tabContents?: string };
+  keepMount?: boolean;
 }
 
 export interface AccordionExtendedProps

--- a/src/js/components/Accordion/propTypes.js
+++ b/src/js/components/Accordion/propTypes.js
@@ -17,6 +17,7 @@ if (process.env.NODE_ENV !== 'production') {
     messages: PropTypes.shape({
       tabContents: PropTypes.string,
     }),
+    keepMount: PropTypes.bool,
   };
 }
 export const AccordionPropTypes = PropType;

--- a/src/js/components/AccordionPanel/AccordionPanel.js
+++ b/src/js/components/AccordionPanel/AccordionPanel.js
@@ -12,8 +12,8 @@ import { AccordionPanelPropTypes } from './propTypes';
 import { useThemeValue } from '../../utils/useThemeValue';
 
 const HiddenBox = styled(Box)`
-  max-height: ${({ hidden }) => (hidden ? '0px' : 'initial')};
-  overflow: ${({ hidden }) => (hidden ? 'hidden' : 'visible')};
+  max-height: ${({ hide }) => (hide ? '0px' : 'initial')};
+  overflow: ${({ hide }) => (hide ? 'hidden' : 'visible')};
 `;
 
 const AccordionPanel = forwardRef(
@@ -177,7 +177,7 @@ const AccordionPanel = forwardRef(
             <Collapsible open={active}>{children}</Collapsible>
           )}
           {!animate && keepMount && (
-            <HiddenBox hidden={!active}>{children}</HiddenBox>
+            <HiddenBox hide={!active}>{children}</HiddenBox>
           )}
           {!animate && !keepMount && active && children}
         </Box>

--- a/src/js/components/AccordionPanel/AccordionPanel.js
+++ b/src/js/components/AccordionPanel/AccordionPanel.js
@@ -1,5 +1,6 @@
 import React, { forwardRef, useContext, useMemo, useState } from 'react';
 
+import styled from 'styled-components';
 import { normalizeColor, parseMetricToNum, useId } from '../../utils';
 import { Box } from '../Box';
 import { Button } from '../Button';
@@ -9,6 +10,11 @@ import { Heading } from '../Heading';
 import { AccordionContext } from '../Accordion/AccordionContext';
 import { AccordionPanelPropTypes } from './propTypes';
 import { useThemeValue } from '../../utils/useThemeValue';
+
+const HiddenBox = styled(Box)`
+  max-height: ${({ hidden }) => (hidden ? '0px' : 'initial')};
+  overflow: ${({ hidden }) => (hidden ? 'hidden' : 'visible')};
+`;
 
 const AccordionPanel = forwardRef(
   (
@@ -28,7 +34,7 @@ const AccordionPanel = forwardRef(
   ) => {
     const panelButtonId = useId();
     const { theme } = useThemeValue();
-    const { active, animate, level, onPanelChange } =
+    const { active, animate, level, onPanelChange, keepMount } =
       useContext(AccordionContext);
     const [hover, setHover] = useState(undefined);
     const [focus, setFocus] = useState();
@@ -162,11 +168,18 @@ const AccordionPanel = forwardRef(
           border={contentBorder}
           aria-labelledby={panelButtonId}
         >
-          {animate ? (
-            <Collapsible open={active}>{children}</Collapsible>
-          ) : (
-            active && children
+          {animate && keepMount && (
+            <Collapsible open={active} keepMount={keepMount}>
+              {children}
+            </Collapsible>
           )}
+          {animate && !keepMount && (
+            <Collapsible open={active}>{children}</Collapsible>
+          )}
+          {!animate && keepMount && (
+            <HiddenBox hidden={!active}>{children}</HiddenBox>
+          )}
+          {!animate && !keepMount && active && children}
         </Box>
       </Box>
     );

--- a/src/js/components/Collapsible/Collapsible.js
+++ b/src/js/components/Collapsible/Collapsible.js
@@ -19,8 +19,13 @@ const AnimatedBox = styled(Box)`
       overflow: ${props.animate || !props.open ? 'hidden' : 'visible'};`}
 `;
 
+const HiddenBox = styled(Box)`
+  max-height: ${({ hidden }) => (hidden ? '0px' : 'initial')};
+  overflow: ${({ hidden }) => (hidden ? 'hidden' : 'visible')};
+`;
+
 const Collapsible = forwardRef(
-  ({ children, direction, open: openArg }, ref) => {
+  ({ children, direction, open: openArg, keepMount }, ref) => {
     const { theme } = useThemeValue();
     const [open, setOpen] = useState(openArg);
     const [animate, setAnimate] = useState(false);
@@ -115,7 +120,12 @@ const Collapsible = forwardRef(
         // skipped if animation is in progress
         shouldOpen={!animate && shouldOpen}
       >
-        {shouldOpen || open || animate ? children : null}
+        {keepMount && (
+          <HiddenBox hidden={!(shouldOpen || open || animate)}>
+            {children}
+          </HiddenBox>
+        )}
+        {!keepMount && (shouldOpen || open || animate) && children}
       </AnimatedBox>
     );
   },

--- a/src/js/components/Collapsible/Collapsible.js
+++ b/src/js/components/Collapsible/Collapsible.js
@@ -20,8 +20,8 @@ const AnimatedBox = styled(Box)`
 `;
 
 const HiddenBox = styled(Box)`
-  max-height: ${({ hidden }) => (hidden ? '0px' : 'initial')};
-  overflow: ${({ hidden }) => (hidden ? 'hidden' : 'visible')};
+  max-height: ${({ hide }) => (hide ? '0px' : 'initial')};
+  overflow: ${({ hide }) => (hide ? 'hidden' : 'visible')};
 `;
 
 const Collapsible = forwardRef(
@@ -121,7 +121,7 @@ const Collapsible = forwardRef(
         shouldOpen={!animate && shouldOpen}
       >
         {keepMount && (
-          <HiddenBox hidden={!(shouldOpen || open || animate)}>
+          <HiddenBox hide={!(shouldOpen || open || animate)}>
             {children}
           </HiddenBox>
         )}

--- a/src/js/components/Collapsible/__tests__/Collapsible-test.tsx
+++ b/src/js/components/Collapsible/__tests__/Collapsible-test.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import 'jest-styled-components';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { axe } from 'jest-axe';
 import 'jest-axe/extend-expect';
 import 'regenerator-runtime/runtime';
+import '@testing-library/jest-dom';
 
 import { Collapsible } from '..';
 import { Grommet } from '../../Grommet';
@@ -59,5 +60,18 @@ describe('Collapsible', () => {
       </Grommet>,
     );
     expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test('should keep mount content', () => {
+    render(
+      <Grommet>
+        <Collapsible open={false} keepMount>
+          <Text>Example</Text>
+        </Collapsible>
+      </Grommet>,
+    );
+
+    const collapsibleContent = screen.getByText('Example');
+    expect(collapsibleContent).toBeInTheDocument();
   });
 });

--- a/src/js/components/Collapsible/index.d.ts
+++ b/src/js/components/Collapsible/index.d.ts
@@ -3,6 +3,7 @@ import * as React from 'react';
 export interface CollapsibleProps {
   open?: boolean;
   direction?: 'horizontal' | 'vertical';
+  keepMount?: boolean;
 }
 
 type divProps = React.DetailedHTMLProps<

--- a/src/js/components/Collapsible/propTypes.js
+++ b/src/js/components/Collapsible/propTypes.js
@@ -5,6 +5,7 @@ if (process.env.NODE_ENV !== 'production') {
   PropType = {
     open: PropTypes.bool,
     direction: PropTypes.oneOf(['horizontal', 'vertical']),
+    keepMount: PropType.bool,
   };
 }
 export const CollapsiblePropTypes = PropType;

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -11,6 +11,7 @@ exports[`Components loads 1`] = `
       "animate": [Function],
       "children": [Function],
       "gridArea": [Function],
+      "keepMount": [Function],
       "level": [Function],
       "margin": [Function],
       "messages": [Function],
@@ -260,6 +261,7 @@ exports[`Components loads 1`] = `
     "$$typeof": Symbol(react.forward_ref),
     "propTypes": {
       "direction": [Function],
+      "keepMount": undefined,
       "open": [Function],
     },
     "render": [Function],


### PR DESCRIPTION
When an accordion panel are callapsed its content are removed from DOM. If an accordion containing input fields within a form is collapsed, its inputs are unmounted, causing the form to submit an incomplete or invalid data set (https://design-system.hpe.design/templates/forms/managing-child-objects?q=child).

In this PR I added a `keepMount` prop to `Accordion` and `Collapsible` component to prevent content umounting.

`Accordion` and `Collapsible` docs may be update adding `keepMount` prop description.