### PR TITLE
add notification theme object

### DIFF
--- a/src/js/components/Notification/Notification.js
+++ b/src/js/components/Notification/Notification.js
@@ -194,7 +194,7 @@ const Notification = ({
         <NotificationAnchor
           // create space between first anchor and
           // text content and next anchor
-          margin={{ right: 'xsmall' }}
+          margin={{ right: theme.notification.actions?.marginRight }}
           {...action}
           {...theme.notification.actions}
           // add a space between anchors to allow for wrapping
@@ -210,7 +210,11 @@ const Notification = ({
           color={messageColor}
           direction={direction}
         >
-          <Text margin={{ right: 'xsmall' }}>{message}</Text>
+          <Text
+            margin={{ right: theme.notification.message?.text?.marginRight }}
+          >
+            {message}
+          </Text>
           {/* include actions with message so it wraps with message */}
           {actions}
         </Message>
@@ -230,7 +234,7 @@ const Notification = ({
       // let internal box control pad
       pad={undefined}
       direction="row"
-      gap="small"
+      gap={theme.notification?.gap}
       id={toast ? undefined : id}
       {...rest}
     >

--- a/src/js/components/Notification/Notification.js
+++ b/src/js/components/Notification/Notification.js
@@ -194,7 +194,7 @@ const Notification = ({
         <NotificationAnchor
           // create space between first anchor and
           // text content and next anchor
-          margin={{ right: theme.notification.actions?.marginRight }}
+          margin={theme.notification.actions?.margin}
           {...action}
           {...theme.notification.actions}
           // add a space between anchors to allow for wrapping
@@ -210,9 +210,7 @@ const Notification = ({
           color={messageColor}
           direction={direction}
         >
-          <Text
-            margin={{ right: theme.notification.message?.text?.marginRight }}
-          >
+          <Text margin={theme.notification.message?.text?.margin}>
             {message}
           </Text>
           {/* include actions with message so it wraps with message */}

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -1294,7 +1294,7 @@ export interface ThemeType {
     iconContainer?: BoxProps;
     textContainer?: BoxProps;
     title?: TextProps;
-    message?: TextProps & { fill?: boolean; text?: TextProps };
+    message?: TextProps & { fill?: boolean; text?: { margin?: MarginType } };
     close?: {
       icon?: React.ReactNode | Icon;
       color?: ColorType;

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -1280,6 +1280,7 @@ export interface ThemeType {
     actions?: AnchorProps;
     container?: BoxProps;
     direction?: 'column' | 'row';
+    gap?: GapType;
     global?: {
       direction?: 'column' | 'row';
       container?: BoxProps;
@@ -1293,7 +1294,7 @@ export interface ThemeType {
     iconContainer?: BoxProps;
     textContainer?: BoxProps;
     title?: TextProps;
-    message?: TextProps & { fill?: boolean };
+    message?: TextProps & { fill?: boolean; text?: TextProps };
     close?: {
       icon?: React.ReactNode | Icon;
       color?: ColorType;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1321,6 +1321,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
     notification: {
       actions: {
         // any anchor props
+        marginRight: 'xsmall',
       },
       direction: 'column',
       container: {
@@ -1331,6 +1332,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
           color: 'background-front',
         },
       },
+      gap: 'small',
       global: {
         direction: 'row',
         container: {
@@ -1372,6 +1374,9 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         // any text props
         margin: 'none',
         // fill: undefined,
+        text: {
+          marginRight: 'xsmall',
+        },
       },
       close: {
         icon: FormClose,

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1321,7 +1321,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
     notification: {
       actions: {
         // any anchor props
-        marginRight: 'xsmall',
+        margin: { right: 'xsmall' },
       },
       direction: 'column',
       container: {
@@ -1375,7 +1375,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         margin: 'none',
         // fill: undefined,
         text: {
-          marginRight: 'xsmall',
+          margin: { right: 'xsmall' },
         },
       },
       close: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds theme objects for the Notification component.
Based on changes in https://github.com/grommet/grommet/pull/7591
#### Where should the reviewer start?
notification.js
#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
https://github.com/grommet/grommet/pull/7591
#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
yes
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible

