### PR TITLE
add paragraph theme object

### DIFF
--- a/src/js/components/Paragraph/ParagraphSkeleton.js
+++ b/src/js/components/Paragraph/ParagraphSkeleton.js
@@ -12,7 +12,7 @@ const ParagraphSkeleton = forwardRef(({ fill, size: sizeProp }, ref) => {
   return (
     <Box
       ref={ref}
-      gap="xsmall"
+      gap={theme.paragraph?.skeleton?.gap}
       width={{ max: fill ? 'none' : data && data.maxWidth }}
     >
       <Skeleton height={height} />

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -1580,6 +1580,9 @@ export interface ThemeType {
       height?: string;
       maxWidth?: string;
     };
+    skeleton?: {
+      gap?: GapType;
+    };
   };
   radioButton?: {
     extend?: ExtendType;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1739,6 +1739,9 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       large: { ...fontSizing(1) },
       xlarge: { ...fontSizing(2) },
       xxlarge: { ...fontSizing(4) },
+      skeleton: {
+        gap: 'xsmall',
+      },
     },
     thumbsRating: {
       // dislike: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds theme objects for the Paragraph component.
Based on changes in https://github.com/grommet/grommet/pull/7591
#### Where should the reviewer start?
paragraph.js
#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
https://github.com/grommet/grommet/pull/7591
#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
yes
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible

