### PR TITLE
Downgrade CircleCI Node.js from 25 to 24

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 defaults: &defaults
   working_directory: ~/grommet-ci
   docker:
-    - image: cimg/node:24.3.1-browsers
+    - image: cimg/node:24.13.1-browsers
 jobs:
   checkout:
     <<: *defaults


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This pull request fixes CircleCI build failures by downgrading Node.js from version 25 to the LTS version 24. The changes resolve Storybook build crashes and Chrome installation issues while ensuring proper resource class compatibility with the CircleCI plan.
#### Where should the reviewer start?
config.yml file
#### What testing has been done on this PR?
Verified that Node.js 24 LTS is compatible with Storybook 8.6.14 and webpack 5
#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
The original issue stemmed from Chrome version 132.0.6834.110 no longer being available in Google's CDN, causing 404 errors during installation. When we fixed this by upgrading to Node.js 25 inadvertently caused Storybook build failures because Node 25 is not LTS and has compatibility issues with the current Storybook/webpack toolchain. This PR resolves both issues by:

- Using Node.js 24 LTS for stability
- Installing latest Chrome automatically
- #### What are the relevant issues?
CircleCI builds failing with "Google Chrome installation 404 errors"
Storybook builds crashing with exit code 105 during Terser optimization
#### Screenshots (if appropriate)
n/a
#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
backwards compatible