### PR TITLE
Add Pagination theme objects

### DIFF
--- a/src/js/components/Pagination/Pagination.js
+++ b/src/js/components/Pagination/Pagination.js
@@ -243,7 +243,7 @@ const Pagination = forwardRef(
       <StyledPaginationContainer
         direction="row"
         align="center"
-        gap={{ column: 'xsmall', row: 'small' }}
+        gap={theme.pagination.withControls?.gap}
         wrap
         flex={false}
         {...theme.pagination.container}
@@ -263,7 +263,7 @@ const Pagination = forwardRef(
         <Box
           align="center"
           direction="row"
-          gap={{ column: 'xsmall', row: 'small' }}
+          gap={theme.pagination.withControls?.gap}
           wrap
         >
           {stepOptions && (

--- a/src/js/components/Pagination/Pagination.js
+++ b/src/js/components/Pagination/Pagination.js
@@ -231,7 +231,8 @@ const Pagination = forwardRef(
       return (
         <StyledPaginationContainer
           flex={false}
-          {...theme.pagination.container}
+          // {...theme.pagination.container}
+          {...{ ...theme.pagination.container, gap: undefined }}
           {...passThemeFlag}
           {...rest}
         >
@@ -243,7 +244,7 @@ const Pagination = forwardRef(
       <StyledPaginationContainer
         direction="row"
         align="center"
-        gap={theme.pagination.withControls?.gap}
+        // gap={theme.pagination.withControls?.gap}
         wrap
         flex={false}
         {...theme.pagination.container}
@@ -263,7 +264,8 @@ const Pagination = forwardRef(
         <Box
           align="center"
           direction="row"
-          gap={theme.pagination.withControls?.gap}
+          // gap={theme.pagination.withControls?.gap}
+          gap={theme.pagination.container?.gap}
           wrap
         >
           {stepOptions && (

--- a/src/js/components/Pagination/Pagination.js
+++ b/src/js/components/Pagination/Pagination.js
@@ -231,7 +231,6 @@ const Pagination = forwardRef(
       return (
         <StyledPaginationContainer
           flex={false}
-          // {...theme.pagination.container}
           {...{ ...theme.pagination.container, gap: undefined }}
           {...passThemeFlag}
           {...rest}
@@ -244,7 +243,6 @@ const Pagination = forwardRef(
       <StyledPaginationContainer
         direction="row"
         align="center"
-        // gap={theme.pagination.withControls?.gap}
         wrap
         flex={false}
         {...theme.pagination.container}
@@ -264,7 +262,6 @@ const Pagination = forwardRef(
         <Box
           align="center"
           direction="row"
-          // gap={theme.pagination.withControls?.gap}
           gap={theme.pagination.container?.gap}
           wrap
         >

--- a/src/js/components/Pagination/PaginationStep.js
+++ b/src/js/components/Pagination/PaginationStep.js
@@ -16,7 +16,12 @@ export const PaginationStep = ({
   const { theme } = useThemeValue();
 
   return (
-    <Box direction="row" align="center" gap="xsmall" {...rest}>
+    <Box
+      direction="row"
+      align="center"
+      gap={theme.pagination?.step?.container?.gap}
+      {...rest}
+    >
       <Text>{formatMessage({ id: 'pagination.stepLabel', messages })}</Text>
       <Select
         options={options}

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -1582,6 +1582,14 @@ export interface ThemeType {
       next?: React.ReactNode | Icon;
       previous?: React.ReactNode | Icon;
     };
+    step?: {
+      container?: {
+        gap?: GapType;
+      };
+    };
+    withControls?: {
+      gap?: GapType;
+    };
   };
   paragraph?: {
     extend?: ExtendType;

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -1587,9 +1587,6 @@ export interface ThemeType {
         gap?: GapType;
       };
     };
-    withControls?: {
-      gap?: GapType;
-    };
   };
   paragraph?: {
     extend?: ExtendType;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1767,7 +1767,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       step: {
         container: {
           gap: 'xsmall',
-        }
+        },
       },
       withControls: {
         gap: { column: 'xsmall', row: 'small' },

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1764,6 +1764,14 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         next: Next,
         previous: Previous,
       },
+      step: {
+        container: {
+          gap: 'xsmall',
+        }
+      },
+      withControls: {
+        gap: { column: 'xsmall', row: 'small' },
+      },
     },
     paragraph: {
       font: {

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1748,10 +1748,11 @@ export const generate = (baseSpacing = 24, scale = 6) => {
           },
         },
       },
-      // container: {
-      //   // any box props,
-      //   extend: undefined,
-      // },
+      container: {
+        gap: { column: 'xsmall', row: 'small' },
+        // any box props,
+        // extend: undefined,
+      },
       controls: {
         align: 'center',
         direction: 'row',
@@ -1768,9 +1769,6 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         container: {
           gap: 'xsmall',
         },
-      },
-      withControls: {
-        gap: { column: 'xsmall', row: 'small' },
       },
     },
     paragraph: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds theme objects for the Pagination component. Based on changes in https://github.com/grommet/grommet/pull/7591

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
