### PR TITLE
set aria-disabled to true if onSelect prop is not provided

### DIFF
--- a/src/js/components/Calendar/Calendar.js
+++ b/src/js/components/Calendar/Calendar.js
@@ -282,6 +282,7 @@ const CalendarDay = forwardRef(
 
 const CalendarCustomDay = ({
   'aria-selected': ariaSelected,
+  'aria-disabled': ariaDisabled,
   children,
   fill,
   size,
@@ -292,6 +293,7 @@ const CalendarCustomDay = ({
     return (
       <StyledDayContainer
         aria-selected={ariaSelected}
+        aria-disabled={ariaDisabled}
         role="gridcell"
         sizeProp={size}
         fillContainer={fill}
@@ -900,6 +902,7 @@ const Calendar = forwardRef(
             <CalendarCustomDay
               key={day.getTime()}
               aria-selected={selected}
+              aria-disabled={dayDisabled}
               buttonProps={
                 onSelect
                   ? {

--- a/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.tsx.snap
+++ b/src/js/components/Calendar/__tests__/__snapshots__/Calendar-test.tsx.snap
@@ -3025,6 +3025,7 @@ exports[`Calendar children 1`] = `
               role="row"
             >
               <div
+                aria-disabled="false"
                 aria-selected="false"
                 class="c12"
                 role="gridcell"
@@ -3036,6 +3037,7 @@ exports[`Calendar children 1`] = `
                 </div>
               </div>
               <div
+                aria-disabled="false"
                 aria-selected="false"
                 class="c12"
                 role="gridcell"
@@ -3047,6 +3049,7 @@ exports[`Calendar children 1`] = `
                 </div>
               </div>
               <div
+                aria-disabled="false"
                 aria-selected="false"
                 class="c12"
                 role="gridcell"
@@ -3058,6 +3061,7 @@ exports[`Calendar children 1`] = `
                 </div>
               </div>
               <div
+                aria-disabled="false"
                 aria-selected="false"
                 class="c12"
                 role="gridcell"
@@ -3069,6 +3073,7 @@ exports[`Calendar children 1`] = `
                 </div>
               </div>
               <div
+                aria-disabled="false"
                 aria-selected="false"
                 class="c12"
                 role="gridcell"
@@ -3080,6 +3085,7 @@ exports[`Calendar children 1`] = `
                 </div>
               </div>
               <div
+                aria-disabled="false"
                 aria-selected="false"
                 class="c12"
                 role="gridcell"
@@ -3091,6 +3097,7 @@ exports[`Calendar children 1`] = `
                 </div>
               </div>
               <div
+                aria-disabled="false"
                 aria-selected="false"
                 class="c12"
                 role="gridcell"
@@ -3107,6 +3114,7 @@ exports[`Calendar children 1`] = `
               role="row"
             >
               <div
+                aria-disabled="false"
                 aria-selected="false"
                 class="c12"
                 role="gridcell"
@@ -3118,6 +3126,7 @@ exports[`Calendar children 1`] = `
                 </div>
               </div>
               <div
+                aria-disabled="false"
                 aria-selected="false"
                 class="c12"
                 role="gridcell"
@@ -3129,6 +3138,7 @@ exports[`Calendar children 1`] = `
                 </div>
               </div>
               <div
+                aria-disabled="false"
                 aria-selected="false"
                 class="c12"
                 role="gridcell"
@@ -3140,6 +3150,7 @@ exports[`Calendar children 1`] = `
                 </div>
               </div>
               <div
+                aria-disabled="false"
                 aria-selected="false"
                 class="c12"
                 role="gridcell"
@@ -3151,6 +3162,7 @@ exports[`Calendar children 1`] = `
                 </div>
               </div>
               <div
+                aria-disabled="false"
                 aria-selected="false"
                 class="c12"
                 role="gridcell"
@@ -3162,6 +3174,7 @@ exports[`Calendar children 1`] = `
                 </div>
               </div>
               <div
+                aria-disabled="false"
                 aria-selected="false"
                 class="c12"
                 role="gridcell"
@@ -3173,6 +3186,7 @@ exports[`Calendar children 1`] = `
                 </div>
               </div>
               <div
+                aria-disabled="false"
                 aria-selected="false"
                 class="c12"
                 role="gridcell"
@@ -3189,6 +3203,7 @@ exports[`Calendar children 1`] = `
               role="row"
             >
               <div
+                aria-disabled="false"
                 aria-selected="false"
                 class="c12"
                 role="gridcell"
@@ -3200,6 +3215,7 @@ exports[`Calendar children 1`] = `
                 </div>
               </div>
               <div
+                aria-disabled="false"
                 aria-selected="false"
                 class="c12"
                 role="gridcell"
@@ -3211,6 +3227,7 @@ exports[`Calendar children 1`] = `
                 </div>
               </div>
               <div
+                aria-disabled="false"
                 aria-selected="false"
                 class="c12"
                 role="gridcell"
@@ -3222,6 +3239,7 @@ exports[`Calendar children 1`] = `
                 </div>
               </div>
               <div
+                aria-disabled="false"
                 aria-selected="true"
                 class="c12"
                 role="gridcell"
@@ -3233,6 +3251,7 @@ exports[`Calendar children 1`] = `
                 </div>
               </div>
               <div
+                aria-disabled="false"
                 aria-selected="false"
                 class="c12"
                 role="gridcell"
@@ -3244,6 +3263,7 @@ exports[`Calendar children 1`] = `
                 </div>
               </div>
               <div
+                aria-disabled="false"
                 aria-selected="false"
                 class="c12"
                 role="gridcell"
@@ -3255,6 +3275,7 @@ exports[`Calendar children 1`] = `
                 </div>
               </div>
               <div
+                aria-disabled="false"
                 aria-selected="false"
                 class="c12"
                 role="gridcell"
@@ -3271,6 +3292,7 @@ exports[`Calendar children 1`] = `
               role="row"
             >
               <div
+                aria-disabled="false"
                 aria-selected="false"
                 class="c12"
                 role="gridcell"
@@ -3282,6 +3304,7 @@ exports[`Calendar children 1`] = `
                 </div>
               </div>
               <div
+                aria-disabled="false"
                 aria-selected="false"
                 class="c12"
                 role="gridcell"
@@ -3293,6 +3316,7 @@ exports[`Calendar children 1`] = `
                 </div>
               </div>
               <div
+                aria-disabled="false"
                 aria-selected="false"
                 class="c12"
                 role="gridcell"
@@ -3304,6 +3328,7 @@ exports[`Calendar children 1`] = `
                 </div>
               </div>
               <div
+                aria-disabled="false"
                 aria-selected="false"
                 class="c12"
                 role="gridcell"
@@ -3315,6 +3340,7 @@ exports[`Calendar children 1`] = `
                 </div>
               </div>
               <div
+                aria-disabled="false"
                 aria-selected="false"
                 class="c12"
                 role="gridcell"
@@ -3326,6 +3352,7 @@ exports[`Calendar children 1`] = `
                 </div>
               </div>
               <div
+                aria-disabled="false"
                 aria-selected="false"
                 class="c12"
                 role="gridcell"
@@ -3337,6 +3364,7 @@ exports[`Calendar children 1`] = `
                 </div>
               </div>
               <div
+                aria-disabled="false"
                 aria-selected="false"
                 class="c12"
                 role="gridcell"
@@ -3353,6 +3381,7 @@ exports[`Calendar children 1`] = `
               role="row"
             >
               <div
+                aria-disabled="false"
                 aria-selected="false"
                 class="c12"
                 role="gridcell"
@@ -3364,6 +3393,7 @@ exports[`Calendar children 1`] = `
                 </div>
               </div>
               <div
+                aria-disabled="false"
                 aria-selected="false"
                 class="c12"
                 role="gridcell"
@@ -3375,6 +3405,7 @@ exports[`Calendar children 1`] = `
                 </div>
               </div>
               <div
+                aria-disabled="false"
                 aria-selected="false"
                 class="c12"
                 role="gridcell"
@@ -3386,6 +3417,7 @@ exports[`Calendar children 1`] = `
                 </div>
               </div>
               <div
+                aria-disabled="false"
                 aria-selected="false"
                 class="c12"
                 role="gridcell"
@@ -3397,6 +3429,7 @@ exports[`Calendar children 1`] = `
                 </div>
               </div>
               <div
+                aria-disabled="false"
                 aria-selected="false"
                 class="c12"
                 role="gridcell"
@@ -3408,6 +3441,7 @@ exports[`Calendar children 1`] = `
                 </div>
               </div>
               <div
+                aria-disabled="false"
                 aria-selected="false"
                 class="c12"
                 role="gridcell"
@@ -3419,6 +3453,7 @@ exports[`Calendar children 1`] = `
                 </div>
               </div>
               <div
+                aria-disabled="false"
                 aria-selected="false"
                 class="c12"
                 role="gridcell"
@@ -3435,6 +3470,7 @@ exports[`Calendar children 1`] = `
               role="row"
             >
               <div
+                aria-disabled="false"
                 aria-selected="false"
                 class="c12"
                 role="gridcell"
@@ -3446,6 +3482,7 @@ exports[`Calendar children 1`] = `
                 </div>
               </div>
               <div
+                aria-disabled="false"
                 aria-selected="false"
                 class="c12"
                 role="gridcell"
@@ -3457,6 +3494,7 @@ exports[`Calendar children 1`] = `
                 </div>
               </div>
               <div
+                aria-disabled="false"
                 aria-selected="false"
                 class="c12"
                 role="gridcell"
@@ -3468,6 +3506,7 @@ exports[`Calendar children 1`] = `
                 </div>
               </div>
               <div
+                aria-disabled="false"
                 aria-selected="false"
                 class="c12"
                 role="gridcell"
@@ -3479,6 +3518,7 @@ exports[`Calendar children 1`] = `
                 </div>
               </div>
               <div
+                aria-disabled="false"
                 aria-selected="false"
                 class="c12"
                 role="gridcell"
@@ -3490,6 +3530,7 @@ exports[`Calendar children 1`] = `
                 </div>
               </div>
               <div
+                aria-disabled="false"
                 aria-selected="false"
                 class="c12"
                 role="gridcell"
@@ -3501,6 +3542,7 @@ exports[`Calendar children 1`] = `
                 </div>
               </div>
               <div
+                aria-disabled="false"
                 aria-selected="false"
                 class="c12"
                 role="gridcell"


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
- sets aria-disabled to true if onSelect prop is not provide in alignment with [Grommet documentation](https://v2.grommet.io/calendar#onSelect)

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
- https://github.com/grommet/grommet/issues/7721

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Yes

#### Should this PR be mentioned in the release notes?
Yes

#### Is this change backwards compatible or is it a breaking change?
Yes
