### PR TITLE
Add DataTable theme objects

### DIFF
--- a/src/js/components/DataTable/Footer.js
+++ b/src/js/components/DataTable/Footer.js
@@ -35,8 +35,8 @@ const Footer = forwardRef(
           {groups && (
             <TableCell
               plain
-              size={theme.dataTable.footer.cell.size}
-              pad={theme.dataTable.footer.cell.pad}
+              size={theme.dataTable.footer.groups.size}
+              pad={theme.dataTable.footer.groups.pad}
               verticalAlign="top"
               background={cellProps.background}
               border={cellProps.border}

--- a/src/js/components/DataTable/Footer.js
+++ b/src/js/components/DataTable/Footer.js
@@ -27,6 +27,7 @@ const Footer = forwardRef(
   ) => {
     const pin = pinProp ? ['bottom'] : [];
     const { passThemeFlag } = useThemeValue();
+    const { theme } = useThemeValue();
 
     return (
       <StyledDataTableFooter ref={ref} fillProp={fill} pin={pinProp} {...rest}>
@@ -34,8 +35,8 @@ const Footer = forwardRef(
           {groups && (
             <TableCell
               plain
-              size="xxsmall"
-              pad="none"
+              size={theme.dataTable.footer.cell.size}
+              pad={theme.dataTable.footer.cell.pad}
               verticalAlign="top"
               background={cellProps.background}
               border={cellProps.border}

--- a/src/js/components/DataTable/Header.js
+++ b/src/js/components/DataTable/Header.js
@@ -300,7 +300,13 @@ const Header = forwardRef(
               )}
             </StyledDataTableCell>
           )}
-          {rowDetails && <TableCell size="xxsmall" plain pad="none" />}
+          {rowDetails && (
+            <TableCell
+              size={theme.dataTable.rowDetails?.size}
+              plain
+              pad={theme.dataTable.rowDetails?.pad}
+            />
+          )}
           {columns.map(
             ({
               property,
@@ -398,7 +404,7 @@ const Header = forwardRef(
                     <Box
                       direction="row"
                       align="center"
-                      gap="xsmall"
+                      gap={theme.dataTable.sorter?.gap}
                       justify={align}
                     >
                       {content}

--- a/src/js/components/DataTable/Searcher.js
+++ b/src/js/components/DataTable/Searcher.js
@@ -5,7 +5,6 @@ import { FormSearch } from 'grommet-icons/icons/FormSearch';
 import { Box } from '../Box';
 import { Button } from '../Button';
 import { Keyboard } from '../Keyboard';
-import { Text } from '../Text';
 import { TextInput } from '../TextInput';
 import { MessageContext } from '../../contexts/MessageContext';
 import { normalizeColor } from '../../utils';
@@ -60,7 +59,7 @@ const Searcher = ({
         flex
         // padding right is not needed any longer. There is margin
         // right set already on the container, see Header.js
-        pad={{ left: 'small' }}
+        pad={theme.dataTable.searcher?.pad}
       >
         <TextInput
           name={`search-${property}`}
@@ -73,35 +72,21 @@ const Searcher = ({
       </Box>
     </Keyboard>
   ) : (
-    <>
-      {filters[property] ? (
-        <Box
-          flex={false}
-          pad={{ horizontal: 'small' }}
-          direction="row"
-          align="center"
-        >
-          <Text>{filters[property]}</Text>
-        </Box>
-      ) : null}
-      <Button
-        ref={buttonRef}
-        a11yTitle={a11yTitle}
-        icon={
-          <FormSearch
-            color={normalizeColor(
-              filtering === property ? 'brand' : 'border',
-              theme,
-            )}
-          />
-        }
-        hoverIndicator
-        focusIndicator={focusIndicator}
-        onClick={() =>
-          onFiltering(filtering === property ? undefined : property)
-        }
-      />
-    </>
+    <Button
+      ref={buttonRef}
+      a11yTitle={a11yTitle}
+      icon={
+        <FormSearch
+          color={normalizeColor(
+            filtering === property ? 'brand' : 'border',
+            theme,
+          )}
+        />
+      }
+      hoverIndicator
+      focusIndicator={focusIndicator}
+      onClick={() => onFiltering(filtering === property ? undefined : property)}
+    />
   );
 };
 

--- a/src/js/components/DataTable/Sorter.js
+++ b/src/js/components/DataTable/Sorter.js
@@ -33,7 +33,7 @@ const Sorter = ({
       direction="row"
       justify={align}
       align="center"
-      gap="xsmall"
+      gap={theme.dataTable.sorter?.gap}
       fill={fill}
     >
       {children}

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -871,7 +871,7 @@ export interface ThemeType {
     };
     container?: BoxProps;
     footer?: {
-      cell?: {
+      groups?: {
         pad?: PadType;
         size?: string;
       };

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -870,6 +870,12 @@ export interface ThemeType {
       };
     };
     container?: BoxProps;
+    footer?: {
+      cell?: {
+        pad?: PadType;
+        size?: string;
+      };
+    };
     header?: {
       background?: BackgroundType;
       border?: BorderType;
@@ -937,6 +943,16 @@ export interface ThemeType {
     };
     primary?: {
       weight?: string;
+    };
+    rowDetails?: {
+      pad?: PadType;
+      size?: string;
+    };
+    searcher?: {
+      pad?: PadType;
+    };
+    sorter?: {
+      gap?: GapType;
     };
   };
   diagram?: {

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -951,7 +951,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         // extend: undefined,
       },
       footer: {
-        cell: {
+        groups: {
           pad: 'none',
           size: 'xxsmall',
         },
@@ -978,14 +978,6 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         //   background: undefined,
         // },
         // pad: undefined,
-        // searcher: {
-        //   pad: {
-        //     left: 'small',
-        //   },
-        // },
-        // sorter: {
-        //   gap: 'xsmall',
-        // },
         units: {
           color: 'text-xweak',
           margin: { left: 'xsmall' },
@@ -1016,8 +1008,8 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         // },
       },
       rowDetails: {
-        size: 'xxsmall',
         pad: 'none',
+        size: 'xxsmall',
       },
       searcher: {
         pad: {

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -950,6 +950,12 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         gap: 'xsmall',
         // extend: undefined,
       },
+      footer: {
+        cell: {
+          pad: 'none',
+          size: 'xxsmall',
+        },
+      },
       groupHeader: {
         // background: undefined,
         // border: undefined,
@@ -972,6 +978,14 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         //   background: undefined,
         // },
         // pad: undefined,
+        // searcher: {
+        //   pad: {
+        //     left: 'small',
+        //   },
+        // },
+        // sorter: {
+        //   gap: 'xsmall',
+        // },
         units: {
           color: 'text-xweak',
           margin: { left: 'xsmall' },
@@ -1000,6 +1014,18 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         //     size: undefined,
         //   },
         // },
+      },
+      rowDetails: {
+        size: 'xxsmall',
+        pad: 'none',
+      },
+      searcher: {
+        pad: {
+          left: 'small',
+        },
+      },
+      sorter: {
+        gap: 'xsmall',
       },
     },
     diagram: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds theme objects for the DataTable component. Based on changes in https://github.com/grommet/grommet/pull/7591

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
