### PR TITLE
Adds `theme.meter.background`

### DIFF
--- a/src/js/components/Meter/Meter.js
+++ b/src/js/components/Meter/Meter.js
@@ -28,8 +28,7 @@ const Meter = forwardRef(
     const { theme } = useThemeValue();
     const { format } = useContext(MessageContext);
 
-    const background = backgroundProp ||
-      theme.meter?.background || { color: 'light-2', opacity: 'medium' };
+    const background = backgroundProp || theme.meter?.background;
 
     // normalize values to an array of objects
     const values = useMemo(() => {

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -1473,7 +1473,7 @@ export interface ThemeType {
     };
   };
   meter?: {
-    background?: ColorType;
+    background?: BackgroundType;
     color?: ColorType;
     colors?: GraphColorsType;
     extend?: ExtendType;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1509,8 +1509,8 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       },
     },
     meter: {
+      background: { color: 'light-2', opacity: 'medium' },
       color: 'graph-0',
-      // background: undefined,
       // colors: [] || colors: ['graph-0', 'graph-1', 'graph-2', 'graph-3'],
       // extend: undefined,
       // gap: undefined,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds `theme.meter.background` to the theme so that this value can be theme driven instead of just prop driven.

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Yes
#### Should this PR be mentioned in the release notes?
Yes
#### Is this change backwards compatible or is it a breaking change?
Backwards compatible