### PR TITLE
fix DataTable columns do not receive the hover state when onClickRow …

### DIFF
--- a/src/js/components/DataTable/Body.js
+++ b/src/js/components/DataTable/Body.js
@@ -184,7 +184,8 @@ const Row = memo(
             key={column.property}
             background={
               (isSelected && cellProps.selected.background) ||
-              (column.pin && cellProps.pinned.background) ||
+              (active && cellProps.active?.background) ||
+              (focused && cellProps.focused?.background) ||
               cellProps.background
             }
             border={(column.pin && cellProps.pinned.border) || cellProps.border}

--- a/src/js/components/DataTable/__tests__/DataTable-test.tsx
+++ b/src/js/components/DataTable/__tests__/DataTable-test.tsx
@@ -924,6 +924,54 @@ describe('DataTable', () => {
     expect(onExpand.mock.results[0].value).toMatchSnapshot();
   });
 
+  // first row is pinned
+  const columns = [
+    {
+      property: 'name',
+      header: 'Name',
+      pin: true,
+    },
+    {
+      property: 'location',
+      header: 'Location',
+    },
+  ];
+
+  const data = [
+    { name: 'Jet', location: 'Palo Alto' },
+    { name: 'Michael', location: 'Boise' },
+  ];
+
+  test('pinned columns have same background as selected row', () => {
+    const { getByText } = render(
+      <Grommet>
+        <DataTable
+          columns={columns}
+          data={data}
+          rowProps={{
+            Jet: { background: 'background-selected-primary' },
+          }}
+        />
+      </Grommet>,
+    );
+
+    // Find the pinned cell and a regular cell in the selected row
+    const pinnedText = getByText('Jet');
+    const regularText = getByText('Palo Alto');
+
+    const pinnedCell = pinnedText.closest('td') || pinnedText.closest('th');
+    const regularCell = regularText.closest('td') || regularText.closest('th');
+
+    expect(pinnedCell).not.toBeNull();
+    expect(regularCell).not.toBeNull();
+
+    const pinnedBg = window.getComputedStyle(pinnedCell!).backgroundColor;
+    const regularBg = window.getComputedStyle(regularCell!).backgroundColor;
+
+    // Assert that both backgrounds are the same
+    expect(pinnedBg).toBe(regularBg);
+  });
+
   test('replace', () => {
     const { container } = render(
       <Grommet>

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.tsx.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.tsx.snap
@@ -20039,26 +20039,13 @@ exports[`DataTable pin + background 1`] = `
   font-weight: inherit;
   text-align: inherit;
   text-align: start;
-  background: red;
   padding-left: 12px;
   padding-right: 12px;
   padding-top: 6px;
   padding-bottom: 6px;
 }
 
-.c14 {
-  margin: 0;
-  padding: 0;
-  font-weight: inherit;
-  text-align: inherit;
-  text-align: start;
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
-.c16 {
+.c15 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -20073,7 +20060,7 @@ exports[`DataTable pin + background 1`] = `
   padding-bottom: 6px;
 }
 
-.c19 {
+.c18 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -20086,7 +20073,7 @@ exports[`DataTable pin + background 1`] = `
   padding-bottom: 6px;
 }
 
-.c20 {
+.c19 {
   margin: 0;
   padding: 0;
   font-weight: inherit;
@@ -20159,7 +20146,7 @@ exports[`DataTable pin + background 1`] = `
   outline: none;
 }
 
-.c15 {
+.c14 {
   position: sticky;
   bottom: 0;
   z-index: 1;
@@ -20184,14 +20171,14 @@ exports[`DataTable pin + background 1`] = `
   z-index: 1;
 }
 
-.c17 {
+.c16 {
   position: sticky;
   bottom: 0;
   left: 0;
   z-index: 2;
 }
 
-.c18 {
+.c17 {
   position: sticky;
   bottom: 0;
   z-index: 1;
@@ -20262,7 +20249,7 @@ exports[`DataTable pin + background 1`] = `
           </div>
         </th>
         <td
-          class="c14 "
+          class="c10 "
         >
           <div
             class="c12"
@@ -20293,7 +20280,7 @@ exports[`DataTable pin + background 1`] = `
           </div>
         </th>
         <td
-          class="c14 "
+          class="c10 "
         >
           <div
             class="c12"
@@ -20308,13 +20295,13 @@ exports[`DataTable pin + background 1`] = `
       </tr>
     </tbody>
     <tfoot
-      class="StyledTable__StyledTableFooter-sc-1m3u5g-5 c15"
+      class="StyledTable__StyledTableFooter-sc-1m3u5g-5 c14"
     >
       <tr
         class="StyledTable__StyledTableRow-sc-1m3u5g-2"
       >
         <td
-          class="c16 c17"
+          class="c15 c16"
         >
           <div
             class="c12"
@@ -20327,7 +20314,7 @@ exports[`DataTable pin + background 1`] = `
           </div>
         </td>
         <td
-          class="c16 c18"
+          class="c15 c17"
         >
           <div
             class="c12"
@@ -20398,7 +20385,7 @@ exports[`DataTable pin + background 1`] = `
           </div>
         </th>
         <td
-          class="c14 "
+          class="c10 "
         >
           <div
             class="c12"
@@ -20429,7 +20416,7 @@ exports[`DataTable pin + background 1`] = `
           </div>
         </th>
         <td
-          class="c14 "
+          class="c10 "
         >
           <div
             class="c12"
@@ -20450,7 +20437,7 @@ exports[`DataTable pin + background 1`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2"
       >
         <td
-          class="c19 c11"
+          class="c18 c11"
         >
           <div
             class="c12"
@@ -20463,7 +20450,7 @@ exports[`DataTable pin + background 1`] = `
           </div>
         </td>
         <td
-          class="c19 "
+          class="c18 "
         >
           <div
             class="c12"
@@ -20482,7 +20469,7 @@ exports[`DataTable pin + background 1`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
       >
         <th
-          class="c20 c11"
+          class="c19 c11"
           id="grommet-data-table-header-a"
           scope="col"
         >
@@ -20497,7 +20484,7 @@ exports[`DataTable pin + background 1`] = `
           </div>
         </th>
         <th
-          class="c20 "
+          class="c19 "
           id="grommet-data-table-header-b"
           scope="col"
         >
@@ -20534,7 +20521,7 @@ exports[`DataTable pin + background 1`] = `
           </div>
         </th>
         <td
-          class="c14 "
+          class="c10 "
         >
           <div
             class="c12"
@@ -20565,7 +20552,7 @@ exports[`DataTable pin + background 1`] = `
           </div>
         </th>
         <td
-          class="c14 "
+          class="c10 "
         >
           <div
             class="c12"
@@ -20580,13 +20567,13 @@ exports[`DataTable pin + background 1`] = `
       </tr>
     </tbody>
     <tfoot
-      class="StyledTable__StyledTableFooter-sc-1m3u5g-5 c15"
+      class="StyledTable__StyledTableFooter-sc-1m3u5g-5 c14"
     >
       <tr
         class="StyledTable__StyledTableRow-sc-1m3u5g-2"
       >
         <td
-          class="c16 c17"
+          class="c15 c16"
         >
           <div
             class="c12"
@@ -20599,7 +20586,7 @@ exports[`DataTable pin + background 1`] = `
           </div>
         </td>
         <td
-          class="c16 c18"
+          class="c15 c17"
         >
           <div
             class="c12"


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR ensures that when a column is pinned, it maintains the same background color as the rest of the row.
#### Where should the reviewer start?
body.js
#### What testing has been done on this PR?
locally 

DataTable columns do not receive the hover state when onClickRow + pinned use the following to test
```
{
      property: 'name',
      pin: true,
      primary: true,
      header: 'Name',
...
}
<DataTable
    onClickRow={}
```

#### How should this be manually tested?
```
{
      property: 'name',
      pin: true,
      primary: true,
      header: 'Name',
...
}
<DataTable
    onClickRow={}
```

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
This was found while working on the DS example pages. 
#### What are the relevant issues?
closes #4877
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible