### PR TITLE
fix bug with `onclickitem` in List

### DIFF
--- a/src/js/components/List/List.js
+++ b/src/js/components/List/List.js
@@ -281,15 +281,19 @@ const List = React.forwardRef(
           event.persist();
           updateFocused(nextFocused);
           const adjustedEvent = event;
-          adjustedEvent.item = data[nextFocused];
-          adjustedEvent.index = nextFocused;
+          // When paginated, use 'items'
+          const currentItems = !paginate ? orderingData || data : items;
+          adjustedEvent.item = currentItems[nextFocused];
+          adjustedEvent.index = !paginate
+            ? nextFocused
+            : (paginationProps.page - 1) * step + nextFocused;
           onClickItem(adjustedEvent);
           sendAnalytics({
             type: 'listItemClick',
             element: listRef.current,
             event: adjustedEvent,
-            item: data[nextFocused],
-            index: nextFocused,
+            item: adjustedEvent.item,
+            index: adjustedEvent.index,
           });
         }
       }

--- a/src/js/components/List/__tests__/List-test.tsx
+++ b/src/js/components/List/__tests__/List-test.tsx
@@ -1235,4 +1235,57 @@ describe('List pinned', () => {
     expect(iconStyle.stroke).toBe('pink');
     expect(iconStyle.fill).toBe('pink');
   });
+
+  test('onClickItem with pagination returns correct item and index', () => {
+    const onClickItem = jest.fn();
+    const paginatedData: string[] = [];
+    for (let i = 0; i < 15; i += 1) {
+      paginatedData.push(`entry-${i}`);
+    }
+
+    const { getByText, getByLabelText } = render(
+      <Grommet>
+        <List
+          data={paginatedData}
+          onClickItem={onClickItem}
+          paginate
+          step={5}
+        />
+      </Grommet>,
+    );
+
+    // Click first item on page 1
+    fireEvent.click(getByText('entry-0'));
+    expect(onClickItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        item: 'entry-0',
+        index: 0,
+      }),
+    );
+
+    fireEvent.click(getByLabelText('Go to next page'));
+
+    // Click first item on page 2 - should be entry-5, index 5
+    fireEvent.click(getByText('entry-5'));
+    expect(onClickItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        item: 'entry-5',
+        index: 5,
+      }),
+    );
+
+    // Navigate to page 3 using aria-label
+    fireEvent.click(getByLabelText('Go to next page'));
+
+    // Click first item on page 3 - should be entry-10, index 10
+    fireEvent.click(getByText('entry-10'));
+    expect(onClickItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        item: 'entry-10',
+        index: 10,
+      }),
+    );
+
+    expect(onClickItem).toHaveBeenCalledTimes(3);
+  });
 });


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
fixes a pagination regression that was introduced in v2.48.0 where `onClickItem` was returning incorrect items and indices when `paginate` is set.

Before: Clicking items on paginated pages 2+ would return the wrong item.
After: `onClickItem` correctly returns the actual clicked item and its absolute index in the full dataset.
#### Where should the reviewer start?
List.js
#### What testing has been done on this PR?
locally and added a test 

to test locally you can use this story 

```
import React from 'react';

import { Box, List, Layer, Button, Text } from 'grommet';

const locations = [
  'Boise',
  'Fort Collins',
  'Los Gatos',
  'Palo Alto',
  'San Francisco',
];

const data = [];

for (let i = 0; i < 40; i += 1) {
  data.push({
    entry: `entry-${i + 1}`,
    location: locations[i % locations.length],
    date: `2018-07-${(i % 30) + 1}`,
    percent: (i % 11) * 10,
    paid: ((i + 1) * 17) % 1000,
  });
}

export const OnClickItemList = () => {
  const [clicked, setClicked] = React.useState();
  const [show, setShow] = React.useState();

  return (
    <Box align="center" pad="large" gap="large">
      <List
        aria-label="onClickItem list"
        data={data.slice(0, 10)}
        onClickItem={(event) => {
          setShow(true);
          setClicked(event.item);
        }}
        paginate
        step={5}
      />

      {show && (
        <Layer
          position="center"
          onEsc={() => setShow(false)}
          onClickOutside={() => setShow(false)}
        >
          <Box margin="medium">
            <Text>{clicked && JSON.stringify(clicked, null, 2)}</Text>
            <Button
              margin={{ top: 'medium' }}
              label="close"
              onClick={() => setShow(false)}
            />
          </Box>
        </Layer>
      )}
    </Box>
  );
};

OnClickItemList.storyName = 'onClickItem';

OnClickItemList.parameters = {
  // chromatic disabled because snapshot is covered by jest testing
  // and snapshot is the same as selection
  chromatic: { disable: true },
};

export default {
  title: 'Visualizations/List/onClickItem',
};

```
#### How should this be manually tested?
storybook with above story
#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
closes #7831 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible