### PR TITLE
add datafilters theme object

### DIFF
--- a/src/js/components/DataFilters/DataFilters.js
+++ b/src/js/components/DataFilters/DataFilters.js
@@ -126,9 +126,7 @@ export const DataFilters = ({
 
   content = (
     <DataForm
-      // is this clear enough? this pad is applied
-      // when DataFilters is controlled via drop or layer
-      pad={controlled ? theme.dataFilters?.content?.pad : undefined}
+      pad={controlled ? theme.dataFilters?.pad : undefined}
       onDone={() => setShowContent(false)}
       updateOn={updateOn}
       {...(!controlled ? rest : { fill: 'vertical' })}
@@ -202,7 +200,7 @@ export const DataFilters = ({
           onClickOutside={() => setShowContent(undefined)}
           onEsc={() => setShowContent(undefined)}
         >
-          <Box width={theme.dataFilters?.content?.width}>{content}</Box>
+          <Box width={theme.dataFilters?.width}>{content}</Box>
         </Layer>
       )}
     </Box>

--- a/src/js/components/DataFilters/DataFilters.js
+++ b/src/js/components/DataFilters/DataFilters.js
@@ -100,7 +100,7 @@ export const DataFilters = ({
   );
 
   const clearControl = badge && clearFilters && (
-    <Box flex={false} margin={{ start: 'small' }}>
+    <Box flex={false} margin={theme.dataFilters?.clearControl?.margin}>
       <DataClearFilters />
     </Box>
   );
@@ -126,7 +126,9 @@ export const DataFilters = ({
 
   content = (
     <DataForm
-      pad={controlled ? 'medium' : undefined}
+      // is this clear enough? this pad is applied
+      // when DataFilters is controlled via drop or layer
+      pad={controlled ? theme.dataFilters?.content?.pad : undefined}
       onDone={() => setShowContent(false)}
       updateOn={updateOn}
       {...(!controlled ? rest : { fill: 'vertical' })}
@@ -200,7 +202,7 @@ export const DataFilters = ({
           onClickOutside={() => setShowContent(undefined)}
           onEsc={() => setShowContent(undefined)}
         >
-          <Box width={{ min: 'medium' }}>{content}</Box>
+          <Box width={theme.dataFilters?.content?.width}>{content}</Box>
         </Layer>
       )}
     </Box>

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -853,10 +853,8 @@ export interface ThemeType {
     clearControl?: {
       margin?: MarginType;
     };
-    content?: {
-      pad?: PadType;
-      width?: WidthType;
-    };
+    pad?: PadType;
+    width?: WidthType;
   };
   dateInput?: {
     container?: {

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -880,6 +880,7 @@ export interface ThemeType {
     };
     pad?: PadType;
     width?: WidthType;
+  }
   dataSummary?: {
     margin?: MarginType;
     separator?: {

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -28,6 +28,7 @@ import {
   SkeletonColorsType,
   AlignSelfType,
   AlignType,
+  WidthType,
 } from '../utils';
 
 import { AnchorProps } from '../components/Anchor/index';
@@ -846,6 +847,15 @@ export interface ThemeType {
     };
     selectMultiple?: {
       dropHeight?: string;
+    };
+  };
+  dataFilters?: {
+    clearControl?: {
+      margin?: MarginType;
+    };
+    content?: {
+      pad?: PadType;
+      width?: WidthType;
     };
   };
   dateInput?: {

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -916,10 +916,8 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       clearControl: {
         margin: { start: 'small' },
       },
-      content: {
-        pad: 'medium',
-        width: { min: 'medium' },
-      },
+      pad: 'medium',
+      width: { min: 'medium' },
     },
     dateInput: {
       container: {

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -912,6 +912,15 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         dropHeight: 'medium',
       },
     },
+    dataFilters: {
+      clearControl: {
+        margin: { start: 'small' },
+      },
+      content: {
+        pad: 'medium',
+        width: { min: 'medium' },
+      },
+    },
     dateInput: {
       container: {
         round: 'xxsmall',


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds theme objects for the dataFilters component.
Based on changes in https://github.com/grommet/grommet/pull/7591
#### Where should the reviewer start?
dataFilters.js
#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
https://github.com/grommet/grommet/pull/7591
#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
yes
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible


