### PR TITLE
add tag to anchor story

### DIFF
--- a/storybook/main.js
+++ b/storybook/main.js
@@ -40,9 +40,4 @@ module.exports = {
   typescript: {
     reactDocgen: 'react-docgen-typescript',
   },
-
-  // Exclude internal stories only in production builds
-  tags: {
-    exclude: process.env.NODE_ENV === 'production' ? ['internal'] : [],
-  },
 };

--- a/storybook/preview.js
+++ b/storybook/preview.js
@@ -88,6 +88,12 @@ export const decorators = [
 
 export const parameters = {
   layout: 'fullscreen',
+  tags: {
+    exclude:
+      process.env.NODE_ENV === 'production' && !isChromatic()
+        ? ['internal']
+        : [],
+  },
   options: {
     storySort: (first, second) => {
       /**


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR adds a `tag` to the Anchor story to test if it works correctly with only being deployed on chromatic and dev mode and not the actual deploy.
#### Where should the reviewer start?
anchor/gap.stories
#### What testing has been done on this PR?
locally see if the story shows up in the deployed storybook 
#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
Look at default tag "test" and see if story does not show up in deployed story. POC
#### What are the relevant issues?
closes https://github.com/grommet/hpe-design-system/issues/5620
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
backwards compatible