### PR TITLE
add menu theme object

### DIFF
--- a/src/js/components/Menu/Menu.js
+++ b/src/js/components/Menu/Menu.js
@@ -251,9 +251,11 @@ const Menu = forwardRef((props, ref) => {
   if (children) {
     content = children;
   } else if (!theme.button.default) {
-    // we are not going to change pad to a theme object
-    // since this will not be rendered in the hpe theme
-    // since we have theme.button.default
+    /*
+    Not adding a theme object now because this code path
+    is not used in the HPE theme, but we may add theme
+    support here in the future.
+    */
     content = (
       <Box
         direction="row"
@@ -310,9 +312,11 @@ const Menu = forwardRef((props, ref) => {
     // Determine whether the label is done as a child or
     // as an option Button kind property.
     const child = !theme.button.option ? (
-      // we are not going to change pad to a theme object
-      // since this will not be rendered in the hpe theme
-      // since we have theme.button.default
+    /*
+     Not adding a theme object now because this code path
+     is not used in the HPE theme, but we may add theme
+     support here in the future.
+     */
       <Box
         align={theme.menu.item?.align || 'start'}
         pad="small"

--- a/src/js/components/Menu/Menu.js
+++ b/src/js/components/Menu/Menu.js
@@ -251,13 +251,16 @@ const Menu = forwardRef((props, ref) => {
   if (children) {
     content = children;
   } else if (!theme.button.default) {
+    // we are not going to change pad to a theme object
+    // since this will not be rendered in the hpe theme
+    // since we have theme.button.default
     content = (
       <Box
         direction="row"
         justify={justifyContent}
         align="center"
-        pad={theme.menu.label?.pad}
-        gap={label && icon !== false ? theme.menu.label?.gap : undefined}
+        pad="small"
+        gap={label && icon !== false ? 'small' : undefined}
       >
         <Text size={size}>{label}</Text>
         {menuIcon}
@@ -307,9 +310,12 @@ const Menu = forwardRef((props, ref) => {
     // Determine whether the label is done as a child or
     // as an option Button kind property.
     const child = !theme.button.option ? (
+      // we are not going to change pad to a theme object
+      // since this will not be rendered in the hpe theme
+      // since we have theme.button.default
       <Box
         align={theme.menu.item?.align || 'start'}
-        pad={theme.menu.item?.pad}
+        pad="small"
         direction="row"
         gap={item.gap || theme.menu.item?.gap}
         justify={item.justify || theme.menu.item?.justify}

--- a/src/js/components/Menu/Menu.js
+++ b/src/js/components/Menu/Menu.js
@@ -256,8 +256,8 @@ const Menu = forwardRef((props, ref) => {
         direction="row"
         justify={justifyContent}
         align="center"
-        pad="small"
-        gap={label && icon !== false ? 'small' : undefined}
+        pad={theme.menu.label?.pad}
+        gap={label && icon !== false ? theme.menu.label?.gap : undefined}
       >
         <Text size={size}>{label}</Text>
         {menuIcon}
@@ -309,7 +309,7 @@ const Menu = forwardRef((props, ref) => {
     const child = !theme.button.option ? (
       <Box
         align={theme.menu.item?.align || 'start'}
-        pad="small"
+        pad={theme.menu.item?.pad}
         direction="row"
         gap={item.gap || theme.menu.item?.gap}
         justify={item.justify || theme.menu.item?.justify}

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -1269,6 +1269,7 @@ export interface ThemeType {
     item?:
       | ButtonType & {
           align?: AlignType;
+          pad?: PadType;
         };
     drop?: DropType;
     extend?: ExtendType;
@@ -1285,6 +1286,10 @@ export interface ThemeType {
       down?: any;
       up?: any;
       color?: ColorType;
+    };
+    label?: {
+      pad?: PadType;
+      gap?: GapType;
     };
   };
   meter?: {

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -1269,7 +1269,6 @@ export interface ThemeType {
     item?:
       | ButtonType & {
           align?: AlignType;
-          pad?: PadType;
         };
     drop?: DropType;
     extend?: ExtendType;
@@ -1286,10 +1285,6 @@ export interface ThemeType {
       down?: any;
       up?: any;
       color?: ColorType;
-    };
-    label?: {
-      pad?: PadType;
-      gap?: GapType;
     };
   };
   meter?: {

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1264,7 +1264,9 @@ export const generate = (baseSpacing = 24, scale = 6) => {
     },
     menu: {
       // background: undefined,
-      // item: undefined,
+      item: {
+        pad: 'small',
+      },
       // extend: undefined,
       drop: {
         align: {
@@ -1294,6 +1296,10 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         down: FormDown,
         // up: undefined,
         // color: { dark: undefined, light: undefined },
+      },
+      label: {
+        pad: 'small',
+        gap: 'small',
       },
     },
     meter: {

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1265,6 +1265,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
     menu: {
       // background: undefined,
       // extend: undefined,
+      // item: undefined,
       drop: {
         align: {
           top: 'top',

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1264,9 +1264,6 @@ export const generate = (baseSpacing = 24, scale = 6) => {
     },
     menu: {
       // background: undefined,
-      item: {
-        pad: 'small',
-      },
       // extend: undefined,
       drop: {
         align: {
@@ -1296,10 +1293,6 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         down: FormDown,
         // up: undefined,
         // color: { dark: undefined, light: undefined },
-      },
-      label: {
-        pad: 'small',
-        gap: 'small',
       },
     },
     meter: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds theme objects for the Menu component.
Based on changes in https://github.com/grommet/grommet/pull/7591
#### Where should the reviewer start?
menu.js
#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
https://github.com/grommet/grommet/pull/7591
#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
yes
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible


