### PR TITLE
Add CheckBox theme objects

### DIFF
--- a/src/js/components/CheckBox/CheckBox.js
+++ b/src/js/components/CheckBox/CheckBox.js
@@ -168,7 +168,7 @@ const CheckBox = forwardRef(
       <StyledCheckBox
         align="center"
         justify="center"
-        margin={label && { [side]: theme.checkBox.gap || 'small' }}
+        margin={label && { [side]: theme.checkBox.gap }}
         {...themeableProps}
       >
         <StyledCheckBoxInput

--- a/src/js/components/CheckBoxGroup/CheckBoxGroup.js
+++ b/src/js/components/CheckBoxGroup/CheckBoxGroup.js
@@ -80,12 +80,7 @@ const CheckBoxGroup = forwardRef(
         aria-labelledby={ariaLabelledByProp || ariaLabelledBy}
         role="group"
         {...theme.checkBoxGroup.container}
-        gap={
-          gap ||
-          (theme.checkBoxGroup.container && theme.checkBoxGroup.container.gap
-            ? theme.checkBoxGroup.container.gap
-            : 'small') // consistent with RadioButtonGroup default
-        }
+        gap={gap || theme.checkBoxGroup?.container?.gap}
         id={id}
         {...passThemeFlag}
         {...rest}

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -784,7 +784,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       },
       // color: { dark: undefined, light: undefined },
       // extend: undefined,
-      // gap: undefined
+      gap: 'small',
       hover: {
         border: {
           color: {
@@ -820,10 +820,11 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       },
     },
     checkBoxGroup: {
-      // container: {
-      //   // any box props
-      //   extend: undefined,
-      // },
+      container: {
+        //   // any box props
+        //   extend: undefined,
+        gap: 'small',
+      },
     },
     clock: {
       analog: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds theme objects for the CheckBox and CheckBoxGroup component. Based on changes in https://github.com/grommet/grommet/pull/7591

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
