### PR TITLE
Add DataTableColumns theme objects

### DIFF
--- a/src/js/components/DataTableColumns/DataTableColumns.js
+++ b/src/js/components/DataTableColumns/DataTableColumns.js
@@ -21,11 +21,6 @@ const dropProps = {
   align: { top: 'bottom', left: 'left' },
 };
 
-const tabsProps = {
-  drop: { pad: 'small' },
-  noDrop: { justify: 'start' },
-};
-
 // options can either be an array of property names or an array of objects.
 // The form value always uses an array of property names.
 const optionsToValue = (options) =>
@@ -52,6 +47,12 @@ const Content = ({ drop, options = [], ...rest }) => {
   const { id: dataId, messages } = useContext(DataContext);
   const { useFormInput } = useContext(FormContext);
   const { format } = useContext(MessageContext);
+  const { theme } = useThemeValue();
+
+  const tabsProps = {
+    drop: { pad: theme.dataTableColumns.tabs.pad },
+    noDrop: { justify: theme.dataTableColumns.tabs.justify },
+  };
 
   // If the user searches for a particular option, render
   // the filtered list of options.
@@ -117,7 +118,10 @@ const Content = ({ drop, options = [], ...rest }) => {
             messages: messages?.dataTableColumns,
           })}
         >
-          <Box pad={{ vertical: 'small' }} gap="xsmall">
+          <Box
+            pad={theme.dataTableColumns.selectColumns.pad}
+            gap={theme.dataTableColumns.selectColumns.gap}
+          >
             <TextInput
               type="search"
               icon={<Search />}
@@ -151,7 +155,7 @@ const Content = ({ drop, options = [], ...rest }) => {
             messages: messages?.dataTableColumns,
           })}
         >
-          <Box pad={{ top: 'small' }}>
+          <Box pad={theme.dataTableColumns.orderColumns.pad}>
             <List
               id={`${dataId}--order-columns`}
               aria-labelledby={`${dataId}--order-columns-tab`}

--- a/src/js/components/DataTableColumns/DataTableColumns.js
+++ b/src/js/components/DataTableColumns/DataTableColumns.js
@@ -51,7 +51,7 @@ const Content = ({ drop, options = [], ...rest }) => {
 
   const tabsProps = {
     drop: { pad: theme.dataTableColumns.tabs.pad },
-    noDrop: { justify: theme.dataTableColumns.tabs.justify },
+    noDrop: { justify: 'start' },
   };
 
   // If the user searches for a particular option, render

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -930,14 +930,6 @@ export interface ThemeType {
   dataTableColumns?: {
     tabs?: {
       pad?: PadType;
-      justify?:
-        | 'around'
-        | 'between'
-        | 'center'
-        | 'end'
-        | 'evenly'
-        | 'start'
-        | 'stretch';
     };
     selectColumns?: {
       pad?: PadType;

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -927,6 +927,26 @@ export interface ThemeType {
       weight?: string;
     };
   };
+  dataTableColumns?: {
+    tabs?: {
+      pad?: PadType;
+      justify?:
+        | 'around'
+        | 'between'
+        | 'center'
+        | 'end'
+        | 'evenly'
+        | 'start'
+        | 'stretch';
+    };
+    selectColumns?: {
+      pad?: PadType;
+      gap?: GapType;
+    };
+    orderColumns?: {
+      pad?: PadType;
+    };
+  };
   diagram?: {
     extend?: ExtendType;
     line?: {

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -990,6 +990,23 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         // },
       },
     },
+    dataTableColumns: {
+      tabs: {
+        pad: 'small',
+        justify: 'start',
+      },
+      selectColumns: {
+        pad: {
+          vertical: 'small',
+        },
+        gap: 'xsmall',
+      },
+      orderColumns: {
+        pad: {
+          top: 'small',
+        },
+      },
+    },
     diagram: {
       // extend: undefined,
       line: {

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -993,7 +993,6 @@ export const generate = (baseSpacing = 24, scale = 6) => {
     dataTableColumns: {
       tabs: {
         pad: 'small',
-        justify: 'start',
       },
       selectColumns: {
         pad: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds theme objects for the DataTableColumns component. Based on changes in https://github.com/grommet/grommet/pull/7591

Note I removed `theme.dataTableColumns.tabs.justify` because i felt like we didn't need to add the justify prop to the theme for the t-shirt size changes

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
