### PR TITLE
Rename box.border.size to box.border.offset

### DIFF
--- a/src/js/components/Box/StyledBox.js
+++ b/src/js/components/Box/StyledBox.js
@@ -399,7 +399,7 @@ const gapGapStyle = (directionProp, gap, responsive, border, theme) => {
   }
 
   if (border === 'between' || (border && border.side === 'between')) {
-    const borderSize = border.size || theme.box.border.size;
+    const borderSize = border.size || theme.box.border.offset;
     const borderMetric = theme.global.borderSize[borderSize] || borderSize;
     const borderOffset = `${
       parseMetricToNum(metric) / 2 - parseMetricToNum(borderMetric) / 2

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -609,7 +609,7 @@ export interface ThemeType {
   };
   box?: {
     border?: {
-      size?: string;
+      offset?: string;
     };
     extend?: ExtendType;
     responsiveBreakpoint?: string;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -462,7 +462,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
     },
     box: {
       border: {
-        size: 'xsmall',
+        offset: 'xsmall',
       },
       responsiveBreakpoint: 'small', // when we switch rows to columns
       // extend: undefined,


### PR DESCRIPTION
#### What does this PR do?
Change `box.border.size` to `box.border.offset` because this naming more accurately reflects it's usage

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible (this hasn't been released yet)