### PR TITLE
add theme object radiobutton radiobuttongroup

### DIFF
--- a/src/js/components/RadioButton/RadioButton.js
+++ b/src/js/components/RadioButton/RadioButton.js
@@ -82,7 +82,12 @@ const RadioButton = forwardRef(
         <StyledRadioButton
           flex={false}
           margin={
-            label ? { right: theme.radioButton.gap || 'small' } : undefined
+            label
+              ? {
+                  right:
+                    theme.radioButton.gap || theme.radioButton.labelMarginRight,
+                }
+              : undefined
           }
           {...passThemeFlag}
         >

--- a/src/js/components/RadioButton/RadioButton.js
+++ b/src/js/components/RadioButton/RadioButton.js
@@ -81,7 +81,7 @@ const RadioButton = forwardRef(
       >
         <StyledRadioButton
           flex={false}
-          margin={label ? theme.radioButton.label?.margin : undefined}
+          margin={label ? { right: theme.radioButton.gap } : undefined}
           {...passThemeFlag}
         >
           <StyledRadioButtonInput

--- a/src/js/components/RadioButton/RadioButton.js
+++ b/src/js/components/RadioButton/RadioButton.js
@@ -81,14 +81,7 @@ const RadioButton = forwardRef(
       >
         <StyledRadioButton
           flex={false}
-          margin={
-            label
-              ? {
-                  right:
-                    theme.radioButton.gap || theme.radioButton.labelMarginRight,
-                }
-              : undefined
-          }
+          margin={label ? theme.radioButton.label?.margin : undefined}
           {...passThemeFlag}
         >
           <StyledRadioButtonInput

--- a/src/js/components/RadioButtonGroup/RadioButtonGroup.js
+++ b/src/js/components/RadioButtonGroup/RadioButtonGroup.js
@@ -124,13 +124,7 @@ const RadioButtonGroup = forwardRef(
           ref={ref}
           role="radiogroup"
           {...theme.radioButtonGroup.container}
-          gap={
-            gap ||
-            (theme.radioButtonGroup.container &&
-            theme.radioButtonGroup.container.gap
-              ? theme.radioButtonGroup.container.gap
-              : 'small')
-          }
+          gap={gap || theme.radioButtonGroup.container?.gap}
           {...rest}
         >
           {options.map(

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -1622,6 +1622,7 @@ export interface ThemeType {
     font?: {
       weight?: number | string;
     };
+    labelMarginRight?: string;
   };
   nameValueList?: {
     gap?: {

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -1622,7 +1622,9 @@ export interface ThemeType {
     font?: {
       weight?: number | string;
     };
-    labelMarginRight?: string;
+    label?: {
+      margin?: MarginType;
+    };
   };
   nameValueList?: {
     gap?: {

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -1622,9 +1622,6 @@ export interface ThemeType {
     font?: {
       weight?: number | string;
     };
-    label?: {
-      margin?: MarginType;
-    };
   };
   nameValueList?: {
     gap?: {

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1811,9 +1811,13 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       container: {
         // extend: undefined
       },
+      labelMarginRight: 'small',
     },
     radioButtonGroup: {
-      // container: {}, // any box props
+      // any box props
+      container: {
+        gap: 'small',
+      },
     },
     rangeInput: {
       disabled: {

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1811,7 +1811,11 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       container: {
         // extend: undefined
       },
-      labelMarginRight: 'small',
+      label: {
+        margin: {
+          right: 'small',
+        },
+      },
     },
     radioButtonGroup: {
       // any box props

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1811,11 +1811,6 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       container: {
         // extend: undefined
       },
-      label: {
-        margin: {
-          right: 'small',
-        },
-      },
     },
     radioButtonGroup: {
       // any box props


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds theme objects for the RadioButton and RadioButtonGroup component. Based on changes in https://github.com/grommet/grommet/pull/7591

#### Where should the reviewer start?
RadioButton.js
RadioButtonGroup.js
#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
https://github.com/grommet/grommet/pull/7591
#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
yes
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible
