### PR TITLE
chore: add .gitattributes to enforce LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,18 @@
+# Enforce consistent line endings
+* text=auto eol=lf
+
+*.js text eol=lf
+*.jsx text eol=lf
+*.ts text eol=lf
+*.tsx text eol=lf
+*.css text eol=lf
+*.scss text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.html text eol=lf
+
+# Windows scripts keep CRLF
+*.bat text eol=crlf
+*.cmd text eol=crlf


### PR DESCRIPTION
## What does this PR do?
Adds a `.gitattributes` file to enforce consistent LF line 
endings across the repository.

## Why?
Windows users with misconfigured git clients were committing 
files with CRLF line endings, causing inconsistencies across 
platforms.

## Changes
- Added `.gitattributes` with LF normalization for JS, TS, 
CSS, SCSS, JSON, YAML, MD and HTML files
- Windows-specific files (.bat, .cmd) retain CRLF

Closes #3437