### PR TITLE
Add Footer theme objects

### DIFF
--- a/src/js/components/Footer/Footer.js
+++ b/src/js/components/Footer/Footer.js
@@ -1,17 +1,21 @@
 import React from 'react';
 
 import { Box } from '../Box';
+import { useThemeValue } from '../../utils/useThemeValue';
 
-const Footer = ({ ...rest }) => (
-  <Box
-    as="footer"
-    align="center"
-    direction="row"
-    flex={false}
-    gap="medium"
-    justify="between"
-    {...rest}
-  />
-);
+const Footer = ({ ...rest }) => {
+  const { theme } = useThemeValue();
+  return (
+    <Box
+      as="footer"
+      align="center"
+      direction="row"
+      flex={false}
+      gap={theme.footer?.gap}
+      justify="between"
+      {...rest}
+    />
+  );
+};
 
 export { Footer };

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -962,6 +962,9 @@ export interface ThemeType {
     pad?: PadType;
     round?: RoundType;
   };
+  footer?: {
+    gap?: GapType;
+  };
   formField?: {
     border?: BorderType & {
       error?: {

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1034,6 +1034,9 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       },
       // extend: undefined,
     },
+    footer: {
+      gap: 'medium',
+    },
     formField: {
       // [inputname]: {
       //  container: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds theme objects for the Footer component. Based on changes in https://github.com/grommet/grommet/pull/7591

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
