### PR TITLE
add sidebar theme object

### DIFF
--- a/src/js/components/Sidebar/Sidebar.js
+++ b/src/js/components/Sidebar/Sidebar.js
@@ -1,13 +1,22 @@
 import React from 'react';
 import { Box } from '../Box';
 import { SidebarPropTypes } from './propTypes';
+import { useThemeValue } from '../../utils/useThemeValue';
 
-export const Sidebar = ({ children, footer, header, ...rest }) => (
-  <Box pad="small" gap="large" height={{ min: '100%' }} {...rest}>
-    {header}
-    <Box flex>{children}</Box>
-    {footer}
-  </Box>
-);
+export const Sidebar = ({ children, footer, header, ...rest }) => {
+  const { theme } = useThemeValue();
+  return (
+    <Box
+      height={{ min: '100%' }}
+      gap={theme.sideBar.gap}
+      pad={theme.sideBar.pad}
+      {...rest}
+    >
+      {header}
+      <Box flex>{children}</Box>
+      {footer}
+    </Box>
+  );
+};
 
 Sidebar.propTypes = SidebarPropTypes;

--- a/src/js/components/Sidebar/Sidebar.js
+++ b/src/js/components/Sidebar/Sidebar.js
@@ -8,7 +8,7 @@ export const Sidebar = ({ children, footer, header, ...rest }) => {
   return (
     <Box
       height={{ min: '100%' }}
-      gap={theme.sideBar.gap}
+      gap={theme.sidebar.gap}
       pad={theme.sideBar.pad}
       {...rest}
     >

--- a/src/js/components/Sidebar/Sidebar.js
+++ b/src/js/components/Sidebar/Sidebar.js
@@ -9,7 +9,7 @@ export const Sidebar = ({ children, footer, header, ...rest }) => {
     <Box
       height={{ min: '100%' }}
       gap={theme.sidebar.gap}
-      pad={theme.sideBar.pad}
+      pad={theme.sidebar.pad}
       {...rest}
     >
       {header}

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -1736,6 +1736,10 @@ export interface ThemeType {
       extend?: ExtendType;
     };
   };
+  sideBar?: {
+    gap?: GapType;
+    pad?: PadType;
+  };
   skeleton?: BoxProps & { colors?: SkeletonColorsType; extend?: ExtendType };
   skipLinks?: {
     position?: LayerPositionType;

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -1736,7 +1736,7 @@ export interface ThemeType {
       extend?: ExtendType;
     };
   };
-  sideBar?: {
+  sidebar?: {
     gap?: GapType;
     pad?: PadType;
   };

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1909,7 +1909,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       //   extend: () => undefined,
       // },
     },
-    sideBar: {
+    sidebar: {
       gap: 'large',
       pad: 'small',
     },

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1909,6 +1909,10 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       //   extend: () => undefined,
       // },
     },
+    sideBar: {
+      gap: 'large',
+      pad: 'small',
+    },
     skeleton: {
       border: false,
       colors: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds theme objects for the Sidebar component.
Based on changes in https://github.com/grommet/grommet/pull/7591
#### Where should the reviewer start?
sidebar.js
#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
https://github.com/grommet/grommet/pull/7591
#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
yes
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible
