### PR TITLE
Add DateInput theme objects

### DIFF
--- a/src/js/components/DateInput/DateInput.js
+++ b/src/js/components/DateInput/DateInput.js
@@ -91,9 +91,7 @@ const DateInput = forwardRef(
     const announce = useContext(AnnounceContext);
     const { format: formatMessage } = useContext(MessageContext);
     const iconSize =
-      (theme.icon?.matchSize && rest.size) ||
-      theme.dateInput.icon?.size ||
-      'medium';
+      (theme.icon?.matchSize && rest.size) || theme.dateInput.icon?.size;
     const { useFormInput } = useContext(FormContext);
     const ref = useForwardedRef(refArg);
     const containerRef = useRef();
@@ -303,7 +301,11 @@ Use the icon prop instead.`,
         disabled={disabled}
         plain
         icon={icon || MaskedInputIcon || <CalendarIcon size={iconSize} />}
-        margin={reverse ? { left: 'small' } : { right: 'small' }}
+        margin={
+          reverse
+            ? { left: theme.dateInput.button?.margin?.left }
+            : { right: theme.dateInput.button?.margin?.right }
+        }
       />
     );
 

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -840,6 +840,9 @@ export interface ThemeType {
     };
   };
   dateInput?: {
+    button?: {
+      margin?: MarginType;
+    };
     container?: {
       round?: RoundType;
     };

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -904,12 +904,18 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       // },
     },
     dateInput: {
+      button: {
+        margin: {
+          right: 'small',
+          left: 'small',
+        },
+      },
       container: {
         round: 'xxsmall',
       },
-      // icon: {
-      //   size: undefined,
-      // },
+      icon: {
+        size: 'medium',
+      },
     },
     dataTable: {
       // body: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds theme objects for the DateInput component. Based on changes in https://github.com/grommet/grommet/pull/7591

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
