### PR TITLE
Use theme value for expanderCell instead of hardcoded t-shirt size

### DIFF
--- a/src/js/components/DataTable/ExpanderCell.js
+++ b/src/js/components/DataTable/ExpanderCell.js
@@ -106,17 +106,21 @@ const ExpanderCell = ({
   context,
   expandLabel,
   ...rest
-}) => (
-  <TableCell
-    background={background}
-    border={border}
-    size="xxsmall"
-    plain="noPad"
-    verticalAlign={context === 'groupEnd' ? 'bottom' : 'top'}
-  >
-    <ExpanderControl context={context} expandLabel={expandLabel} {...rest} />
-  </TableCell>
-);
+}) => {
+  const { theme } = useThemeValue();
+
+  return (
+    <TableCell
+      background={background}
+      border={border}
+      size={theme.dataTable.expand?.size}
+      plain="noPad"
+      verticalAlign={context === 'groupEnd' ? 'bottom' : 'top'}
+    >
+      <ExpanderControl context={context} expandLabel={expandLabel} {...rest} />
+    </TableCell>
+  );
+};
 ExpanderCell.displayName = 'ExpanderCell';
 
 export { ExpanderCell };

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.tsx.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.tsx.snap
@@ -57328,8 +57328,8 @@ exports[`DataTable theme search pad, search text pad, sort gap, and expand size 
   padding: 0;
   font-weight: inherit;
   text-align: inherit;
-  width: 48px;
-  max-width: 48px;
+  width: 768px;
+  max-width: 768px;
   overflow: hidden;
   vertical-align: top;
   text-align: start;
@@ -57364,8 +57364,8 @@ exports[`DataTable theme search pad, search text pad, sort gap, and expand size 
   padding: 0;
   font-weight: inherit;
   text-align: inherit;
-  width: 48px;
-  max-width: 48px;
+  width: 768px;
+  max-width: 768px;
   overflow: hidden;
   vertical-align: top;
   text-align: start;


### PR DESCRIPTION
#### What does this PR do?
Use the theme value for the DataTable expander cell width instead of a hard coded t-shirt size.

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

Before (hpe theme):
<img width="1034" height="848" alt="Screenshot 2025-10-02 at 10 05 37 AM" src="https://github.com/user-attachments/assets/2d2e21a9-afa2-4774-b232-eaa2bc997f14" />

After (hpe theme):
<img width="574" height="526" alt="Screenshot 2025-10-02 at 10 24 56 AM" src="https://github.com/user-attachments/assets/5e1566fb-46b2-4b43-9cc1-6fb28ec7fcb9" />


#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?


#### Is this change backwards compatible or is it a breaking change?
