### PR TITLE
fix(Button): color prop on default Button sets text color, not background

### DIFF
--- a/src/js/components/Button/Button.js
+++ b/src/js/components/Button/Button.js
@@ -82,9 +82,19 @@ const getIconColor = (paths = [], theme, colorProp, kind) => {
     }
 
     if (obj) {
+      // For default kind buttons, color prop should be used as text color,
+      // not as background replacement.
+      const isDefaultKind =
+        paths[index] === 'default' ||
+        (paths[index] && paths[index].endsWith('.default'));
+
       // use passed in color for background if the theme has a background color
+      // but not for default kind buttons where color means text color
       const background =
-        colorProp && obj.background && obj.background.color
+        colorProp &&
+        obj.background &&
+        obj.background.color &&
+        !isDefaultKind
           ? colorProp
           : obj.background;
 
@@ -107,12 +117,13 @@ const getIconColor = (paths = [], theme, colorProp, kind) => {
         if (obj?.icon?.props?.color) color = obj.icon.props.color;
       }
       // use passed in color for text if the theme doesn't have
-      // background or border color
+      // background or border color, or if this is a default kind button
       if (!color)
         color =
           colorProp &&
-          (!obj.background || !obj.background.color) &&
-          (!obj.border || !obj.border.color)
+          (isDefaultKind ||
+            ((!obj.background || !obj.background.color) &&
+              (!obj.border || !obj.border.color)))
             ? colorProp
             : objColor;
 

--- a/src/js/components/Button/StyledButtonKind.js
+++ b/src/js/components/Button/StyledButtonKind.js
@@ -148,22 +148,17 @@ const kindStyle = ({
 
   const iconOnly = hasIcon && !hasLabel;
   const pad = padFromTheme(size, theme, themeObj, kind, iconOnly);
+  // For default kind buttons, color prop should change text color,
+  // not the background. Check the button's overall kind so that
+  // state paths like 'active' and 'disabled' also respect this.
+  const isDefaultKind =
+    kind === 'default' || (typeof kind === 'string' && kind.endsWith('.default'));
   themePaths.base.forEach((themePath) => {
     const obj = getPath(themeObj, themePath);
     if (obj) {
-      // For default kind buttons, color prop should change text color,
-      // not the background. Only pass colorValue to kindPartStyles for
-      // non-default kinds (e.g. primary, secondary) where it should
-      // replace the background.
-      const isDefaultKind =
-        themePath === 'default' ||
-        (themePath && themePath.endsWith('.default'));
       styles.push(
         kindPartStyles(obj, theme, isDefaultKind ? undefined : colorValue),
       );
-      if (isDefaultKind && colorValue) {
-        styles.push(`color: ${normalizeColor(colorValue, theme)};`);
-      }
       if (obj.border && obj.border.width && pad && !obj.padding) {
         // Adjust padding from the button.size or just top button.padding
         // to deal with the kind's border width. But don't override any
@@ -172,6 +167,11 @@ const kindStyle = ({
       }
     }
   });
+  // Apply explicit text color after all base paths so it wins the
+  // cascade over any auto-computed text colors from state paths.
+  if (isDefaultKind && colorValue) {
+    styles.push(`color: ${normalizeColor(colorValue, theme)};`);
+  }
 
   // do the styling from the root of the object if caller passes one
   if (!themePaths.base.length && typeof kind === 'object') {

--- a/src/js/components/Button/StyledButtonKind.js
+++ b/src/js/components/Button/StyledButtonKind.js
@@ -8,6 +8,7 @@ import {
   unfocusStyle,
   genericStyles,
   kindPartStyles,
+  normalizeColor,
   parseMetricToNum,
 } from '../../utils';
 
@@ -150,7 +151,19 @@ const kindStyle = ({
   themePaths.base.forEach((themePath) => {
     const obj = getPath(themeObj, themePath);
     if (obj) {
-      styles.push(kindPartStyles(obj, theme, colorValue));
+      // For default kind buttons, color prop should change text color,
+      // not the background. Only pass colorValue to kindPartStyles for
+      // non-default kinds (e.g. primary, secondary) where it should
+      // replace the background.
+      const isDefaultKind =
+        themePath === 'default' ||
+        (themePath && themePath.endsWith('.default'));
+      styles.push(
+        kindPartStyles(obj, theme, isDefaultKind ? undefined : colorValue),
+      );
+      if (isDefaultKind && colorValue) {
+        styles.push(`color: ${normalizeColor(colorValue, theme)};`);
+      }
       if (obj.border && obj.border.width && pad && !obj.padding) {
         // Adjust padding from the button.size or just top button.padding
         // to deal with the kind's border width. But don't override any

--- a/src/js/components/Button/StyledButtonKind.js
+++ b/src/js/components/Button/StyledButtonKind.js
@@ -152,7 +152,8 @@ const kindStyle = ({
   // not the background. Check the button's overall kind so that
   // state paths like 'active' and 'disabled' also respect this.
   const isDefaultKind =
-    kind === 'default' || (typeof kind === 'string' && kind.endsWith('.default'));
+    kind === 'default' ||
+    (typeof kind === 'string' && kind.endsWith('.default'));
   themePaths.base.forEach((themePath) => {
     const obj = getPath(themeObj, themePath);
     if (obj) {

--- a/src/js/components/Button/__tests__/Button-kind-test.js
+++ b/src/js/components/Button/__tests__/Button-kind-test.js
@@ -99,10 +99,7 @@ describe('Button kind', () => {
       </Grommet>,
     );
     const button = container.querySelector('button');
-    expect(button).toHaveStyleRule(
-      'color',
-      expect.stringContaining('#FF0000'),
-    );
+    expect(button).toHaveStyleRule('color', expect.stringContaining('#FF0000'));
     expect(button).not.toHaveStyleRule(
       'background-color',
       expect.stringContaining('#FF0000'),
@@ -986,6 +983,20 @@ describe('Button kind', () => {
     );
 
     expect(asFragment()).toMatchSnapshot();
+  });
+
+  test('default button color prop sets text color, not background', () => {
+    const { container } = render(
+      <Grommet theme={buttonKindTheme}>
+        <Button label="Default" color="red" />
+      </Grommet>,
+    );
+    const button = container.querySelector('button');
+    expect(button).toHaveStyleRule('color', expect.stringContaining('red'));
+    expect(button).not.toHaveStyleRule(
+      'background-color',
+      expect.stringContaining('red'),
+    );
   });
 
   test('theme busy gap', () => {

--- a/src/js/components/Button/__tests__/Button-kind-test.js
+++ b/src/js/components/Button/__tests__/Button-kind-test.js
@@ -79,6 +79,37 @@ describe('Button kind', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  test('default button color prop sets text color, not background', () => {
+    const { container } = render(
+      <Grommet
+        theme={{
+          button: {
+            default: {
+              background: {
+                color: '#666666',
+              },
+              border: {
+                color: '#666666',
+              },
+            },
+          },
+        }}
+      >
+        <Button label="Test" color="#FF0000" />
+      </Grommet>,
+    );
+    const button = container.querySelector('button');
+    expect(button).toHaveStyleRule(
+      'color',
+      expect.stringContaining('#FF0000'),
+    );
+    expect(button).not.toHaveStyleRule(
+      'background-color',
+      expect.stringContaining('#FF0000'),
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
   test(`mouseOver and mouseOut events`, async () => {
     const { container, getByText } = render(
       <Grommet

--- a/src/js/components/Button/__tests__/Button-kind-test.js
+++ b/src/js/components/Button/__tests__/Button-kind-test.js
@@ -985,17 +985,69 @@ describe('Button kind', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
-  test('default button color prop sets text color, not background', () => {
+  test('default button color prop sets text color with buttonKindTheme', () => {
     const { container } = render(
       <Grommet theme={buttonKindTheme}>
-        <Button label="Default" color="red" />
+        <Button label="Default" color="#FF0000" />
       </Grommet>,
     );
     const button = container.querySelector('button');
-    expect(button).toHaveStyleRule('color', expect.stringContaining('red'));
+    expect(button).toHaveStyleRule('color', expect.stringContaining('#FF0000'));
     expect(button).not.toHaveStyleRule(
       'background-color',
-      expect.stringContaining('red'),
+      expect.stringContaining('#FF0000'),
+    );
+  });
+
+  test('default button color prop in active state sets text color', () => {
+    const { container } = render(
+      <Grommet
+        theme={{
+          button: {
+            default: {
+              background: { color: '#666666' },
+              border: { color: '#666666' },
+            },
+            active: {
+              background: { color: '#333333' },
+            },
+          },
+        }}
+      >
+        <Button label="Active" color="#FF0000" active />
+      </Grommet>,
+    );
+    const button = container.querySelector('button');
+    expect(button).toHaveStyleRule('color', expect.stringContaining('#FF0000'));
+    expect(button).not.toHaveStyleRule(
+      'background-color',
+      expect.stringContaining('#FF0000'),
+    );
+  });
+
+  test('default button color prop when disabled sets text color', () => {
+    const { container } = render(
+      <Grommet
+        theme={{
+          button: {
+            default: {
+              background: { color: '#666666' },
+              border: { color: '#666666' },
+            },
+            disabled: {
+              opacity: 0.5,
+            },
+          },
+        }}
+      >
+        <Button label="Disabled" color="#FF0000" disabled />
+      </Grommet>,
+    );
+    const button = container.querySelector('button');
+    expect(button).toHaveStyleRule('color', expect.stringContaining('#FF0000'));
+    expect(button).not.toHaveStyleRule(
+      'background-color',
+      expect.stringContaining('#FF0000'),
     );
   });
 

--- a/src/js/components/Button/__tests__/Button-test.tsx
+++ b/src/js/components/Button/__tests__/Button-test.tsx
@@ -682,4 +682,29 @@ describe('Button', () => {
 
     expect(screen.getByLabelText('Add')).toBeInTheDocument();
   });
+
+  test('default button color prop sets text color, not background', () => {
+    const theme: ThemeType = {
+      button: {
+        default: {
+          background: { color: 'white' },
+          border: { color: 'border', width: '2px' },
+          color: 'text',
+        },
+      },
+    };
+
+    const { container } = render(
+      <Grommet theme={theme}>
+        <Button label="Default" color="red" />
+      </Grommet>,
+    );
+    const button = container.querySelector('button')!;
+    // color prop should set text color, not background
+    expect(button).toHaveStyleRule('color', expect.stringContaining('red'));
+    expect(button).not.toHaveStyleRule(
+      'background-color',
+      expect.stringContaining('red'),
+    );
+  });
 });

--- a/src/js/components/Button/__tests__/Button-test.tsx
+++ b/src/js/components/Button/__tests__/Button-test.tsx
@@ -696,15 +696,15 @@ describe('Button', () => {
 
     const { container } = render(
       <Grommet theme={theme}>
-        <Button label="Default" color="red" />
+        <Button label="Default" color="#FF0000" />
       </Grommet>,
     );
     const button = container.querySelector('button')!;
     // color prop should set text color, not background
-    expect(button).toHaveStyleRule('color', expect.stringContaining('red'));
+    expect(button).toHaveStyleRule('color', expect.stringContaining('#FF0000'));
     expect(button).not.toHaveStyleRule(
       'background-color',
-      expect.stringContaining('red'),
+      expect.stringContaining('#FF0000'),
     );
   });
 });

--- a/src/js/components/Button/__tests__/__snapshots__/Button-kind-test.js.snap
+++ b/src/js/components/Button/__tests__/__snapshots__/Button-kind-test.js.snap
@@ -1213,8 +1213,8 @@ exports[`Button kind button icon colors 1`] = `
   flex: 0 0 auto;
   width: 24px;
   height: 24px;
-  fill: #666666;
-  stroke: #666666;
+  fill: #000;
+  stroke: #000;
 }
 
 .c2 g {
@@ -1255,8 +1255,9 @@ exports[`Button kind button icon colors 1`] = `
   padding: 4px 22px;
   font-size: 18px;
   line-height: 0;
-  background-color: #000;
+  background-color: rgba(102, 102, 102, 1);
   border-color: #666666;
+  color: #000;
   text-align: center;
   transition-property: color,background-color,border-color,box-shadow;
   transition-duration: 0.1s;
@@ -1955,6 +1956,94 @@ exports[`Button kind default button 1`] = `
     class="c1"
     type="button"
   />
+</div>
+`;
+
+exports[`Button kind default button color prop sets text color, not background 1`] = `
+.c1 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  border-radius: 18px;
+  padding: 4px 22px;
+  font-size: 18px;
+  line-height: 24px;
+  background-color: rgba(102, 102, 102, 1);
+  color: #f8f8f8;
+  border-color: #666666;
+  color: #FF0000;
+  text-align: center;
+  transition-property: color,background-color,border-color,box-shadow;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+}
+
+.c1:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c1:focus >circle,
+.c1:focus >ellipse,
+.c1:focus >line,
+.c1:focus >path,
+.c1:focus >polygon,
+.c1:focus >polyline,
+.c1:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c1:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c1:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c1:focus:not(:focus-visible) >circle,
+.c1:focus:not(:focus-visible) >ellipse,
+.c1:focus:not(:focus-visible) >line,
+.c1:focus:not(:focus-visible) >path,
+.c1:focus:not(:focus-visible) >polygon,
+.c1:focus:not(:focus-visible) >polyline,
+.c1:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c1:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+<div
+  class="c0"
+>
+  <button
+    class="c1"
+    type="button"
+  >
+    Test
+  </button>
 </div>
 `;
 


### PR DESCRIPTION
## What

Fixes #7880 - Setting `color` prop on a default Button incorrectly changes the background color instead of the text color.

## Root Cause

In `kindPartStyles()` (`styles.js`), when the theme object has a `background` property, `colorValue` replaces it via `backgroundStyle(colorValue || obj.background, ...)`. This is correct for primary/secondary buttons (where `color` should set the background), but wrong for default buttons (where `color` should set the text color per the docs).

The same issue exists in `getIconColor()` (`Button.js`), where `colorProp` replaces the background for icon color calculation.

## Fix

**StyledButtonKind.js** - `kindStyle()`: Detect default kind theme paths and:
- Don't pass `colorValue` to `kindPartStyles()` (prevents background replacement)
- Apply `colorValue` as text color via `normalizeColor()`  

**Button.js** - `getIconColor()`: For default kind paths:
- Don't use `colorProp` as background replacement
- Use `colorProp` as text color so icon matches the label

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| `<Button color='red' label='Test' />` (default) | Background turns red | Text turns red |
| `<Button primary color='red' label='Test' />` | Background turns red | Background turns red (unchanged) |

## Tests

Added test `default button color prop sets text color, not background` with a theme defining `button.default` with background, verifying the rendered output via snapshot.