### PR TITLE
add anchor theme object

### DIFF
--- a/src/js/components/Anchor/StyledAnchor.js
+++ b/src/js/components/Anchor/StyledAnchor.js
@@ -75,7 +75,7 @@ const StyledAnchor = styled.a.withConfig(styledComponentsConfig)`
     edgeStyle(
       'padding',
       props.theme.anchor.iconOnly.pad,
-      props.responsive,
+      false,
       props.theme.global.edgeSize.responsiveBreakpoint,
       props.theme,
     )}

--- a/src/js/components/Anchor/StyledAnchor.js
+++ b/src/js/components/Anchor/StyledAnchor.js
@@ -72,7 +72,7 @@ const StyledAnchor = styled.a.withConfig(styledComponentsConfig)`
     props.hasIcon &&
     !props.hasLabel &&
     `
-    padding: ${props.theme.global.edgeSize.small};
+    padding: ${props.theme.anchor.iconOnly.pad};
   `}
   ${(props) => props.disabled && disabledStyle}
   ${(props) => props.focus && focusStyle()}

--- a/src/js/components/Anchor/StyledAnchor.js
+++ b/src/js/components/Anchor/StyledAnchor.js
@@ -1,6 +1,7 @@
 import styled, { css } from 'styled-components';
 
 import {
+  edgeStyle,
   focusStyle,
   genericStyles,
   normalizeColor,
@@ -71,9 +72,13 @@ const StyledAnchor = styled.a.withConfig(styledComponentsConfig)`
   ${(props) =>
     props.hasIcon &&
     !props.hasLabel &&
-    `
-    padding: ${props.theme.anchor.iconOnly.pad};
-  `}
+    edgeStyle(
+      'padding',
+      props.theme.anchor.iconOnly.pad,
+      props.responsive,
+      props.theme.global.edgeSize.responsiveBreakpoint,
+      props.theme,
+    )}
   ${(props) => props.disabled && disabledStyle}
   ${(props) => props.focus && focusStyle()}
   ${(props) => props.theme.anchor.extend}

--- a/src/js/components/Anchor/__tests__/__snapshots__/Anchor-test.tsx.snap
+++ b/src/js/components/Anchor/__tests__/__snapshots__/Anchor-test.tsx.snap
@@ -2048,7 +2048,7 @@ exports[`Anchor warns about invalid icon render 1`] = `
   font-weight: 600;
   text-decoration: none;
   cursor: pointer;
-  padding: small;
+  padding: 12px;
 }
 
 .c1:hover {

--- a/src/js/components/Anchor/__tests__/__snapshots__/Anchor-test.tsx.snap
+++ b/src/js/components/Anchor/__tests__/__snapshots__/Anchor-test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Anchor blur renders 1`] = `
 .c0 {
@@ -2048,7 +2048,7 @@ exports[`Anchor warns about invalid icon render 1`] = `
   font-weight: 600;
   text-decoration: none;
   cursor: pointer;
-  padding: 12px;
+  padding: small;
 }
 
 .c1:hover {

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -555,6 +555,9 @@ export interface ThemeType {
     icon?: {
       color?: ColorType;
     };
+    iconOnly?: {
+      pad?: PadType;
+    };
     textDecoration?: string;
     size?: {
       medium?: {

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -416,6 +416,9 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       // icon: {
       //   color: undefined
       // },
+      iconOnly: {
+        pad: 'small',
+      },
       textDecoration: 'none',
       fontWeight: 600,
       // size: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds theme objects for the Anchor component.
Based on changes in https://github.com/grommet/grommet/pull/7591
#### Where should the reviewer start?
anchor.js
#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
https://github.com/grommet/grommet/pull/7591
#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
yes
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible
