### PR TITLE
Revert back to node 20 docker img

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 defaults: &defaults
   working_directory: ~/grommet-ci
   docker:
-    - image: cimg/node:24.13.1-browsers
+    - image: cimg/node:20.19.0-browsers
 jobs:
   checkout:
     <<: *defaults


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Revert back to cimg/node:20.19.0-browsers to try and resolve this issue:

<img width="1599" height="700" alt="Screenshot 2026-02-19 at 2 40 45 PM" src="https://github.com/user-attachments/assets/8d5b4331-47f2-4f27-a588-cc9a6e8a9596" />

https://app.circleci.com/pipelines/github/grommet/grommet/17333/workflows/b7113869-da46-4e1c-91d5-02cc100d0d51/jobs/91564

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
