### PR TITLE
Add DataSummary theme objects

### DIFF
--- a/src/js/components/DataSummary/DataSummary.js
+++ b/src/js/components/DataSummary/DataSummary.js
@@ -12,7 +12,7 @@ export const DataSummary = ({ messages, ...rest }) => {
     messages: dataMessages,
     selected,
     total,
-  } = useContext(DataContext)
+  } = useContext(DataContext);
   const { theme } = useThemeValue();
 
   let messageId;

--- a/src/js/components/DataSummary/DataSummary.js
+++ b/src/js/components/DataSummary/DataSummary.js
@@ -2,7 +2,7 @@ import React, { useContext } from 'react';
 import { Text } from '../Text';
 import { DataContext } from '../../contexts/DataContext';
 import { MessageContext } from '../../contexts/MessageContext';
-
+import { useThemeValue } from '../../utils/useThemeValue';
 import { DataSummaryPropTypes } from './propTypes';
 
 export const DataSummary = ({ messages, ...rest }) => {
@@ -12,7 +12,8 @@ export const DataSummary = ({ messages, ...rest }) => {
     messages: dataMessages,
     selected,
     total,
-  } = useContext(DataContext);
+  } = useContext(DataContext)
+  const { theme } = useThemeValue();
 
   let messageId;
   if (total !== filteredTotal) {
@@ -28,7 +29,7 @@ export const DataSummary = ({ messages, ...rest }) => {
   });
 
   return (
-    <Text margin={{ vertical: 'xsmall' }} {...rest}>
+    <Text margin={theme.dataSummary?.container?.margin} {...rest}>
       {format({
         id: messageId,
         messages: messages || dataMessages?.dataSummary,
@@ -42,7 +43,7 @@ export const DataSummary = ({ messages, ...rest }) => {
         <>
           {/* separator with margin to ensure | is not confused 
           as a 1 in the selected count */}
-          <Text margin={{ horizontal: 'small' }}>|</Text>
+          <Text margin={theme.dataSummary?.separator?.margin}>|</Text>
           <Text>
             {format({
               id: 'dataSummary.selected',

--- a/src/js/components/DataSummary/DataSummary.js
+++ b/src/js/components/DataSummary/DataSummary.js
@@ -29,7 +29,7 @@ export const DataSummary = ({ messages, ...rest }) => {
   });
 
   return (
-    <Text margin={theme.dataSummary?.container?.margin} {...rest}>
+    <Text margin={theme.dataSummary?.margin} {...rest}>
       {format({
         id: messageId,
         messages: messages || dataMessages?.dataSummary,

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -849,9 +849,7 @@ export interface ThemeType {
     };
   };
   dataSummary?: {
-    container?: {
-      margin?: MarginType;
-    };
+    margin?: MarginType;
     separator?: {
       margin?: MarginType;
     };

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -822,6 +822,14 @@ export interface ThemeType {
       kind?: string;
     };
   };
+  dataSummary?: {
+    container?: {
+      margin?: MarginType;
+    };
+    separator?: {
+      margin?: MarginType;
+    };
+  };
   dateInput?: {
     container?: {
       round?: RoundType;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -893,6 +893,14 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       //   size: undefined,
       // },
     },
+    dataSummary: {
+      container: {
+        margin: { vertical: 'xsmall' },
+      },
+      separator: {
+        margin: { horizontal: 'small' },
+      },
+    },
     dataTable: {
       // body: {
       //   extend: undefined,

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -921,9 +921,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       // },
     },
     dataSummary: {
-      container: {
-        margin: { vertical: 'xsmall' },
-      },
+      margin: { vertical: 'xsmall' },
       separator: {
         margin: { horizontal: 'small' },
       },


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds theme objects for the DataSummary component. Based on changes in https://github.com/grommet/grommet/pull/7591

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
