### PR TITLE
DataTable - add resizer theme objects for t-shirt values

### DIFF
--- a/src/js/components/DataTable/Resizer.js
+++ b/src/js/components/DataTable/Resizer.js
@@ -20,6 +20,7 @@ import { edgeStyle } from '../../utils/styles';
 // We determined 12 empirically as being wide enough to hit but
 // not too wide to cause false hits.
 const STEP = 12; // Used to determine the width change on resize
+const resizerWidth = 24; // minimum width required for WCAG compliance
 
 const StyledResizer = styled(DropButton)`
   display: flex;
@@ -40,17 +41,10 @@ const StyledResizer = styled(DropButton)`
       props.theme.global.edgeSize.responsiveBreakpoint,
       props.theme,
     )};
-  ${(props) =>
-    edgeStyle(
-      'margin-right',
-      props.theme.dataTable?.resize?.margin?.right,
-      false,
-      props.theme.global.edgeSize.responsiveBreakpoint,
-      props.theme,
-    )};
+  margin-right: -${resizerWidth / 2 - 1}px;
   position: absolute;
   right: 0;
-  width: 24px;
+  width: ${resizerWidth}px;
   height: 100%;
   top: 0;
   cursor: col-resize;

--- a/src/js/components/DataTable/Resizer.js
+++ b/src/js/components/DataTable/Resizer.js
@@ -23,9 +23,9 @@ const STEP = 12; // Used to determine the width change on resize
 const StyledResizer = styled(DropButton)`
   display: flex;
   justify-content: center;
-  padding-top: ${(props) => props.theme.global.edgeSize.xsmall};
-  padding-bottom: ${(props) => props.theme.global.edgeSize.xsmall};
-  margin-right: -${(props) => props.theme.global.edgeSize.small};
+  padding-top: 6px;
+  padding-bottom: 6px;
+  margin-right: -12px;
   position: absolute;
   right: 0;
   width: 24px;

--- a/src/js/components/DataTable/Resizer.js
+++ b/src/js/components/DataTable/Resizer.js
@@ -41,9 +41,19 @@ const StyledResizer = styled(DropButton)`
       props.theme.global.edgeSize.responsiveBreakpoint,
       props.theme,
     )};
-  margin-right: -${resizerWidth / 2 - 1}px;
+  ${(props) =>
+    props.side === 'start' &&
+    `margin-left: -${
+      resizerWidth / 2 - props.theme.global.borderSize.xsmall.replace('px', '')
+    }px;`}
+  ${(props) => props.side === 'start' && `left: 0;`}
+  ${(props) =>
+    props.side === 'end' &&
+    `margin-right: -${
+      resizerWidth / 2 - props.theme.global.borderSize.xsmall.replace('px', '')
+    }px;`}
+  ${(props) => props.side === 'end' && `right: 0;`}
   position: absolute;
-  right: 0;
   width: ${resizerWidth}px;
   height: 100%;
   top: 0;
@@ -235,6 +245,7 @@ const Resizer = ({ onResize, property, headerText, messages, headerId }) => {
           </Box>
         }
         dropAlign={{ top: 'bottom' }}
+        side={border?.side}
       >
         <Box
           border={hover || active ? hoverBorder : border}

--- a/src/js/components/DataTable/Resizer.js
+++ b/src/js/components/DataTable/Resizer.js
@@ -15,6 +15,7 @@ import { DropButton } from '../DropButton';
 import { Keyboard } from '../Keyboard';
 import { useThemeValue } from '../../utils/useThemeValue';
 import { MessageContext } from '../../contexts/MessageContext';
+import { edgeStyle } from '../../utils/styles';
 
 // We determined 12 empirically as being wide enough to hit but
 // not too wide to cause false hits.
@@ -23,9 +24,30 @@ const STEP = 12; // Used to determine the width change on resize
 const StyledResizer = styled(DropButton)`
   display: flex;
   justify-content: center;
-  padding-top: 6px;
-  padding-bottom: 6px;
-  margin-right: -12px;
+  ${(props) =>
+    edgeStyle(
+      'padding-top',
+      props.theme.dataTable?.resize?.padding?.vertical,
+      false,
+      props.theme.global.edgeSize.responsiveBreakpoint,
+      props.theme,
+    )};
+  ${(props) =>
+    edgeStyle(
+      'padding-bottom',
+      props.theme.dataTable?.resize?.padding?.vertical,
+      false,
+      props.theme.global.edgeSize.responsiveBreakpoint,
+      props.theme,
+    )};
+  ${(props) =>
+    edgeStyle(
+      'margin-right',
+      props.theme.dataTable?.resize?.margin?.right,
+      false,
+      props.theme.global.edgeSize.responsiveBreakpoint,
+      props.theme,
+    )};
   position: absolute;
   right: 0;
   width: 24px;

--- a/src/js/components/DataTable/__tests__/DataTable-test.tsx
+++ b/src/js/components/DataTable/__tests__/DataTable-test.tsx
@@ -1249,9 +1249,6 @@ describe('DataTable', () => {
               size: 'xsmall',
             },
           },
-          margin: {
-            right: '-5px',
-          },
           padding: {
             vertical: '7px',
           },

--- a/src/js/components/DataTable/__tests__/DataTable-test.tsx
+++ b/src/js/components/DataTable/__tests__/DataTable-test.tsx
@@ -1249,6 +1249,12 @@ describe('DataTable', () => {
               size: 'xsmall',
             },
           },
+          margin: {
+            right: '-5px',
+          },
+          padding: {
+            vertical: '7px',
+          },
         },
       },
     };

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.tsx.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.tsx.snap
@@ -3786,7 +3786,7 @@ exports[`DataTable custom theme 1`] = `
   justify-content: center;
   padding-top: 7px;
   padding-bottom: 7px;
-  margin-right: -5px;
+  margin-right: -11px;
   position: absolute;
   right: 0;
   width: 24px;
@@ -4102,7 +4102,7 @@ exports[`DataTable custom theme 2`] = `
             aria-orientation="vertical"
             aria-valuenow="0"
             aria-valuetext="Resize A column"
-            class="StyledButton-sc-323bzc-0 jLPXpV Resizer__StyledResizer-sc-8l808w-0 lifotu"
+            class="StyledButton-sc-323bzc-0 jLPXpV Resizer__StyledResizer-sc-8l808w-0 bPhCbC"
             role="separator"
             type="button"
           >

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.tsx.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.tsx.snap
@@ -3787,8 +3787,8 @@ exports[`DataTable custom theme 1`] = `
   padding-top: 7px;
   padding-bottom: 7px;
   margin-right: -11px;
-  position: absolute;
   right: 0;
+  position: absolute;
   width: 24px;
   height: 100%;
   top: 0;
@@ -4102,7 +4102,7 @@ exports[`DataTable custom theme 2`] = `
             aria-orientation="vertical"
             aria-valuenow="0"
             aria-valuetext="Resize A column"
-            class="StyledButton-sc-323bzc-0 jLPXpV Resizer__StyledResizer-sc-8l808w-0 bPhCbC"
+            class="StyledButton-sc-323bzc-0 jLPXpV Resizer__StyledResizer-sc-8l808w-0 eEHzjh"
             role="separator"
             type="button"
           >
@@ -23331,8 +23331,8 @@ exports[`DataTable resizeable 1`] = `
   padding-top: 6px;
   padding-bottom: 6px;
   margin-right: -11px;
-  position: absolute;
   right: 0;
+  position: absolute;
   width: 24px;
   height: 100%;
   top: 0;

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.tsx.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.tsx.snap
@@ -3784,9 +3784,9 @@ exports[`DataTable custom theme 1`] = `
 .c11 {
   display: flex;
   justify-content: center;
-  padding-top: 6px;
-  padding-bottom: 6px;
-  margin-right: -12px;
+  padding-top: 7px;
+  padding-bottom: 7px;
+  margin-right: -5px;
   position: absolute;
   right: 0;
   width: 24px;
@@ -4102,7 +4102,7 @@ exports[`DataTable custom theme 2`] = `
             aria-orientation="vertical"
             aria-valuenow="0"
             aria-valuetext="Resize A column"
-            class="StyledButton-sc-323bzc-0 jLPXpV Resizer__StyledResizer-sc-8l808w-0 jXjIlQ"
+            class="StyledButton-sc-323bzc-0 jLPXpV Resizer__StyledResizer-sc-8l808w-0 lifotu"
             role="separator"
             type="button"
           >
@@ -23330,7 +23330,7 @@ exports[`DataTable resizeable 1`] = `
   justify-content: center;
   padding-top: 6px;
   padding-bottom: 6px;
-  margin-right: -12px;
+  margin-right: -11px;
   position: absolute;
   right: 0;
   width: 24px;

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -1058,6 +1058,12 @@ export interface ThemeType {
           size: string;
         };
       };
+      margin?: {
+        right?: string;
+      };
+      padding?: {
+        vertical?: string;
+      };
     };
     primary?: {
       weight?: string;

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -1058,9 +1058,6 @@ export interface ThemeType {
           size: string;
         };
       };
-      margin?: {
-        right?: string;
-      };
       padding?: {
         vertical?: string;
       };

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1127,9 +1127,6 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         //     size: undefined,
         //   },
         // },
-        margin: {
-          right: '-11px', // offset 12 px padding + 1px border
-        },
         padding: {
           vertical: 'xsmall',
         },

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1127,6 +1127,12 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         //     size: undefined,
         //   },
         // },
+        margin: {
+          right: '-11px', // offset 12 px padding + 1px border
+        },
+        padding: {
+          vertical: 'xsmall',
+        },
       },
       search: {
         pad: {


### PR DESCRIPTION
#### What does this PR do?
Adds theme objects for the DataTable resizer margin and padding.

I adjusted the margin from -12px to -11px because the border was sometimes getting cut off since the resizer has 24px width and the border is 1px. We want the center of the resizer to align with the edge of the cell. So we divide the resizer width by 2 and subtract 1 to account for the border width. The -11px margin-right value means that the border ends up at the edge of the cell and doesn't get cut off.

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?
Yes, theme props should be marked as beta

#### Is this change backwards compatible or is it a breaking change?
backwards compatible