### PR TITLE
Add `theme.tag.hover` support

### DIFF
--- a/src/js/components/Tag/StyledTag.js
+++ b/src/js/components/Tag/StyledTag.js
@@ -1,12 +1,26 @@
 import styled from 'styled-components';
 
-import { borderStyle, roundStyle } from '../../utils';
+import { backgroundStyle, borderStyle, roundStyle } from '../../utils';
 
 import { Button } from '../Button';
 
 export const StyledTagButton = styled(Button)`
+  ${(props) =>
+    props.background && backgroundStyle(props.background, props.theme)}
   ${(props) => props.border && borderStyle(props.border, true, props.theme)}
   ${(props) => props.round && roundStyle(props.round, true, props.theme)}
+  &:hover {
+    ${(props) =>
+      props.background &&
+      props.onClick &&
+      props.theme?.tag?.hover?.background &&
+      backgroundStyle(props.theme.tag.hover.background, props.theme)}
+    ${(props) =>
+      props.border &&
+      props.onClick &&
+      props.theme?.tag?.hover?.border &&
+      borderStyle(props.theme.tag.hover.border, props.theme)}
+  }
 `;
 
 export const StyledRemoveButton = styled(Button)`

--- a/src/js/components/Tag/stories/OnClick.stories.js
+++ b/src/js/components/Tag/stories/OnClick.stories.js
@@ -1,14 +1,32 @@
 import React from 'react';
 
-import { Box, Tag } from 'grommet';
+import { Box, Tag, Grommet } from 'grommet';
+import { hpe } from 'grommet-theme-hpe';
+import { deepMerge } from '../../../utils';
+
+const customTheme = deepMerge(hpe, {
+  tag: {
+    background: 'background-contrast',
+    border: {
+      color: 'transparent',
+    },
+    hover: {
+      background: 'background-contrast-hover',
+    },
+    round: 'small',
+  },
+});
 
 export const OnClick = () => {
   const onClick = () => {};
   return (
-    <Box pad="large" gap="medium" align="start">
-      <Tag name="name" value="value" onClick={onClick} />
-      <Tag value="value" onClick={onClick} />
-    </Box>
+    <Grommet theme={customTheme}>
+      <Box pad="large" gap="medium" align="start">
+        <Tag name="name" value="value" onClick={onClick} />
+        <Tag value="value" onRemove={() => {}} />
+        <Tag value="value" />
+      </Box>
+    </Grommet>
   );
 };
 

--- a/src/js/components/Tag/stories/OnClick.stories.js
+++ b/src/js/components/Tag/stories/OnClick.stories.js
@@ -1,32 +1,14 @@
 import React from 'react';
 
-import { Box, Tag, Grommet } from 'grommet';
-import { hpe } from 'grommet-theme-hpe';
-import { deepMerge } from '../../../utils';
-
-const customTheme = deepMerge(hpe, {
-  tag: {
-    background: 'background-contrast',
-    border: {
-      color: 'transparent',
-    },
-    hover: {
-      background: 'background-contrast-hover',
-    },
-    round: 'small',
-  },
-});
+import { Box, Tag } from 'grommet';
 
 export const OnClick = () => {
   const onClick = () => {};
   return (
-    <Grommet theme={customTheme}>
-      <Box pad="large" gap="medium" align="start">
-        <Tag name="name" value="value" onClick={onClick} />
-        <Tag value="value" onRemove={() => {}} />
-        <Tag value="value" />
-      </Box>
-    </Grommet>
+    <Box pad="large" gap="medium" align="start">
+      <Tag name="name" value="value" onClick={onClick} />
+      <Tag value="value" onClick={onClick} />
+    </Box>
   );
 };
 

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -2079,6 +2079,10 @@ export interface ThemeType {
   tag?: {
     background?: BackgroundType;
     border?: BorderType;
+    hover?: {
+      background?: BackgroundType;
+      border?: BorderType;
+    };
     round?: RoundType;
     name?: TextProps;
     pad?: PadType;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -2291,6 +2291,10 @@ export const generate = (baseSpacing = 24, scale = 6) => {
     tag: {
       // background: undefined,
       border: true,
+      // hover: {
+      //   background: undefined,
+      //   border: undefined,
+      // },
       round: 'large',
       // name: undefined,
       pad: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Add theme support for `theme.tag.hover` (background and border) when `onClick` is applied.

There have been some design discussions around potential Tag style changes for HPE theme. This won't be part of the initial landmark release, but might be a modification in future once more discussion has been had.

So while nothing has been "settled", I wanted to make sure Grommet was in a place to support the style updates if needed (and not require a peerDependency bump again in the theme).

Included a storybook example with the potential desired styles.

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

https://github.com/user-attachments/assets/0fed83ca-e98c-4a0e-b0cb-21cd921bdffe


#### Do the grommet docs need to be updated?
Yes.

#### Should this PR be mentioned in the release notes?
Yes.

#### Is this change backwards compatible or is it a breaking change?
Yes, backwards compatible.