### PR TITLE
add chart theme object

### DIFF
--- a/src/js/components/Chart/Chart.js
+++ b/src/js/components/Chart/Chart.js
@@ -12,7 +12,6 @@ import { useThemeValue } from '../../utils/useThemeValue';
 const gradientMaskColor = '#ffffff';
 
 // use constants so re-renders don't re-trigger effects
-const defaultSize = { height: 'small', width: 'medium' };
 const defaultValues = [];
 
 const Chart = React.forwardRef(
@@ -34,7 +33,7 @@ const Chart = React.forwardRef(
       point,
       round,
       size: sizeProp,
-      thickness = 'medium',
+      thickness,
       type = 'bar',
       values: valuesProp = defaultValues,
       ...rest
@@ -43,6 +42,8 @@ const Chart = React.forwardRef(
   ) => {
     const containerRef = useForwardedRef(ref);
     const { theme, passThemeFlag } = useThemeValue();
+
+    const thicknessValue = thickness || theme.chart?.thickness.default;
 
     const values = useMemo(() => normalizeValues(valuesProp), [valuesProp]);
 
@@ -55,8 +56,11 @@ const Chart = React.forwardRef(
     );
 
     const strokeWidth = useMemo(
-      () => parseMetricToNum(theme.global.edgeSize[thickness] || thickness),
-      [theme.global.edgeSize, thickness],
+      () =>
+        parseMetricToNum(
+          theme.global.edgeSize[thicknessValue] || thicknessValue,
+        ),
+      [theme.global.edgeSize, thicknessValue],
     );
 
     // inset is { top, left, bottom, right }
@@ -124,6 +128,10 @@ const Chart = React.forwardRef(
 
     // size is { width, height }
     const size = useMemo(() => {
+      const defaultSize = {
+        height: theme.chart?.height,
+        width: theme.chart?.width,
+      };
       const gapWidth = gap
         ? parseMetricToNum(theme.global.edgeSize[gap] || gap)
         : strokeWidth;
@@ -171,6 +179,8 @@ const Chart = React.forwardRef(
       strokeWidth,
       theme.global.edgeSize,
       theme.global.size,
+      theme.chart?.height,
+      theme.chart?.width,
       values,
     ]);
 

--- a/src/js/components/DataChart/DataChart.js
+++ b/src/js/components/DataChart/DataChart.js
@@ -45,7 +45,7 @@ const DataChart = forwardRef(
       data = [],
       detail,
       direction = 'vertical',
-      gap = 'small',
+      gap,
       guide: guideProp,
       legend,
       offset,
@@ -197,7 +197,9 @@ const DataChart = forwardRef(
         medium,
       };
       const granularity1 = {
-        ...(heightYGranularity[(size && size.height) || 'small'] || {
+        ...(heightYGranularity[
+          (size && size.height) || theme.dataChart.heightYGranularity
+        ] || {
           fine: 5,
           medium: 3,
         }),
@@ -206,7 +208,13 @@ const DataChart = forwardRef(
       return horizontal
         ? { x: granularity1, y: granularity0 }
         : { x: granularity0, y: granularity1 };
-    }, [charts, data.length, horizontal, size]);
+    }, [
+      charts,
+      data.length,
+      horizontal,
+      size,
+      theme.dataChart.heightYGranularity,
+    ]);
 
     // normalize axis to objects, convert granularity to a number
     const axis = useMemo(() => {
@@ -745,7 +753,7 @@ const DataChart = forwardRef(
           { name: 'xAxis', start: [1, 1], end: [1, 1] },
           { name: 'charts', start: [1, 0], end: [1, 0] },
         ]}
-        gap={gap}
+        gap={gap || theme.dataChart?.gap}
         {...rest}
       >
         {xAxisElement}

--- a/src/js/components/DataChart/Detail.js
+++ b/src/js/components/DataChart/Detail.js
@@ -224,7 +224,7 @@ const Detail = ({
           <Box pad="small" background={{ color: 'background-back' }}>
             <Grid
               columns={['auto', 'auto', 'auto']}
-              gap="xsmall"
+              gap={theme.dataChart.detail.gap}
               align="center"
             >
               {series

--- a/src/js/components/DataChart/Legend.js
+++ b/src/js/components/DataChart/Legend.js
@@ -3,6 +3,7 @@ import { Box } from '../Box';
 import { Button } from '../Button';
 import { Text } from '../Text';
 import { Swatch } from './Swatch';
+import { useThemeValue } from '../../utils/useThemeValue';
 
 const Legend = ({
   activeProperty,
@@ -10,6 +11,7 @@ const Legend = ({
   seriesStyles,
   setActiveProperty,
 }) => {
+  const { theme } = useThemeValue();
   const series = useMemo(
     () => seriesProp.filter((s) => seriesStyles[s.property]),
     [seriesProp, seriesStyles],
@@ -22,7 +24,12 @@ const Legend = ({
     [series, seriesStyles],
   );
   return (
-    <Box margin={{ top: 'small' }} direction="row" wrap gap="small">
+    <Box
+      margin={theme.dataChart.legend.margin}
+      direction="row"
+      wrap
+      gap={theme.dataChart.legend.gap}
+    >
       {series.map(({ property, label }) => {
         const isActive = property === activeProperty;
         const swatchProps = {};
@@ -40,8 +47,8 @@ const Legend = ({
             key={property}
             direction="row"
             align="center"
-            pad={{ horizontal: 'small', vertical: 'xsmall' }}
-            gap="xsmall"
+            pad={theme.dataChart?.legend?.item?.pad}
+            gap={theme.dataChart?.legend?.item?.gap}
           >
             <Swatch {...seriesStyles[property]} {...swatchProps} />
             <Text {...textProps}>{label || property}</Text>

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -742,6 +742,18 @@ export interface ThemeType {
   chart?: {
     color?: ColorType;
     extend?: ExtendType;
+    height?: string;
+    thickness?: {
+      default?: string;
+      pad?: {
+        xlarge?: PadType;
+        large?: PadType;
+        medium?: PadType;
+        small?: PadType;
+        xsmall?: PadType;
+      };
+    };
+    width?: string;
   };
   checkBox?: {
     border?: {
@@ -820,6 +832,23 @@ export interface ThemeType {
         xlarge?: string;
         huge?: string;
       };
+    };
+    dataChart?: {
+      gap?: GapType;
+      detail?: {
+        grid?: {
+          gap?: GridGapType;
+        };
+      };
+      legend?: {
+        margin?: MarginType;
+        gap?: GapType;
+        item?: {
+          gap?: GapType;
+          pad?: PadType;
+        };
+      };
+      heightYGranularity?: string;
     };
     digital?: {
       text?: {

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -781,6 +781,18 @@ export const generate = (baseSpacing = 24, scale = 6) => {
     },
     chart: {
       color: 'graph-0',
+      height: 'small',
+      thickness: {
+        default: 'medium',
+        pad: {
+          xlarge: 'large',
+          large: 'medium',
+          medium: 'small',
+          small: 'xsmall',
+          xsmall: 'xxsmall',
+        },
+      },
+      width: 'medium',
       // extend: undefined,
     },
     checkBox: {
@@ -902,6 +914,23 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       // button: {
       //   kind: undefined,
       // },
+    },
+    dataChart: {
+      gap: 'small',
+      detail: {
+        grid: {
+          gap: 'xsmall',
+        },
+      },
+      legend: {
+        margin: { top: 'small' },
+        gap: 'small',
+        item: {
+          gap: 'xsmall',
+          pad: { horizontal: 'small', vertical: 'xsmall' },
+        },
+      },
+      heightYGranularity: 'small',
     },
     dataFilter: {
       rangeSelector: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds theme objects for the Chart/DataChart component.
Based on changes in https://github.com/grommet/grommet/pull/7591
#### Where should the reviewer start?
chart.js
dataChart.js
#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
https://github.com/grommet/grommet/pull/7591
#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
yes
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible
