### PR TITLE
Add Calendar theme objects

### DIFF
--- a/src/js/components/Calendar/Calendar.js
+++ b/src/js/components/Calendar/Calendar.js
@@ -44,12 +44,6 @@ import {
 import { setHoursWithOffset } from '../../utils/dates';
 import { useThemeValue } from '../../utils/useThemeValue';
 
-const headingPadMap = {
-  small: 'xsmall',
-  medium: 'small',
-  large: 'medium',
-};
-
 const getLocaleString = (value, locale) =>
   value?.toLocaleDateString(locale, {
     month: 'long',
@@ -684,7 +678,7 @@ const Calendar = forwardRef(
 
       return (
         <Box direction="row" justify="between" align="center">
-          <Header flex pad={{ horizontal: headingPadMap[size] || 'small' }}>
+          <Header flex pad={theme.calendar?.[size]?.header.container.pad}>
             {theme.calendar[size]?.title ? (
               <Text {...theme.calendar[size].title}>{monthAndYear}</Text>
             ) : (

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -638,6 +638,13 @@ export interface ThemeType {
       };
       title?: TextProps;
       fontSize?: string;
+      header?: {
+        container?: {
+          pad?: {
+            horizontal?: string;
+          };
+        };
+      };
       lineHeight?: number;
       daySize?: string;
       slideDuration?: string;
@@ -657,6 +664,13 @@ export interface ThemeType {
       };
       title?: TextProps;
       fontSize?: string;
+      header?: {
+        container?: {
+          pad?: {
+            horizontal?: string;
+          };
+        };
+      };
       lineHeight?: number;
       daySize?: string;
       slideDuration?: string;
@@ -676,6 +690,13 @@ export interface ThemeType {
       };
       title?: TextProps;
       fontSize?: string;
+      header?: {
+        container?: {
+          pad?: {
+            horizontal?: string;
+          };
+        };
+      };
       lineHeight?: number;
       daySize?: string;
       slideDuration?: string;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -672,6 +672,13 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         // },
         // title: {},
         fontSize: `${baseFontSize - fontScale}px`,
+        header: {
+          container: {
+            pad: {
+              horizontal: 'xsmall',
+            },
+          },
+        },
         lineHeight: 1.375,
         daySize: `${(baseSpacing * 8) / 7}px`,
         slideDuration: '0.2s',
@@ -691,6 +698,13 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         // },
         // title: {},
         fontSize: `${baseFontSize}px`,
+        header: {
+          container: {
+            pad: {
+              horizontal: 'small',
+            },
+          },
+        },
         lineHeight: 1.45,
         daySize: `${(baseSpacing * 16) / 7}px`,
         slideDuration: '0.5s',
@@ -710,6 +724,13 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         // },
         // title: {},
         fontSize: `${baseFontSize + 3 * fontScale}px`,
+        header: {
+          container: {
+            pad: {
+              horizontal: 'medium',
+            },
+          },
+        },
         lineHeight: 1.11,
         daySize: `${(baseSpacing * 32) / 7}px`,
         slideDuration: '0.8s',


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds theme objects for the Calendar component. Based on changes in https://github.com/grommet/grommet/pull/7591

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
