### PR TITLE
add theme object rangeselector

### DIFF
--- a/src/js/components/RangeSelector/RangeSelector.js
+++ b/src/js/components/RangeSelector/RangeSelector.js
@@ -375,13 +375,18 @@ const RangeSelector = forwardRef(
           <Text
             ref={minRef}
             textAlign="end"
-            size="small"
-            margin={{ horizontal: 'small' }}
+            // do we need theme for size?
+            size={theme.rangeSelector.label.size}
+            margin={theme.rangeSelector.label.margin}
           >
             {typeof label === 'function' ? label(lower) : lower}
           </Text>
           {content}
-          <Text ref={maxRef} size="small" margin={{ horizontal: 'small' }}>
+          <Text
+            ref={maxRef}
+            size={theme.rangeSelector.label.size}
+            margin={theme.rangeSelector.label.margin}
+          >
             {typeof label === 'function' ? label(upper) : upper}
           </Text>
         </Box>

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -1694,6 +1694,10 @@ export interface ThemeType {
       type?: string;
       size?: EdgeSizeType | string;
     };
+    label?: {
+      margin?: MarginType;
+      size?: string;
+    };
   };
   select?: {
     background?: BackgroundType;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1856,6 +1856,10 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         // type: undefined,
         // size: undefined,
       },
+      label: {
+        margin: { horizontal: 'small' },
+        size: 'small',
+      },
     },
     select: {
       // background: undefined,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds theme objects for the rangeselector component.
Based on changes in https://github.com/grommet/grommet/pull/7591
#### Where should the reviewer start?
rangeselector.js
#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
https://github.com/grommet/grommet/pull/7591
#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
yes
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible
