### PR TITLE
add theme object for video

### DIFF
--- a/src/js/components/Video/Video.js
+++ b/src/js/components/Video/Video.js
@@ -492,7 +492,7 @@ const Video = forwardRef(
                         : undefined
                     }
                     size="full"
-                    thickness="small"
+                    thickness={theme.video?.scrubber?.thickness}
                     values={[{ value: percentagePlayed || 0 }]}
                   />
                   <StyledVideoScrubber
@@ -516,7 +516,7 @@ const Video = forwardRef(
                   />
                 </Stack>
               </Box>
-              <Box pad={{ horizontal: 'small' }}>
+              <Box pad={theme?.video?.time?.container?.pad}>
                 <Text margin="none">{formattedTime}</Text>
               </Box>
             </Box>

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -2035,10 +2035,6 @@ export interface ThemeType {
       container?: {
         pad?: PadType;
       };
-      font?: {
-        size?: string;
-        height?: number;
-      };
     };
   };
   worldMap?: {

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -2029,6 +2029,16 @@ export interface ThemeType {
       track?: {
         color?: ColorType;
       };
+      thickness?: string;
+    };
+    time?: {
+      container?: {
+        pad?: PadType;
+      };
+      font?: {
+        size?: string;
+        height?: number;
+      };
     };
   };
   worldMap?: {

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -2185,6 +2185,14 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         color: 'light-4',
         interval: 10,
         // track: { color: undefined }
+        thickness: 'small',
+      },
+      time: {
+        container: {
+          pad: {
+            horizontal: 'small',
+          },
+        },
       },
     },
     worldMap: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds theme objects for the Video component. 
Based on changes in https://github.com/grommet/grommet/pull/7591
#### Where should the reviewer start?
video.js
#### What testing has been done on this PR?
video.js
#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
Based on changes in https://github.com/grommet/grommet/pull/7591
#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
yes
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible