### PR TITLE
LDS-7922 :

### DIFF
--- a/src/js/components/Grommet/Grommet.js
+++ b/src/js/components/Grommet/Grommet.js
@@ -108,7 +108,7 @@ const Grommet = forwardRef((props, ref) => {
 
   useEffect(() => {
     const onResize = () => {
-      setResponsive(getBreakpoint(document.body.clientWidth, theme));
+      setResponsive(getBreakpoint(document.body?.clientWidth ?? window.innerWidth, theme));
     };
     window.addEventListener('resize', onResize);
     onResize();

--- a/src/js/components/Grommet/Grommet.js
+++ b/src/js/components/Grommet/Grommet.js
@@ -108,7 +108,9 @@ const Grommet = forwardRef((props, ref) => {
 
   useEffect(() => {
     const onResize = () => {
-      setResponsive(getBreakpoint(document.body?.clientWidth ?? window.innerWidth, theme));
+      setResponsive(
+        getBreakpoint(document.body?.clientWidth ?? window.innerWidth, theme),
+      );
     };
     window.addEventListener('resize', onResize);
     onResize();

--- a/src/js/components/Grommet/__tests__/Grommet-test.js
+++ b/src/js/components/Grommet/__tests__/Grommet-test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import 'jest-styled-components';
 
 import { hpe as hpeTheme } from 'grommet-theme-hpe';
@@ -102,6 +102,22 @@ describe('Grommet', () => {
       </Grommet>,
     );
     expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test('onResize does not crash when document.body is null', () => {
+    render(<Grommet>Grommet App</Grommet>);
+
+    const bodySpy = jest.spyOn(document, 'body', 'get').mockReturnValue(null);
+    try {
+      expect(() => {
+        fireEvent(
+          window,
+          new Event('resize', { bubbles: true, cancelable: true }),
+        );
+      }).not.toThrow();
+    } finally {
+      bodySpy.mockRestore();
+    }
   });
 
   test('message format function', () => {


### PR DESCRIPTION
Add a fallback in case of document.body null

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fix the issue in https://github.com/grommet/grommet/issues/7922

#### Where should the reviewer start?
Read the original Pull Request #4959, then read the issue #7922

#### What testing has been done on this PR?
N/A

#### How should this be manually tested?
N/A

#### Do Jest tests follow these best practices?

- [ X ] `screen` is used for querying.
- [ X ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ X ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
No

#### What are the relevant issues?
#7922 

#### Screenshots (if appropriate)
N/A

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Yes