### PR TITLE
add test for pressing escape on layer

### DIFF
--- a/src/js/components/Layer/Layer.js
+++ b/src/js/components/Layer/Layer.js
@@ -93,14 +93,17 @@ const Layer = forwardRef((props, ref) => {
           }
           setTimeout(() => {
             // we add the id and query here so the unit tests work
-            const clone = containerTarget
-              .getRootNode()
-              .getElementById('layerClone');
-            if (clone) {
-              if (containerTarget.contains(clone)) {
-                containerTarget.removeChild(clone);
+            const rootNode = containerTarget.getRootNode();
+            // Not all root nodes (ShadowRoot, DocumentFragment)
+            //  have getElementById.
+            if (rootNode && typeof rootNode.getElementById === 'function') {
+              const clone = rootNode.getElementById('layerClone');
+              if (clone) {
+                if (containerTarget.contains(clone)) {
+                  containerTarget.removeChild(clone);
+                }
+                layerContainer.remove();
               }
-              layerContainer.remove();
             }
           }, animationDuration);
         } else if (containerTarget.contains(layerContainer)) {

--- a/src/js/components/Layer/__tests__/Layer-test.js
+++ b/src/js/components/Layer/__tests__/Layer-test.js
@@ -584,6 +584,23 @@ describe('Layer', () => {
     expect(screen.queryByRole('button', { name: 'Close Layer' })).toBeNull();
     expect(document.activeElement).toBe(triggerButton);
 
+    await act(async () => {
+      fireEvent.click(triggerButton);
+      jest.advanceTimersByTime(0);
+    });
+
+    const closeButton2 = screen.getByRole('button', { name: 'Close Layer' });
+
+    await act(async () => {
+      fireEvent.click(closeButton2);
+      jest.advanceTimersByTime(0);
+      jest.advanceTimersByTime(100);
+    });
+
+    await act(async () => {
+      jest.runOnlyPendingTimers();
+    });
+    expect(document.activeElement).toBe(triggerButton);
     jest.useRealTimers();
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
adds a test for this PR https://github.com/grommet/grommet/pull/7727
#### Where should the reviewer start?
layer test
#### What testing has been done on this PR?
local testing
#### How should this be manually tested?
jest test 
#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
the focus should be placed back on the trigger button when the layer is closed
#### What are the relevant issues?
none
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
backwards compatible