### PR TITLE
Add FileInput theme objects

### DIFF
--- a/src/js/components/FileInput/FileInput.js
+++ b/src/js/components/FileInput/FileInput.js
@@ -206,17 +206,14 @@ const FileInput = forwardRef(
         rightOffset = rightOffsetRemove + parseMetricToNum(rightPad);
       if (files.length === 1 || files.length > aggregateThreshold) {
         rightOffset =
-          rightOffsetBrowse +
-          rightOffsetRemove +
-          parseMetricToNum(theme.global.edgeSize.small) * 2;
+          rightOffsetBrowse + rightOffsetRemove + theme.fileInput.rightOffset;
       } else if (rightOffsetBrowse > rightOffsetRemove) {
-        rightOffset =
-          rightOffsetBrowse + parseMetricToNum(theme.global.edgeSize.small) * 2;
+        rightOffset = rightOffsetBrowse + theme.fileInput.rightOffset;
       } else rightOffset = rightOffsetRemove;
     } else if (!files.length && controlRef.current) {
       rightOffset =
         controlRef.current.getBoundingClientRect().width +
-        parseMetricToNum(theme.global.edgeSize.small) * 2;
+        theme.fileInput.rightOffset;
     }
 
     // Show the number of files when more than one
@@ -371,7 +368,7 @@ const FileInput = forwardRef(
                         alignSelf="center"
                         disabled={disabled}
                         ref={controlRef}
-                        margin="small"
+                        margin={theme.fileInput.anchor.margin}
                         onClick={() => {
                           inputRef.current.click();
                           inputRef.current.focus();
@@ -447,7 +444,7 @@ const FileInput = forwardRef(
                       alignSelf="center"
                       disabled={disabled}
                       ref={controlRef}
-                      margin="small"
+                      margin={theme.fileInput.anchor.margin}
                       onClick={() => {
                         inputRef.current.click();
                         inputRef.current.focus();
@@ -483,7 +480,6 @@ const FileInput = forwardRef(
                   ) : (
                     <Box
                       {...theme.fileInput.label}
-                      gap="xsmall"
                       align="center"
                       direction="row"
                     >
@@ -567,7 +563,7 @@ const FileInput = forwardRef(
                             tabIndex={-1}
                             disabled={disabled}
                             ref={controlRef}
-                            margin="small"
+                            margin={theme.fileInput.anchor.margin}
                             onClick={() => {
                               inputRef.current.click();
                               inputRef.current.focus();

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -947,6 +947,9 @@ export interface ThemeType {
     maxHeight?: string;
   };
   fileInput?: {
+    anchor?: {
+      margin?: MarginType;
+    };
     background?: BackgroundType;
     border?: BorderType;
     dragOver?: {
@@ -970,6 +973,7 @@ export interface ThemeType {
     message?: TextProps & { extend?: ExtendType };
     pad?: PadType;
     round?: RoundType;
+    rightOffset?: Number;
   };
   footer?: {
     gap?: GapType;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1010,6 +1010,9 @@ export const generate = (baseSpacing = 24, scale = 6) => {
     //   maxHeight: undefined,
     // },
     fileInput: {
+      anchor: {
+        margin: 'small',
+      },
       // background: {},
       border: {
         // color: undefined,
@@ -1034,6 +1037,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       },
       // pad: {},
       label: {
+        gap: 'xsmall',
         margin: 'small',
         // extend: undefined,
       },
@@ -1041,6 +1045,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         margin: 'small',
         // extend: undefined,
       },
+      rightOffset: parseMetricToNum(`${baseSpacing / 2}px`) * 2,
       // extend: undefined,
     },
     footer: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds theme objects for the FileInput component. Based on changes in https://github.com/grommet/grommet/pull/7591

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
