### PR TITLE
feat(components): add DualRangeInput component

### DIFF
--- a/src/js/components/DualRangeInput/DualRangeInput.js
+++ b/src/js/components/DualRangeInput/DualRangeInput.js
@@ -1,0 +1,325 @@
+import React, {
+  forwardRef,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import styled, { css } from 'styled-components';
+
+import { Box } from '../Box';
+import { Text } from '../Text';
+import { FormContext } from '../Form/FormContext';
+import {
+  focusStyle,
+  normalizeColor,
+  parseMetricToNum,
+  useForwardedRef,
+} from '../../utils';
+import { DualRangeInputPropTypes } from './propTypes';
+import { useThemeValue } from '../../utils/useThemeValue';
+
+const thumbStyle = (props) => css`
+  box-sizing: border-box;
+  position: relative;
+  border-radius: ${props.theme.global.spacing};
+  height: ${props.theme.global.spacing};
+  width: ${props.theme.global.spacing};
+  overflow: visible;
+  background: ${normalizeColor(
+    props.theme.rangeInput?.thumb?.color || 'control',
+    props.theme,
+  )};
+  -webkit-appearance: none;
+  cursor: pointer;
+  pointer-events: all;
+  ${props.theme.rangeInput?.thumb?.extend || ''}
+`;
+
+const hoverThumbStyle = (props) => css`
+  box-shadow: 0px 0px 0px 2px
+    ${normalizeColor(
+      props.theme.rangeInput?.thumb?.color || 'control',
+      props.theme,
+    )};
+`;
+
+const trackHeight = (props) => props.theme.rangeInput?.track?.height || '4px';
+
+const StyledDualRangeInputContainer = styled(Box)`
+  position: relative;
+  width: 100%;
+  height: ${(props) => props.theme.global.spacing};
+`;
+
+const StyledTrack = styled.div`
+  position: absolute;
+  top: 50%;
+  left: 0;
+  right: 0;
+  height: ${(props) => trackHeight(props)};
+  transform: translateY(-50%);
+  border-radius: ${(props) => trackHeight(props)};
+  background: ${(props) => {
+    const trackColor = props.theme.rangeInput?.track?.color || 'border';
+    const opacity = props.theme.rangeInput?.track?.opacity;
+    const color = normalizeColor(trackColor, props.theme);
+    if (opacity !== undefined) {
+      return `rgba(${color}, ${opacity})`;
+    }
+    return color;
+  }};
+  ${(props) => props.theme.rangeInput?.track?.extend || ''}
+`;
+
+const StyledActiveTrack = styled.div`
+  position: absolute;
+  top: 50%;
+  height: ${(props) => trackHeight(props)};
+  transform: translateY(-50%);
+  border-radius: ${(props) => trackHeight(props)};
+  background: ${(props) =>
+    normalizeColor(props.color || 'control', props.theme)};
+`;
+
+const StyledRangeInput = styled.input`
+  box-sizing: border-box;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  -webkit-appearance: none;
+  background: transparent;
+  margin: 0;
+  padding: 0;
+  pointer-events: none;
+  cursor: pointer;
+  z-index: ${(props) => props.$zIndex || 1};
+
+  &::-moz-focus-inner {
+    border: none;
+  }
+  &::-moz-focus-outer {
+    border: none;
+  }
+
+  /* Webkit thumb */
+  &::-webkit-slider-thumb {
+    ${(props) => thumbStyle(props)}
+    margin-top: -${(props) =>
+      (parseMetricToNum(props.theme.global.spacing) -
+        parseMetricToNum(trackHeight(props))) *
+      0.5}px;
+    ${(props) =>
+      !props.disabled &&
+      css`
+        &:hover {
+          ${hoverThumbStyle(props)}
+        }
+      `}
+  }
+
+  /* Webkit track — invisible since we draw our own */
+  &::-webkit-slider-runnable-track {
+    -webkit-appearance: none;
+    background: transparent;
+    height: ${(props) => trackHeight(props)};
+  }
+
+  /* Firefox thumb */
+  &::-moz-range-thumb {
+    ${(props) => thumbStyle(props)}
+    border: none;
+    ${(props) =>
+      !props.disabled &&
+      css`
+        &:hover {
+          ${hoverThumbStyle(props)}
+        }
+      `}
+  }
+
+  /* Firefox track — invisible */
+  &::-moz-range-track {
+    background: transparent;
+    height: ${(props) => trackHeight(props)};
+  }
+
+  &:focus::-webkit-slider-thumb {
+    ${(props) => props.$showFocus && focusStyle()}
+  }
+
+  &:focus::-moz-range-thumb {
+    ${(props) => props.$showFocus && focusStyle()}
+  }
+
+  &:focus-visible {
+    outline: 0;
+  }
+  &:focus {
+    outline: none;
+  }
+
+  ${(props) => props.theme.rangeInput?.extend || ''}
+`;
+
+const DualRangeInput = forwardRef(
+  (
+    {
+      a11yTitle,
+      color,
+      defaultValues,
+      label,
+      min = 0,
+      max = 100,
+      messages = { lower: 'Lower Bound', upper: 'Upper Bound' },
+      name,
+      onChange,
+      step = 1,
+      values: valuesProp,
+      ...rest
+    },
+    ref,
+  ) => {
+    const { theme } = useThemeValue();
+    const formContext = useContext(FormContext);
+    const containerRef = useForwardedRef(ref);
+    const lowerRef = useRef();
+    const upperRef = useRef();
+    const [focusedThumb, setFocusedThumb] = useState(null);
+
+    const [values, setValues] = formContext.useFormInput({
+      name,
+      value: valuesProp,
+      initialValue: defaultValues || [min, max],
+    });
+
+    const [lower, upper] = values;
+
+    const change = useCallback(
+      (nextValues) => {
+        setValues(nextValues);
+        if (onChange) onChange(nextValues);
+      },
+      [onChange, setValues],
+    );
+
+    const lowerPercent = useMemo(
+      () => ((lower - min) / (max - min)) * 100,
+      [lower, min, max],
+    );
+    const upperPercent = useMemo(
+      () => ((upper - min) / (max - min)) * 100,
+      [upper, min, max],
+    );
+
+    // Determine which slider should be on top based on proximity to max
+    // When both thumbs are at the same position, we need the lower thumb
+    // to be grabbable when at min, and upper when at max
+    const lowerOnTop = lower === upper && lower === max;
+
+    const handleLowerChange = useCallback(
+      (event) => {
+        const newValue = Number(event.target.value);
+        if (newValue <= upper) {
+          change([newValue, upper]);
+        }
+      },
+      [change, upper],
+    );
+
+    const handleUpperChange = useCallback(
+      (event) => {
+        const newValue = Number(event.target.value);
+        if (newValue >= lower) {
+          change([lower, newValue]);
+        }
+      },
+      [change, lower],
+    );
+
+    const content = (
+      <StyledDualRangeInputContainer
+        ref={containerRef}
+        theme={theme}
+        {...(label ? {} : rest)}
+      >
+        {/* Background track */}
+        <StyledTrack theme={theme} />
+
+        {/* Active range track */}
+        <StyledActiveTrack
+          theme={theme}
+          color={color}
+          style={{
+            left: `${lowerPercent}%`,
+            width: `${upperPercent - lowerPercent}%`,
+          }}
+        />
+
+        {/* Lower range input */}
+        <StyledRangeInput
+          ref={lowerRef}
+          type="range"
+          aria-label={messages.lower || 'Lower Bound'}
+          aria-valuemin={min}
+          aria-valuemax={max}
+          aria-valuenow={lower}
+          min={min}
+          max={max}
+          step={step}
+          value={lower}
+          onChange={handleLowerChange}
+          onFocus={() => setFocusedThumb('lower')}
+          onBlur={() => setFocusedThumb(null)}
+          $showFocus={focusedThumb === 'lower'}
+          $zIndex={lowerOnTop ? 3 : 2}
+          theme={theme}
+        />
+
+        {/* Upper range input */}
+        <StyledRangeInput
+          ref={upperRef}
+          type="range"
+          aria-label={messages.upper || 'Upper Bound'}
+          aria-valuemin={min}
+          aria-valuemax={max}
+          aria-valuenow={upper}
+          min={min}
+          max={max}
+          step={step}
+          value={upper}
+          onChange={handleUpperChange}
+          onFocus={() => setFocusedThumb('upper')}
+          onBlur={() => setFocusedThumb(null)}
+          $showFocus={focusedThumb === 'upper'}
+          $zIndex={lowerOnTop ? 2 : 3}
+          theme={theme}
+        />
+      </StyledDualRangeInputContainer>
+    );
+
+    if (label) {
+      return (
+        <Box direction="row" align="center" fill {...rest}>
+          <Text size="small" margin={{ horizontal: 'small' }}>
+            {typeof label === 'function' ? label(lower) : lower}
+          </Text>
+          {content}
+          <Text size="small" margin={{ horizontal: 'small' }}>
+            {typeof label === 'function' ? label(upper) : upper}
+          </Text>
+        </Box>
+      );
+    }
+
+    return content;
+  },
+);
+
+DualRangeInput.displayName = 'DualRangeInput';
+DualRangeInput.propTypes = DualRangeInputPropTypes;
+
+export { DualRangeInput };

--- a/src/js/components/DualRangeInput/README.md
+++ b/src/js/components/DualRangeInput/README.md
@@ -1,0 +1,4 @@
+## DualRangeInput
+A dual-thumb range input component that allows selecting a range (min and max values)
+with the visual appearance of a native range slider. It uses two overlapping range
+inputs to provide an accessible and familiar interface for range selection.

--- a/src/js/components/DualRangeInput/__tests__/DualRangeInput-test.tsx
+++ b/src/js/components/DualRangeInput/__tests__/DualRangeInput-test.tsx
@@ -1,0 +1,199 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import 'jest-styled-components';
+import 'jest-axe/extend-expect';
+import 'regenerator-runtime/runtime';
+import '@testing-library/jest-dom';
+
+import { Grommet } from '../../Grommet';
+import { DualRangeInput } from '..';
+
+describe('DualRangeInput', () => {
+  test('should have no accessibility violations', async () => {
+    const { container, asFragment } = render(
+      <Grommet>
+        <DualRangeInput values={[20, 80]} />
+      </Grommet>,
+    );
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  test('renders with default props', () => {
+    const { asFragment } = render(
+      <Grommet>
+        <DualRangeInput values={[25, 75]} />
+      </Grommet>,
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  test('renders outside Grommet wrapper', () => {
+    const { asFragment } = render(<DualRangeInput values={[25, 75]} />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  test('renders with min and max', () => {
+    const { asFragment } = render(
+      <Grommet>
+        <DualRangeInput min={10} max={50} values={[20, 40]} />
+      </Grommet>,
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  test('renders with step', () => {
+    const { asFragment } = render(
+      <Grommet>
+        <DualRangeInput min={0} max={100} step={10} values={[20, 80]} />
+      </Grommet>,
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  test('renders with label boolean', () => {
+    const { asFragment } = render(
+      <Grommet>
+        <DualRangeInput values={[20, 80]} label />
+      </Grommet>,
+    );
+    expect(asFragment()).toMatchSnapshot();
+    expect(screen.getByText('20')).toBeTruthy();
+    expect(screen.getByText('80')).toBeTruthy();
+  });
+
+  test('renders with label function', () => {
+    const { asFragment } = render(
+      <Grommet>
+        <DualRangeInput values={[20, 80]} label={(value) => `${value}%`} />
+      </Grommet>,
+    );
+    expect(asFragment()).toMatchSnapshot();
+    expect(screen.getByText('20%')).toBeTruthy();
+    expect(screen.getByText('80%')).toBeTruthy();
+  });
+
+  test('renders with color', () => {
+    const { asFragment } = render(
+      <Grommet>
+        <DualRangeInput values={[20, 80]} color="brand" />
+      </Grommet>,
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  test('renders with custom messages', () => {
+    render(
+      <Grommet>
+        <DualRangeInput
+          values={[20, 80]}
+          messages={{ lower: 'Minimum Cores', upper: 'Maximum Cores' }}
+        />
+      </Grommet>,
+    );
+    expect(screen.getByLabelText('Minimum Cores')).toBeTruthy();
+    expect(screen.getByLabelText('Maximum Cores')).toBeTruthy();
+  });
+
+  test('lower value change calls onChange', () => {
+    const onChange = jest.fn();
+    render(
+      <Grommet>
+        <DualRangeInput
+          min={0}
+          max={100}
+          values={[20, 80]}
+          onChange={onChange}
+        />
+      </Grommet>,
+    );
+
+    const lowerSlider = screen.getByLabelText('Lower Bound');
+    fireEvent.change(lowerSlider, { target: { value: '30' } });
+    expect(onChange).toHaveBeenCalledWith([30, 80]);
+  });
+
+  test('upper value change calls onChange', () => {
+    const onChange = jest.fn();
+    render(
+      <Grommet>
+        <DualRangeInput
+          min={0}
+          max={100}
+          values={[20, 80]}
+          onChange={onChange}
+        />
+      </Grommet>,
+    );
+
+    const upperSlider = screen.getByLabelText('Upper Bound');
+    fireEvent.change(upperSlider, { target: { value: '60' } });
+    expect(onChange).toHaveBeenCalledWith([20, 60]);
+  });
+
+  test('lower value cannot exceed upper value', () => {
+    const onChange = jest.fn();
+    render(
+      <Grommet>
+        <DualRangeInput
+          min={0}
+          max={100}
+          values={[20, 80]}
+          onChange={onChange}
+        />
+      </Grommet>,
+    );
+
+    const lowerSlider = screen.getByLabelText('Lower Bound');
+    fireEvent.change(lowerSlider, { target: { value: '90' } });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  test('upper value cannot go below lower value', () => {
+    const onChange = jest.fn();
+    render(
+      <Grommet>
+        <DualRangeInput
+          min={0}
+          max={100}
+          values={[20, 80]}
+          onChange={onChange}
+        />
+      </Grommet>,
+    );
+
+    const upperSlider = screen.getByLabelText('Upper Bound');
+    fireEvent.change(upperSlider, { target: { value: '10' } });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  test('uses defaultValues when values is not provided', () => {
+    const { asFragment } = render(
+      <Grommet>
+        <DualRangeInput defaultValues={[30, 70]} />
+      </Grommet>,
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  test('aria attributes are set correctly', () => {
+    render(
+      <Grommet>
+        <DualRangeInput min={0} max={100} values={[25, 75]} />
+      </Grommet>,
+    );
+
+    const lowerSlider = screen.getByLabelText('Lower Bound');
+    expect(lowerSlider).toHaveAttribute('aria-valuemin', '0');
+    expect(lowerSlider).toHaveAttribute('aria-valuemax', '100');
+    expect(lowerSlider).toHaveAttribute('aria-valuenow', '25');
+
+    const upperSlider = screen.getByLabelText('Upper Bound');
+    expect(upperSlider).toHaveAttribute('aria-valuemin', '0');
+    expect(upperSlider).toHaveAttribute('aria-valuemax', '100');
+    expect(upperSlider).toHaveAttribute('aria-valuenow', '75');
+  });
+});

--- a/src/js/components/DualRangeInput/__tests__/__snapshots__/DualRangeInput-test.tsx.snap
+++ b/src/js/components/DualRangeInput/__tests__/__snapshots__/DualRangeInput-test.tsx.snap
@@ -1,0 +1,2277 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`DualRangeInput renders outside Grommet wrapper 1`] = `
+<DocumentFragment>
+  .c0 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.c1 {
+  position: relative;
+  width: 100%;
+  height: 24px;
+}
+
+.c2 {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  right: 0;
+  height: 4px;
+  transform: translateY(-50%);
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.33);
+}
+
+.c3 {
+  position: absolute;
+  top: 50%;
+  height: 4px;
+  transform: translateY(-50%);
+  border-radius: 4px;
+  background: #7D4CDB;
+}
+
+.c4 {
+  box-sizing: border-box;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  -webkit-appearance: none;
+  background: transparent;
+  margin: 0;
+  padding: 0;
+  pointer-events: none;
+  cursor: pointer;
+  z-index: 2;
+}
+
+.c4::-moz-focus-inner {
+  border: none;
+}
+
+.c4::-moz-focus-outer {
+  border: none;
+}
+
+.c4::-webkit-slider-thumb {
+  box-sizing: border-box;
+  position: relative;
+  border-radius: 24px;
+  height: 24px;
+  width: 24px;
+  overflow: visible;
+  background: #7D4CDB;
+  -webkit-appearance: none;
+  cursor: pointer;
+  pointer-events: all;
+  margin-top: -10px;
+}
+
+.c4::-webkit-slider-thumb:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c4::-webkit-slider-runnable-track {
+  -webkit-appearance: none;
+  background: transparent;
+  height: 4px;
+}
+
+.c4::-moz-range-thumb {
+  box-sizing: border-box;
+  position: relative;
+  border-radius: 24px;
+  height: 24px;
+  width: 24px;
+  overflow: visible;
+  background: #7D4CDB;
+  -webkit-appearance: none;
+  cursor: pointer;
+  pointer-events: all;
+  border: none;
+}
+
+.c4::-moz-range-thumb:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c4::-moz-range-track {
+  background: transparent;
+  height: 4px;
+}
+
+.c4:focus-visible {
+  outline: 0;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c5 {
+  box-sizing: border-box;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  -webkit-appearance: none;
+  background: transparent;
+  margin: 0;
+  padding: 0;
+  pointer-events: none;
+  cursor: pointer;
+  z-index: 3;
+}
+
+.c5::-moz-focus-inner {
+  border: none;
+}
+
+.c5::-moz-focus-outer {
+  border: none;
+}
+
+.c5::-webkit-slider-thumb {
+  box-sizing: border-box;
+  position: relative;
+  border-radius: 24px;
+  height: 24px;
+  width: 24px;
+  overflow: visible;
+  background: #7D4CDB;
+  -webkit-appearance: none;
+  cursor: pointer;
+  pointer-events: all;
+  margin-top: -10px;
+}
+
+.c5::-webkit-slider-thumb:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c5::-webkit-slider-runnable-track {
+  -webkit-appearance: none;
+  background: transparent;
+  height: 4px;
+}
+
+.c5::-moz-range-thumb {
+  box-sizing: border-box;
+  position: relative;
+  border-radius: 24px;
+  height: 24px;
+  width: 24px;
+  overflow: visible;
+  background: #7D4CDB;
+  -webkit-appearance: none;
+  cursor: pointer;
+  pointer-events: all;
+  border: none;
+}
+
+.c5::-moz-range-thumb:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c5::-moz-range-track {
+  background: transparent;
+  height: 4px;
+}
+
+.c5:focus-visible {
+  outline: 0;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+<div
+    class="c0 c1"
+  >
+    <div
+      class="c2"
+    />
+    <div
+      class="c3"
+      style="left: 25%; width: 50%;"
+    />
+    <input
+      aria-label="Lower Bound"
+      aria-valuemax="100"
+      aria-valuemin="0"
+      aria-valuenow="25"
+      class="c4"
+      max="100"
+      min="0"
+      step="1"
+      type="range"
+      value="25"
+    />
+    <input
+      aria-label="Upper Bound"
+      aria-valuemax="100"
+      aria-valuemin="0"
+      aria-valuenow="75"
+      class="c5"
+      max="100"
+      min="0"
+      step="1"
+      type="range"
+      value="75"
+    />
+  </div>
+</DocumentFragment>
+`;
+
+exports[`DualRangeInput renders with color 1`] = `
+<DocumentFragment>
+  .c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.c2 {
+  position: relative;
+  width: 100%;
+  height: 24px;
+}
+
+.c3 {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  right: 0;
+  height: 4px;
+  transform: translateY(-50%);
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.33);
+}
+
+.c4 {
+  position: absolute;
+  top: 50%;
+  height: 4px;
+  transform: translateY(-50%);
+  border-radius: 4px;
+  background: #7D4CDB;
+}
+
+.c5 {
+  box-sizing: border-box;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  -webkit-appearance: none;
+  background: transparent;
+  margin: 0;
+  padding: 0;
+  pointer-events: none;
+  cursor: pointer;
+  z-index: 2;
+}
+
+.c5::-moz-focus-inner {
+  border: none;
+}
+
+.c5::-moz-focus-outer {
+  border: none;
+}
+
+.c5::-webkit-slider-thumb {
+  box-sizing: border-box;
+  position: relative;
+  border-radius: 24px;
+  height: 24px;
+  width: 24px;
+  overflow: visible;
+  background: #7D4CDB;
+  -webkit-appearance: none;
+  cursor: pointer;
+  pointer-events: all;
+  margin-top: -10px;
+}
+
+.c5::-webkit-slider-thumb:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c5::-webkit-slider-runnable-track {
+  -webkit-appearance: none;
+  background: transparent;
+  height: 4px;
+}
+
+.c5::-moz-range-thumb {
+  box-sizing: border-box;
+  position: relative;
+  border-radius: 24px;
+  height: 24px;
+  width: 24px;
+  overflow: visible;
+  background: #7D4CDB;
+  -webkit-appearance: none;
+  cursor: pointer;
+  pointer-events: all;
+  border: none;
+}
+
+.c5::-moz-range-thumb:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c5::-moz-range-track {
+  background: transparent;
+  height: 4px;
+}
+
+.c5:focus-visible {
+  outline: 0;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c6 {
+  box-sizing: border-box;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  -webkit-appearance: none;
+  background: transparent;
+  margin: 0;
+  padding: 0;
+  pointer-events: none;
+  cursor: pointer;
+  z-index: 3;
+}
+
+.c6::-moz-focus-inner {
+  border: none;
+}
+
+.c6::-moz-focus-outer {
+  border: none;
+}
+
+.c6::-webkit-slider-thumb {
+  box-sizing: border-box;
+  position: relative;
+  border-radius: 24px;
+  height: 24px;
+  width: 24px;
+  overflow: visible;
+  background: #7D4CDB;
+  -webkit-appearance: none;
+  cursor: pointer;
+  pointer-events: all;
+  margin-top: -10px;
+}
+
+.c6::-webkit-slider-thumb:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c6::-webkit-slider-runnable-track {
+  -webkit-appearance: none;
+  background: transparent;
+  height: 4px;
+}
+
+.c6::-moz-range-thumb {
+  box-sizing: border-box;
+  position: relative;
+  border-radius: 24px;
+  height: 24px;
+  width: 24px;
+  overflow: visible;
+  background: #7D4CDB;
+  -webkit-appearance: none;
+  cursor: pointer;
+  pointer-events: all;
+  border: none;
+}
+
+.c6::-moz-range-thumb:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c6::-moz-range-track {
+  background: transparent;
+  height: 4px;
+}
+
+.c6:focus-visible {
+  outline: 0;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+<div
+    class="c0"
+  >
+    <div
+      class="c1 c2"
+    >
+      <div
+        class="c3"
+      />
+      <div
+        class="c4"
+        color="brand"
+        style="left: 20%; width: 60%;"
+      />
+      <input
+        aria-label="Lower Bound"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="20"
+        class="c5"
+        max="100"
+        min="0"
+        step="1"
+        type="range"
+        value="20"
+      />
+      <input
+        aria-label="Upper Bound"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="80"
+        class="c6"
+        max="100"
+        min="0"
+        step="1"
+        type="range"
+        value="80"
+      />
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`DualRangeInput renders with default props 1`] = `
+<DocumentFragment>
+  .c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.c2 {
+  position: relative;
+  width: 100%;
+  height: 24px;
+}
+
+.c3 {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  right: 0;
+  height: 4px;
+  transform: translateY(-50%);
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.33);
+}
+
+.c4 {
+  position: absolute;
+  top: 50%;
+  height: 4px;
+  transform: translateY(-50%);
+  border-radius: 4px;
+  background: #7D4CDB;
+}
+
+.c5 {
+  box-sizing: border-box;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  -webkit-appearance: none;
+  background: transparent;
+  margin: 0;
+  padding: 0;
+  pointer-events: none;
+  cursor: pointer;
+  z-index: 2;
+}
+
+.c5::-moz-focus-inner {
+  border: none;
+}
+
+.c5::-moz-focus-outer {
+  border: none;
+}
+
+.c5::-webkit-slider-thumb {
+  box-sizing: border-box;
+  position: relative;
+  border-radius: 24px;
+  height: 24px;
+  width: 24px;
+  overflow: visible;
+  background: #7D4CDB;
+  -webkit-appearance: none;
+  cursor: pointer;
+  pointer-events: all;
+  margin-top: -10px;
+}
+
+.c5::-webkit-slider-thumb:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c5::-webkit-slider-runnable-track {
+  -webkit-appearance: none;
+  background: transparent;
+  height: 4px;
+}
+
+.c5::-moz-range-thumb {
+  box-sizing: border-box;
+  position: relative;
+  border-radius: 24px;
+  height: 24px;
+  width: 24px;
+  overflow: visible;
+  background: #7D4CDB;
+  -webkit-appearance: none;
+  cursor: pointer;
+  pointer-events: all;
+  border: none;
+}
+
+.c5::-moz-range-thumb:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c5::-moz-range-track {
+  background: transparent;
+  height: 4px;
+}
+
+.c5:focus-visible {
+  outline: 0;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c6 {
+  box-sizing: border-box;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  -webkit-appearance: none;
+  background: transparent;
+  margin: 0;
+  padding: 0;
+  pointer-events: none;
+  cursor: pointer;
+  z-index: 3;
+}
+
+.c6::-moz-focus-inner {
+  border: none;
+}
+
+.c6::-moz-focus-outer {
+  border: none;
+}
+
+.c6::-webkit-slider-thumb {
+  box-sizing: border-box;
+  position: relative;
+  border-radius: 24px;
+  height: 24px;
+  width: 24px;
+  overflow: visible;
+  background: #7D4CDB;
+  -webkit-appearance: none;
+  cursor: pointer;
+  pointer-events: all;
+  margin-top: -10px;
+}
+
+.c6::-webkit-slider-thumb:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c6::-webkit-slider-runnable-track {
+  -webkit-appearance: none;
+  background: transparent;
+  height: 4px;
+}
+
+.c6::-moz-range-thumb {
+  box-sizing: border-box;
+  position: relative;
+  border-radius: 24px;
+  height: 24px;
+  width: 24px;
+  overflow: visible;
+  background: #7D4CDB;
+  -webkit-appearance: none;
+  cursor: pointer;
+  pointer-events: all;
+  border: none;
+}
+
+.c6::-moz-range-thumb:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c6::-moz-range-track {
+  background: transparent;
+  height: 4px;
+}
+
+.c6:focus-visible {
+  outline: 0;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+<div
+    class="c0"
+  >
+    <div
+      class="c1 c2"
+    >
+      <div
+        class="c3"
+      />
+      <div
+        class="c4"
+        style="left: 25%; width: 50%;"
+      />
+      <input
+        aria-label="Lower Bound"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="25"
+        class="c5"
+        max="100"
+        min="0"
+        step="1"
+        type="range"
+        value="25"
+      />
+      <input
+        aria-label="Upper Bound"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="75"
+        class="c6"
+        max="100"
+        min="0"
+        step="1"
+        type="range"
+        value="75"
+      />
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`DualRangeInput renders with label boolean 1`] = `
+<DocumentFragment>
+  .c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  width: 100%;
+  height: 100%;
+}
+
+.c3 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.c2 {
+  margin-left: 12px;
+  margin-right: 12px;
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.c4 {
+  position: relative;
+  width: 100%;
+  height: 24px;
+}
+
+.c5 {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  right: 0;
+  height: 4px;
+  transform: translateY(-50%);
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.33);
+}
+
+.c6 {
+  position: absolute;
+  top: 50%;
+  height: 4px;
+  transform: translateY(-50%);
+  border-radius: 4px;
+  background: #7D4CDB;
+}
+
+.c7 {
+  box-sizing: border-box;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  -webkit-appearance: none;
+  background: transparent;
+  margin: 0;
+  padding: 0;
+  pointer-events: none;
+  cursor: pointer;
+  z-index: 2;
+}
+
+.c7::-moz-focus-inner {
+  border: none;
+}
+
+.c7::-moz-focus-outer {
+  border: none;
+}
+
+.c7::-webkit-slider-thumb {
+  box-sizing: border-box;
+  position: relative;
+  border-radius: 24px;
+  height: 24px;
+  width: 24px;
+  overflow: visible;
+  background: #7D4CDB;
+  -webkit-appearance: none;
+  cursor: pointer;
+  pointer-events: all;
+  margin-top: -10px;
+}
+
+.c7::-webkit-slider-thumb:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c7::-webkit-slider-runnable-track {
+  -webkit-appearance: none;
+  background: transparent;
+  height: 4px;
+}
+
+.c7::-moz-range-thumb {
+  box-sizing: border-box;
+  position: relative;
+  border-radius: 24px;
+  height: 24px;
+  width: 24px;
+  overflow: visible;
+  background: #7D4CDB;
+  -webkit-appearance: none;
+  cursor: pointer;
+  pointer-events: all;
+  border: none;
+}
+
+.c7::-moz-range-thumb:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c7::-moz-range-track {
+  background: transparent;
+  height: 4px;
+}
+
+.c7:focus-visible {
+  outline: 0;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c8 {
+  box-sizing: border-box;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  -webkit-appearance: none;
+  background: transparent;
+  margin: 0;
+  padding: 0;
+  pointer-events: none;
+  cursor: pointer;
+  z-index: 3;
+}
+
+.c8::-moz-focus-inner {
+  border: none;
+}
+
+.c8::-moz-focus-outer {
+  border: none;
+}
+
+.c8::-webkit-slider-thumb {
+  box-sizing: border-box;
+  position: relative;
+  border-radius: 24px;
+  height: 24px;
+  width: 24px;
+  overflow: visible;
+  background: #7D4CDB;
+  -webkit-appearance: none;
+  cursor: pointer;
+  pointer-events: all;
+  margin-top: -10px;
+}
+
+.c8::-webkit-slider-thumb:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c8::-webkit-slider-runnable-track {
+  -webkit-appearance: none;
+  background: transparent;
+  height: 4px;
+}
+
+.c8::-moz-range-thumb {
+  box-sizing: border-box;
+  position: relative;
+  border-radius: 24px;
+  height: 24px;
+  width: 24px;
+  overflow: visible;
+  background: #7D4CDB;
+  -webkit-appearance: none;
+  cursor: pointer;
+  pointer-events: all;
+  border: none;
+}
+
+.c8::-moz-range-thumb:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c8::-moz-range-track {
+  background: transparent;
+  height: 4px;
+}
+
+.c8:focus-visible {
+  outline: 0;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+<div
+    class="c0"
+  >
+    <div
+      class="c1"
+    >
+      <span
+        class="c2"
+      >
+        20
+      </span>
+      <div
+        class="c3 c4"
+      >
+        <div
+          class="c5"
+        />
+        <div
+          class="c6"
+          style="left: 20%; width: 60%;"
+        />
+        <input
+          aria-label="Lower Bound"
+          aria-valuemax="100"
+          aria-valuemin="0"
+          aria-valuenow="20"
+          class="c7"
+          max="100"
+          min="0"
+          step="1"
+          type="range"
+          value="20"
+        />
+        <input
+          aria-label="Upper Bound"
+          aria-valuemax="100"
+          aria-valuemin="0"
+          aria-valuenow="80"
+          class="c8"
+          max="100"
+          min="0"
+          step="1"
+          type="range"
+          value="80"
+        />
+      </div>
+      <span
+        class="c2"
+      >
+        80
+      </span>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`DualRangeInput renders with label function 1`] = `
+<DocumentFragment>
+  .c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: center;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  width: 100%;
+  height: 100%;
+}
+
+.c3 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.c2 {
+  margin-left: 12px;
+  margin-right: 12px;
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.c4 {
+  position: relative;
+  width: 100%;
+  height: 24px;
+}
+
+.c5 {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  right: 0;
+  height: 4px;
+  transform: translateY(-50%);
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.33);
+}
+
+.c6 {
+  position: absolute;
+  top: 50%;
+  height: 4px;
+  transform: translateY(-50%);
+  border-radius: 4px;
+  background: #7D4CDB;
+}
+
+.c7 {
+  box-sizing: border-box;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  -webkit-appearance: none;
+  background: transparent;
+  margin: 0;
+  padding: 0;
+  pointer-events: none;
+  cursor: pointer;
+  z-index: 2;
+}
+
+.c7::-moz-focus-inner {
+  border: none;
+}
+
+.c7::-moz-focus-outer {
+  border: none;
+}
+
+.c7::-webkit-slider-thumb {
+  box-sizing: border-box;
+  position: relative;
+  border-radius: 24px;
+  height: 24px;
+  width: 24px;
+  overflow: visible;
+  background: #7D4CDB;
+  -webkit-appearance: none;
+  cursor: pointer;
+  pointer-events: all;
+  margin-top: -10px;
+}
+
+.c7::-webkit-slider-thumb:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c7::-webkit-slider-runnable-track {
+  -webkit-appearance: none;
+  background: transparent;
+  height: 4px;
+}
+
+.c7::-moz-range-thumb {
+  box-sizing: border-box;
+  position: relative;
+  border-radius: 24px;
+  height: 24px;
+  width: 24px;
+  overflow: visible;
+  background: #7D4CDB;
+  -webkit-appearance: none;
+  cursor: pointer;
+  pointer-events: all;
+  border: none;
+}
+
+.c7::-moz-range-thumb:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c7::-moz-range-track {
+  background: transparent;
+  height: 4px;
+}
+
+.c7:focus-visible {
+  outline: 0;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c8 {
+  box-sizing: border-box;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  -webkit-appearance: none;
+  background: transparent;
+  margin: 0;
+  padding: 0;
+  pointer-events: none;
+  cursor: pointer;
+  z-index: 3;
+}
+
+.c8::-moz-focus-inner {
+  border: none;
+}
+
+.c8::-moz-focus-outer {
+  border: none;
+}
+
+.c8::-webkit-slider-thumb {
+  box-sizing: border-box;
+  position: relative;
+  border-radius: 24px;
+  height: 24px;
+  width: 24px;
+  overflow: visible;
+  background: #7D4CDB;
+  -webkit-appearance: none;
+  cursor: pointer;
+  pointer-events: all;
+  margin-top: -10px;
+}
+
+.c8::-webkit-slider-thumb:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c8::-webkit-slider-runnable-track {
+  -webkit-appearance: none;
+  background: transparent;
+  height: 4px;
+}
+
+.c8::-moz-range-thumb {
+  box-sizing: border-box;
+  position: relative;
+  border-radius: 24px;
+  height: 24px;
+  width: 24px;
+  overflow: visible;
+  background: #7D4CDB;
+  -webkit-appearance: none;
+  cursor: pointer;
+  pointer-events: all;
+  border: none;
+}
+
+.c8::-moz-range-thumb:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c8::-moz-range-track {
+  background: transparent;
+  height: 4px;
+}
+
+.c8:focus-visible {
+  outline: 0;
+}
+
+.c8:focus {
+  outline: none;
+}
+
+<div
+    class="c0"
+  >
+    <div
+      class="c1"
+    >
+      <span
+        class="c2"
+      >
+        20%
+      </span>
+      <div
+        class="c3 c4"
+      >
+        <div
+          class="c5"
+        />
+        <div
+          class="c6"
+          style="left: 20%; width: 60%;"
+        />
+        <input
+          aria-label="Lower Bound"
+          aria-valuemax="100"
+          aria-valuemin="0"
+          aria-valuenow="20"
+          class="c7"
+          max="100"
+          min="0"
+          step="1"
+          type="range"
+          value="20"
+        />
+        <input
+          aria-label="Upper Bound"
+          aria-valuemax="100"
+          aria-valuemin="0"
+          aria-valuenow="80"
+          class="c8"
+          max="100"
+          min="0"
+          step="1"
+          type="range"
+          value="80"
+        />
+      </div>
+      <span
+        class="c2"
+      >
+        80%
+      </span>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`DualRangeInput renders with min and max 1`] = `
+<DocumentFragment>
+  .c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.c2 {
+  position: relative;
+  width: 100%;
+  height: 24px;
+}
+
+.c3 {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  right: 0;
+  height: 4px;
+  transform: translateY(-50%);
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.33);
+}
+
+.c4 {
+  position: absolute;
+  top: 50%;
+  height: 4px;
+  transform: translateY(-50%);
+  border-radius: 4px;
+  background: #7D4CDB;
+}
+
+.c5 {
+  box-sizing: border-box;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  -webkit-appearance: none;
+  background: transparent;
+  margin: 0;
+  padding: 0;
+  pointer-events: none;
+  cursor: pointer;
+  z-index: 2;
+}
+
+.c5::-moz-focus-inner {
+  border: none;
+}
+
+.c5::-moz-focus-outer {
+  border: none;
+}
+
+.c5::-webkit-slider-thumb {
+  box-sizing: border-box;
+  position: relative;
+  border-radius: 24px;
+  height: 24px;
+  width: 24px;
+  overflow: visible;
+  background: #7D4CDB;
+  -webkit-appearance: none;
+  cursor: pointer;
+  pointer-events: all;
+  margin-top: -10px;
+}
+
+.c5::-webkit-slider-thumb:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c5::-webkit-slider-runnable-track {
+  -webkit-appearance: none;
+  background: transparent;
+  height: 4px;
+}
+
+.c5::-moz-range-thumb {
+  box-sizing: border-box;
+  position: relative;
+  border-radius: 24px;
+  height: 24px;
+  width: 24px;
+  overflow: visible;
+  background: #7D4CDB;
+  -webkit-appearance: none;
+  cursor: pointer;
+  pointer-events: all;
+  border: none;
+}
+
+.c5::-moz-range-thumb:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c5::-moz-range-track {
+  background: transparent;
+  height: 4px;
+}
+
+.c5:focus-visible {
+  outline: 0;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c6 {
+  box-sizing: border-box;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  -webkit-appearance: none;
+  background: transparent;
+  margin: 0;
+  padding: 0;
+  pointer-events: none;
+  cursor: pointer;
+  z-index: 3;
+}
+
+.c6::-moz-focus-inner {
+  border: none;
+}
+
+.c6::-moz-focus-outer {
+  border: none;
+}
+
+.c6::-webkit-slider-thumb {
+  box-sizing: border-box;
+  position: relative;
+  border-radius: 24px;
+  height: 24px;
+  width: 24px;
+  overflow: visible;
+  background: #7D4CDB;
+  -webkit-appearance: none;
+  cursor: pointer;
+  pointer-events: all;
+  margin-top: -10px;
+}
+
+.c6::-webkit-slider-thumb:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c6::-webkit-slider-runnable-track {
+  -webkit-appearance: none;
+  background: transparent;
+  height: 4px;
+}
+
+.c6::-moz-range-thumb {
+  box-sizing: border-box;
+  position: relative;
+  border-radius: 24px;
+  height: 24px;
+  width: 24px;
+  overflow: visible;
+  background: #7D4CDB;
+  -webkit-appearance: none;
+  cursor: pointer;
+  pointer-events: all;
+  border: none;
+}
+
+.c6::-moz-range-thumb:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c6::-moz-range-track {
+  background: transparent;
+  height: 4px;
+}
+
+.c6:focus-visible {
+  outline: 0;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+<div
+    class="c0"
+  >
+    <div
+      class="c1 c2"
+    >
+      <div
+        class="c3"
+      />
+      <div
+        class="c4"
+        style="left: 25%; width: 50%;"
+      />
+      <input
+        aria-label="Lower Bound"
+        aria-valuemax="50"
+        aria-valuemin="10"
+        aria-valuenow="20"
+        class="c5"
+        max="50"
+        min="10"
+        step="1"
+        type="range"
+        value="20"
+      />
+      <input
+        aria-label="Upper Bound"
+        aria-valuemax="50"
+        aria-valuemin="10"
+        aria-valuenow="40"
+        class="c6"
+        max="50"
+        min="10"
+        step="1"
+        type="range"
+        value="40"
+      />
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`DualRangeInput renders with step 1`] = `
+<DocumentFragment>
+  .c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.c2 {
+  position: relative;
+  width: 100%;
+  height: 24px;
+}
+
+.c3 {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  right: 0;
+  height: 4px;
+  transform: translateY(-50%);
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.33);
+}
+
+.c4 {
+  position: absolute;
+  top: 50%;
+  height: 4px;
+  transform: translateY(-50%);
+  border-radius: 4px;
+  background: #7D4CDB;
+}
+
+.c5 {
+  box-sizing: border-box;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  -webkit-appearance: none;
+  background: transparent;
+  margin: 0;
+  padding: 0;
+  pointer-events: none;
+  cursor: pointer;
+  z-index: 2;
+}
+
+.c5::-moz-focus-inner {
+  border: none;
+}
+
+.c5::-moz-focus-outer {
+  border: none;
+}
+
+.c5::-webkit-slider-thumb {
+  box-sizing: border-box;
+  position: relative;
+  border-radius: 24px;
+  height: 24px;
+  width: 24px;
+  overflow: visible;
+  background: #7D4CDB;
+  -webkit-appearance: none;
+  cursor: pointer;
+  pointer-events: all;
+  margin-top: -10px;
+}
+
+.c5::-webkit-slider-thumb:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c5::-webkit-slider-runnable-track {
+  -webkit-appearance: none;
+  background: transparent;
+  height: 4px;
+}
+
+.c5::-moz-range-thumb {
+  box-sizing: border-box;
+  position: relative;
+  border-radius: 24px;
+  height: 24px;
+  width: 24px;
+  overflow: visible;
+  background: #7D4CDB;
+  -webkit-appearance: none;
+  cursor: pointer;
+  pointer-events: all;
+  border: none;
+}
+
+.c5::-moz-range-thumb:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c5::-moz-range-track {
+  background: transparent;
+  height: 4px;
+}
+
+.c5:focus-visible {
+  outline: 0;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c6 {
+  box-sizing: border-box;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  -webkit-appearance: none;
+  background: transparent;
+  margin: 0;
+  padding: 0;
+  pointer-events: none;
+  cursor: pointer;
+  z-index: 3;
+}
+
+.c6::-moz-focus-inner {
+  border: none;
+}
+
+.c6::-moz-focus-outer {
+  border: none;
+}
+
+.c6::-webkit-slider-thumb {
+  box-sizing: border-box;
+  position: relative;
+  border-radius: 24px;
+  height: 24px;
+  width: 24px;
+  overflow: visible;
+  background: #7D4CDB;
+  -webkit-appearance: none;
+  cursor: pointer;
+  pointer-events: all;
+  margin-top: -10px;
+}
+
+.c6::-webkit-slider-thumb:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c6::-webkit-slider-runnable-track {
+  -webkit-appearance: none;
+  background: transparent;
+  height: 4px;
+}
+
+.c6::-moz-range-thumb {
+  box-sizing: border-box;
+  position: relative;
+  border-radius: 24px;
+  height: 24px;
+  width: 24px;
+  overflow: visible;
+  background: #7D4CDB;
+  -webkit-appearance: none;
+  cursor: pointer;
+  pointer-events: all;
+  border: none;
+}
+
+.c6::-moz-range-thumb:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c6::-moz-range-track {
+  background: transparent;
+  height: 4px;
+}
+
+.c6:focus-visible {
+  outline: 0;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+<div
+    class="c0"
+  >
+    <div
+      class="c1 c2"
+    >
+      <div
+        class="c3"
+      />
+      <div
+        class="c4"
+        style="left: 20%; width: 60%;"
+      />
+      <input
+        aria-label="Lower Bound"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="20"
+        class="c5"
+        max="100"
+        min="0"
+        step="10"
+        type="range"
+        value="20"
+      />
+      <input
+        aria-label="Upper Bound"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="80"
+        class="c6"
+        max="100"
+        min="0"
+        step="10"
+        type="range"
+        value="80"
+      />
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`DualRangeInput should have no accessibility violations 1`] = `
+<DocumentFragment>
+  .c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.c2 {
+  position: relative;
+  width: 100%;
+  height: 24px;
+}
+
+.c3 {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  right: 0;
+  height: 4px;
+  transform: translateY(-50%);
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.33);
+}
+
+.c4 {
+  position: absolute;
+  top: 50%;
+  height: 4px;
+  transform: translateY(-50%);
+  border-radius: 4px;
+  background: #7D4CDB;
+}
+
+.c5 {
+  box-sizing: border-box;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  -webkit-appearance: none;
+  background: transparent;
+  margin: 0;
+  padding: 0;
+  pointer-events: none;
+  cursor: pointer;
+  z-index: 2;
+}
+
+.c5::-moz-focus-inner {
+  border: none;
+}
+
+.c5::-moz-focus-outer {
+  border: none;
+}
+
+.c5::-webkit-slider-thumb {
+  box-sizing: border-box;
+  position: relative;
+  border-radius: 24px;
+  height: 24px;
+  width: 24px;
+  overflow: visible;
+  background: #7D4CDB;
+  -webkit-appearance: none;
+  cursor: pointer;
+  pointer-events: all;
+  margin-top: -10px;
+}
+
+.c5::-webkit-slider-thumb:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c5::-webkit-slider-runnable-track {
+  -webkit-appearance: none;
+  background: transparent;
+  height: 4px;
+}
+
+.c5::-moz-range-thumb {
+  box-sizing: border-box;
+  position: relative;
+  border-radius: 24px;
+  height: 24px;
+  width: 24px;
+  overflow: visible;
+  background: #7D4CDB;
+  -webkit-appearance: none;
+  cursor: pointer;
+  pointer-events: all;
+  border: none;
+}
+
+.c5::-moz-range-thumb:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c5::-moz-range-track {
+  background: transparent;
+  height: 4px;
+}
+
+.c5:focus-visible {
+  outline: 0;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c6 {
+  box-sizing: border-box;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  -webkit-appearance: none;
+  background: transparent;
+  margin: 0;
+  padding: 0;
+  pointer-events: none;
+  cursor: pointer;
+  z-index: 3;
+}
+
+.c6::-moz-focus-inner {
+  border: none;
+}
+
+.c6::-moz-focus-outer {
+  border: none;
+}
+
+.c6::-webkit-slider-thumb {
+  box-sizing: border-box;
+  position: relative;
+  border-radius: 24px;
+  height: 24px;
+  width: 24px;
+  overflow: visible;
+  background: #7D4CDB;
+  -webkit-appearance: none;
+  cursor: pointer;
+  pointer-events: all;
+  margin-top: -10px;
+}
+
+.c6::-webkit-slider-thumb:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c6::-webkit-slider-runnable-track {
+  -webkit-appearance: none;
+  background: transparent;
+  height: 4px;
+}
+
+.c6::-moz-range-thumb {
+  box-sizing: border-box;
+  position: relative;
+  border-radius: 24px;
+  height: 24px;
+  width: 24px;
+  overflow: visible;
+  background: #7D4CDB;
+  -webkit-appearance: none;
+  cursor: pointer;
+  pointer-events: all;
+  border: none;
+}
+
+.c6::-moz-range-thumb:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c6::-moz-range-track {
+  background: transparent;
+  height: 4px;
+}
+
+.c6:focus-visible {
+  outline: 0;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+<div
+    class="c0"
+  >
+    <div
+      class="c1 c2"
+    >
+      <div
+        class="c3"
+      />
+      <div
+        class="c4"
+        style="left: 20%; width: 60%;"
+      />
+      <input
+        aria-label="Lower Bound"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="20"
+        class="c5"
+        max="100"
+        min="0"
+        step="1"
+        type="range"
+        value="20"
+      />
+      <input
+        aria-label="Upper Bound"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="80"
+        class="c6"
+        max="100"
+        min="0"
+        step="1"
+        type="range"
+        value="80"
+      />
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`DualRangeInput uses defaultValues when values is not provided 1`] = `
+<DocumentFragment>
+  .c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.c2 {
+  position: relative;
+  width: 100%;
+  height: 24px;
+}
+
+.c3 {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  right: 0;
+  height: 4px;
+  transform: translateY(-50%);
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.33);
+}
+
+.c4 {
+  position: absolute;
+  top: 50%;
+  height: 4px;
+  transform: translateY(-50%);
+  border-radius: 4px;
+  background: #7D4CDB;
+}
+
+.c5 {
+  box-sizing: border-box;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  -webkit-appearance: none;
+  background: transparent;
+  margin: 0;
+  padding: 0;
+  pointer-events: none;
+  cursor: pointer;
+  z-index: 2;
+}
+
+.c5::-moz-focus-inner {
+  border: none;
+}
+
+.c5::-moz-focus-outer {
+  border: none;
+}
+
+.c5::-webkit-slider-thumb {
+  box-sizing: border-box;
+  position: relative;
+  border-radius: 24px;
+  height: 24px;
+  width: 24px;
+  overflow: visible;
+  background: #7D4CDB;
+  -webkit-appearance: none;
+  cursor: pointer;
+  pointer-events: all;
+  margin-top: -10px;
+}
+
+.c5::-webkit-slider-thumb:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c5::-webkit-slider-runnable-track {
+  -webkit-appearance: none;
+  background: transparent;
+  height: 4px;
+}
+
+.c5::-moz-range-thumb {
+  box-sizing: border-box;
+  position: relative;
+  border-radius: 24px;
+  height: 24px;
+  width: 24px;
+  overflow: visible;
+  background: #7D4CDB;
+  -webkit-appearance: none;
+  cursor: pointer;
+  pointer-events: all;
+  border: none;
+}
+
+.c5::-moz-range-thumb:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c5::-moz-range-track {
+  background: transparent;
+  height: 4px;
+}
+
+.c5:focus-visible {
+  outline: 0;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c6 {
+  box-sizing: border-box;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  -webkit-appearance: none;
+  background: transparent;
+  margin: 0;
+  padding: 0;
+  pointer-events: none;
+  cursor: pointer;
+  z-index: 3;
+}
+
+.c6::-moz-focus-inner {
+  border: none;
+}
+
+.c6::-moz-focus-outer {
+  border: none;
+}
+
+.c6::-webkit-slider-thumb {
+  box-sizing: border-box;
+  position: relative;
+  border-radius: 24px;
+  height: 24px;
+  width: 24px;
+  overflow: visible;
+  background: #7D4CDB;
+  -webkit-appearance: none;
+  cursor: pointer;
+  pointer-events: all;
+  margin-top: -10px;
+}
+
+.c6::-webkit-slider-thumb:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c6::-webkit-slider-runnable-track {
+  -webkit-appearance: none;
+  background: transparent;
+  height: 4px;
+}
+
+.c6::-moz-range-thumb {
+  box-sizing: border-box;
+  position: relative;
+  border-radius: 24px;
+  height: 24px;
+  width: 24px;
+  overflow: visible;
+  background: #7D4CDB;
+  -webkit-appearance: none;
+  cursor: pointer;
+  pointer-events: all;
+  border: none;
+}
+
+.c6::-moz-range-thumb:hover {
+  box-shadow: 0px 0px 0px 2px #7D4CDB;
+}
+
+.c6::-moz-range-track {
+  background: transparent;
+  height: 4px;
+}
+
+.c6:focus-visible {
+  outline: 0;
+}
+
+.c6:focus {
+  outline: none;
+}
+
+<div
+    class="c0"
+  >
+    <div
+      class="c1 c2"
+    >
+      <div
+        class="c3"
+      />
+      <div
+        class="c4"
+        style="left: 30%; width: 40%;"
+      />
+      <input
+        aria-label="Lower Bound"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="30"
+        class="c5"
+        max="100"
+        min="0"
+        step="1"
+        type="range"
+        value="30"
+      />
+      <input
+        aria-label="Upper Bound"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="70"
+        class="c6"
+        max="100"
+        min="0"
+        step="1"
+        type="range"
+        value="70"
+      />
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/src/js/components/DualRangeInput/index.d.ts
+++ b/src/js/components/DualRangeInput/index.d.ts
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import { A11yTitleType, ColorType } from '../../utils';
+
+export interface DualRangeInputProps {
+  a11yTitle?: A11yTitleType;
+  color?: ColorType;
+  defaultValues?: number[];
+  label?: boolean | ((value: number) => React.ReactNode);
+  max?: number;
+  messages?: { lower?: string; upper?: string };
+  min?: number;
+  name?: string;
+  onChange?: (values: [number, number]) => void;
+  step?: number;
+  values?: number[];
+}
+
+export interface DualRangeInputExtendedProps
+  extends DualRangeInputProps,
+    Omit<
+      React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLDivElement>,
+        HTMLDivElement
+      >,
+      'color' | 'onChange'
+    > {}
+
+declare const DualRangeInput: React.FC<DualRangeInputExtendedProps>;
+
+export { DualRangeInput };

--- a/src/js/components/DualRangeInput/index.js
+++ b/src/js/components/DualRangeInput/index.js
@@ -1,0 +1,1 @@
+export { DualRangeInput } from './DualRangeInput';

--- a/src/js/components/DualRangeInput/propTypes.js
+++ b/src/js/components/DualRangeInput/propTypes.js
@@ -1,0 +1,23 @@
+import PropTypes from 'prop-types';
+import { colorPropType } from '../../utils/general-prop-types';
+
+let PropType = {};
+if (process.env.NODE_ENV !== 'production') {
+  PropType = {
+    a11yTitle: PropTypes.string,
+    color: colorPropType,
+    defaultValues: PropTypes.arrayOf(PropTypes.number),
+    label: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
+    max: PropTypes.number,
+    messages: PropTypes.shape({
+      lower: PropTypes.string,
+      upper: PropTypes.string,
+    }),
+    min: PropTypes.number,
+    name: PropTypes.string,
+    onChange: PropTypes.func,
+    step: PropTypes.number,
+    values: PropTypes.arrayOf(PropTypes.number),
+  };
+}
+export const DualRangeInputPropTypes = PropType;

--- a/src/js/components/DualRangeInput/stories/Label.stories.js
+++ b/src/js/components/DualRangeInput/stories/Label.stories.js
@@ -1,0 +1,42 @@
+import React, { useState } from 'react';
+
+import { Box, DualRangeInput } from 'grommet';
+
+export const WithLabel = () => {
+  const [values, setValues] = useState([8, 144]);
+
+  return (
+    <Box align="center" pad="large" width="medium">
+      <DualRangeInput
+        min={0}
+        max={256}
+        step={8}
+        values={values}
+        onChange={(nextValues) => setValues(nextValues)}
+        label
+        messages={{ lower: 'Minimum Cores', upper: 'Maximum Cores' }}
+      />
+    </Box>
+  );
+};
+
+export const WithLabelFunction = () => {
+  const [values, setValues] = useState([20, 80]);
+
+  return (
+    <Box align="center" pad="large" width="medium">
+      <DualRangeInput
+        min={0}
+        max={100}
+        step={5}
+        values={values}
+        onChange={(nextValues) => setValues(nextValues)}
+        label={(value) => `${value}%`}
+      />
+    </Box>
+  );
+};
+
+export default {
+  title: 'Input/DualRangeInput/Label',
+};

--- a/src/js/components/DualRangeInput/stories/Simple.stories.js
+++ b/src/js/components/DualRangeInput/stories/Simple.stories.js
@@ -1,0 +1,24 @@
+import React, { useState } from 'react';
+
+import { Box, DualRangeInput } from 'grommet';
+
+export const Simple = () => {
+  const [values, setValues] = useState([25, 75]);
+
+  return (
+    <Box align="center" pad="large">
+      <DualRangeInput
+        a11yTitle="Select range"
+        min={0}
+        max={100}
+        step={1}
+        values={values}
+        onChange={(nextValues) => setValues(nextValues)}
+      />
+    </Box>
+  );
+};
+
+export default {
+  title: 'Input/DualRangeInput/Simple',
+};

--- a/src/js/components/DualRangeInput/stories/Themed.stories.js
+++ b/src/js/components/DualRangeInput/stories/Themed.stories.js
@@ -1,0 +1,26 @@
+import React, { useState } from 'react';
+
+import { Box, DualRangeInput, Heading } from 'grommet';
+
+export const Themed = () => {
+  const [values, setValues] = useState([20, 80]);
+
+  return (
+    <Box align="center" pad="large" width="medium">
+      <Heading level={3}>Cores</Heading>
+      <DualRangeInput
+        min={0}
+        max={100}
+        step={1}
+        values={values}
+        onChange={(nextValues) => setValues(nextValues)}
+        color="brand"
+        label
+      />
+    </Box>
+  );
+};
+
+export default {
+  title: 'Input/DualRangeInput/Themed',
+};

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -405,6 +405,23 @@ exports[`Components loads 1`] = `
     },
     "render": [Function],
   },
+  "DualRangeInput": {
+    "$$typeof": Symbol(react.forward_ref),
+    "propTypes": {
+      "a11yTitle": [Function],
+      "color": [Function],
+      "defaultValues": [Function],
+      "label": [Function],
+      "max": [Function],
+      "messages": [Function],
+      "min": [Function],
+      "name": [Function],
+      "onChange": [Function],
+      "step": [Function],
+      "values": [Function],
+    },
+    "render": [Function],
+  },
   "FileInput": {
     "$$typeof": Symbol(react.forward_ref),
     "propTypes": {

--- a/src/js/components/index.d.ts
+++ b/src/js/components/index.d.ts
@@ -34,6 +34,7 @@ export * from './Diagram';
 export * from './Distribution';
 export * from './Drop';
 export * from './DropButton';
+export * from './DualRangeInput';
 export * from './FileInput';
 export * from './Footer';
 export * from './Form';

--- a/src/js/components/index.js
+++ b/src/js/components/index.js
@@ -33,6 +33,7 @@ export * from './Diagram';
 export * from './Distribution';
 export * from './Drop';
 export * from './DropButton';
+export * from './DualRangeInput';
 export * from './FileInput';
 export * from './Footer';
 export * from './Form';


### PR DESCRIPTION
#### What does this PR do?
Adds a new component that renders two thumbs on a shared track using the visual style of RangeInput (thin track + circular thumbs), allowing selection of a min/max range.

- DualRangeInput.js: two overlapping <input type="range"> elements with a custom CSS track; reuses rangeInput theme tokens
- propTypes.js, index.d.ts, index.js: prop validation, TypeScript types and barrel export
- Stories: Simple, Label, Themed
- Registered in components/index.js, components/index.d.ts, and updated components snapshot

#### Where should the reviewer start?
`src/js/components/DualRangeInput`

#### What testing has been done on this PR?

- 15 tests covering a11y, rendering, onChange, value constraints, and aria attributes

#### How should this be manually tested?

I validated manually via storybook.

#### Do Jest tests follow these best practices?

- [x] `screen` is used for querying.
- [x] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [x] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

The current `<RangeSelector />` component doesn't meet my UI needs. I considered extending `<RangeInput />` or `<RangeInput />` but ultimately opted for a new `<DualRangeInput />` component. It's the cleanest approach, avoids polluting existing components, and the overlapping-inputs technique is proven and accessible. It would live alongside `<RangeInput />` and `<RangeSelector />` in the component library. In summary I choose this approach because:
 
- Two overlapping <input type="range"> elements with shared styling from StyledRangeInput
- This is a well-known web pattern for dual-thumb sliders
- Clean separation — no risk to existing `<RangeSelector />` or `<RangeInput />`

#### What are the relevant issues?
N/A

#### Screenshots (if appropriate)
![dual-range-input](https://github.com/user-attachments/assets/6289360b-ac8e-478c-b59b-f6688237282b)

#### Do the grommet docs need to be updated?

yes if included.

#### Should this PR be mentioned in the release notes?

yes if included.

#### Is this change backwards compatible or is it a breaking change?

backwards compatible. only new things are added.