### PR TITLE
Add Distribution theme objects

### DIFF
--- a/src/js/components/Distribution/Distribution.js
+++ b/src/js/components/Distribution/Distribution.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { Box } from '../Box';
 import { Text } from '../Text';
 import { DistributionPropTypes } from './propTypes';
+import { useThemeValue } from '../../utils/useThemeValue';
 
 const Value = ({ basis, children }) => (
   <Box basis={basis} flex="shrink" overflow="hidden">
@@ -29,10 +30,11 @@ const Distribution = ({
   children = defaultChildrenPropValue,
   direction = 'row',
   fill,
-  gap = 'xsmall',
+  gap,
   values = defaultValues,
   ...rest
 }) => {
+  const { theme } = useThemeValue();
   if (values.length === 1) {
     const value = values[0];
     return (
@@ -89,7 +91,7 @@ const Distribution = ({
         basis={basis}
         flex={basis ? 'shrink' : true}
         overflow="hidden"
-        gap={gap}
+        gap={gap || theme.distribution?.gap}
         fill={fill}
         {...rest}
       >
@@ -97,7 +99,7 @@ const Distribution = ({
           values={values.slice(0, subIndex)}
           basis={childBasis[0]}
           direction={direction === 'row' ? 'column' : 'row'}
-          gap={gap}
+          gap={gap || theme.distribution?.gap}
         >
           {children}
         </Distribution>
@@ -105,7 +107,7 @@ const Distribution = ({
           values={values.slice(subIndex)}
           basis={childBasis[1]}
           direction={direction === 'row' ? 'column' : 'row'}
-          gap={gap}
+          gap={gap || theme.distribution?.gap}
         >
           {children}
         </Distribution>

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -933,6 +933,9 @@ export interface ThemeType {
       color?: ColorType;
     };
   };
+  distribution?: {
+    gap?: GapType;
+  };
   drop?: {
     extend?: ExtendType;
     maxHeight?: string;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -996,6 +996,9 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         color: 'graph-0',
       },
     },
+    distribution: {
+      gap: 'xsmall',
+    },
     // drop: {
     //   extend: undefined,
     //   maxHeight: undefined,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds theme objects for the Distribution component. Based on changes in https://github.com/grommet/grommet/pull/7591
#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
