### PR TITLE
Add MaskedInput theme objects

### DIFF
--- a/src/js/components/MaskedInput/MaskedInput.js
+++ b/src/js/components/MaskedInput/MaskedInput.js
@@ -485,9 +485,7 @@ const MaskedInput = forwardRef(
                   // Determine whether the label is done as a child or
                   // as an option Button kind property.
                   const child = !theme.button.option ? (
-                    <Box pad={{ horizontal: 'small', vertical: 'xsmall' }}>
-                      {option}
-                    </Box>
+                    <Box pad={theme.maskedInput?.option?.pad}>{option}</Box>
                   ) : undefined;
                   // if we have a child, turn on plain, and hoverIndicator
 

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -1275,6 +1275,9 @@ export interface ThemeType {
     disabled?: {
       opacity?: OpacityType;
     };
+    option?: {
+      pad?: PadType;
+    };
   };
   menu?: {
     background?: BackgroundType;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1273,6 +1273,9 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       // },
       // extend: undefined,
       // disabled: { opacity: undefined },
+      option: {
+        pad: { horizontal: 'small', vertical: 'xsmall' },
+      },
     },
     menu: {
       // background: undefined,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds theme objects for the MaskedInput component. Based on changes in https://github.com/grommet/grommet/pull/7591

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
