### PR TITLE
fix: remove pinned Chrome version to resolve CircleCI 404 errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,9 @@ jobs:
           command: yarn test-bundlesize
   test:
     <<: *defaults
-    resource_class: medium
+    resource_class: small
+    # Assigned a size small resource class because we currently only have 3 end
+    # to end tests. As we expand our e2e testing we may want to adjust this.
     steps:
       - attach_workspace:
           at: ~/grommet-ci
@@ -96,17 +98,6 @@ jobs:
           name: Start project
           command: yarn start
           background: true
-      - run:
-          name: Wait for server to be ready
-          command: |
-            for i in {1..60}; do
-              if curl -f http://localhost:8080 >/dev/null 2>&1; then
-                echo "Server is ready!"
-                break
-              fi
-              echo "Waiting for server... ($i/60)"
-              sleep 1
-            done
       - run:
           name: End to end test
           command: yarn test-e2e-ci


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
- Remove chrome-version: 132.0.6834.110 from browser-tools/install-chrome
- Let CircleCI install latest stable Chrome version automatically
- Fixes 404 errors when Google removes old Chrome versions from CDN

#### Where should the reviewer start?
config.yml
#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
backwards compatible