### PR TITLE
add nav theme object

### DIFF
--- a/src/js/components/Nav/Nav.js
+++ b/src/js/components/Nav/Nav.js
@@ -1,9 +1,10 @@
 import React from 'react';
-
 import { Box } from '../Box';
+import { useThemeValue } from '../../utils/useThemeValue';
 
-const Nav = ({ ...rest }) => (
-  <Box as="nav" flex={false} gap="medium" {...rest} />
-);
+const Nav = ({ ...rest }) => {
+  const { theme } = useThemeValue();
+  return <Box as="nav" flex={false} gap={theme.nav?.gap} {...rest} />;
+};
 
 export { Nav };

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -1276,6 +1276,9 @@ export interface ThemeType {
     extend?: ExtendType;
     gap?: GapType;
   };
+  nav?: {
+    gap?: GapType;
+  };
   notification?: {
     actions?: AnchorProps;
     container?: BoxProps;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1318,6 +1318,9 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         color: 'text',
       },
     },
+    nav: {
+      gap: 'medium',
+    },
     notification: {
       actions: {
         // any anchor props


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds theme objects for the Nav component.
Based on changes in https://github.com/grommet/grommet/pull/7591
#### Where should the reviewer start?
nav.js
#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
https://github.com/grommet/grommet/pull/7591
#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
yes
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible


