### PR TITLE
Add `theme.spinner.responsive`

### DIFF
--- a/src/js/components/Spinner/Spinner.js
+++ b/src/js/components/Spinner/Spinner.js
@@ -10,9 +10,19 @@ import { Box } from '../Box';
 import { SpinnerPropTypes } from './propTypes';
 import { useThemeValue } from '../../utils/useThemeValue';
 
-const BasicSpinner = ({ ref, size, ...rest }) => (
-  <Box flex={false} height={size} width={size} ref={ref} {...rest} />
-);
+const BasicSpinner = ({ ref, size, ...rest }) => {
+  const { theme } = useThemeValue();
+  return (
+    <Box
+      flex={false}
+      height={size}
+      width={size}
+      ref={ref}
+      responsive={theme.spinner.responsive}
+      {...rest}
+    />
+  );
+};
 /**
  * If the user is calling <Spinner>…</Spinner> with children, it will take
  * precedence over theme styling. Yet, it will still inherit the

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -1942,6 +1942,7 @@ export interface ThemeType {
       | { color?: ColorType }
       | { size?: 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | string };
     icon?: React.ReactNode | Icon;
+    responsive?: true;
     size?: {
       xsmall?: string;
       small?: string;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1940,6 +1940,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         size: 'small',
       },
       // icon: undefined
+      responsive: true,
       size: {
         xsmall: `${baseSpacing * 0.75}px`,
         small: `${baseSpacing}px`, // default 24


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

In HPE theme, we don't want Spinner to drop down its border thickness at small breakpoints. Previously, "medium" border for desktop and mobile was the same. With t-shirt size adjustments, this isn't the case.
 
#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
