### PR TITLE
DateInput — Ensure disabled applies to calendar button

### DIFF
--- a/src/js/components/DateInput/DateInput.js
+++ b/src/js/components/DateInput/DateInput.js
@@ -290,6 +290,7 @@ Use the icon prop instead.`,
 
     const DateInputButton = readOnlyCopy ? (
       <CopyButton
+        disabled={disabled}
         onBlurCopy={onBlurCopy}
         onClickCopy={onClickCopy}
         readOnlyCopyPrompt={readOnlyCopyPrompt}

--- a/src/js/components/DateInput/DateInput.js
+++ b/src/js/components/DateInput/DateInput.js
@@ -270,6 +270,7 @@ Use the icon prop instead.`,
         <DropButton
           ref={ref}
           id={id}
+          disabled={disabled}
           dropProps={{ align: calendarDropdownAlign, ...dropProps }}
           dropContent={calendar}
           icon={icon || MaskedInputIcon || <CalendarIcon size={iconSize} />}
@@ -299,6 +300,7 @@ Use the icon prop instead.`,
     ) : (
       <Button
         onClick={open ? closeCalendar : openCalendar}
+        disabled={disabled}
         plain
         icon={icon || MaskedInputIcon || <CalendarIcon size={iconSize} />}
         margin={reverse ? { left: 'small' } : { right: 'small' }}

--- a/src/js/components/DateInput/DateInput.js
+++ b/src/js/components/DateInput/DateInput.js
@@ -270,7 +270,6 @@ Use the icon prop instead.`,
         <DropButton
           ref={ref}
           id={id}
-          disabled={disabled}
           dropProps={{ align: calendarDropdownAlign, ...dropProps }}
           dropContent={calendar}
           icon={icon || MaskedInputIcon || <CalendarIcon size={iconSize} />}

--- a/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.tsx.snap
+++ b/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.tsx.snap
@@ -6092,8 +6092,6 @@ exports[`DateInput disabled 1`] = `
   border: none;
   padding: 0;
   text-align: inherit;
-  opacity: 0.3;
-  cursor: default;
   line-height: 0;
   padding: 12px;
 }
@@ -6144,7 +6142,6 @@ exports[`DateInput disabled 1`] = `
   <button
     aria-label="Open Drop"
     class="c1"
-    disabled=""
     type="button"
   >
     <svg

--- a/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.tsx.snap
+++ b/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.tsx.snap
@@ -6092,6 +6092,8 @@ exports[`DateInput disabled 1`] = `
   border: none;
   padding: 0;
   text-align: inherit;
+  opacity: 0.3;
+  cursor: default;
   line-height: 0;
   padding: 12px;
 }
@@ -6142,6 +6144,7 @@ exports[`DateInput disabled 1`] = `
   <button
     aria-label="Open Drop"
     class="c1"
+    disabled=""
     type="button"
   >
     <svg
@@ -6936,6 +6939,8 @@ exports[`DateInput format disabled 1`] = `
   border: none;
   padding: 0;
   text-align: inherit;
+  opacity: 0.3;
+  cursor: default;
   line-height: 0;
 }
 
@@ -7088,6 +7093,7 @@ exports[`DateInput format disabled 1`] = `
     </div>
     <button
       class="c5"
+      disabled=""
       type="button"
     >
       <svg

--- a/src/js/components/TextInput/CopyButton.js
+++ b/src/js/components/TextInput/CopyButton.js
@@ -17,6 +17,7 @@ const StyledButton = styled(Button)`
 `;
 
 export const CopyButton = ({
+  disabled,
   onClickCopy,
   onBlurCopy,
   readOnlyCopyPrompt,
@@ -28,6 +29,7 @@ export const CopyButton = ({
   return (
     <Tip dropProps={{ align: { bottom: 'top' } }} content={tip}>
       <StyledButton
+        disabled={disabled}
         onClick={onClickCopy}
         icon={<Copy />}
         pad={{

--- a/src/js/components/TextInput/TextInput.js
+++ b/src/js/components/TextInput/TextInput.js
@@ -74,6 +74,7 @@ const TextInput = forwardRef(
       a11yTitle,
       defaultSuggestion,
       defaultValue,
+      disabled,
       dropAlign = defaultDropAlign,
       dropHeight,
       dropTarget,
@@ -480,6 +481,7 @@ const TextInput = forwardRef(
 
     const ReadOnlyCopyButton = (
       <CopyButton
+        disabled={disabled}
         onBlurCopy={onBlurCopy}
         onClickCopy={onClickCopy}
         readOnlyCopyPrompt={readOnlyCopyPrompt}
@@ -515,6 +517,7 @@ const TextInput = forwardRef(
             id={id}
             name={name}
             autoComplete="off"
+            disabled={disabled}
             plain={plain}
             placeholder={
               typeof placeholder === 'string' ? placeholder : undefined


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

When DateInput is disabled, the calendar button in the input should also be `disabled` to avoid making it seem like the user can change the date.

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #7526 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
