### PR TITLE
Ensure all buttons and anchors in FileInput are disabled when input is

### DIFF
--- a/src/js/components/Anchor/Anchor.js
+++ b/src/js/components/Anchor/Anchor.js
@@ -96,10 +96,14 @@ const Anchor = forwardRef(
         reverse={reverse}
         href={!disabled ? href : undefined}
         onClick={!disabled ? onClick : undefined}
-        onFocus={(event) => {
-          setFocus(true);
-          if (onFocus) onFocus(event);
-        }}
+        onFocus={
+          !disabled
+            ? (event) => {
+                setFocus(true);
+                if (onFocus) onFocus(event);
+              }
+            : undefined
+        }
         onBlur={(event) => {
           setFocus(false);
           if (onBlur) onBlur(event);

--- a/src/js/components/FileInput/FileInput.js
+++ b/src/js/components/FileInput/FileInput.js
@@ -347,6 +347,7 @@ const FileInput = forwardRef(
                       <Button
                         // The focus here is redundant for keyboard users
                         tabIndex={-1}
+                        disabled={disabled}
                         ref={controlRef}
                         kind={theme.fileInput.button}
                         label={format({
@@ -363,6 +364,7 @@ const FileInput = forwardRef(
                         // The focus here is redundant for keyboard users
                         tabIndex={-1}
                         alignSelf="center"
+                        disabled={disabled}
                         ref={controlRef}
                         margin="small"
                         onClick={() => {
@@ -421,6 +423,7 @@ const FileInput = forwardRef(
                     <Button
                       // The focus here is redundant for keyboard users
                       tabIndex={-1}
+                      disabled={disabled}
                       ref={controlRef}
                       kind={theme.fileInput.button}
                       label={format({
@@ -437,6 +440,7 @@ const FileInput = forwardRef(
                       // The focus here is redundant for keyboard users
                       tabIndex={-1}
                       alignSelf="center"
+                      disabled={disabled}
                       ref={controlRef}
                       margin="small"
                       onClick={() => {
@@ -518,6 +522,7 @@ const FileInput = forwardRef(
                         <Button
                           // The focus here is redundant for keyboard users
                           tabIndex={-1}
+                          disabled={disabled}
                           ref={controlRef}
                           kind={theme.fileInput.button}
                           label={format({
@@ -533,6 +538,7 @@ const FileInput = forwardRef(
                         <Anchor
                           // The focus here is redundant for keyboard users
                           tabIndex={-1}
+                          disabled={disabled}
                           ref={controlRef}
                           margin="small"
                           onClick={() => {

--- a/src/js/components/FileInput/__tests__/__snapshots__/FileInput-test.tsx.snap
+++ b/src/js/components/FileInput/__tests__/__snapshots__/FileInput-test.tsx.snap
@@ -1085,10 +1085,9 @@ exports[`FileInput disabled 1`] = `
   cursor: pointer;
   align-self: center;
   margin: 12px;
-}
-
-.c6:hover {
-  text-decoration: underline;
+  opacity: 0.3;
+  cursor: default;
+  text-decoration: none;
 }
 
 .c5 {
@@ -1207,6 +1206,7 @@ exports[`FileInput disabled 1`] = `
       </span>
       <a
         class="c6"
+        disabled=""
         tabindex="-1"
       >
         browse
@@ -1334,10 +1334,9 @@ exports[`FileInput disabled with file selected 1`] = `
   text-decoration: none;
   cursor: pointer;
   margin: 12px;
-}
-
-.c13:hover {
-  text-decoration: underline;
+  opacity: 0.3;
+  cursor: default;
+  text-decoration: none;
 }
 
 .c2 {
@@ -1585,6 +1584,7 @@ exports[`FileInput disabled with file selected 1`] = `
               </button>
               <a
                 class="c13"
+                disabled=""
                 tabindex="-1"
               >
                 browse


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

When FileInput is `disabled`, the internal "Browse" button/anchor should also be `disabled`. Currently, the functionality of the container disables them, but their visual and cursor styling isn't disabled. This fixes that.
 
#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #7528 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
