### PR TITLE
Bump bundle size due to recent config.yml updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -213,7 +213,7 @@
   "bundlesize": [
     {
       "path": "./dist/grommet.min.js",
-      "maxSize": "193 kB"
+      "maxSize": "191.99 kB"
     }
   ],
   "keywords": [


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Bump bundle size from 192KB to 193KB due to failing [circleCI](https://app.circleci.com/pipelines/github/grommet/grommet/17313/workflows/12543771-1ee2-43b7-aa84-975de6ba270c/jobs/91423). 

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)
<img width="1050" height="393" alt="image" src="https://github.com/user-attachments/assets/d0b57a3e-3f61-4e4a-a45d-3a0d9a86e131" />

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
