### PR TITLE
Add theme support for `theme.dataChart.granularity.y`

### DIFF
--- a/src/js/components/DataChart/DataChart.js
+++ b/src/js/components/DataChart/DataChart.js
@@ -211,6 +211,7 @@ const DataChart = forwardRef(
         ? { x: granularity1, y: granularity0 }
         : { x: granularity0, y: granularity1 };
     }, [charts, data.length, horizontal, size, theme]);
+    
     // normalize axis to objects, convert granularity to a number
     const axis = useMemo(() => {
       if (!axisProp) return undefined;

--- a/src/js/components/DataChart/DataChart.js
+++ b/src/js/components/DataChart/DataChart.js
@@ -196,8 +196,10 @@ const DataChart = forwardRef(
         fine: data.length,
         medium,
       };
+      const yGranularity =
+        theme.dataChart?.granularity?.y || heightYGranularity;
       const granularity1 = {
-        ...(heightYGranularity[
+        ...(yGranularity[
           (size && size.height) || theme.dataChart.size?.height
         ] || {
           fine: 5,
@@ -209,7 +211,6 @@ const DataChart = forwardRef(
         ? { x: granularity1, y: granularity0 }
         : { x: granularity0, y: granularity1 };
     }, [charts, data.length, horizontal, size, theme]);
-
     // normalize axis to objects, convert granularity to a number
     const axis = useMemo(() => {
       if (!axisProp) return undefined;

--- a/src/js/components/DataChart/DataChart.js
+++ b/src/js/components/DataChart/DataChart.js
@@ -211,7 +211,6 @@ const DataChart = forwardRef(
         ? { x: granularity1, y: granularity0 }
         : { x: granularity0, y: granularity1 };
     }, [charts, data.length, horizontal, size, theme]);
-    
     // normalize axis to objects, convert granularity to a number
     const axis = useMemo(() => {
       if (!axisProp) return undefined;

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -856,6 +856,14 @@ export interface ThemeType {
     };
     dataChart?: {
       gap?: GapType;
+      granularity?: {
+        y?: {
+          [key: string]: {
+            fine: number;
+            medium: number;
+          };
+        };
+      };
       detail?: {
         gap?: GridGapType;
       };

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -945,6 +945,9 @@ export const generate = (baseSpacing = 24, scale = 6) => {
     },
     dataChart: {
       gap: 'small',
+      // granularity: {
+      //   y: {},
+      // },
       detail: {
         gap: 'xsmall',
       },


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Since grommet-theme-hpe is expanding the range of t-shirt sizes, need a way to redefine our desired granularities.

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
