### PR TITLE
Add DataFilter theme objects

### DIFF
--- a/src/js/components/DataFilter/DataFilter.js
+++ b/src/js/components/DataFilter/DataFilter.js
@@ -9,6 +9,7 @@ import { DataFilterPropTypes } from './propTypes';
 import { getDecimalCount } from '../RangeSelector/RangeSelector';
 import { DataFormContext } from '../../contexts/DataFormContext';
 import { selectInputId } from '../Select/utils';
+import { useThemeValue } from '../../utils/useThemeValue';
 
 // empirical constants for when we change inputs
 const maxCheckBoxGroupOptions = 4;
@@ -90,6 +91,7 @@ export const DataFilter = ({
   } = useContext(DataContext);
   const { inDataForm } = useContext(DataFormContext);
   const [searchText, setSearchText] = useState('');
+  const { theme } = useThemeValue();
 
   const [options, range] = useMemo(() => {
     if (children) return [undefined, undefined]; // caller driving
@@ -190,8 +192,7 @@ export const DataFilter = ({
           min={range[0]}
           max={range[1]}
           step={step}
-          size="full"
-          round="small"
+          {...theme.dataFilter?.rangeSelector}
         />
       );
     } else if (options) {
@@ -219,7 +220,6 @@ export const DataFilter = ({
           <SelectMultiple
             aria-label={ariaLabel}
             id={id}
-            dropHeight="medium"
             name={property}
             showSelectedInline
             options={searchedOptions}
@@ -231,6 +231,7 @@ export const DataFilter = ({
             onClose={() => setSearchText('')}
             labelKey="label"
             valueKey={{ key: 'value', reduce: true }}
+            {...theme.dataFilter?.selectMultiple}
           />
         );
         htmlFor = selectInputId(id);

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -822,6 +822,15 @@ export interface ThemeType {
       kind?: string;
     };
   };
+  dataFilter?: {
+    rangeSelector?: {
+      size?: string;
+      round?: string;
+    };
+    selectMultiple?: {
+      dropHeight?: string;
+    };
+  };
   dateInput?: {
     container?: {
       round?: RoundType;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -885,6 +885,15 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       //   kind: undefined,
       // },
     },
+    dataFilter: {
+      rangeSelector: {
+        size: 'full',
+        round: 'small',
+      },
+      selectMultiple: {
+        dropHeight: 'medium',
+      },
+    },
     dateInput: {
       container: {
         round: 'xxsmall',


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds theme objects for the DataFilter component. Based on changes in https://github.com/grommet/grommet/pull/7591

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
