### PR TITLE
fix(DataTable): add aria-sort="none" and aria-hidden for unsorted columns

### DIFF
--- a/src/js/components/DataTable/Header.js
+++ b/src/js/components/DataTable/Header.js
@@ -381,6 +381,7 @@ const Header = forwardRef(
                     }
                   } else if (theme.dataTable.icons.sortable) {
                     Icon = theme.dataTable.icons.sortable;
+                    ariaSort = 'none';
                   }
                 }
 
@@ -404,7 +405,12 @@ const Header = forwardRef(
                       justify={align}
                     >
                       {content}
-                      {Icon && <Icon aria-label={iconAriaLabel} />}
+                      {Icon && (
+                        <Icon
+                          aria-label={iconAriaLabel}
+                          aria-hidden={!iconAriaLabel ? true : undefined}
+                        />
+                      )}
                     </Box>
                   </StyledHeaderCellButton>
                 );

--- a/src/js/components/DataTable/Header.js
+++ b/src/js/components/DataTable/Header.js
@@ -379,8 +379,10 @@ const Header = forwardRef(
                         messages,
                       });
                     }
-                  } else if (theme.dataTable.icons.sortable) {
-                    Icon = theme.dataTable.icons.sortable;
+                  } else {
+                    if (theme.dataTable.icons.sortable) {
+                      Icon = theme.dataTable.icons.sortable;
+                    }
                     ariaSort = 'none';
                   }
                 }

--- a/src/js/components/DataTable/Header.js
+++ b/src/js/components/DataTable/Header.js
@@ -316,6 +316,8 @@ const Header = forwardRef(
               units,
             }) => {
               let content;
+              const headerLabel =
+                typeof header === 'string' ? header : property;
               const unitsContent = units ? (
                 <Text {...textProps} {...theme.dataTable.header.units}>
                   {units}
@@ -390,6 +392,15 @@ const Header = forwardRef(
                 content = (
                   <StyledHeaderCellButton
                     plain
+                    a11yTitle={
+                      ariaSort === 'none'
+                        ? format({
+                            id: 'dataTable.sortable',
+                            messages,
+                            values: { label: headerLabel },
+                          })
+                        : undefined
+                    }
                     column={property}
                     fill="vertical"
                     focusIndicator={size ? 'inset' : undefined}
@@ -527,9 +538,7 @@ const Header = forwardRef(
                         onResize(prop, width);
                         updateWidths(prop, width);
                       }}
-                      headerText={
-                        typeof header === 'string' ? header : property
-                      }
+                      headerText={headerLabel}
                       messages={messages}
                       headerId={headerId}
                     />

--- a/src/js/components/DataTable/Header.js
+++ b/src/js/components/DataTable/Header.js
@@ -362,31 +362,27 @@ const Header = forwardRef(
               if (onSort && sortable !== false) {
                 let Icon;
                 let iconAriaLabel;
-                if (onSort && sortable !== false) {
-                  if (sort && sort.property === property) {
-                    Icon =
-                      theme.dataTable.icons[
-                        sort.direction !== 'asc' ? 'ascending' : 'descending'
-                      ];
-                    if (sort.direction === 'asc') {
-                      ariaSort = 'ascending';
-                      iconAriaLabel = format({
-                        id: 'dataTable.ascending',
-                        messages,
-                      });
-                    } else if (sort.direction === 'desc') {
-                      ariaSort = 'descending';
-                      iconAriaLabel = format({
-                        id: 'dataTable.descending',
-                        messages,
-                      });
-                    }
-                  } else {
-                    if (theme.dataTable.icons.sortable) {
-                      Icon = theme.dataTable.icons.sortable;
-                    }
-                    ariaSort = 'none';
+                ariaSort = 'none';
+                if (sort && sort.property === property) {
+                  Icon =
+                    theme.dataTable.icons[
+                      sort.direction !== 'asc' ? 'ascending' : 'descending'
+                    ];
+                  if (sort.direction === 'asc') {
+                    ariaSort = 'ascending';
+                    iconAriaLabel = format({
+                      id: 'dataTable.ascending',
+                      messages,
+                    });
+                  } else if (sort.direction === 'desc') {
+                    ariaSort = 'descending';
+                    iconAriaLabel = format({
+                      id: 'dataTable.descending',
+                      messages,
+                    });
                   }
+                } else if (theme.dataTable.icons.sortable) {
+                  Icon = theme.dataTable.icons.sortable;
                 }
 
                 content = (

--- a/src/js/components/DataTable/__tests__/DataTable-test.tsx
+++ b/src/js/components/DataTable/__tests__/DataTable-test.tsx
@@ -178,6 +178,33 @@ describe('DataTable', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  test('sortable columns have aria-sort="none" when unsorted', () => {
+    const { getByText } = render(
+      <Grommet>
+        <DataTable
+          columns={[
+            { property: 'a', header: 'A' },
+            { property: 'b', header: 'B' },
+          ]}
+          data={[
+            { a: 'zero', b: 0 },
+            { a: 'one', b: 1 },
+          ]}
+          sortable
+        />
+      </Grommet>,
+    );
+
+    const headerA = getByText('A').closest('th');
+    const headerB = getByText('B').closest('th');
+    expect(headerA).toHaveAttribute('aria-sort', 'none');
+    expect(headerB).toHaveAttribute('aria-sort', 'none');
+
+    fireEvent.click(getByText('A'));
+    expect(headerA).toHaveAttribute('aria-sort', 'ascending');
+    expect(headerB).toHaveAttribute('aria-sort', 'none');
+  });
+
   test('sort null data', () => {
     const { container, getByText } = render(
       <Grommet>

--- a/src/js/components/DataTable/__tests__/DataTable-test.tsx
+++ b/src/js/components/DataTable/__tests__/DataTable-test.tsx
@@ -214,6 +214,23 @@ describe('DataTable', () => {
     ).toBeInTheDocument();
   });
 
+  test('sortable columns have aria-sort when sortable icon is not rendered', () => {
+    const { getByText } = render(
+      <Grommet theme={{ dataTable: { icons: { sortable: undefined } } }}>
+        <DataTable
+          columns={[{ property: 'a', header: 'A' }]}
+          data={[{ a: 'zero' }, { a: 'one' }]}
+          sortable
+        />
+      </Grommet>,
+    );
+
+    expect(getByText('A').closest('th')).toHaveAttribute('aria-sort', 'none');
+    expect(
+      screen.getByRole('button', { name: 'A, sortable' }),
+    ).toBeInTheDocument();
+  });
+
   test('sort null data', () => {
     const { container, getByText } = render(
       <Grommet>

--- a/src/js/components/DataTable/__tests__/DataTable-test.tsx
+++ b/src/js/components/DataTable/__tests__/DataTable-test.tsx
@@ -199,10 +199,19 @@ describe('DataTable', () => {
     const headerB = getByText('B').closest('th');
     expect(headerA).toHaveAttribute('aria-sort', 'none');
     expect(headerB).toHaveAttribute('aria-sort', 'none');
+    expect(
+      screen.getByRole('button', { name: 'A, sortable' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'B, sortable' }),
+    ).toBeInTheDocument();
 
     fireEvent.click(getByText('A'));
     expect(headerA).toHaveAttribute('aria-sort', 'ascending');
     expect(headerB).toHaveAttribute('aria-sort', 'none');
+    expect(
+      screen.getByRole('button', { name: 'B, sortable' }),
+    ).toBeInTheDocument();
   });
 
   test('sort null data', () => {

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.tsx.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.tsx.snap
@@ -3386,27 +3386,27 @@ exports[`DataTable click 1`] = `
 
 exports[`DataTable click 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
+  class="StyledGrommet-sc-19lkkz7-0 iQmOCy"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 gfvJtN StyledDataTable-sc-xrlyjm-0 iySlWL"
+    class="StyledTable-sc-1m3u5g-6 hItFIU StyledDataTable-sc-xrlyjm-0 bhJXnf"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-5"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 ktKCWw"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 hGRSSL"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksVeQF StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jabPpn StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           id="grommet-data-table-header-a"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
+            class="StyledBox-sc-13pk1d4-0 faLdcD"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               A
             </span>
@@ -3415,21 +3415,21 @@ exports[`DataTable click 2`] = `
       </tr>
     </thead>
     <tbody
-      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 buut"
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 dRPopI"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 fSkwcW"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 dUdAYb"
         tabindex="-1"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 gIpquo"
+              class="StyledText-sc-1sadyjn-0 bAcCYq"
             >
               alpha
             </span>
@@ -3437,18 +3437,18 @@ exports[`DataTable click 2`] = `
         </th>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iQTwbZ"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 gFGXBk"
         tabindex="0"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 gIpquo"
+              class="StyledText-sc-1sadyjn-0 bAcCYq"
             >
               beta
             </span>
@@ -3894,6 +3894,7 @@ exports[`DataTable custom theme 1`] = `
           scope="col"
         />
         <th
+          aria-sort="none"
           class="c4 "
           id="grommet-data-table-header-a"
           scope="col"
@@ -4057,39 +4058,40 @@ exports[`DataTable custom theme 1`] = `
 
 exports[`DataTable custom theme 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
+  class="StyledGrommet-sc-19lkkz7-0 iQmOCy"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 gfvJtN StyledDataTable-sc-xrlyjm-0 iySlWL"
+    class="StyledTable-sc-1m3u5g-6 hItFIU StyledDataTable-sc-xrlyjm-0 bhJXnf"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-5"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 ktKCWw"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 hGRSSL"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bUfbvl StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 guqRSX StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="col"
         />
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hdohsq StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          aria-sort="none"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 eJWsnI StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           id="grommet-data-table-header-a"
           scope="col"
           style="box-sizing: border-box; position: relative; overflow: visible;"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 cyLFae"
+            class="StyledBox-sc-13pk1d4-0 eeJSdc"
           >
             <button
-              class="StyledButton-sc-323bzc-0 gVLKEX Header__StyledHeaderCellButton-sc-1baku5q-0 ksMNO"
+              class="StyledButton-sc-323bzc-0 efbshF Header__StyledHeaderCellButton-sc-1baku5q-0 dudWar"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 bHjtLJ"
+                class="StyledBox-sc-13pk1d4-0 ABJcL"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 gIpquo"
+                  class="StyledText-sc-1sadyjn-0 bAcCYq"
                 >
                   A
                 </span>
@@ -4102,52 +4104,52 @@ exports[`DataTable custom theme 2`] = `
             aria-orientation="vertical"
             aria-valuenow="0"
             aria-valuetext="Resize A column"
-            class="StyledButton-sc-323bzc-0 idJamt Resizer__StyledResizer-sc-8l808w-0 jVCVpX"
+            class="StyledButton-sc-323bzc-0 cGdjir Resizer__StyledResizer-sc-8l808w-0 kABhyr"
             role="separator"
             type="button"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 cScBIm"
+              class="StyledBox-sc-13pk1d4-0 hpUfog"
             />
           </button>
         </th>
       </tr>
     </thead>
     <tbody
-      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 buut"
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 dRPopI"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
       >
         <td
           aria-disabled="true"
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gIvIGX StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hxldGp StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 bknumx"
+            class="StyledBox-sc-13pk1d4-0 iSpovP"
             style="height: 0px;"
           >
             <label
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 citkSF"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 gOUajv"
               disabled=""
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 gOFJEd StyledCheckBox-sc-1dbk5ju-6 ewFUzs"
+                class="StyledBox-sc-13pk1d4-0 kdNZWX StyledCheckBox-sc-1dbk5ju-6 jHuWbF"
                 disabled=""
               >
                 <input
                   aria-label="unselect alpha"
                   checked=""
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 jyDGaE"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 bEaKNg"
                   disabled=""
                   type="checkbox"
                 />
                 <div
-                  class="StyledBox-sc-13pk1d4-0 gHSfwH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 bwjtfK"
+                  class="StyledBox-sc-13pk1d4-0 cJyZCd StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 hZZOmF"
                   disabled=""
                 >
                   <svg
-                    class="StyledCheckBox__StyledCheckBoxIcon-sc-1dbk5ju-0 gLSxni"
+                    class="StyledCheckBox__StyledCheckBoxIcon-sc-1dbk5ju-0 eNRRvC"
                     disabled=""
                     preserveAspectRatio="xMidYMid meet"
                     viewBox="0 0 24 24"
@@ -4167,14 +4169,14 @@ exports[`DataTable custom theme 2`] = `
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 gIpquo"
+              class="StyledText-sc-1sadyjn-0 bAcCYq"
             >
               alpha
             </span>
@@ -4182,32 +4184,32 @@ exports[`DataTable custom theme 2`] = `
         </th>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
       >
         <td
           aria-disabled="true"
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gIvIGX StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hxldGp StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 bknumx"
+            class="StyledBox-sc-13pk1d4-0 iSpovP"
             style="height: 0px;"
           >
             <label
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 citkSF"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 gOUajv"
               disabled=""
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 gOFJEd StyledCheckBox-sc-1dbk5ju-6 ewFUzs"
+                class="StyledBox-sc-13pk1d4-0 kdNZWX StyledCheckBox-sc-1dbk5ju-6 jHuWbF"
                 disabled=""
               >
                 <input
                   aria-label="select beta"
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 jyDGaE"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 bEaKNg"
                   disabled=""
                   type="checkbox"
                 />
                 <div
-                  class="StyledBox-sc-13pk1d4-0 jbiGIb StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 bwjtfK"
+                  class="StyledBox-sc-13pk1d4-0 hSCSzp StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 hZZOmF"
                   disabled=""
                 />
               </div>
@@ -4215,14 +4217,14 @@ exports[`DataTable custom theme 2`] = `
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 gIpquo"
+              class="StyledText-sc-1sadyjn-0 bAcCYq"
             >
               beta
             </span>
@@ -4424,27 +4426,27 @@ exports[`DataTable disable row click using space key press 1`] = `
 
 exports[`DataTable disable row click using space key press 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
+  class="StyledGrommet-sc-19lkkz7-0 iQmOCy"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 gfvJtN StyledDataTable-sc-xrlyjm-0 iySlWL"
+    class="StyledTable-sc-1m3u5g-6 hItFIU StyledDataTable-sc-xrlyjm-0 bhJXnf"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-5"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 ktKCWw"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 hGRSSL"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksVeQF StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jabPpn StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           id="grommet-data-table-header-name"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
+            class="StyledBox-sc-13pk1d4-0 faLdcD"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               Name
             </span>
@@ -4453,22 +4455,22 @@ exports[`DataTable disable row click using space key press 2`] = `
       </tr>
     </thead>
     <tbody
-      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 buut"
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 dRPopI"
     >
       <tr
         aria-disabled="true"
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 fSkwcW"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 dUdAYb"
         tabindex="0"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 gIpquo"
+              class="StyledText-sc-1sadyjn-0 bAcCYq"
             >
               alpha
             </span>
@@ -4689,27 +4691,27 @@ exports[`DataTable disabled click 1`] = `
 
 exports[`DataTable disabled click 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
+  class="StyledGrommet-sc-19lkkz7-0 iQmOCy"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 gfvJtN StyledDataTable-sc-xrlyjm-0 iySlWL"
+    class="StyledTable-sc-1m3u5g-6 hItFIU StyledDataTable-sc-xrlyjm-0 bhJXnf"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-5"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 ktKCWw"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 hGRSSL"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksVeQF StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jabPpn StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           id="grommet-data-table-header-a"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
+            class="StyledBox-sc-13pk1d4-0 faLdcD"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               A
             </span>
@@ -4718,22 +4720,22 @@ exports[`DataTable disabled click 2`] = `
       </tr>
     </thead>
     <tbody
-      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 buut"
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 dRPopI"
     >
       <tr
         aria-disabled="true"
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 fSkwcW"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 dUdAYb"
         tabindex="-1"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 gIpquo"
+              class="StyledText-sc-1sadyjn-0 bAcCYq"
             >
               alpha
             </span>
@@ -4741,18 +4743,18 @@ exports[`DataTable disabled click 2`] = `
         </th>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iQTwbZ"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 gFGXBk"
         tabindex="0"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 gIpquo"
+              class="StyledText-sc-1sadyjn-0 bAcCYq"
             >
               beta
             </span>
@@ -8180,36 +8182,36 @@ exports[`DataTable groupBy 1`] = `
 
 exports[`DataTable groupBy 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
+  class="StyledGrommet-sc-19lkkz7-0 iQmOCy"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 gfvJtN StyledDataTable-sc-xrlyjm-0 iySlWL"
+    class="StyledTable-sc-1m3u5g-6 hItFIU StyledDataTable-sc-xrlyjm-0 bhJXnf"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-5"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 ktKCWw"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 hGRSSL"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 fRAYyo"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kCKEbm"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 hJyDbY"
+            class="StyledBox-sc-13pk1d4-0 ccXjKC"
             style="height: 0px;"
           >
             <button
               aria-expanded="false"
               aria-label="expand all"
-              class="StyledButton-sc-323bzc-0 kPGkLU"
+              class="StyledButton-sc-323bzc-0 gxPxGa"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 iXSmVm"
+                class="StyledBox-sc-13pk1d4-0 jAIAuI"
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-sc-ofa7kd-0 cbAOVH"
+                  class="StyledIcon-sc-ofa7kd-0 dJyQSO"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -8224,30 +8226,30 @@ exports[`DataTable groupBy 2`] = `
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksVeQF StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jabPpn StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           id="grommet-data-table-header-a"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
+            class="StyledBox-sc-13pk1d4-0 faLdcD"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               A
             </span>
           </div>
         </th>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksVeQF StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jabPpn StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           id="grommet-data-table-header-b"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
+            class="StyledBox-sc-13pk1d4-0 faLdcD"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               B
             </span>
@@ -8256,30 +8258,30 @@ exports[`DataTable groupBy 2`] = `
       </tr>
     </thead>
     <tbody
-      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 buut"
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 dRPopI"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 lgcZWa"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bJGbBs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 hJyDbY"
+            class="StyledBox-sc-13pk1d4-0 ccXjKC"
             style="height: 0px;"
           >
             <button
               aria-expanded="false"
               aria-label="expand "
-              class="StyledButton-sc-323bzc-0 kPGkLU"
+              class="StyledButton-sc-323bzc-0 gxPxGa"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 iXSmVm"
+                class="StyledBox-sc-13pk1d4-0 jAIAuI"
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-sc-ofa7kd-0 cbAOVH"
+                  class="StyledIcon-sc-ofa7kd-0 dJyQSO"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -8294,49 +8296,49 @@ exports[`DataTable groupBy 2`] = `
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               one
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           />
         </td>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 lgcZWa"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bJGbBs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 hJyDbY"
+            class="StyledBox-sc-13pk1d4-0 ccXjKC"
             style="height: 0px;"
           >
             <button
               aria-expanded="false"
               aria-label="expand "
-              class="StyledButton-sc-323bzc-0 kPGkLU"
+              class="StyledButton-sc-323bzc-0 gxPxGa"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 iXSmVm"
+                class="StyledBox-sc-13pk1d4-0 jAIAuI"
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-sc-ofa7kd-0 cbAOVH"
+                  class="StyledIcon-sc-ofa7kd-0 dJyQSO"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -8351,24 +8353,24 @@ exports[`DataTable groupBy 2`] = `
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               two
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           />
         </td>
       </tr>
@@ -9499,36 +9501,36 @@ exports[`DataTable groupBy property 1`] = `
 
 exports[`DataTable groupBy property 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
+  class="StyledGrommet-sc-19lkkz7-0 iQmOCy"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 gfvJtN StyledDataTable-sc-xrlyjm-0 iySlWL"
+    class="StyledTable-sc-1m3u5g-6 hItFIU StyledDataTable-sc-xrlyjm-0 bhJXnf"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-5"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 ktKCWw"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 hGRSSL"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 fRAYyo"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kCKEbm"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 hJyDbY"
+            class="StyledBox-sc-13pk1d4-0 ccXjKC"
             style="height: 0px;"
           >
             <button
               aria-expanded="false"
               aria-label="expand all"
-              class="StyledButton-sc-323bzc-0 kPGkLU"
+              class="StyledButton-sc-323bzc-0 gxPxGa"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 iXSmVm"
+                class="StyledBox-sc-13pk1d4-0 jAIAuI"
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-sc-ofa7kd-0 cbAOVH"
+                  class="StyledIcon-sc-ofa7kd-0 dJyQSO"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -9543,30 +9545,30 @@ exports[`DataTable groupBy property 2`] = `
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksVeQF StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jabPpn StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           id="grommet-data-table-header-a"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
+            class="StyledBox-sc-13pk1d4-0 faLdcD"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               A
             </span>
           </div>
         </th>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksVeQF StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jabPpn StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           id="grommet-data-table-header-b"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
+            class="StyledBox-sc-13pk1d4-0 faLdcD"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               B
             </span>
@@ -9575,30 +9577,30 @@ exports[`DataTable groupBy property 2`] = `
       </tr>
     </thead>
     <tbody
-      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 buut"
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 dRPopI"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 lgcZWa"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bJGbBs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 hJyDbY"
+            class="StyledBox-sc-13pk1d4-0 ccXjKC"
             style="height: 0px;"
           >
             <button
               aria-expanded="false"
               aria-label="expand "
-              class="StyledButton-sc-323bzc-0 kPGkLU"
+              class="StyledButton-sc-323bzc-0 gxPxGa"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 iXSmVm"
+                class="StyledBox-sc-13pk1d4-0 jAIAuI"
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-sc-ofa7kd-0 cbAOVH"
+                  class="StyledIcon-sc-ofa7kd-0 dJyQSO"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -9613,49 +9615,49 @@ exports[`DataTable groupBy property 2`] = `
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               one
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           />
         </td>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 lgcZWa"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bJGbBs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 hJyDbY"
+            class="StyledBox-sc-13pk1d4-0 ccXjKC"
             style="height: 0px;"
           >
             <button
               aria-expanded="false"
               aria-label="expand "
-              class="StyledButton-sc-323bzc-0 kPGkLU"
+              class="StyledButton-sc-323bzc-0 gxPxGa"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 iXSmVm"
+                class="StyledBox-sc-13pk1d4-0 jAIAuI"
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-sc-ofa7kd-0 cbAOVH"
+                  class="StyledIcon-sc-ofa7kd-0 dJyQSO"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -9670,24 +9672,24 @@ exports[`DataTable groupBy property 2`] = `
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               two
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           />
         </td>
       </tr>
@@ -10006,7 +10008,7 @@ exports[`DataTable groupBy toggle 1`] = `
 
 exports[`DataTable groupBy toggle 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
+  class="StyledGrommet-sc-19lkkz7-0 iQmOCy"
 >
   <button
     type="button"
@@ -10014,13 +10016,13 @@ exports[`DataTable groupBy toggle 2`] = `
     toggle
   </button>
   <table
-    class="StyledTable-sc-1m3u5g-6 gfvJtN StyledDataTable-sc-xrlyjm-0 iySlWL"
+    class="StyledTable-sc-1m3u5g-6 hItFIU StyledDataTable-sc-xrlyjm-0 bhJXnf"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-5"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 ktKCWw"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 hGRSSL"
       >
         .c4 {
   display: inline-block;
@@ -10206,30 +10208,30 @@ exports[`DataTable groupBy toggle 2`] = `
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksVeQF StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jabPpn StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           id="grommet-data-table-header-a"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
+            class="StyledBox-sc-13pk1d4-0 faLdcD"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               A
             </span>
           </div>
         </th>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksVeQF StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jabPpn StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           id="grommet-data-table-header-b"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
+            class="StyledBox-sc-13pk1d4-0 faLdcD"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               B
             </span>
@@ -10585,7 +10587,7 @@ exports[`DataTable groupBy toggle 2`] = `
 
 exports[`DataTable groupBy toggle 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
+  class="StyledGrommet-sc-19lkkz7-0 iQmOCy"
 >
   <button
     type="button"
@@ -10593,39 +10595,39 @@ exports[`DataTable groupBy toggle 3`] = `
     toggle
   </button>
   <table
-    class="StyledTable-sc-1m3u5g-6 gfvJtN StyledDataTable-sc-xrlyjm-0 iySlWL"
+    class="StyledTable-sc-1m3u5g-6 hItFIU StyledDataTable-sc-xrlyjm-0 bhJXnf"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-5"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 ktKCWw"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 hGRSSL"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksVeQF StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jabPpn StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           id="grommet-data-table-header-a"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
+            class="StyledBox-sc-13pk1d4-0 faLdcD"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               A
             </span>
           </div>
         </th>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksVeQF StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jabPpn StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           id="grommet-data-table-header-b"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
+            class="StyledBox-sc-13pk1d4-0 faLdcD"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               B
             </span>
@@ -11337,36 +11339,36 @@ exports[`DataTable messages prop overrides theme messages 1`] = `
 
 exports[`DataTable messages prop overrides theme messages 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
+  class="StyledGrommet-sc-19lkkz7-0 iQmOCy"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 gfvJtN StyledDataTable-sc-xrlyjm-0 iySlWL"
+    class="StyledTable-sc-1m3u5g-6 hItFIU StyledDataTable-sc-xrlyjm-0 bhJXnf"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-5"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 ktKCWw"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 hGRSSL"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 fRAYyo"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kCKEbm"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 hJyDbY"
+            class="StyledBox-sc-13pk1d4-0 ccXjKC"
             style="height: 0px;"
           >
             <button
               aria-expanded="false"
               aria-label="expand all"
-              class="StyledButton-sc-323bzc-0 kPGkLU"
+              class="StyledButton-sc-323bzc-0 gxPxGa"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 iXSmVm"
+                class="StyledBox-sc-13pk1d4-0 jAIAuI"
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-sc-ofa7kd-0 cbAOVH"
+                  class="StyledIcon-sc-ofa7kd-0 dJyQSO"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -11381,30 +11383,30 @@ exports[`DataTable messages prop overrides theme messages 2`] = `
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksVeQF StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jabPpn StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           id="grommet-data-table-header-a"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
+            class="StyledBox-sc-13pk1d4-0 faLdcD"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               A
             </span>
           </div>
         </th>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksVeQF StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jabPpn StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           id="grommet-data-table-header-b"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
+            class="StyledBox-sc-13pk1d4-0 faLdcD"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               B
             </span>
@@ -11413,26 +11415,26 @@ exports[`DataTable messages prop overrides theme messages 2`] = `
       </tr>
     </thead>
     <tbody
-      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 buut"
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 dRPopI"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 lgcZWa"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bJGbBs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 hJyDbY"
+            class="StyledBox-sc-13pk1d4-0 ccXjKC"
             style="height: 0px;"
           >
             <button
               aria-expanded="true"
               aria-label="colapsar"
-              class="StyledButton-sc-323bzc-0 kPGkLU"
+              class="StyledButton-sc-323bzc-0 gxPxGa"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 iXSmVm"
+                class="StyledBox-sc-13pk1d4-0 jAIAuI"
               >
                 .c0 {
   display: inline-block;
@@ -11491,24 +11493,24 @@ exports[`DataTable messages prop overrides theme messages 2`] = `
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               one
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           />
         </td>
       </tr>
@@ -11909,27 +11911,27 @@ exports[`DataTable messages prop overrides theme messages 2`] = `
         </td>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 lgcZWa"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bJGbBs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 hJyDbY"
+            class="StyledBox-sc-13pk1d4-0 ccXjKC"
             style="height: 0px;"
           >
             <button
               aria-expanded="false"
               aria-label="expandir"
-              class="StyledButton-sc-323bzc-0 kPGkLU"
+              class="StyledButton-sc-323bzc-0 gxPxGa"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 iXSmVm"
+                class="StyledBox-sc-13pk1d4-0 jAIAuI"
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-sc-ofa7kd-0 cbAOVH"
+                  class="StyledIcon-sc-ofa7kd-0 dJyQSO"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -11944,24 +11946,24 @@ exports[`DataTable messages prop overrides theme messages 2`] = `
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               two
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           />
         </td>
       </tr>
@@ -15091,36 +15093,36 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 1`
 
 exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
+  class="StyledGrommet-sc-19lkkz7-0 iQmOCy"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 gfvJtN StyledDataTable-sc-xrlyjm-0 iySlWL"
+    class="StyledTable-sc-1m3u5g-6 hItFIU StyledDataTable-sc-xrlyjm-0 bhJXnf"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-5"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 ktKCWw"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 hGRSSL"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 fRAYyo"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kCKEbm"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 hJyDbY"
+            class="StyledBox-sc-13pk1d4-0 ccXjKC"
             style="height: 0px;"
           >
             <button
               aria-expanded="false"
               aria-label="expand all"
-              class="StyledButton-sc-323bzc-0 kPGkLU"
+              class="StyledButton-sc-323bzc-0 gxPxGa"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 iXSmVm"
+                class="StyledBox-sc-13pk1d4-0 jAIAuI"
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-sc-ofa7kd-0 cbAOVH"
+                  class="StyledIcon-sc-ofa7kd-0 dJyQSO"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -15135,26 +15137,26 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kdJQYN StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jThOtf StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 bknumx"
+            class="StyledBox-sc-13pk1d4-0 iSpovP"
             style="height: 0px;"
           >
             <label
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hhAlPI"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 byaRhK"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 gOFJEd StyledCheckBox-sc-1dbk5ju-6 ewFUzs"
+                class="StyledBox-sc-13pk1d4-0 kdNZWX StyledCheckBox-sc-1dbk5ju-6 jHuWbF"
               >
                 <input
                   aria-label="unselect all"
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 yZiQM"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNNTU"
                   type="checkbox"
                 />
                 <div
-                  class="StyledBox-sc-13pk1d4-0 gHSfwH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 bwjtfK"
+                  class="StyledBox-sc-13pk1d4-0 cJyZCd StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 hZZOmF"
                 >
                   .c0 {
   box-sizing: border-box;
@@ -15196,30 +15198,30 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
           </div>
         </th>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksVeQF StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jabPpn StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           id="grommet-data-table-header-a"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
+            class="StyledBox-sc-13pk1d4-0 faLdcD"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               A
             </span>
           </div>
         </th>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksVeQF StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jabPpn StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           id="grommet-data-table-header-b"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
+            class="StyledBox-sc-13pk1d4-0 faLdcD"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               B
             </span>
@@ -15228,30 +15230,30 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
       </tr>
     </thead>
     <tbody
-      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 buut"
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 dRPopI"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 lgcZWa"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bJGbBs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 hJyDbY"
+            class="StyledBox-sc-13pk1d4-0 ccXjKC"
             style="height: 0px;"
           >
             <button
               aria-expanded="false"
               aria-label="expand "
-              class="StyledButton-sc-323bzc-0 kPGkLU"
+              class="StyledButton-sc-323bzc-0 gxPxGa"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 iXSmVm"
+                class="StyledBox-sc-13pk1d4-0 jAIAuI"
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-sc-ofa7kd-0 cbAOVH"
+                  class="StyledIcon-sc-ofa7kd-0 dJyQSO"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -15266,25 +15268,25 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gIvIGX"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hxldGp"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 bknumx"
+            class="StyledBox-sc-13pk1d4-0 iSpovP"
             style="height: 0px;"
           >
             <label
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hhAlPI"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 byaRhK"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 gOFJEd StyledCheckBox-sc-1dbk5ju-6 ewFUzs"
+                class="StyledBox-sc-13pk1d4-0 kdNZWX StyledCheckBox-sc-1dbk5ju-6 jHuWbF"
               >
                 <input
                   aria-label="unselect one"
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 yZiQM"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNNTU"
                   type="checkbox"
                 />
                 <div
-                  class="StyledBox-sc-13pk1d4-0 gHSfwH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 bwjtfK"
+                  class="StyledBox-sc-13pk1d4-0 cJyZCd StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 hZZOmF"
                 >
                   .c0 {
   box-sizing: border-box;
@@ -15326,49 +15328,49 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               one
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           />
         </td>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 lgcZWa"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bJGbBs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 hJyDbY"
+            class="StyledBox-sc-13pk1d4-0 ccXjKC"
             style="height: 0px;"
           >
             <button
               aria-expanded="false"
               aria-label="expand "
-              class="StyledButton-sc-323bzc-0 kPGkLU"
+              class="StyledButton-sc-323bzc-0 gxPxGa"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 iXSmVm"
+                class="StyledBox-sc-13pk1d4-0 jAIAuI"
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-sc-ofa7kd-0 cbAOVH"
+                  class="StyledIcon-sc-ofa7kd-0 dJyQSO"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -15383,25 +15385,25 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gIvIGX"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hxldGp"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 bknumx"
+            class="StyledBox-sc-13pk1d4-0 iSpovP"
             style="height: 0px;"
           >
             <label
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hhAlPI"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 byaRhK"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 gOFJEd StyledCheckBox-sc-1dbk5ju-6 ewFUzs"
+                class="StyledBox-sc-13pk1d4-0 kdNZWX StyledCheckBox-sc-1dbk5ju-6 jHuWbF"
               >
                 <input
                   aria-label="unselect two"
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 yZiQM"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNNTU"
                   type="checkbox"
                 />
                 <div
-                  class="StyledBox-sc-13pk1d4-0 gHSfwH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 bwjtfK"
+                  class="StyledBox-sc-13pk1d4-0 cJyZCd StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 hZZOmF"
                 >
                   .c0 {
   box-sizing: border-box;
@@ -15443,24 +15445,24 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               two
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           />
         </td>
       </tr>
@@ -15471,36 +15473,36 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
 
 exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
+  class="StyledGrommet-sc-19lkkz7-0 iQmOCy"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 gfvJtN StyledDataTable-sc-xrlyjm-0 iySlWL"
+    class="StyledTable-sc-1m3u5g-6 hItFIU StyledDataTable-sc-xrlyjm-0 bhJXnf"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-5"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 ktKCWw"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 hGRSSL"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 fRAYyo"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kCKEbm"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 hJyDbY"
+            class="StyledBox-sc-13pk1d4-0 ccXjKC"
             style="height: 0px;"
           >
             <button
               aria-expanded="false"
               aria-label="expand all"
-              class="StyledButton-sc-323bzc-0 kPGkLU"
+              class="StyledButton-sc-323bzc-0 gxPxGa"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 iXSmVm"
+                class="StyledBox-sc-13pk1d4-0 jAIAuI"
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-sc-ofa7kd-0 cbAOVH"
+                  class="StyledIcon-sc-ofa7kd-0 dJyQSO"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -15515,56 +15517,56 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kdJQYN StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jThOtf StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 bknumx"
+            class="StyledBox-sc-13pk1d4-0 iSpovP"
             style="height: 0px;"
           >
             <label
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hhAlPI"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 byaRhK"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 gOFJEd StyledCheckBox-sc-1dbk5ju-6 ewFUzs"
+                class="StyledBox-sc-13pk1d4-0 kdNZWX StyledCheckBox-sc-1dbk5ju-6 jHuWbF"
               >
                 <input
                   aria-label="select all"
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 yZiQM"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNNTU"
                   type="checkbox"
                 />
                 <div
-                  class="StyledBox-sc-13pk1d4-0 jbiGIb StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 bwjtfK"
+                  class="StyledBox-sc-13pk1d4-0 hSCSzp StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 hZZOmF"
                 />
               </div>
             </label>
           </div>
         </th>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksVeQF StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jabPpn StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           id="grommet-data-table-header-a"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
+            class="StyledBox-sc-13pk1d4-0 faLdcD"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               A
             </span>
           </div>
         </th>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksVeQF StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jabPpn StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           id="grommet-data-table-header-b"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
+            class="StyledBox-sc-13pk1d4-0 faLdcD"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               B
             </span>
@@ -15573,30 +15575,30 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
       </tr>
     </thead>
     <tbody
-      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 buut"
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 dRPopI"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 lgcZWa"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bJGbBs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 hJyDbY"
+            class="StyledBox-sc-13pk1d4-0 ccXjKC"
             style="height: 0px;"
           >
             <button
               aria-expanded="false"
               aria-label="expand "
-              class="StyledButton-sc-323bzc-0 kPGkLU"
+              class="StyledButton-sc-323bzc-0 gxPxGa"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 iXSmVm"
+                class="StyledBox-sc-13pk1d4-0 jAIAuI"
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-sc-ofa7kd-0 cbAOVH"
+                  class="StyledIcon-sc-ofa7kd-0 dJyQSO"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -15611,74 +15613,74 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gIvIGX"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hxldGp"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 bknumx"
+            class="StyledBox-sc-13pk1d4-0 iSpovP"
             style="height: 0px;"
           >
             <label
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hhAlPI"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 byaRhK"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 gOFJEd StyledCheckBox-sc-1dbk5ju-6 ewFUzs"
+                class="StyledBox-sc-13pk1d4-0 kdNZWX StyledCheckBox-sc-1dbk5ju-6 jHuWbF"
               >
                 <input
                   aria-label="select one"
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 yZiQM"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNNTU"
                   type="checkbox"
                 />
                 <div
-                  class="StyledBox-sc-13pk1d4-0 jbiGIb StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 bwjtfK"
+                  class="StyledBox-sc-13pk1d4-0 hSCSzp StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 hZZOmF"
                 />
               </div>
             </label>
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               one
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           />
         </td>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 lgcZWa"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bJGbBs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 hJyDbY"
+            class="StyledBox-sc-13pk1d4-0 ccXjKC"
             style="height: 0px;"
           >
             <button
               aria-expanded="false"
               aria-label="expand "
-              class="StyledButton-sc-323bzc-0 kPGkLU"
+              class="StyledButton-sc-323bzc-0 gxPxGa"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 iXSmVm"
+                class="StyledBox-sc-13pk1d4-0 jAIAuI"
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-sc-ofa7kd-0 cbAOVH"
+                  class="StyledIcon-sc-ofa7kd-0 dJyQSO"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -15693,49 +15695,49 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gIvIGX"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hxldGp"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 bknumx"
+            class="StyledBox-sc-13pk1d4-0 iSpovP"
             style="height: 0px;"
           >
             <label
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hhAlPI"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 byaRhK"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 gOFJEd StyledCheckBox-sc-1dbk5ju-6 ewFUzs"
+                class="StyledBox-sc-13pk1d4-0 kdNZWX StyledCheckBox-sc-1dbk5ju-6 jHuWbF"
               >
                 <input
                   aria-label="select two"
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 yZiQM"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNNTU"
                   type="checkbox"
                 />
                 <div
-                  class="StyledBox-sc-13pk1d4-0 jbiGIb StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 bwjtfK"
+                  class="StyledBox-sc-13pk1d4-0 hSCSzp StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 hZZOmF"
                 />
               </div>
             </label>
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               two
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           />
         </td>
       </tr>
@@ -16274,38 +16276,38 @@ exports[`DataTable onSelect select/unselect all 1`] = `
 
 exports[`DataTable onSelect select/unselect all 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
+  class="StyledGrommet-sc-19lkkz7-0 iQmOCy"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 gfvJtN StyledDataTable-sc-xrlyjm-0 iySlWL"
+    class="StyledTable-sc-1m3u5g-6 hItFIU StyledDataTable-sc-xrlyjm-0 bhJXnf"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-5"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 ktKCWw"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 hGRSSL"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kdJQYN StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jThOtf StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 bknumx"
+            class="StyledBox-sc-13pk1d4-0 iSpovP"
             style="height: 0px;"
           >
             <label
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hhAlPI"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 byaRhK"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 gOFJEd StyledCheckBox-sc-1dbk5ju-6 ewFUzs"
+                class="StyledBox-sc-13pk1d4-0 kdNZWX StyledCheckBox-sc-1dbk5ju-6 jHuWbF"
               >
                 <input
                   aria-label="unselect all"
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 yZiQM"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNNTU"
                   type="checkbox"
                 />
                 <div
-                  class="StyledBox-sc-13pk1d4-0 gHSfwH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 bwjtfK"
+                  class="StyledBox-sc-13pk1d4-0 cJyZCd StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 hZZOmF"
                 >
                   .c0 {
   box-sizing: border-box;
@@ -16339,30 +16341,30 @@ exports[`DataTable onSelect select/unselect all 2`] = `
           </div>
         </th>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksVeQF StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jabPpn StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           id="grommet-data-table-header-a"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
+            class="StyledBox-sc-13pk1d4-0 faLdcD"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               A
             </span>
           </div>
         </th>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksVeQF StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jabPpn StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           id="grommet-data-table-header-b"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
+            class="StyledBox-sc-13pk1d4-0 faLdcD"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               B
             </span>
@@ -16371,31 +16373,31 @@ exports[`DataTable onSelect select/unselect all 2`] = `
       </tr>
     </thead>
     <tbody
-      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 buut"
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 dRPopI"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gIvIGX StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hxldGp StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 bknumx"
+            class="StyledBox-sc-13pk1d4-0 iSpovP"
             style="height: 0px;"
           >
             <label
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hhAlPI"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 byaRhK"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 gOFJEd StyledCheckBox-sc-1dbk5ju-6 ewFUzs"
+                class="StyledBox-sc-13pk1d4-0 kdNZWX StyledCheckBox-sc-1dbk5ju-6 jHuWbF"
               >
                 <input
                   aria-label="unselect 1.1"
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 yZiQM"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNNTU"
                   type="checkbox"
                 />
                 <div
-                  class="StyledBox-sc-13pk1d4-0 gHSfwH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 bwjtfK"
+                  class="StyledBox-sc-13pk1d4-0 cJyZCd StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 hZZOmF"
                 >
                   .c0 {
   box-sizing: border-box;
@@ -16429,27 +16431,27 @@ exports[`DataTable onSelect select/unselect all 2`] = `
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               one
             </span>
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 gIpquo"
+              class="StyledText-sc-1sadyjn-0 bAcCYq"
             >
               1.1
             </span>
@@ -16457,28 +16459,28 @@ exports[`DataTable onSelect select/unselect all 2`] = `
         </th>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gIvIGX StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hxldGp StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 bknumx"
+            class="StyledBox-sc-13pk1d4-0 iSpovP"
             style="height: 0px;"
           >
             <label
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hhAlPI"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 byaRhK"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 gOFJEd StyledCheckBox-sc-1dbk5ju-6 ewFUzs"
+                class="StyledBox-sc-13pk1d4-0 kdNZWX StyledCheckBox-sc-1dbk5ju-6 jHuWbF"
               >
                 <input
                   aria-label="unselect 1.2"
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 yZiQM"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNNTU"
                   type="checkbox"
                 />
                 <div
-                  class="StyledBox-sc-13pk1d4-0 gHSfwH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 bwjtfK"
+                  class="StyledBox-sc-13pk1d4-0 cJyZCd StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 hZZOmF"
                 >
                   .c0 {
   box-sizing: border-box;
@@ -16512,27 +16514,27 @@ exports[`DataTable onSelect select/unselect all 2`] = `
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               one
             </span>
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 gIpquo"
+              class="StyledText-sc-1sadyjn-0 bAcCYq"
             >
               1.2
             </span>
@@ -16540,28 +16542,28 @@ exports[`DataTable onSelect select/unselect all 2`] = `
         </th>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gIvIGX StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hxldGp StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 bknumx"
+            class="StyledBox-sc-13pk1d4-0 iSpovP"
             style="height: 0px;"
           >
             <label
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hhAlPI"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 byaRhK"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 gOFJEd StyledCheckBox-sc-1dbk5ju-6 ewFUzs"
+                class="StyledBox-sc-13pk1d4-0 kdNZWX StyledCheckBox-sc-1dbk5ju-6 jHuWbF"
               >
                 <input
                   aria-label="unselect 2.1"
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 yZiQM"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNNTU"
                   type="checkbox"
                 />
                 <div
-                  class="StyledBox-sc-13pk1d4-0 gHSfwH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 bwjtfK"
+                  class="StyledBox-sc-13pk1d4-0 cJyZCd StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 hZZOmF"
                 >
                   .c0 {
   box-sizing: border-box;
@@ -16595,27 +16597,27 @@ exports[`DataTable onSelect select/unselect all 2`] = `
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               two
             </span>
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 gIpquo"
+              class="StyledText-sc-1sadyjn-0 bAcCYq"
             >
               2.1
             </span>
@@ -16623,28 +16625,28 @@ exports[`DataTable onSelect select/unselect all 2`] = `
         </th>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gIvIGX StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hxldGp StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 bknumx"
+            class="StyledBox-sc-13pk1d4-0 iSpovP"
             style="height: 0px;"
           >
             <label
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hhAlPI"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 byaRhK"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 gOFJEd StyledCheckBox-sc-1dbk5ju-6 ewFUzs"
+                class="StyledBox-sc-13pk1d4-0 kdNZWX StyledCheckBox-sc-1dbk5ju-6 jHuWbF"
               >
                 <input
                   aria-label="unselect 2.2"
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 yZiQM"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNNTU"
                   type="checkbox"
                 />
                 <div
-                  class="StyledBox-sc-13pk1d4-0 gHSfwH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 bwjtfK"
+                  class="StyledBox-sc-13pk1d4-0 cJyZCd StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 hZZOmF"
                 >
                   .c0 {
   box-sizing: border-box;
@@ -16678,27 +16680,27 @@ exports[`DataTable onSelect select/unselect all 2`] = `
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               two
             </span>
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 gIpquo"
+              class="StyledText-sc-1sadyjn-0 bAcCYq"
             >
               2.2
             </span>
@@ -16712,68 +16714,68 @@ exports[`DataTable onSelect select/unselect all 2`] = `
 
 exports[`DataTable onSelect select/unselect all 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
+  class="StyledGrommet-sc-19lkkz7-0 iQmOCy"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 gfvJtN StyledDataTable-sc-xrlyjm-0 iySlWL"
+    class="StyledTable-sc-1m3u5g-6 hItFIU StyledDataTable-sc-xrlyjm-0 bhJXnf"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-5"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 ktKCWw"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 hGRSSL"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kdJQYN StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jThOtf StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 bknumx"
+            class="StyledBox-sc-13pk1d4-0 iSpovP"
             style="height: 0px;"
           >
             <label
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hhAlPI"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 byaRhK"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 gOFJEd StyledCheckBox-sc-1dbk5ju-6 ewFUzs"
+                class="StyledBox-sc-13pk1d4-0 kdNZWX StyledCheckBox-sc-1dbk5ju-6 jHuWbF"
               >
                 <input
                   aria-label="select all"
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 yZiQM"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNNTU"
                   type="checkbox"
                 />
                 <div
-                  class="StyledBox-sc-13pk1d4-0 jbiGIb StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 bwjtfK"
+                  class="StyledBox-sc-13pk1d4-0 hSCSzp StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 hZZOmF"
                 />
               </div>
             </label>
           </div>
         </th>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksVeQF StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jabPpn StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           id="grommet-data-table-header-a"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
+            class="StyledBox-sc-13pk1d4-0 faLdcD"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               A
             </span>
           </div>
         </th>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksVeQF StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jabPpn StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           id="grommet-data-table-header-b"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
+            class="StyledBox-sc-13pk1d4-0 faLdcD"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               B
             </span>
@@ -16782,58 +16784,58 @@ exports[`DataTable onSelect select/unselect all 3`] = `
       </tr>
     </thead>
     <tbody
-      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 buut"
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 dRPopI"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gIvIGX StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hxldGp StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 bknumx"
+            class="StyledBox-sc-13pk1d4-0 iSpovP"
             style="height: 0px;"
           >
             <label
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hhAlPI"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 byaRhK"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 gOFJEd StyledCheckBox-sc-1dbk5ju-6 ewFUzs"
+                class="StyledBox-sc-13pk1d4-0 kdNZWX StyledCheckBox-sc-1dbk5ju-6 jHuWbF"
               >
                 <input
                   aria-label="select 1.1"
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 yZiQM"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNNTU"
                   type="checkbox"
                 />
                 <div
-                  class="StyledBox-sc-13pk1d4-0 jbiGIb StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 bwjtfK"
+                  class="StyledBox-sc-13pk1d4-0 hSCSzp StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 hZZOmF"
                 />
               </div>
             </label>
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               one
             </span>
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 gIpquo"
+              class="StyledText-sc-1sadyjn-0 bAcCYq"
             >
               1.1
             </span>
@@ -16841,55 +16843,55 @@ exports[`DataTable onSelect select/unselect all 3`] = `
         </th>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gIvIGX StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hxldGp StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 bknumx"
+            class="StyledBox-sc-13pk1d4-0 iSpovP"
             style="height: 0px;"
           >
             <label
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hhAlPI"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 byaRhK"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 gOFJEd StyledCheckBox-sc-1dbk5ju-6 ewFUzs"
+                class="StyledBox-sc-13pk1d4-0 kdNZWX StyledCheckBox-sc-1dbk5ju-6 jHuWbF"
               >
                 <input
                   aria-label="select 1.2"
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 yZiQM"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNNTU"
                   type="checkbox"
                 />
                 <div
-                  class="StyledBox-sc-13pk1d4-0 jbiGIb StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 bwjtfK"
+                  class="StyledBox-sc-13pk1d4-0 hSCSzp StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 hZZOmF"
                 />
               </div>
             </label>
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               one
             </span>
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 gIpquo"
+              class="StyledText-sc-1sadyjn-0 bAcCYq"
             >
               1.2
             </span>
@@ -16897,55 +16899,55 @@ exports[`DataTable onSelect select/unselect all 3`] = `
         </th>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gIvIGX StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hxldGp StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 bknumx"
+            class="StyledBox-sc-13pk1d4-0 iSpovP"
             style="height: 0px;"
           >
             <label
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hhAlPI"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 byaRhK"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 gOFJEd StyledCheckBox-sc-1dbk5ju-6 ewFUzs"
+                class="StyledBox-sc-13pk1d4-0 kdNZWX StyledCheckBox-sc-1dbk5ju-6 jHuWbF"
               >
                 <input
                   aria-label="select 2.1"
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 yZiQM"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNNTU"
                   type="checkbox"
                 />
                 <div
-                  class="StyledBox-sc-13pk1d4-0 jbiGIb StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 bwjtfK"
+                  class="StyledBox-sc-13pk1d4-0 hSCSzp StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 hZZOmF"
                 />
               </div>
             </label>
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               two
             </span>
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 gIpquo"
+              class="StyledText-sc-1sadyjn-0 bAcCYq"
             >
               2.1
             </span>
@@ -16953,55 +16955,55 @@ exports[`DataTable onSelect select/unselect all 3`] = `
         </th>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gIvIGX StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hxldGp StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 bknumx"
+            class="StyledBox-sc-13pk1d4-0 iSpovP"
             style="height: 0px;"
           >
             <label
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hhAlPI"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 byaRhK"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 gOFJEd StyledCheckBox-sc-1dbk5ju-6 ewFUzs"
+                class="StyledBox-sc-13pk1d4-0 kdNZWX StyledCheckBox-sc-1dbk5ju-6 jHuWbF"
               >
                 <input
                   aria-label="select 2.2"
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 yZiQM"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNNTU"
                   type="checkbox"
                 />
                 <div
-                  class="StyledBox-sc-13pk1d4-0 jbiGIb StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 bwjtfK"
+                  class="StyledBox-sc-13pk1d4-0 hSCSzp StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 hZZOmF"
                 />
               </div>
             </label>
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               two
             </span>
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 gIpquo"
+              class="StyledText-sc-1sadyjn-0 bAcCYq"
             >
               2.2
             </span>
@@ -17222,6 +17224,7 @@ exports[`DataTable onSort 1`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
       >
         <th
+          aria-sort="none"
           class="c3 "
           id="grommet-data-table-header-a"
           scope="col"
@@ -17246,6 +17249,7 @@ exports[`DataTable onSort 1`] = `
           </div>
         </th>
         <th
+          aria-sort="none"
           class="c3 "
           id="grommet-data-table-header-b"
           scope="col"
@@ -17374,35 +17378,35 @@ exports[`DataTable onSort 1`] = `
 
 exports[`DataTable onSort 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
+  class="StyledGrommet-sc-19lkkz7-0 iQmOCy"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 gfvJtN StyledDataTable-sc-xrlyjm-0 iySlWL"
+    class="StyledTable-sc-1m3u5g-6 hItFIU StyledDataTable-sc-xrlyjm-0 bhJXnf"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-5"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 ktKCWw"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 hGRSSL"
       >
         <th
           aria-sort="ascending"
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kzbMTh StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 beksZj StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           id="grommet-data-table-header-a"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
+            class="StyledBox-sc-13pk1d4-0 faLdcD"
           >
             <button
-              class="StyledButton-sc-323bzc-0 gVLKEX Header__StyledHeaderCellButton-sc-1baku5q-0 llZrcE"
+              class="StyledButton-sc-323bzc-0 efbshF Header__StyledHeaderCellButton-sc-1baku5q-0 gRxSZx"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 bHjtLJ"
+                class="StyledBox-sc-13pk1d4-0 ABJcL"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 iuKlFO"
+                  class="StyledText-sc-1sadyjn-0 cejToA"
                 >
                   A
                 </span>
@@ -17474,22 +17478,23 @@ exports[`DataTable onSort 2`] = `
           </div>
         </th>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kzbMTh StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          aria-sort="none"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 beksZj StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           id="grommet-data-table-header-b"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
+            class="StyledBox-sc-13pk1d4-0 faLdcD"
           >
             <button
-              class="StyledButton-sc-323bzc-0 gVLKEX Header__StyledHeaderCellButton-sc-1baku5q-0 llZrcE"
+              class="StyledButton-sc-323bzc-0 efbshF Header__StyledHeaderCellButton-sc-1baku5q-0 gRxSZx"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 bHjtLJ"
+                class="StyledBox-sc-13pk1d4-0 ABJcL"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 iuKlFO"
+                  class="StyledText-sc-1sadyjn-0 cejToA"
                 >
                   B
                 </span>
@@ -17500,33 +17505,33 @@ exports[`DataTable onSort 2`] = `
       </tr>
     </thead>
     <tbody
-      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 buut"
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 dRPopI"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 gIpquo"
+              class="StyledText-sc-1sadyjn-0 bAcCYq"
             >
               one
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               1
             </span>
@@ -17534,30 +17539,30 @@ exports[`DataTable onSort 2`] = `
         </td>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 gIpquo"
+              class="StyledText-sc-1sadyjn-0 bAcCYq"
             >
               two
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               2
             </span>
@@ -17565,30 +17570,30 @@ exports[`DataTable onSort 2`] = `
         </td>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 gIpquo"
+              class="StyledText-sc-1sadyjn-0 bAcCYq"
             >
               zero
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               0
             </span>
@@ -17893,6 +17898,7 @@ exports[`DataTable onSort external 1`] = `
           </div>
         </th>
         <th
+          aria-sort="none"
           class="c3 "
           id="grommet-data-table-header-b"
           scope="col"
@@ -18021,40 +18027,40 @@ exports[`DataTable onSort external 1`] = `
 
 exports[`DataTable onSort external 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
+  class="StyledGrommet-sc-19lkkz7-0 iQmOCy"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 gfvJtN StyledDataTable-sc-xrlyjm-0 iySlWL"
+    class="StyledTable-sc-1m3u5g-6 hItFIU StyledDataTable-sc-xrlyjm-0 bhJXnf"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-5"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 ktKCWw"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 hGRSSL"
       >
         <th
           aria-sort="descending"
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kzbMTh StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 beksZj StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           id="grommet-data-table-header-a"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
+            class="StyledBox-sc-13pk1d4-0 faLdcD"
           >
             <button
-              class="StyledButton-sc-323bzc-0 gVLKEX Header__StyledHeaderCellButton-sc-1baku5q-0 llZrcE"
+              class="StyledButton-sc-323bzc-0 efbshF Header__StyledHeaderCellButton-sc-1baku5q-0 gRxSZx"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 bHjtLJ"
+                class="StyledBox-sc-13pk1d4-0 ABJcL"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 iuKlFO"
+                  class="StyledText-sc-1sadyjn-0 cejToA"
                 >
                   A
                 </span>
                 <div
-                  class="StyledBox__StyledBoxGap-sc-13pk1d4-1 DBOrP"
+                  class="StyledBox__StyledBoxGap-sc-13pk1d4-1 MZaCP"
                 />
                 .c0 {
   display: inline-block;
@@ -18109,22 +18115,23 @@ exports[`DataTable onSort external 2`] = `
           </div>
         </th>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kzbMTh StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          aria-sort="none"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 beksZj StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           id="grommet-data-table-header-b"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
+            class="StyledBox-sc-13pk1d4-0 faLdcD"
           >
             <button
-              class="StyledButton-sc-323bzc-0 gVLKEX Header__StyledHeaderCellButton-sc-1baku5q-0 llZrcE"
+              class="StyledButton-sc-323bzc-0 efbshF Header__StyledHeaderCellButton-sc-1baku5q-0 gRxSZx"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 bHjtLJ"
+                class="StyledBox-sc-13pk1d4-0 ABJcL"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 iuKlFO"
+                  class="StyledText-sc-1sadyjn-0 cejToA"
                 >
                   B
                 </span>
@@ -18135,33 +18142,33 @@ exports[`DataTable onSort external 2`] = `
       </tr>
     </thead>
     <tbody
-      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 buut"
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 dRPopI"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 gIpquo"
+              class="StyledText-sc-1sadyjn-0 bAcCYq"
             >
               zero
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               0
             </span>
@@ -18169,30 +18176,30 @@ exports[`DataTable onSort external 2`] = `
         </td>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 gIpquo"
+              class="StyledText-sc-1sadyjn-0 bAcCYq"
             >
               one
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               1
             </span>
@@ -18200,30 +18207,30 @@ exports[`DataTable onSort external 2`] = `
         </td>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 gIpquo"
+              class="StyledText-sc-1sadyjn-0 bAcCYq"
             >
               two
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               2
             </span>
@@ -23733,27 +23740,27 @@ exports[`DataTable row click using space key press 1`] = `
 
 exports[`DataTable row click using space key press 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
+  class="StyledGrommet-sc-19lkkz7-0 iQmOCy"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 gfvJtN StyledDataTable-sc-xrlyjm-0 iySlWL"
+    class="StyledTable-sc-1m3u5g-6 hItFIU StyledDataTable-sc-xrlyjm-0 bhJXnf"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-5"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 ktKCWw"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 hGRSSL"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksVeQF StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jabPpn StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           id="grommet-data-table-header-name"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
+            class="StyledBox-sc-13pk1d4-0 faLdcD"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               Name
             </span>
@@ -23762,21 +23769,21 @@ exports[`DataTable row click using space key press 2`] = `
       </tr>
     </thead>
     <tbody
-      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 buut"
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 dRPopI"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iQTwbZ"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 gFGXBk"
         tabindex="0"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 gIpquo"
+              class="StyledText-sc-1sadyjn-0 bAcCYq"
             >
               alpha
             </span>
@@ -26268,38 +26275,38 @@ exports[`DataTable select 1`] = `
 
 exports[`DataTable select 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
+  class="StyledGrommet-sc-19lkkz7-0 iQmOCy"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 gfvJtN StyledDataTable-sc-xrlyjm-0 iySlWL"
+    class="StyledTable-sc-1m3u5g-6 hItFIU StyledDataTable-sc-xrlyjm-0 bhJXnf"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-5"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 ktKCWw"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 hGRSSL"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kdJQYN StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jThOtf StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 bknumx"
+            class="StyledBox-sc-13pk1d4-0 iSpovP"
             style="height: 0px;"
           >
             <label
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hhAlPI"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 byaRhK"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 gOFJEd StyledCheckBox-sc-1dbk5ju-6 ewFUzs"
+                class="StyledBox-sc-13pk1d4-0 kdNZWX StyledCheckBox-sc-1dbk5ju-6 jHuWbF"
               >
                 <input
                   aria-label="unselect all"
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 yZiQM"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNNTU"
                   type="checkbox"
                 />
                 <div
-                  class="StyledBox-sc-13pk1d4-0 gHSfwH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 bwjtfK"
+                  class="StyledBox-sc-13pk1d4-0 cJyZCd StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 hZZOmF"
                 >
                   .c0 {
   box-sizing: border-box;
@@ -26333,15 +26340,15 @@ exports[`DataTable select 2`] = `
           </div>
         </th>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksVeQF StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jabPpn StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           id="grommet-data-table-header-a"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
+            class="StyledBox-sc-13pk1d4-0 faLdcD"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               A
             </span>
@@ -26350,35 +26357,35 @@ exports[`DataTable select 2`] = `
       </tr>
     </thead>
     <tbody
-      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 buut"
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 dRPopI"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gIvIGX StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hxldGp StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 bknumx"
+            class="StyledBox-sc-13pk1d4-0 iSpovP"
             style="height: 0px;"
           >
             <label
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hhAlPI"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 byaRhK"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 gOFJEd StyledCheckBox-sc-1dbk5ju-6 ewFUzs"
+                class="StyledBox-sc-13pk1d4-0 kdNZWX StyledCheckBox-sc-1dbk5ju-6 jHuWbF"
               >
                 <input
                   aria-label="unselect alpha"
                   checked=""
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 yZiQM"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNNTU"
                   type="checkbox"
                 />
                 <div
-                  class="StyledBox-sc-13pk1d4-0 gHSfwH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 bwjtfK"
+                  class="StyledBox-sc-13pk1d4-0 cJyZCd StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 hZZOmF"
                 >
                   <svg
-                    class="StyledCheckBox__StyledCheckBoxIcon-sc-1dbk5ju-0 gLSxni"
+                    class="StyledCheckBox__StyledCheckBoxIcon-sc-1dbk5ju-0 eNRRvC"
                     preserveAspectRatio="xMidYMid meet"
                     viewBox="0 0 24 24"
                   >
@@ -26393,14 +26400,14 @@ exports[`DataTable select 2`] = `
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 gIpquo"
+              class="StyledText-sc-1sadyjn-0 bAcCYq"
             >
               alpha
             </span>
@@ -26408,28 +26415,28 @@ exports[`DataTable select 2`] = `
         </th>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gIvIGX StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hxldGp StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 bknumx"
+            class="StyledBox-sc-13pk1d4-0 iSpovP"
             style="height: 0px;"
           >
             <label
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hhAlPI"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 byaRhK"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 gOFJEd StyledCheckBox-sc-1dbk5ju-6 ewFUzs"
+                class="StyledBox-sc-13pk1d4-0 kdNZWX StyledCheckBox-sc-1dbk5ju-6 jHuWbF"
               >
                 <input
                   aria-label="unselect beta"
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 yZiQM"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNNTU"
                   type="checkbox"
                 />
                 <div
-                  class="StyledBox-sc-13pk1d4-0 gHSfwH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 bwjtfK"
+                  class="StyledBox-sc-13pk1d4-0 cJyZCd StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 hZZOmF"
                 >
                   .c0 {
   box-sizing: border-box;
@@ -26463,14 +26470,14 @@ exports[`DataTable select 2`] = `
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 gIpquo"
+              class="StyledText-sc-1sadyjn-0 bAcCYq"
             >
               beta
             </span>
@@ -26878,31 +26885,31 @@ exports[`DataTable select with allowSelectAll={false} 1`] = `
 
 exports[`DataTable select with allowSelectAll={false} 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
+  class="StyledGrommet-sc-19lkkz7-0 iQmOCy"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 gfvJtN StyledDataTable-sc-xrlyjm-0 iySlWL"
+    class="StyledTable-sc-1m3u5g-6 hItFIU StyledDataTable-sc-xrlyjm-0 bhJXnf"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-5"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 ktKCWw"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 hGRSSL"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kdJQYN StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jThOtf StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="col"
         />
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksVeQF StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jabPpn StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           id="grommet-data-table-header-a"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
+            class="StyledBox-sc-13pk1d4-0 faLdcD"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               A
             </span>
@@ -26911,35 +26918,35 @@ exports[`DataTable select with allowSelectAll={false} 2`] = `
       </tr>
     </thead>
     <tbody
-      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 buut"
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 dRPopI"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gIvIGX StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hxldGp StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 bknumx"
+            class="StyledBox-sc-13pk1d4-0 iSpovP"
             style="height: 0px;"
           >
             <label
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hhAlPI"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 byaRhK"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 gOFJEd StyledCheckBox-sc-1dbk5ju-6 ewFUzs"
+                class="StyledBox-sc-13pk1d4-0 kdNZWX StyledCheckBox-sc-1dbk5ju-6 jHuWbF"
               >
                 <input
                   aria-label="unselect alpha"
                   checked=""
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 yZiQM"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNNTU"
                   type="checkbox"
                 />
                 <div
-                  class="StyledBox-sc-13pk1d4-0 gHSfwH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 bwjtfK"
+                  class="StyledBox-sc-13pk1d4-0 cJyZCd StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 hZZOmF"
                 >
                   <svg
-                    class="StyledCheckBox__StyledCheckBoxIcon-sc-1dbk5ju-0 gLSxni"
+                    class="StyledCheckBox__StyledCheckBoxIcon-sc-1dbk5ju-0 eNRRvC"
                     preserveAspectRatio="xMidYMid meet"
                     viewBox="0 0 24 24"
                   >
@@ -26954,14 +26961,14 @@ exports[`DataTable select with allowSelectAll={false} 2`] = `
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 gIpquo"
+              class="StyledText-sc-1sadyjn-0 bAcCYq"
             >
               alpha
             </span>
@@ -26969,28 +26976,28 @@ exports[`DataTable select with allowSelectAll={false} 2`] = `
         </th>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gIvIGX StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hxldGp StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 bknumx"
+            class="StyledBox-sc-13pk1d4-0 iSpovP"
             style="height: 0px;"
           >
             <label
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hhAlPI"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 byaRhK"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 gOFJEd StyledCheckBox-sc-1dbk5ju-6 ewFUzs"
+                class="StyledBox-sc-13pk1d4-0 kdNZWX StyledCheckBox-sc-1dbk5ju-6 jHuWbF"
               >
                 <input
                   aria-label="unselect beta"
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 yZiQM"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNNTU"
                   type="checkbox"
                 />
                 <div
-                  class="StyledBox-sc-13pk1d4-0 gHSfwH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 bwjtfK"
+                  class="StyledBox-sc-13pk1d4-0 cJyZCd StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 hZZOmF"
                 >
                   .c0 {
   box-sizing: border-box;
@@ -27024,14 +27031,14 @@ exports[`DataTable select with allowSelectAll={false} 2`] = `
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 gIpquo"
+              class="StyledText-sc-1sadyjn-0 bAcCYq"
             >
               beta
             </span>
@@ -41483,48 +41490,48 @@ exports[`DataTable should render new data when page changes 1`] = `
 
 exports[`DataTable should render new data when page changes 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
+  class="StyledGrommet-sc-19lkkz7-0 iQmOCy"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 RYmEp StyledDataTable__StyledContainer-sc-xrlyjm-1 eqDRet"
+    class="StyledBox-sc-13pk1d4-0 eLlRsv StyledDataTable__StyledContainer-sc-xrlyjm-1 ijKmFk"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hUfIKl"
+      class="StyledBox-sc-13pk1d4-0 kZxVGb"
     >
       <table
-        class="StyledTable-sc-1m3u5g-6 gfvJtN StyledDataTable-sc-xrlyjm-0 iySlWL"
+        class="StyledTable-sc-1m3u5g-6 hItFIU StyledDataTable-sc-xrlyjm-0 bhJXnf"
       >
         <thead
           class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-5"
         >
           <tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 ktKCWw"
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 hGRSSL"
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksVeQF StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 jabPpn StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
               id="grommet-data-table-header-a"
               scope="col"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kTYaFZ"
+                class="StyledBox-sc-13pk1d4-0 faLdcD"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 iuKlFO"
+                  class="StyledText-sc-1sadyjn-0 cejToA"
                 >
                   A
                 </span>
               </div>
             </th>
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksVeQF StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 jabPpn StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
               id="grommet-data-table-header-b"
               scope="col"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kTYaFZ"
+                class="StyledBox-sc-13pk1d4-0 faLdcD"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 iuKlFO"
+                  class="StyledText-sc-1sadyjn-0 cejToA"
                 >
                   B
                 </span>
@@ -41533,7 +41540,7 @@ exports[`DataTable should render new data when page changes 2`] = `
           </tr>
         </thead>
         <tbody
-          class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 buut"
+          class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 dRPopI"
         >
           .c2 {
   display: flex;
@@ -46894,29 +46901,29 @@ exports[`DataTable should render new data when page changes 2`] = `
       </table>
     </div>
     <div
-      class="StyledBox__StyledBoxGap-sc-13pk1d4-1 fjqMzP"
+      class="StyledBox__StyledBoxGap-sc-13pk1d4-1 cKRbXv"
     />
     <div
-      class="StyledBox-sc-13pk1d4-0 iKrjnc Pagination__StyledPaginationContainer-sc-rnlw6m-0"
+      class="StyledBox-sc-13pk1d4-0 jjMhUu Pagination__StyledPaginationContainer-sc-rnlw6m-0"
     >
       <nav
         aria-label="Pagination Navigation"
-        class="StyledBox-sc-13pk1d4-0 kvqQSo"
+        class="StyledBox-sc-13pk1d4-0 kBbldi"
       >
         <ul
-          class="StyledBox-sc-13pk1d4-0 fLmLVT"
+          class="StyledBox-sc-13pk1d4-0 bPPvCJ"
         >
           <li
-            class="StyledPageControl__StyledContainer-sc-1vlfaez-1 jLcxjj"
+            class="StyledPageControl__StyledContainer-sc-1vlfaez-1 budBqk"
           >
             <button
               aria-label="Go to previous page"
-              class="StyledButtonKind-sc-1vhfpnt-0 cyhaTC StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iIrhyI"
+              class="StyledButtonKind-sc-1vhfpnt-0 bKxNBy StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 gHDXxA"
               type="button"
             >
               <svg
                 aria-label="Previous"
-                class="StyledIcon-sc-ofa7kd-0 dQGxSn"
+                class="StyledIcon-sc-ofa7kd-0 cDZJSy"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -46929,41 +46936,41 @@ exports[`DataTable should render new data when page changes 2`] = `
             </button>
           </li>
           <li
-            class="StyledPageControl__StyledContainer-sc-1vlfaez-1 jLcxjj"
+            class="StyledPageControl__StyledContainer-sc-1vlfaez-1 budBqk"
           >
             <button
               aria-label="Go to page 1"
-              class="StyledButtonKind-sc-1vhfpnt-0 eQoSrm StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iIrhyI"
+              class="StyledButtonKind-sc-1vhfpnt-0 isArty StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 gHDXxA"
               type="button"
             >
               1
             </button>
           </li>
           <li
-            class="StyledPageControl__StyledContainer-sc-1vlfaez-1 jLcxjj"
+            class="StyledPageControl__StyledContainer-sc-1vlfaez-1 budBqk"
           >
             <button
               aria-current="page"
               aria-label="Go to page 2"
-              class="StyledButtonKind-sc-1vhfpnt-0 ecJohc StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iIrhyI"
+              class="StyledButtonKind-sc-1vhfpnt-0 kgFhFU StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 gHDXxA"
               type="button"
             >
               2
             </button>
           </li>
           <li
-            class="StyledPageControl__StyledContainer-sc-1vlfaez-1 jLcxjj"
+            class="StyledPageControl__StyledContainer-sc-1vlfaez-1 budBqk"
           >
             <button
               aria-disabled="true"
               aria-label="Go to next page"
-              class="StyledButtonKind-sc-1vhfpnt-0 kTFFQa StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iIrhyI"
+              class="StyledButtonKind-sc-1vhfpnt-0 coAhHy StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 gHDXxA"
               disabled=""
               type="button"
             >
               <svg
                 aria-label="Next"
-                class="StyledIcon-sc-ofa7kd-0 blUuJr"
+                class="StyledIcon-sc-ofa7kd-0 fmAnVC"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -51733,36 +51740,36 @@ exports[`DataTable should use theme icons 1`] = `
 
 exports[`DataTable should use theme icons 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
+  class="StyledGrommet-sc-19lkkz7-0 iQmOCy"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 gfvJtN StyledDataTable-sc-xrlyjm-0 iySlWL"
+    class="StyledTable-sc-1m3u5g-6 hItFIU StyledDataTable-sc-xrlyjm-0 bhJXnf"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-5"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 ktKCWw"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 hGRSSL"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksVeQF StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jabPpn StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           id="grommet-data-table-header-a"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 jDPdXr"
+            class="StyledBox-sc-13pk1d4-0 bvGdsN"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 cyLFae"
+              class="StyledBox-sc-13pk1d4-0 eeJSdc"
             >
               <span
-                class="StyledText-sc-1sadyjn-0 iuKlFO"
+                class="StyledText-sc-1sadyjn-0 cejToA"
               >
                 A
               </span>
             </div>
             <div
-              class="StyledBox__StyledBoxGap-sc-13pk1d4-1 izwkgv"
+              class="StyledBox__StyledBoxGap-sc-13pk1d4-1 qcwOP"
             />
             .c0 {
   display: flex;
@@ -51873,20 +51880,20 @@ exports[`DataTable should use theme icons 2`] = `
       </tr>
     </thead>
     <tbody
-      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 buut"
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 dRPopI"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 gIpquo"
+              class="StyledText-sc-1sadyjn-0 bAcCYq"
             >
               []
             </span>
@@ -52191,6 +52198,7 @@ exports[`DataTable sort 1`] = `
           </div>
         </th>
         <th
+          aria-sort="none"
           class="c3 "
           id="grommet-data-table-header-b"
           scope="col"
@@ -52682,6 +52690,7 @@ exports[`DataTable sort controlled 1`] = `
             </div>
           </th>
           <th
+            aria-sort="none"
             class="c4 "
             id="grommet-data-table-header-b"
             scope="col"
@@ -53174,6 +53183,7 @@ exports[`DataTable sort controlled 2`] = `
             </div>
           </th>
           <th
+            aria-sort="none"
             class="c4 "
             id="grommet-data-table-header-b"
             scope="col"
@@ -53594,6 +53604,7 @@ exports[`DataTable sort external 1`] = `
           </div>
         </th>
         <th
+          aria-sort="none"
           class="c3 "
           id="grommet-data-table-header-b"
           scope="col"
@@ -53973,6 +53984,7 @@ exports[`DataTable sort nested object 1`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
       >
         <th
+          aria-sort="none"
           class="c3 "
           id="grommet-data-table-header-a"
           scope="col"
@@ -54392,6 +54404,7 @@ exports[`DataTable sort nested object with onSort 1`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
       >
         <th
+          aria-sort="none"
           class="c3 "
           id="grommet-data-table-header-a"
           scope="col"
@@ -54767,6 +54780,7 @@ exports[`DataTable sort null data 1`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
       >
         <th
+          aria-sort="none"
           class="c3 "
           id="grommet-data-table-header-a"
           scope="col"
@@ -54791,6 +54805,7 @@ exports[`DataTable sort null data 1`] = `
           </div>
         </th>
         <th
+          aria-sort="none"
           class="c3 "
           id="grommet-data-table-header-b"
           scope="col"
@@ -54815,6 +54830,7 @@ exports[`DataTable sort null data 1`] = `
           </div>
         </th>
         <th
+          aria-sort="none"
           class="c3 "
           id="grommet-data-table-header-c"
           scope="col"
@@ -54839,6 +54855,7 @@ exports[`DataTable sort null data 1`] = `
           </div>
         </th>
         <th
+          aria-sort="none"
           class="c3 "
           id="grommet-data-table-header-d"
           scope="col"
@@ -55066,35 +55083,35 @@ exports[`DataTable sort null data 1`] = `
 
 exports[`DataTable sort null data 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
+  class="StyledGrommet-sc-19lkkz7-0 iQmOCy"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 gfvJtN StyledDataTable-sc-xrlyjm-0 iySlWL"
+    class="StyledTable-sc-1m3u5g-6 hItFIU StyledDataTable-sc-xrlyjm-0 bhJXnf"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-5"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 ktKCWw"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 hGRSSL"
       >
         <th
           aria-sort="ascending"
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kzbMTh StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 beksZj StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           id="grommet-data-table-header-a"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
+            class="StyledBox-sc-13pk1d4-0 faLdcD"
           >
             <button
-              class="StyledButton-sc-323bzc-0 gVLKEX Header__StyledHeaderCellButton-sc-1baku5q-0 llZrcE"
+              class="StyledButton-sc-323bzc-0 efbshF Header__StyledHeaderCellButton-sc-1baku5q-0 gRxSZx"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 bHjtLJ"
+                class="StyledBox-sc-13pk1d4-0 ABJcL"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 iuKlFO"
+                  class="StyledText-sc-1sadyjn-0 cejToA"
                 >
                   A
                 </span>
@@ -55166,22 +55183,23 @@ exports[`DataTable sort null data 2`] = `
           </div>
         </th>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kzbMTh StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          aria-sort="none"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 beksZj StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           id="grommet-data-table-header-b"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
+            class="StyledBox-sc-13pk1d4-0 faLdcD"
           >
             <button
-              class="StyledButton-sc-323bzc-0 gVLKEX Header__StyledHeaderCellButton-sc-1baku5q-0 llZrcE"
+              class="StyledButton-sc-323bzc-0 efbshF Header__StyledHeaderCellButton-sc-1baku5q-0 gRxSZx"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 bHjtLJ"
+                class="StyledBox-sc-13pk1d4-0 ABJcL"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 iuKlFO"
+                  class="StyledText-sc-1sadyjn-0 cejToA"
                 >
                   B
                 </span>
@@ -55190,22 +55208,23 @@ exports[`DataTable sort null data 2`] = `
           </div>
         </th>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kzbMTh StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          aria-sort="none"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 beksZj StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           id="grommet-data-table-header-c"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
+            class="StyledBox-sc-13pk1d4-0 faLdcD"
           >
             <button
-              class="StyledButton-sc-323bzc-0 gVLKEX Header__StyledHeaderCellButton-sc-1baku5q-0 llZrcE"
+              class="StyledButton-sc-323bzc-0 efbshF Header__StyledHeaderCellButton-sc-1baku5q-0 gRxSZx"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 bHjtLJ"
+                class="StyledBox-sc-13pk1d4-0 ABJcL"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 iuKlFO"
+                  class="StyledText-sc-1sadyjn-0 cejToA"
                 >
                   C
                 </span>
@@ -55214,22 +55233,23 @@ exports[`DataTable sort null data 2`] = `
           </div>
         </th>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kzbMTh StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          aria-sort="none"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 beksZj StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           id="grommet-data-table-header-d"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
+            class="StyledBox-sc-13pk1d4-0 faLdcD"
           >
             <button
-              class="StyledButton-sc-323bzc-0 gVLKEX Header__StyledHeaderCellButton-sc-1baku5q-0 llZrcE"
+              class="StyledButton-sc-323bzc-0 efbshF Header__StyledHeaderCellButton-sc-1baku5q-0 gRxSZx"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 bHjtLJ"
+                class="StyledBox-sc-13pk1d4-0 ABJcL"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 iuKlFO"
+                  class="StyledText-sc-1sadyjn-0 cejToA"
                 >
                   D
                 </span>
@@ -55240,53 +55260,53 @@ exports[`DataTable sort null data 2`] = `
       </tr>
     </thead>
     <tbody
-      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 buut"
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 dRPopI"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           />
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               0
             </span>
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               first
             </span>
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               y
             </span>
@@ -55409,98 +55429,98 @@ exports[`DataTable sort null data 2`] = `
         </td>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 gIpquo"
+              class="StyledText-sc-1sadyjn-0 bAcCYq"
             >
               one
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               1
             </span>
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           />
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           />
         </td>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 gIpquo"
+              class="StyledText-sc-1sadyjn-0 bAcCYq"
             >
               two
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               2
             </span>
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               second
             </span>
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           />
         </td>
       </tr>
@@ -55511,34 +55531,35 @@ exports[`DataTable sort null data 2`] = `
 
 exports[`DataTable sort null data 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
+  class="StyledGrommet-sc-19lkkz7-0 iQmOCy"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 gfvJtN StyledDataTable-sc-xrlyjm-0 iySlWL"
+    class="StyledTable-sc-1m3u5g-6 hItFIU StyledDataTable-sc-xrlyjm-0 bhJXnf"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-5"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 ktKCWw"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 hGRSSL"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kzbMTh StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          aria-sort="none"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 beksZj StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           id="grommet-data-table-header-a"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
+            class="StyledBox-sc-13pk1d4-0 faLdcD"
           >
             <button
-              class="StyledButton-sc-323bzc-0 gVLKEX Header__StyledHeaderCellButton-sc-1baku5q-0 llZrcE"
+              class="StyledButton-sc-323bzc-0 efbshF Header__StyledHeaderCellButton-sc-1baku5q-0 gRxSZx"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 bHjtLJ"
+                class="StyledBox-sc-13pk1d4-0 ABJcL"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 iuKlFO"
+                  class="StyledText-sc-1sadyjn-0 cejToA"
                 >
                   A
                 </span>
@@ -55547,22 +55568,23 @@ exports[`DataTable sort null data 3`] = `
           </div>
         </th>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kzbMTh StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          aria-sort="none"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 beksZj StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           id="grommet-data-table-header-b"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
+            class="StyledBox-sc-13pk1d4-0 faLdcD"
           >
             <button
-              class="StyledButton-sc-323bzc-0 gVLKEX Header__StyledHeaderCellButton-sc-1baku5q-0 llZrcE"
+              class="StyledButton-sc-323bzc-0 efbshF Header__StyledHeaderCellButton-sc-1baku5q-0 gRxSZx"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 bHjtLJ"
+                class="StyledBox-sc-13pk1d4-0 ABJcL"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 iuKlFO"
+                  class="StyledText-sc-1sadyjn-0 cejToA"
                 >
                   B
                 </span>
@@ -55572,22 +55594,22 @@ exports[`DataTable sort null data 3`] = `
         </th>
         <th
           aria-sort="ascending"
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kzbMTh StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 beksZj StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           id="grommet-data-table-header-c"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
+            class="StyledBox-sc-13pk1d4-0 faLdcD"
           >
             <button
-              class="StyledButton-sc-323bzc-0 gVLKEX Header__StyledHeaderCellButton-sc-1baku5q-0 llZrcE"
+              class="StyledButton-sc-323bzc-0 efbshF Header__StyledHeaderCellButton-sc-1baku5q-0 gRxSZx"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 bHjtLJ"
+                class="StyledBox-sc-13pk1d4-0 ABJcL"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 iuKlFO"
+                  class="StyledText-sc-1sadyjn-0 cejToA"
                 >
                   C
                 </span>
@@ -55659,22 +55681,23 @@ exports[`DataTable sort null data 3`] = `
           </div>
         </th>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kzbMTh StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          aria-sort="none"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 beksZj StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           id="grommet-data-table-header-d"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
+            class="StyledBox-sc-13pk1d4-0 faLdcD"
           >
             <button
-              class="StyledButton-sc-323bzc-0 gVLKEX Header__StyledHeaderCellButton-sc-1baku5q-0 llZrcE"
+              class="StyledButton-sc-323bzc-0 efbshF Header__StyledHeaderCellButton-sc-1baku5q-0 gRxSZx"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 bHjtLJ"
+                class="StyledBox-sc-13pk1d4-0 ABJcL"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 iuKlFO"
+                  class="StyledText-sc-1sadyjn-0 cejToA"
                 >
                   D
                 </span>
@@ -55685,92 +55708,92 @@ exports[`DataTable sort null data 3`] = `
       </tr>
     </thead>
     <tbody
-      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 buut"
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 dRPopI"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 gIpquo"
+              class="StyledText-sc-1sadyjn-0 bAcCYq"
             >
               one
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               1
             </span>
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           />
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           />
         </td>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           />
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               3
             </span>
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           />
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               z
             </span>
@@ -55899,53 +55922,53 @@ exports[`DataTable sort null data 3`] = `
         </td>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 gIpquo"
+              class="StyledText-sc-1sadyjn-0 bAcCYq"
             >
               two
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               2
             </span>
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               second
             </span>
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           />
         </td>
       </tr>
@@ -55956,34 +55979,35 @@ exports[`DataTable sort null data 3`] = `
 
 exports[`DataTable sort null data 4`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
+  class="StyledGrommet-sc-19lkkz7-0 iQmOCy"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 gfvJtN StyledDataTable-sc-xrlyjm-0 iySlWL"
+    class="StyledTable-sc-1m3u5g-6 hItFIU StyledDataTable-sc-xrlyjm-0 bhJXnf"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-5"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 ktKCWw"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 hGRSSL"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kzbMTh StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          aria-sort="none"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 beksZj StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           id="grommet-data-table-header-a"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
+            class="StyledBox-sc-13pk1d4-0 faLdcD"
           >
             <button
-              class="StyledButton-sc-323bzc-0 gVLKEX Header__StyledHeaderCellButton-sc-1baku5q-0 llZrcE"
+              class="StyledButton-sc-323bzc-0 efbshF Header__StyledHeaderCellButton-sc-1baku5q-0 gRxSZx"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 bHjtLJ"
+                class="StyledBox-sc-13pk1d4-0 ABJcL"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 iuKlFO"
+                  class="StyledText-sc-1sadyjn-0 cejToA"
                 >
                   A
                 </span>
@@ -55992,22 +56016,23 @@ exports[`DataTable sort null data 4`] = `
           </div>
         </th>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kzbMTh StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          aria-sort="none"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 beksZj StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           id="grommet-data-table-header-b"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
+            class="StyledBox-sc-13pk1d4-0 faLdcD"
           >
             <button
-              class="StyledButton-sc-323bzc-0 gVLKEX Header__StyledHeaderCellButton-sc-1baku5q-0 llZrcE"
+              class="StyledButton-sc-323bzc-0 efbshF Header__StyledHeaderCellButton-sc-1baku5q-0 gRxSZx"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 bHjtLJ"
+                class="StyledBox-sc-13pk1d4-0 ABJcL"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 iuKlFO"
+                  class="StyledText-sc-1sadyjn-0 cejToA"
                 >
                   B
                 </span>
@@ -56016,22 +56041,23 @@ exports[`DataTable sort null data 4`] = `
           </div>
         </th>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kzbMTh StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          aria-sort="none"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 beksZj StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           id="grommet-data-table-header-c"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
+            class="StyledBox-sc-13pk1d4-0 faLdcD"
           >
             <button
-              class="StyledButton-sc-323bzc-0 gVLKEX Header__StyledHeaderCellButton-sc-1baku5q-0 llZrcE"
+              class="StyledButton-sc-323bzc-0 efbshF Header__StyledHeaderCellButton-sc-1baku5q-0 gRxSZx"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 bHjtLJ"
+                class="StyledBox-sc-13pk1d4-0 ABJcL"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 iuKlFO"
+                  class="StyledText-sc-1sadyjn-0 cejToA"
                 >
                   C
                 </span>
@@ -56041,22 +56067,22 @@ exports[`DataTable sort null data 4`] = `
         </th>
         <th
           aria-sort="ascending"
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kzbMTh StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 beksZj StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           id="grommet-data-table-header-d"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
+            class="StyledBox-sc-13pk1d4-0 faLdcD"
           >
             <button
-              class="StyledButton-sc-323bzc-0 gVLKEX Header__StyledHeaderCellButton-sc-1baku5q-0 llZrcE"
+              class="StyledButton-sc-323bzc-0 efbshF Header__StyledHeaderCellButton-sc-1baku5q-0 gRxSZx"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 bHjtLJ"
+                class="StyledBox-sc-13pk1d4-0 ABJcL"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 iuKlFO"
+                  class="StyledText-sc-1sadyjn-0 cejToA"
                 >
                   D
                 </span>
@@ -56130,149 +56156,149 @@ exports[`DataTable sort null data 4`] = `
       </tr>
     </thead>
     <tbody
-      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 buut"
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 dRPopI"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 gIpquo"
+              class="StyledText-sc-1sadyjn-0 bAcCYq"
             >
               one
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               1
             </span>
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           />
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           />
         </td>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 gIpquo"
+              class="StyledText-sc-1sadyjn-0 bAcCYq"
             >
               two
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               2
             </span>
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               second
             </span>
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           />
         </td>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           />
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               0
             </span>
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               first
             </span>
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               y
             </span>
@@ -56608,6 +56634,7 @@ exports[`DataTable sortable 1`] = `
         class="StyledTable__StyledTableRow-sc-1m3u5g-2 "
       >
         <th
+          aria-sort="none"
           class="c3 "
           id="grommet-data-table-header-a"
           scope="col"
@@ -56632,6 +56659,7 @@ exports[`DataTable sortable 1`] = `
           </div>
         </th>
         <th
+          aria-sort="none"
           class="c3 "
           id="grommet-data-table-header-b"
           scope="col"
@@ -56760,35 +56788,35 @@ exports[`DataTable sortable 1`] = `
 
 exports[`DataTable sortable 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
+  class="StyledGrommet-sc-19lkkz7-0 iQmOCy"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 gfvJtN StyledDataTable-sc-xrlyjm-0 iySlWL"
+    class="StyledTable-sc-1m3u5g-6 hItFIU StyledDataTable-sc-xrlyjm-0 bhJXnf"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-5"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 ktKCWw"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 hGRSSL"
       >
         <th
           aria-sort="ascending"
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kzbMTh StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 beksZj StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           id="grommet-data-table-header-a"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
+            class="StyledBox-sc-13pk1d4-0 faLdcD"
           >
             <button
-              class="StyledButton-sc-323bzc-0 gVLKEX Header__StyledHeaderCellButton-sc-1baku5q-0 llZrcE"
+              class="StyledButton-sc-323bzc-0 efbshF Header__StyledHeaderCellButton-sc-1baku5q-0 gRxSZx"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 bHjtLJ"
+                class="StyledBox-sc-13pk1d4-0 ABJcL"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 iuKlFO"
+                  class="StyledText-sc-1sadyjn-0 cejToA"
                 >
                   A
                 </span>
@@ -56860,22 +56888,23 @@ exports[`DataTable sortable 2`] = `
           </div>
         </th>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kzbMTh StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          aria-sort="none"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 beksZj StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           id="grommet-data-table-header-b"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
+            class="StyledBox-sc-13pk1d4-0 faLdcD"
           >
             <button
-              class="StyledButton-sc-323bzc-0 gVLKEX Header__StyledHeaderCellButton-sc-1baku5q-0 llZrcE"
+              class="StyledButton-sc-323bzc-0 efbshF Header__StyledHeaderCellButton-sc-1baku5q-0 gRxSZx"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 bHjtLJ"
+                class="StyledBox-sc-13pk1d4-0 ABJcL"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 iuKlFO"
+                  class="StyledText-sc-1sadyjn-0 cejToA"
                 >
                   B
                 </span>
@@ -56886,33 +56915,33 @@ exports[`DataTable sortable 2`] = `
       </tr>
     </thead>
     <tbody
-      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 buut"
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 dRPopI"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 gIpquo"
+              class="StyledText-sc-1sadyjn-0 bAcCYq"
             >
               one
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               1
             </span>
@@ -56920,30 +56949,30 @@ exports[`DataTable sortable 2`] = `
         </td>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 gIpquo"
+              class="StyledText-sc-1sadyjn-0 bAcCYq"
             >
               two
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               2
             </span>
@@ -56951,30 +56980,30 @@ exports[`DataTable sortable 2`] = `
         </td>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 gIpquo"
+              class="StyledText-sc-1sadyjn-0 bAcCYq"
             >
               zero
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 RYmEp"
+            class="StyledBox-sc-13pk1d4-0 eLlRsv"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 iuKlFO"
+              class="StyledText-sc-1sadyjn-0 cejToA"
             >
               0
             </span>
@@ -57521,6 +57550,7 @@ exports[`DataTable theme search pad, search text pad, sort gap, and expand size 
           class="c8"
         />
         <th
+          aria-sort="none"
           class="c9 "
           id="grommet-data-table-header-a"
           scope="col"
@@ -57567,6 +57597,7 @@ exports[`DataTable theme search pad, search text pad, sort gap, and expand size 
           </div>
         </th>
         <th
+          aria-sort="none"
           class="c9 "
           id="grommet-data-table-header-b"
           scope="col"

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.tsx.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.tsx.snap
@@ -3386,27 +3386,27 @@ exports[`DataTable click 1`] = `
 
 exports[`DataTable click 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 iQmOCy"
+  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 hItFIU StyledDataTable-sc-xrlyjm-0 bhJXnf"
+    class="StyledTable-sc-1m3u5g-6 gfvJtN StyledDataTable-sc-xrlyjm-0 iySlWL"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-5"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 hGRSSL"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 ktKCWw"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jabPpn StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksVeQF StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           id="grommet-data-table-header-a"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 faLdcD"
+            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               A
             </span>
@@ -3415,21 +3415,21 @@ exports[`DataTable click 2`] = `
       </tr>
     </thead>
     <tbody
-      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 dRPopI"
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 buut"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 dUdAYb"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 fSkwcW"
         tabindex="-1"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 bAcCYq"
+              class="StyledText-sc-1sadyjn-0 gIpquo"
             >
               alpha
             </span>
@@ -3437,18 +3437,18 @@ exports[`DataTable click 2`] = `
         </th>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 gFGXBk"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iQTwbZ"
         tabindex="0"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 bAcCYq"
+              class="StyledText-sc-1sadyjn-0 gIpquo"
             >
               beta
             </span>
@@ -4059,41 +4059,41 @@ exports[`DataTable custom theme 1`] = `
 
 exports[`DataTable custom theme 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 iQmOCy"
+  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 hItFIU StyledDataTable-sc-xrlyjm-0 bhJXnf"
+    class="StyledTable-sc-1m3u5g-6 gfvJtN StyledDataTable-sc-xrlyjm-0 iySlWL"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-5"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 hGRSSL"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 ktKCWw"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 guqRSX StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bUfbvl StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="col"
         />
         <th
           aria-sort="none"
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 eJWsnI StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hdohsq StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           id="grommet-data-table-header-a"
           scope="col"
           style="box-sizing: border-box; position: relative; overflow: visible;"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eeJSdc"
+            class="StyledBox-sc-13pk1d4-0 cyLFae"
           >
             <button
               aria-label="A, sortable"
-              class="StyledButton-sc-323bzc-0 efbshF Header__StyledHeaderCellButton-sc-1baku5q-0 dudWar"
+              class="StyledButton-sc-323bzc-0 gVLKEX Header__StyledHeaderCellButton-sc-1baku5q-0 ksMNO"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 ABJcL"
+                class="StyledBox-sc-13pk1d4-0 bHjtLJ"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 bAcCYq"
+                  class="StyledText-sc-1sadyjn-0 gIpquo"
                 >
                   A
                 </span>
@@ -4106,52 +4106,52 @@ exports[`DataTable custom theme 2`] = `
             aria-orientation="vertical"
             aria-valuenow="0"
             aria-valuetext="Resize A column"
-            class="StyledButton-sc-323bzc-0 cGdjir Resizer__StyledResizer-sc-8l808w-0 kABhyr"
+            class="StyledButton-sc-323bzc-0 idJamt Resizer__StyledResizer-sc-8l808w-0 jVCVpX"
             role="separator"
             type="button"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 hpUfog"
+              class="StyledBox-sc-13pk1d4-0 cScBIm"
             />
           </button>
         </th>
       </tr>
     </thead>
     <tbody
-      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 dRPopI"
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 buut"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
       >
         <td
           aria-disabled="true"
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hxldGp StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gIvIGX StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 iSpovP"
+            class="StyledBox-sc-13pk1d4-0 bknumx"
             style="height: 0px;"
           >
             <label
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 gOUajv"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 citkSF"
               disabled=""
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kdNZWX StyledCheckBox-sc-1dbk5ju-6 jHuWbF"
+                class="StyledBox-sc-13pk1d4-0 gOFJEd StyledCheckBox-sc-1dbk5ju-6 ewFUzs"
                 disabled=""
               >
                 <input
                   aria-label="unselect alpha"
                   checked=""
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 bEaKNg"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 jyDGaE"
                   disabled=""
                   type="checkbox"
                 />
                 <div
-                  class="StyledBox-sc-13pk1d4-0 cJyZCd StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 hZZOmF"
+                  class="StyledBox-sc-13pk1d4-0 gHSfwH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 bwjtfK"
                   disabled=""
                 >
                   <svg
-                    class="StyledCheckBox__StyledCheckBoxIcon-sc-1dbk5ju-0 eNRRvC"
+                    class="StyledCheckBox__StyledCheckBoxIcon-sc-1dbk5ju-0 gLSxni"
                     disabled=""
                     preserveAspectRatio="xMidYMid meet"
                     viewBox="0 0 24 24"
@@ -4171,14 +4171,14 @@ exports[`DataTable custom theme 2`] = `
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 bAcCYq"
+              class="StyledText-sc-1sadyjn-0 gIpquo"
             >
               alpha
             </span>
@@ -4186,32 +4186,32 @@ exports[`DataTable custom theme 2`] = `
         </th>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
       >
         <td
           aria-disabled="true"
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hxldGp StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gIvIGX StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 iSpovP"
+            class="StyledBox-sc-13pk1d4-0 bknumx"
             style="height: 0px;"
           >
             <label
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 gOUajv"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 citkSF"
               disabled=""
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kdNZWX StyledCheckBox-sc-1dbk5ju-6 jHuWbF"
+                class="StyledBox-sc-13pk1d4-0 gOFJEd StyledCheckBox-sc-1dbk5ju-6 ewFUzs"
                 disabled=""
               >
                 <input
                   aria-label="select beta"
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 bEaKNg"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 jyDGaE"
                   disabled=""
                   type="checkbox"
                 />
                 <div
-                  class="StyledBox-sc-13pk1d4-0 hSCSzp StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 hZZOmF"
+                  class="StyledBox-sc-13pk1d4-0 jbiGIb StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 bwjtfK"
                   disabled=""
                 />
               </div>
@@ -4219,14 +4219,14 @@ exports[`DataTable custom theme 2`] = `
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 bAcCYq"
+              class="StyledText-sc-1sadyjn-0 gIpquo"
             >
               beta
             </span>
@@ -4428,27 +4428,27 @@ exports[`DataTable disable row click using space key press 1`] = `
 
 exports[`DataTable disable row click using space key press 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 iQmOCy"
+  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 hItFIU StyledDataTable-sc-xrlyjm-0 bhJXnf"
+    class="StyledTable-sc-1m3u5g-6 gfvJtN StyledDataTable-sc-xrlyjm-0 iySlWL"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-5"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 hGRSSL"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 ktKCWw"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jabPpn StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksVeQF StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           id="grommet-data-table-header-name"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 faLdcD"
+            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               Name
             </span>
@@ -4457,22 +4457,22 @@ exports[`DataTable disable row click using space key press 2`] = `
       </tr>
     </thead>
     <tbody
-      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 dRPopI"
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 buut"
     >
       <tr
         aria-disabled="true"
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 dUdAYb"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 fSkwcW"
         tabindex="0"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 bAcCYq"
+              class="StyledText-sc-1sadyjn-0 gIpquo"
             >
               alpha
             </span>
@@ -4693,27 +4693,27 @@ exports[`DataTable disabled click 1`] = `
 
 exports[`DataTable disabled click 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 iQmOCy"
+  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 hItFIU StyledDataTable-sc-xrlyjm-0 bhJXnf"
+    class="StyledTable-sc-1m3u5g-6 gfvJtN StyledDataTable-sc-xrlyjm-0 iySlWL"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-5"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 hGRSSL"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 ktKCWw"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jabPpn StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksVeQF StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           id="grommet-data-table-header-a"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 faLdcD"
+            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               A
             </span>
@@ -4722,22 +4722,22 @@ exports[`DataTable disabled click 2`] = `
       </tr>
     </thead>
     <tbody
-      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 dRPopI"
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 buut"
     >
       <tr
         aria-disabled="true"
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 dUdAYb"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 fSkwcW"
         tabindex="-1"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 bAcCYq"
+              class="StyledText-sc-1sadyjn-0 gIpquo"
             >
               alpha
             </span>
@@ -4745,18 +4745,18 @@ exports[`DataTable disabled click 2`] = `
         </th>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 gFGXBk"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iQTwbZ"
         tabindex="0"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 bAcCYq"
+              class="StyledText-sc-1sadyjn-0 gIpquo"
             >
               beta
             </span>
@@ -8184,36 +8184,36 @@ exports[`DataTable groupBy 1`] = `
 
 exports[`DataTable groupBy 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 iQmOCy"
+  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 hItFIU StyledDataTable-sc-xrlyjm-0 bhJXnf"
+    class="StyledTable-sc-1m3u5g-6 gfvJtN StyledDataTable-sc-xrlyjm-0 iySlWL"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-5"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 hGRSSL"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 ktKCWw"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kCKEbm"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 fRAYyo"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ccXjKC"
+            class="StyledBox-sc-13pk1d4-0 hJyDbY"
             style="height: 0px;"
           >
             <button
               aria-expanded="false"
               aria-label="expand all"
-              class="StyledButton-sc-323bzc-0 gxPxGa"
+              class="StyledButton-sc-323bzc-0 kPGkLU"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 jAIAuI"
+                class="StyledBox-sc-13pk1d4-0 iXSmVm"
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-sc-ofa7kd-0 dJyQSO"
+                  class="StyledIcon-sc-ofa7kd-0 cbAOVH"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -8228,30 +8228,30 @@ exports[`DataTable groupBy 2`] = `
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jabPpn StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksVeQF StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           id="grommet-data-table-header-a"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 faLdcD"
+            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               A
             </span>
           </div>
         </th>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jabPpn StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksVeQF StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           id="grommet-data-table-header-b"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 faLdcD"
+            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               B
             </span>
@@ -8260,30 +8260,30 @@ exports[`DataTable groupBy 2`] = `
       </tr>
     </thead>
     <tbody
-      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 dRPopI"
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 buut"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bJGbBs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 lgcZWa"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ccXjKC"
+            class="StyledBox-sc-13pk1d4-0 hJyDbY"
             style="height: 0px;"
           >
             <button
               aria-expanded="false"
               aria-label="expand "
-              class="StyledButton-sc-323bzc-0 gxPxGa"
+              class="StyledButton-sc-323bzc-0 kPGkLU"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 jAIAuI"
+                class="StyledBox-sc-13pk1d4-0 iXSmVm"
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-sc-ofa7kd-0 dJyQSO"
+                  class="StyledIcon-sc-ofa7kd-0 cbAOVH"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -8298,49 +8298,49 @@ exports[`DataTable groupBy 2`] = `
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               one
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           />
         </td>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bJGbBs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 lgcZWa"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ccXjKC"
+            class="StyledBox-sc-13pk1d4-0 hJyDbY"
             style="height: 0px;"
           >
             <button
               aria-expanded="false"
               aria-label="expand "
-              class="StyledButton-sc-323bzc-0 gxPxGa"
+              class="StyledButton-sc-323bzc-0 kPGkLU"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 jAIAuI"
+                class="StyledBox-sc-13pk1d4-0 iXSmVm"
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-sc-ofa7kd-0 dJyQSO"
+                  class="StyledIcon-sc-ofa7kd-0 cbAOVH"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -8355,24 +8355,24 @@ exports[`DataTable groupBy 2`] = `
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               two
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           />
         </td>
       </tr>
@@ -9503,36 +9503,36 @@ exports[`DataTable groupBy property 1`] = `
 
 exports[`DataTable groupBy property 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 iQmOCy"
+  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 hItFIU StyledDataTable-sc-xrlyjm-0 bhJXnf"
+    class="StyledTable-sc-1m3u5g-6 gfvJtN StyledDataTable-sc-xrlyjm-0 iySlWL"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-5"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 hGRSSL"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 ktKCWw"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kCKEbm"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 fRAYyo"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ccXjKC"
+            class="StyledBox-sc-13pk1d4-0 hJyDbY"
             style="height: 0px;"
           >
             <button
               aria-expanded="false"
               aria-label="expand all"
-              class="StyledButton-sc-323bzc-0 gxPxGa"
+              class="StyledButton-sc-323bzc-0 kPGkLU"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 jAIAuI"
+                class="StyledBox-sc-13pk1d4-0 iXSmVm"
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-sc-ofa7kd-0 dJyQSO"
+                  class="StyledIcon-sc-ofa7kd-0 cbAOVH"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -9547,30 +9547,30 @@ exports[`DataTable groupBy property 2`] = `
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jabPpn StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksVeQF StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           id="grommet-data-table-header-a"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 faLdcD"
+            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               A
             </span>
           </div>
         </th>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jabPpn StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksVeQF StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           id="grommet-data-table-header-b"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 faLdcD"
+            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               B
             </span>
@@ -9579,30 +9579,30 @@ exports[`DataTable groupBy property 2`] = `
       </tr>
     </thead>
     <tbody
-      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 dRPopI"
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 buut"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bJGbBs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 lgcZWa"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ccXjKC"
+            class="StyledBox-sc-13pk1d4-0 hJyDbY"
             style="height: 0px;"
           >
             <button
               aria-expanded="false"
               aria-label="expand "
-              class="StyledButton-sc-323bzc-0 gxPxGa"
+              class="StyledButton-sc-323bzc-0 kPGkLU"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 jAIAuI"
+                class="StyledBox-sc-13pk1d4-0 iXSmVm"
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-sc-ofa7kd-0 dJyQSO"
+                  class="StyledIcon-sc-ofa7kd-0 cbAOVH"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -9617,49 +9617,49 @@ exports[`DataTable groupBy property 2`] = `
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               one
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           />
         </td>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bJGbBs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 lgcZWa"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ccXjKC"
+            class="StyledBox-sc-13pk1d4-0 hJyDbY"
             style="height: 0px;"
           >
             <button
               aria-expanded="false"
               aria-label="expand "
-              class="StyledButton-sc-323bzc-0 gxPxGa"
+              class="StyledButton-sc-323bzc-0 kPGkLU"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 jAIAuI"
+                class="StyledBox-sc-13pk1d4-0 iXSmVm"
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-sc-ofa7kd-0 dJyQSO"
+                  class="StyledIcon-sc-ofa7kd-0 cbAOVH"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -9674,24 +9674,24 @@ exports[`DataTable groupBy property 2`] = `
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               two
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           />
         </td>
       </tr>
@@ -10010,7 +10010,7 @@ exports[`DataTable groupBy toggle 1`] = `
 
 exports[`DataTable groupBy toggle 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 iQmOCy"
+  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
 >
   <button
     type="button"
@@ -10018,13 +10018,13 @@ exports[`DataTable groupBy toggle 2`] = `
     toggle
   </button>
   <table
-    class="StyledTable-sc-1m3u5g-6 hItFIU StyledDataTable-sc-xrlyjm-0 bhJXnf"
+    class="StyledTable-sc-1m3u5g-6 gfvJtN StyledDataTable-sc-xrlyjm-0 iySlWL"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-5"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 hGRSSL"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 ktKCWw"
       >
         .c4 {
   display: inline-block;
@@ -10210,30 +10210,30 @@ exports[`DataTable groupBy toggle 2`] = `
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jabPpn StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksVeQF StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           id="grommet-data-table-header-a"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 faLdcD"
+            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               A
             </span>
           </div>
         </th>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jabPpn StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksVeQF StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           id="grommet-data-table-header-b"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 faLdcD"
+            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               B
             </span>
@@ -10589,7 +10589,7 @@ exports[`DataTable groupBy toggle 2`] = `
 
 exports[`DataTable groupBy toggle 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 iQmOCy"
+  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
 >
   <button
     type="button"
@@ -10597,39 +10597,39 @@ exports[`DataTable groupBy toggle 3`] = `
     toggle
   </button>
   <table
-    class="StyledTable-sc-1m3u5g-6 hItFIU StyledDataTable-sc-xrlyjm-0 bhJXnf"
+    class="StyledTable-sc-1m3u5g-6 gfvJtN StyledDataTable-sc-xrlyjm-0 iySlWL"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-5"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 hGRSSL"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 ktKCWw"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jabPpn StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksVeQF StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           id="grommet-data-table-header-a"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 faLdcD"
+            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               A
             </span>
           </div>
         </th>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jabPpn StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksVeQF StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           id="grommet-data-table-header-b"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 faLdcD"
+            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               B
             </span>
@@ -11341,36 +11341,36 @@ exports[`DataTable messages prop overrides theme messages 1`] = `
 
 exports[`DataTable messages prop overrides theme messages 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 iQmOCy"
+  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 hItFIU StyledDataTable-sc-xrlyjm-0 bhJXnf"
+    class="StyledTable-sc-1m3u5g-6 gfvJtN StyledDataTable-sc-xrlyjm-0 iySlWL"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-5"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 hGRSSL"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 ktKCWw"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kCKEbm"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 fRAYyo"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ccXjKC"
+            class="StyledBox-sc-13pk1d4-0 hJyDbY"
             style="height: 0px;"
           >
             <button
               aria-expanded="false"
               aria-label="expand all"
-              class="StyledButton-sc-323bzc-0 gxPxGa"
+              class="StyledButton-sc-323bzc-0 kPGkLU"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 jAIAuI"
+                class="StyledBox-sc-13pk1d4-0 iXSmVm"
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-sc-ofa7kd-0 dJyQSO"
+                  class="StyledIcon-sc-ofa7kd-0 cbAOVH"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -11385,30 +11385,30 @@ exports[`DataTable messages prop overrides theme messages 2`] = `
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jabPpn StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksVeQF StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           id="grommet-data-table-header-a"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 faLdcD"
+            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               A
             </span>
           </div>
         </th>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jabPpn StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksVeQF StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           id="grommet-data-table-header-b"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 faLdcD"
+            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               B
             </span>
@@ -11417,26 +11417,26 @@ exports[`DataTable messages prop overrides theme messages 2`] = `
       </tr>
     </thead>
     <tbody
-      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 dRPopI"
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 buut"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bJGbBs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 lgcZWa"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ccXjKC"
+            class="StyledBox-sc-13pk1d4-0 hJyDbY"
             style="height: 0px;"
           >
             <button
               aria-expanded="true"
               aria-label="colapsar"
-              class="StyledButton-sc-323bzc-0 gxPxGa"
+              class="StyledButton-sc-323bzc-0 kPGkLU"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 jAIAuI"
+                class="StyledBox-sc-13pk1d4-0 iXSmVm"
               >
                 .c0 {
   display: inline-block;
@@ -11495,24 +11495,24 @@ exports[`DataTable messages prop overrides theme messages 2`] = `
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               one
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           />
         </td>
       </tr>
@@ -11913,27 +11913,27 @@ exports[`DataTable messages prop overrides theme messages 2`] = `
         </td>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bJGbBs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 lgcZWa"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ccXjKC"
+            class="StyledBox-sc-13pk1d4-0 hJyDbY"
             style="height: 0px;"
           >
             <button
               aria-expanded="false"
               aria-label="expandir"
-              class="StyledButton-sc-323bzc-0 gxPxGa"
+              class="StyledButton-sc-323bzc-0 kPGkLU"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 jAIAuI"
+                class="StyledBox-sc-13pk1d4-0 iXSmVm"
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-sc-ofa7kd-0 dJyQSO"
+                  class="StyledIcon-sc-ofa7kd-0 cbAOVH"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -11948,24 +11948,24 @@ exports[`DataTable messages prop overrides theme messages 2`] = `
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               two
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           />
         </td>
       </tr>
@@ -15095,36 +15095,36 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 1`
 
 exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 iQmOCy"
+  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 hItFIU StyledDataTable-sc-xrlyjm-0 bhJXnf"
+    class="StyledTable-sc-1m3u5g-6 gfvJtN StyledDataTable-sc-xrlyjm-0 iySlWL"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-5"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 hGRSSL"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 ktKCWw"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kCKEbm"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 fRAYyo"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ccXjKC"
+            class="StyledBox-sc-13pk1d4-0 hJyDbY"
             style="height: 0px;"
           >
             <button
               aria-expanded="false"
               aria-label="expand all"
-              class="StyledButton-sc-323bzc-0 gxPxGa"
+              class="StyledButton-sc-323bzc-0 kPGkLU"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 jAIAuI"
+                class="StyledBox-sc-13pk1d4-0 iXSmVm"
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-sc-ofa7kd-0 dJyQSO"
+                  class="StyledIcon-sc-ofa7kd-0 cbAOVH"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -15139,26 +15139,26 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jThOtf StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kdJQYN StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 iSpovP"
+            class="StyledBox-sc-13pk1d4-0 bknumx"
             style="height: 0px;"
           >
             <label
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 byaRhK"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hhAlPI"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kdNZWX StyledCheckBox-sc-1dbk5ju-6 jHuWbF"
+                class="StyledBox-sc-13pk1d4-0 gOFJEd StyledCheckBox-sc-1dbk5ju-6 ewFUzs"
               >
                 <input
                   aria-label="unselect all"
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNNTU"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 yZiQM"
                   type="checkbox"
                 />
                 <div
-                  class="StyledBox-sc-13pk1d4-0 cJyZCd StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 hZZOmF"
+                  class="StyledBox-sc-13pk1d4-0 gHSfwH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 bwjtfK"
                 >
                   .c0 {
   box-sizing: border-box;
@@ -15200,30 +15200,30 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
           </div>
         </th>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jabPpn StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksVeQF StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           id="grommet-data-table-header-a"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 faLdcD"
+            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               A
             </span>
           </div>
         </th>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jabPpn StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksVeQF StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           id="grommet-data-table-header-b"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 faLdcD"
+            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               B
             </span>
@@ -15232,30 +15232,30 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
       </tr>
     </thead>
     <tbody
-      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 dRPopI"
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 buut"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bJGbBs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 lgcZWa"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ccXjKC"
+            class="StyledBox-sc-13pk1d4-0 hJyDbY"
             style="height: 0px;"
           >
             <button
               aria-expanded="false"
               aria-label="expand "
-              class="StyledButton-sc-323bzc-0 gxPxGa"
+              class="StyledButton-sc-323bzc-0 kPGkLU"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 jAIAuI"
+                class="StyledBox-sc-13pk1d4-0 iXSmVm"
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-sc-ofa7kd-0 dJyQSO"
+                  class="StyledIcon-sc-ofa7kd-0 cbAOVH"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -15270,25 +15270,25 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hxldGp"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gIvIGX"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 iSpovP"
+            class="StyledBox-sc-13pk1d4-0 bknumx"
             style="height: 0px;"
           >
             <label
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 byaRhK"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hhAlPI"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kdNZWX StyledCheckBox-sc-1dbk5ju-6 jHuWbF"
+                class="StyledBox-sc-13pk1d4-0 gOFJEd StyledCheckBox-sc-1dbk5ju-6 ewFUzs"
               >
                 <input
                   aria-label="unselect one"
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNNTU"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 yZiQM"
                   type="checkbox"
                 />
                 <div
-                  class="StyledBox-sc-13pk1d4-0 cJyZCd StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 hZZOmF"
+                  class="StyledBox-sc-13pk1d4-0 gHSfwH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 bwjtfK"
                 >
                   .c0 {
   box-sizing: border-box;
@@ -15330,49 +15330,49 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               one
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           />
         </td>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bJGbBs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 lgcZWa"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ccXjKC"
+            class="StyledBox-sc-13pk1d4-0 hJyDbY"
             style="height: 0px;"
           >
             <button
               aria-expanded="false"
               aria-label="expand "
-              class="StyledButton-sc-323bzc-0 gxPxGa"
+              class="StyledButton-sc-323bzc-0 kPGkLU"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 jAIAuI"
+                class="StyledBox-sc-13pk1d4-0 iXSmVm"
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-sc-ofa7kd-0 dJyQSO"
+                  class="StyledIcon-sc-ofa7kd-0 cbAOVH"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -15387,25 +15387,25 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hxldGp"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gIvIGX"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 iSpovP"
+            class="StyledBox-sc-13pk1d4-0 bknumx"
             style="height: 0px;"
           >
             <label
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 byaRhK"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hhAlPI"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kdNZWX StyledCheckBox-sc-1dbk5ju-6 jHuWbF"
+                class="StyledBox-sc-13pk1d4-0 gOFJEd StyledCheckBox-sc-1dbk5ju-6 ewFUzs"
               >
                 <input
                   aria-label="unselect two"
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNNTU"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 yZiQM"
                   type="checkbox"
                 />
                 <div
-                  class="StyledBox-sc-13pk1d4-0 cJyZCd StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 hZZOmF"
+                  class="StyledBox-sc-13pk1d4-0 gHSfwH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 bwjtfK"
                 >
                   .c0 {
   box-sizing: border-box;
@@ -15447,24 +15447,24 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               two
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           />
         </td>
       </tr>
@@ -15475,36 +15475,36 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 2`
 
 exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 iQmOCy"
+  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 hItFIU StyledDataTable-sc-xrlyjm-0 bhJXnf"
+    class="StyledTable-sc-1m3u5g-6 gfvJtN StyledDataTable-sc-xrlyjm-0 iySlWL"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-5"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 hGRSSL"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 ktKCWw"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kCKEbm"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 fRAYyo"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ccXjKC"
+            class="StyledBox-sc-13pk1d4-0 hJyDbY"
             style="height: 0px;"
           >
             <button
               aria-expanded="false"
               aria-label="expand all"
-              class="StyledButton-sc-323bzc-0 gxPxGa"
+              class="StyledButton-sc-323bzc-0 kPGkLU"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 jAIAuI"
+                class="StyledBox-sc-13pk1d4-0 iXSmVm"
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-sc-ofa7kd-0 dJyQSO"
+                  class="StyledIcon-sc-ofa7kd-0 cbAOVH"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -15519,56 +15519,56 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jThOtf StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kdJQYN StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 iSpovP"
+            class="StyledBox-sc-13pk1d4-0 bknumx"
             style="height: 0px;"
           >
             <label
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 byaRhK"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hhAlPI"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kdNZWX StyledCheckBox-sc-1dbk5ju-6 jHuWbF"
+                class="StyledBox-sc-13pk1d4-0 gOFJEd StyledCheckBox-sc-1dbk5ju-6 ewFUzs"
               >
                 <input
                   aria-label="select all"
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNNTU"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 yZiQM"
                   type="checkbox"
                 />
                 <div
-                  class="StyledBox-sc-13pk1d4-0 hSCSzp StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 hZZOmF"
+                  class="StyledBox-sc-13pk1d4-0 jbiGIb StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 bwjtfK"
                 />
               </div>
             </label>
           </div>
         </th>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jabPpn StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksVeQF StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           id="grommet-data-table-header-a"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 faLdcD"
+            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               A
             </span>
           </div>
         </th>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jabPpn StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksVeQF StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           id="grommet-data-table-header-b"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 faLdcD"
+            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               B
             </span>
@@ -15577,30 +15577,30 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
       </tr>
     </thead>
     <tbody
-      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 dRPopI"
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 buut"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bJGbBs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 lgcZWa"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ccXjKC"
+            class="StyledBox-sc-13pk1d4-0 hJyDbY"
             style="height: 0px;"
           >
             <button
               aria-expanded="false"
               aria-label="expand "
-              class="StyledButton-sc-323bzc-0 gxPxGa"
+              class="StyledButton-sc-323bzc-0 kPGkLU"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 jAIAuI"
+                class="StyledBox-sc-13pk1d4-0 iXSmVm"
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-sc-ofa7kd-0 dJyQSO"
+                  class="StyledIcon-sc-ofa7kd-0 cbAOVH"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -15615,74 +15615,74 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hxldGp"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gIvIGX"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 iSpovP"
+            class="StyledBox-sc-13pk1d4-0 bknumx"
             style="height: 0px;"
           >
             <label
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 byaRhK"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hhAlPI"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kdNZWX StyledCheckBox-sc-1dbk5ju-6 jHuWbF"
+                class="StyledBox-sc-13pk1d4-0 gOFJEd StyledCheckBox-sc-1dbk5ju-6 ewFUzs"
               >
                 <input
                   aria-label="select one"
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNNTU"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 yZiQM"
                   type="checkbox"
                 />
                 <div
-                  class="StyledBox-sc-13pk1d4-0 hSCSzp StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 hZZOmF"
+                  class="StyledBox-sc-13pk1d4-0 jbiGIb StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 bwjtfK"
                 />
               </div>
             </label>
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               one
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           />
         </td>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bJGbBs"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 lgcZWa"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 ccXjKC"
+            class="StyledBox-sc-13pk1d4-0 hJyDbY"
             style="height: 0px;"
           >
             <button
               aria-expanded="false"
               aria-label="expand "
-              class="StyledButton-sc-323bzc-0 gxPxGa"
+              class="StyledButton-sc-323bzc-0 kPGkLU"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 jAIAuI"
+                class="StyledBox-sc-13pk1d4-0 iXSmVm"
               >
                 <svg
                   aria-label="FormDown"
-                  class="StyledIcon-sc-ofa7kd-0 dJyQSO"
+                  class="StyledIcon-sc-ofa7kd-0 cbAOVH"
                   viewBox="0 0 24 24"
                 >
                   <path
@@ -15697,49 +15697,49 @@ exports[`DataTable onSelect + groupBy should select/deselect all when grouped 3`
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hxldGp"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gIvIGX"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 iSpovP"
+            class="StyledBox-sc-13pk1d4-0 bknumx"
             style="height: 0px;"
           >
             <label
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 byaRhK"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hhAlPI"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kdNZWX StyledCheckBox-sc-1dbk5ju-6 jHuWbF"
+                class="StyledBox-sc-13pk1d4-0 gOFJEd StyledCheckBox-sc-1dbk5ju-6 ewFUzs"
               >
                 <input
                   aria-label="select two"
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNNTU"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 yZiQM"
                   type="checkbox"
                 />
                 <div
-                  class="StyledBox-sc-13pk1d4-0 hSCSzp StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 hZZOmF"
+                  class="StyledBox-sc-13pk1d4-0 jbiGIb StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 bwjtfK"
                 />
               </div>
             </label>
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               two
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           />
         </td>
       </tr>
@@ -16278,38 +16278,38 @@ exports[`DataTable onSelect select/unselect all 1`] = `
 
 exports[`DataTable onSelect select/unselect all 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 iQmOCy"
+  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 hItFIU StyledDataTable-sc-xrlyjm-0 bhJXnf"
+    class="StyledTable-sc-1m3u5g-6 gfvJtN StyledDataTable-sc-xrlyjm-0 iySlWL"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-5"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 hGRSSL"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 ktKCWw"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jThOtf StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kdJQYN StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 iSpovP"
+            class="StyledBox-sc-13pk1d4-0 bknumx"
             style="height: 0px;"
           >
             <label
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 byaRhK"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hhAlPI"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kdNZWX StyledCheckBox-sc-1dbk5ju-6 jHuWbF"
+                class="StyledBox-sc-13pk1d4-0 gOFJEd StyledCheckBox-sc-1dbk5ju-6 ewFUzs"
               >
                 <input
                   aria-label="unselect all"
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNNTU"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 yZiQM"
                   type="checkbox"
                 />
                 <div
-                  class="StyledBox-sc-13pk1d4-0 cJyZCd StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 hZZOmF"
+                  class="StyledBox-sc-13pk1d4-0 gHSfwH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 bwjtfK"
                 >
                   .c0 {
   box-sizing: border-box;
@@ -16343,30 +16343,30 @@ exports[`DataTable onSelect select/unselect all 2`] = `
           </div>
         </th>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jabPpn StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksVeQF StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           id="grommet-data-table-header-a"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 faLdcD"
+            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               A
             </span>
           </div>
         </th>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jabPpn StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksVeQF StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           id="grommet-data-table-header-b"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 faLdcD"
+            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               B
             </span>
@@ -16375,31 +16375,31 @@ exports[`DataTable onSelect select/unselect all 2`] = `
       </tr>
     </thead>
     <tbody
-      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 dRPopI"
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 buut"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hxldGp StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gIvIGX StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 iSpovP"
+            class="StyledBox-sc-13pk1d4-0 bknumx"
             style="height: 0px;"
           >
             <label
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 byaRhK"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hhAlPI"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kdNZWX StyledCheckBox-sc-1dbk5ju-6 jHuWbF"
+                class="StyledBox-sc-13pk1d4-0 gOFJEd StyledCheckBox-sc-1dbk5ju-6 ewFUzs"
               >
                 <input
                   aria-label="unselect 1.1"
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNNTU"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 yZiQM"
                   type="checkbox"
                 />
                 <div
-                  class="StyledBox-sc-13pk1d4-0 cJyZCd StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 hZZOmF"
+                  class="StyledBox-sc-13pk1d4-0 gHSfwH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 bwjtfK"
                 >
                   .c0 {
   box-sizing: border-box;
@@ -16433,27 +16433,27 @@ exports[`DataTable onSelect select/unselect all 2`] = `
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               one
             </span>
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 bAcCYq"
+              class="StyledText-sc-1sadyjn-0 gIpquo"
             >
               1.1
             </span>
@@ -16461,28 +16461,28 @@ exports[`DataTable onSelect select/unselect all 2`] = `
         </th>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hxldGp StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gIvIGX StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 iSpovP"
+            class="StyledBox-sc-13pk1d4-0 bknumx"
             style="height: 0px;"
           >
             <label
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 byaRhK"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hhAlPI"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kdNZWX StyledCheckBox-sc-1dbk5ju-6 jHuWbF"
+                class="StyledBox-sc-13pk1d4-0 gOFJEd StyledCheckBox-sc-1dbk5ju-6 ewFUzs"
               >
                 <input
                   aria-label="unselect 1.2"
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNNTU"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 yZiQM"
                   type="checkbox"
                 />
                 <div
-                  class="StyledBox-sc-13pk1d4-0 cJyZCd StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 hZZOmF"
+                  class="StyledBox-sc-13pk1d4-0 gHSfwH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 bwjtfK"
                 >
                   .c0 {
   box-sizing: border-box;
@@ -16516,27 +16516,27 @@ exports[`DataTable onSelect select/unselect all 2`] = `
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               one
             </span>
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 bAcCYq"
+              class="StyledText-sc-1sadyjn-0 gIpquo"
             >
               1.2
             </span>
@@ -16544,28 +16544,28 @@ exports[`DataTable onSelect select/unselect all 2`] = `
         </th>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hxldGp StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gIvIGX StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 iSpovP"
+            class="StyledBox-sc-13pk1d4-0 bknumx"
             style="height: 0px;"
           >
             <label
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 byaRhK"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hhAlPI"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kdNZWX StyledCheckBox-sc-1dbk5ju-6 jHuWbF"
+                class="StyledBox-sc-13pk1d4-0 gOFJEd StyledCheckBox-sc-1dbk5ju-6 ewFUzs"
               >
                 <input
                   aria-label="unselect 2.1"
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNNTU"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 yZiQM"
                   type="checkbox"
                 />
                 <div
-                  class="StyledBox-sc-13pk1d4-0 cJyZCd StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 hZZOmF"
+                  class="StyledBox-sc-13pk1d4-0 gHSfwH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 bwjtfK"
                 >
                   .c0 {
   box-sizing: border-box;
@@ -16599,27 +16599,27 @@ exports[`DataTable onSelect select/unselect all 2`] = `
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               two
             </span>
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 bAcCYq"
+              class="StyledText-sc-1sadyjn-0 gIpquo"
             >
               2.1
             </span>
@@ -16627,28 +16627,28 @@ exports[`DataTable onSelect select/unselect all 2`] = `
         </th>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hxldGp StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gIvIGX StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 iSpovP"
+            class="StyledBox-sc-13pk1d4-0 bknumx"
             style="height: 0px;"
           >
             <label
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 byaRhK"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hhAlPI"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kdNZWX StyledCheckBox-sc-1dbk5ju-6 jHuWbF"
+                class="StyledBox-sc-13pk1d4-0 gOFJEd StyledCheckBox-sc-1dbk5ju-6 ewFUzs"
               >
                 <input
                   aria-label="unselect 2.2"
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNNTU"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 yZiQM"
                   type="checkbox"
                 />
                 <div
-                  class="StyledBox-sc-13pk1d4-0 cJyZCd StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 hZZOmF"
+                  class="StyledBox-sc-13pk1d4-0 gHSfwH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 bwjtfK"
                 >
                   .c0 {
   box-sizing: border-box;
@@ -16682,27 +16682,27 @@ exports[`DataTable onSelect select/unselect all 2`] = `
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               two
             </span>
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 bAcCYq"
+              class="StyledText-sc-1sadyjn-0 gIpquo"
             >
               2.2
             </span>
@@ -16716,68 +16716,68 @@ exports[`DataTable onSelect select/unselect all 2`] = `
 
 exports[`DataTable onSelect select/unselect all 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 iQmOCy"
+  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 hItFIU StyledDataTable-sc-xrlyjm-0 bhJXnf"
+    class="StyledTable-sc-1m3u5g-6 gfvJtN StyledDataTable-sc-xrlyjm-0 iySlWL"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-5"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 hGRSSL"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 ktKCWw"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jThOtf StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kdJQYN StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 iSpovP"
+            class="StyledBox-sc-13pk1d4-0 bknumx"
             style="height: 0px;"
           >
             <label
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 byaRhK"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hhAlPI"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kdNZWX StyledCheckBox-sc-1dbk5ju-6 jHuWbF"
+                class="StyledBox-sc-13pk1d4-0 gOFJEd StyledCheckBox-sc-1dbk5ju-6 ewFUzs"
               >
                 <input
                   aria-label="select all"
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNNTU"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 yZiQM"
                   type="checkbox"
                 />
                 <div
-                  class="StyledBox-sc-13pk1d4-0 hSCSzp StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 hZZOmF"
+                  class="StyledBox-sc-13pk1d4-0 jbiGIb StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 bwjtfK"
                 />
               </div>
             </label>
           </div>
         </th>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jabPpn StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksVeQF StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           id="grommet-data-table-header-a"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 faLdcD"
+            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               A
             </span>
           </div>
         </th>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jabPpn StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksVeQF StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           id="grommet-data-table-header-b"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 faLdcD"
+            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               B
             </span>
@@ -16786,58 +16786,58 @@ exports[`DataTable onSelect select/unselect all 3`] = `
       </tr>
     </thead>
     <tbody
-      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 dRPopI"
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 buut"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hxldGp StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gIvIGX StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 iSpovP"
+            class="StyledBox-sc-13pk1d4-0 bknumx"
             style="height: 0px;"
           >
             <label
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 byaRhK"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hhAlPI"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kdNZWX StyledCheckBox-sc-1dbk5ju-6 jHuWbF"
+                class="StyledBox-sc-13pk1d4-0 gOFJEd StyledCheckBox-sc-1dbk5ju-6 ewFUzs"
               >
                 <input
                   aria-label="select 1.1"
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNNTU"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 yZiQM"
                   type="checkbox"
                 />
                 <div
-                  class="StyledBox-sc-13pk1d4-0 hSCSzp StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 hZZOmF"
+                  class="StyledBox-sc-13pk1d4-0 jbiGIb StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 bwjtfK"
                 />
               </div>
             </label>
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               one
             </span>
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 bAcCYq"
+              class="StyledText-sc-1sadyjn-0 gIpquo"
             >
               1.1
             </span>
@@ -16845,55 +16845,55 @@ exports[`DataTable onSelect select/unselect all 3`] = `
         </th>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hxldGp StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gIvIGX StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 iSpovP"
+            class="StyledBox-sc-13pk1d4-0 bknumx"
             style="height: 0px;"
           >
             <label
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 byaRhK"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hhAlPI"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kdNZWX StyledCheckBox-sc-1dbk5ju-6 jHuWbF"
+                class="StyledBox-sc-13pk1d4-0 gOFJEd StyledCheckBox-sc-1dbk5ju-6 ewFUzs"
               >
                 <input
                   aria-label="select 1.2"
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNNTU"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 yZiQM"
                   type="checkbox"
                 />
                 <div
-                  class="StyledBox-sc-13pk1d4-0 hSCSzp StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 hZZOmF"
+                  class="StyledBox-sc-13pk1d4-0 jbiGIb StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 bwjtfK"
                 />
               </div>
             </label>
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               one
             </span>
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 bAcCYq"
+              class="StyledText-sc-1sadyjn-0 gIpquo"
             >
               1.2
             </span>
@@ -16901,55 +16901,55 @@ exports[`DataTable onSelect select/unselect all 3`] = `
         </th>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hxldGp StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gIvIGX StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 iSpovP"
+            class="StyledBox-sc-13pk1d4-0 bknumx"
             style="height: 0px;"
           >
             <label
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 byaRhK"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hhAlPI"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kdNZWX StyledCheckBox-sc-1dbk5ju-6 jHuWbF"
+                class="StyledBox-sc-13pk1d4-0 gOFJEd StyledCheckBox-sc-1dbk5ju-6 ewFUzs"
               >
                 <input
                   aria-label="select 2.1"
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNNTU"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 yZiQM"
                   type="checkbox"
                 />
                 <div
-                  class="StyledBox-sc-13pk1d4-0 hSCSzp StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 hZZOmF"
+                  class="StyledBox-sc-13pk1d4-0 jbiGIb StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 bwjtfK"
                 />
               </div>
             </label>
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               two
             </span>
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 bAcCYq"
+              class="StyledText-sc-1sadyjn-0 gIpquo"
             >
               2.1
             </span>
@@ -16957,55 +16957,55 @@ exports[`DataTable onSelect select/unselect all 3`] = `
         </th>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hxldGp StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gIvIGX StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 iSpovP"
+            class="StyledBox-sc-13pk1d4-0 bknumx"
             style="height: 0px;"
           >
             <label
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 byaRhK"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hhAlPI"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kdNZWX StyledCheckBox-sc-1dbk5ju-6 jHuWbF"
+                class="StyledBox-sc-13pk1d4-0 gOFJEd StyledCheckBox-sc-1dbk5ju-6 ewFUzs"
               >
                 <input
                   aria-label="select 2.2"
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNNTU"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 yZiQM"
                   type="checkbox"
                 />
                 <div
-                  class="StyledBox-sc-13pk1d4-0 hSCSzp StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 hZZOmF"
+                  class="StyledBox-sc-13pk1d4-0 jbiGIb StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 bwjtfK"
                 />
               </div>
             </label>
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               two
             </span>
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 bAcCYq"
+              class="StyledText-sc-1sadyjn-0 gIpquo"
             >
               2.2
             </span>
@@ -17382,35 +17382,35 @@ exports[`DataTable onSort 1`] = `
 
 exports[`DataTable onSort 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 iQmOCy"
+  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 hItFIU StyledDataTable-sc-xrlyjm-0 bhJXnf"
+    class="StyledTable-sc-1m3u5g-6 gfvJtN StyledDataTable-sc-xrlyjm-0 iySlWL"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-5"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 hGRSSL"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 ktKCWw"
       >
         <th
           aria-sort="ascending"
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 beksZj StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kzbMTh StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           id="grommet-data-table-header-a"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 faLdcD"
+            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
           >
             <button
-              class="StyledButton-sc-323bzc-0 efbshF Header__StyledHeaderCellButton-sc-1baku5q-0 gRxSZx"
+              class="StyledButton-sc-323bzc-0 gVLKEX Header__StyledHeaderCellButton-sc-1baku5q-0 llZrcE"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 ABJcL"
+                class="StyledBox-sc-13pk1d4-0 bHjtLJ"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 cejToA"
+                  class="StyledText-sc-1sadyjn-0 iuKlFO"
                 >
                   A
                 </span>
@@ -17483,23 +17483,23 @@ exports[`DataTable onSort 2`] = `
         </th>
         <th
           aria-sort="none"
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 beksZj StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kzbMTh StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           id="grommet-data-table-header-b"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 faLdcD"
+            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
           >
             <button
               aria-label="B, sortable"
-              class="StyledButton-sc-323bzc-0 efbshF Header__StyledHeaderCellButton-sc-1baku5q-0 gRxSZx"
+              class="StyledButton-sc-323bzc-0 gVLKEX Header__StyledHeaderCellButton-sc-1baku5q-0 llZrcE"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 ABJcL"
+                class="StyledBox-sc-13pk1d4-0 bHjtLJ"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 cejToA"
+                  class="StyledText-sc-1sadyjn-0 iuKlFO"
                 >
                   B
                 </span>
@@ -17510,33 +17510,33 @@ exports[`DataTable onSort 2`] = `
       </tr>
     </thead>
     <tbody
-      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 dRPopI"
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 buut"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 bAcCYq"
+              class="StyledText-sc-1sadyjn-0 gIpquo"
             >
               one
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               1
             </span>
@@ -17544,30 +17544,30 @@ exports[`DataTable onSort 2`] = `
         </td>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 bAcCYq"
+              class="StyledText-sc-1sadyjn-0 gIpquo"
             >
               two
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               2
             </span>
@@ -17575,30 +17575,30 @@ exports[`DataTable onSort 2`] = `
         </td>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 bAcCYq"
+              class="StyledText-sc-1sadyjn-0 gIpquo"
             >
               zero
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               0
             </span>
@@ -18033,40 +18033,40 @@ exports[`DataTable onSort external 1`] = `
 
 exports[`DataTable onSort external 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 iQmOCy"
+  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 hItFIU StyledDataTable-sc-xrlyjm-0 bhJXnf"
+    class="StyledTable-sc-1m3u5g-6 gfvJtN StyledDataTable-sc-xrlyjm-0 iySlWL"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-5"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 hGRSSL"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 ktKCWw"
       >
         <th
           aria-sort="descending"
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 beksZj StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kzbMTh StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           id="grommet-data-table-header-a"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 faLdcD"
+            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
           >
             <button
-              class="StyledButton-sc-323bzc-0 efbshF Header__StyledHeaderCellButton-sc-1baku5q-0 gRxSZx"
+              class="StyledButton-sc-323bzc-0 gVLKEX Header__StyledHeaderCellButton-sc-1baku5q-0 llZrcE"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 ABJcL"
+                class="StyledBox-sc-13pk1d4-0 bHjtLJ"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 cejToA"
+                  class="StyledText-sc-1sadyjn-0 iuKlFO"
                 >
                   A
                 </span>
                 <div
-                  class="StyledBox__StyledBoxGap-sc-13pk1d4-1 MZaCP"
+                  class="StyledBox__StyledBoxGap-sc-13pk1d4-1 DBOrP"
                 />
                 .c0 {
   display: inline-block;
@@ -18122,23 +18122,23 @@ exports[`DataTable onSort external 2`] = `
         </th>
         <th
           aria-sort="none"
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 beksZj StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kzbMTh StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           id="grommet-data-table-header-b"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 faLdcD"
+            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
           >
             <button
               aria-label="B, sortable"
-              class="StyledButton-sc-323bzc-0 efbshF Header__StyledHeaderCellButton-sc-1baku5q-0 gRxSZx"
+              class="StyledButton-sc-323bzc-0 gVLKEX Header__StyledHeaderCellButton-sc-1baku5q-0 llZrcE"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 ABJcL"
+                class="StyledBox-sc-13pk1d4-0 bHjtLJ"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 cejToA"
+                  class="StyledText-sc-1sadyjn-0 iuKlFO"
                 >
                   B
                 </span>
@@ -18149,33 +18149,33 @@ exports[`DataTable onSort external 2`] = `
       </tr>
     </thead>
     <tbody
-      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 dRPopI"
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 buut"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 bAcCYq"
+              class="StyledText-sc-1sadyjn-0 gIpquo"
             >
               zero
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               0
             </span>
@@ -18183,30 +18183,30 @@ exports[`DataTable onSort external 2`] = `
         </td>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 bAcCYq"
+              class="StyledText-sc-1sadyjn-0 gIpquo"
             >
               one
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               1
             </span>
@@ -18214,30 +18214,30 @@ exports[`DataTable onSort external 2`] = `
         </td>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 bAcCYq"
+              class="StyledText-sc-1sadyjn-0 gIpquo"
             >
               two
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               2
             </span>
@@ -23747,27 +23747,27 @@ exports[`DataTable row click using space key press 1`] = `
 
 exports[`DataTable row click using space key press 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 iQmOCy"
+  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 hItFIU StyledDataTable-sc-xrlyjm-0 bhJXnf"
+    class="StyledTable-sc-1m3u5g-6 gfvJtN StyledDataTable-sc-xrlyjm-0 iySlWL"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-5"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 hGRSSL"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 ktKCWw"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jabPpn StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksVeQF StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           id="grommet-data-table-header-name"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 faLdcD"
+            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               Name
             </span>
@@ -23776,21 +23776,21 @@ exports[`DataTable row click using space key press 2`] = `
       </tr>
     </thead>
     <tbody
-      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 dRPopI"
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 buut"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 gFGXBk"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iQTwbZ"
         tabindex="0"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 bAcCYq"
+              class="StyledText-sc-1sadyjn-0 gIpquo"
             >
               alpha
             </span>
@@ -26282,38 +26282,38 @@ exports[`DataTable select 1`] = `
 
 exports[`DataTable select 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 iQmOCy"
+  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 hItFIU StyledDataTable-sc-xrlyjm-0 bhJXnf"
+    class="StyledTable-sc-1m3u5g-6 gfvJtN StyledDataTable-sc-xrlyjm-0 iySlWL"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-5"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 hGRSSL"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 ktKCWw"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jThOtf StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kdJQYN StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 iSpovP"
+            class="StyledBox-sc-13pk1d4-0 bknumx"
             style="height: 0px;"
           >
             <label
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 byaRhK"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hhAlPI"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kdNZWX StyledCheckBox-sc-1dbk5ju-6 jHuWbF"
+                class="StyledBox-sc-13pk1d4-0 gOFJEd StyledCheckBox-sc-1dbk5ju-6 ewFUzs"
               >
                 <input
                   aria-label="unselect all"
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNNTU"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 yZiQM"
                   type="checkbox"
                 />
                 <div
-                  class="StyledBox-sc-13pk1d4-0 cJyZCd StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 hZZOmF"
+                  class="StyledBox-sc-13pk1d4-0 gHSfwH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 bwjtfK"
                 >
                   .c0 {
   box-sizing: border-box;
@@ -26347,15 +26347,15 @@ exports[`DataTable select 2`] = `
           </div>
         </th>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jabPpn StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksVeQF StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           id="grommet-data-table-header-a"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 faLdcD"
+            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               A
             </span>
@@ -26364,35 +26364,35 @@ exports[`DataTable select 2`] = `
       </tr>
     </thead>
     <tbody
-      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 dRPopI"
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 buut"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hxldGp StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gIvIGX StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 iSpovP"
+            class="StyledBox-sc-13pk1d4-0 bknumx"
             style="height: 0px;"
           >
             <label
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 byaRhK"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hhAlPI"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kdNZWX StyledCheckBox-sc-1dbk5ju-6 jHuWbF"
+                class="StyledBox-sc-13pk1d4-0 gOFJEd StyledCheckBox-sc-1dbk5ju-6 ewFUzs"
               >
                 <input
                   aria-label="unselect alpha"
                   checked=""
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNNTU"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 yZiQM"
                   type="checkbox"
                 />
                 <div
-                  class="StyledBox-sc-13pk1d4-0 cJyZCd StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 hZZOmF"
+                  class="StyledBox-sc-13pk1d4-0 gHSfwH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 bwjtfK"
                 >
                   <svg
-                    class="StyledCheckBox__StyledCheckBoxIcon-sc-1dbk5ju-0 eNRRvC"
+                    class="StyledCheckBox__StyledCheckBoxIcon-sc-1dbk5ju-0 gLSxni"
                     preserveAspectRatio="xMidYMid meet"
                     viewBox="0 0 24 24"
                   >
@@ -26407,14 +26407,14 @@ exports[`DataTable select 2`] = `
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 bAcCYq"
+              class="StyledText-sc-1sadyjn-0 gIpquo"
             >
               alpha
             </span>
@@ -26422,28 +26422,28 @@ exports[`DataTable select 2`] = `
         </th>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hxldGp StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gIvIGX StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 iSpovP"
+            class="StyledBox-sc-13pk1d4-0 bknumx"
             style="height: 0px;"
           >
             <label
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 byaRhK"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hhAlPI"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kdNZWX StyledCheckBox-sc-1dbk5ju-6 jHuWbF"
+                class="StyledBox-sc-13pk1d4-0 gOFJEd StyledCheckBox-sc-1dbk5ju-6 ewFUzs"
               >
                 <input
                   aria-label="unselect beta"
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNNTU"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 yZiQM"
                   type="checkbox"
                 />
                 <div
-                  class="StyledBox-sc-13pk1d4-0 cJyZCd StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 hZZOmF"
+                  class="StyledBox-sc-13pk1d4-0 gHSfwH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 bwjtfK"
                 >
                   .c0 {
   box-sizing: border-box;
@@ -26477,14 +26477,14 @@ exports[`DataTable select 2`] = `
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 bAcCYq"
+              class="StyledText-sc-1sadyjn-0 gIpquo"
             >
               beta
             </span>
@@ -26892,31 +26892,31 @@ exports[`DataTable select with allowSelectAll={false} 1`] = `
 
 exports[`DataTable select with allowSelectAll={false} 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 iQmOCy"
+  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 hItFIU StyledDataTable-sc-xrlyjm-0 bhJXnf"
+    class="StyledTable-sc-1m3u5g-6 gfvJtN StyledDataTable-sc-xrlyjm-0 iySlWL"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-5"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 hGRSSL"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 ktKCWw"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jThOtf StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kdJQYN StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="col"
         />
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jabPpn StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksVeQF StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           id="grommet-data-table-header-a"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 faLdcD"
+            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               A
             </span>
@@ -26925,35 +26925,35 @@ exports[`DataTable select with allowSelectAll={false} 2`] = `
       </tr>
     </thead>
     <tbody
-      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 dRPopI"
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 buut"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hxldGp StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gIvIGX StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 iSpovP"
+            class="StyledBox-sc-13pk1d4-0 bknumx"
             style="height: 0px;"
           >
             <label
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 byaRhK"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hhAlPI"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kdNZWX StyledCheckBox-sc-1dbk5ju-6 jHuWbF"
+                class="StyledBox-sc-13pk1d4-0 gOFJEd StyledCheckBox-sc-1dbk5ju-6 ewFUzs"
               >
                 <input
                   aria-label="unselect alpha"
                   checked=""
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNNTU"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 yZiQM"
                   type="checkbox"
                 />
                 <div
-                  class="StyledBox-sc-13pk1d4-0 cJyZCd StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 hZZOmF"
+                  class="StyledBox-sc-13pk1d4-0 gHSfwH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 bwjtfK"
                 >
                   <svg
-                    class="StyledCheckBox__StyledCheckBoxIcon-sc-1dbk5ju-0 eNRRvC"
+                    class="StyledCheckBox__StyledCheckBoxIcon-sc-1dbk5ju-0 gLSxni"
                     preserveAspectRatio="xMidYMid meet"
                     viewBox="0 0 24 24"
                   >
@@ -26968,14 +26968,14 @@ exports[`DataTable select with allowSelectAll={false} 2`] = `
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 bAcCYq"
+              class="StyledText-sc-1sadyjn-0 gIpquo"
             >
               alpha
             </span>
@@ -26983,28 +26983,28 @@ exports[`DataTable select with allowSelectAll={false} 2`] = `
         </th>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
       >
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 hxldGp StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 gIvIGX StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 iSpovP"
+            class="StyledBox-sc-13pk1d4-0 bknumx"
             style="height: 0px;"
           >
             <label
-              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 byaRhK"
+              class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 hhAlPI"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 kdNZWX StyledCheckBox-sc-1dbk5ju-6 jHuWbF"
+                class="StyledBox-sc-13pk1d4-0 gOFJEd StyledCheckBox-sc-1dbk5ju-6 ewFUzs"
               >
                 <input
                   aria-label="unselect beta"
-                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 fNNTU"
+                  class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 yZiQM"
                   type="checkbox"
                 />
                 <div
-                  class="StyledBox-sc-13pk1d4-0 cJyZCd StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 hZZOmF"
+                  class="StyledBox-sc-13pk1d4-0 gHSfwH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 bwjtfK"
                 >
                   .c0 {
   box-sizing: border-box;
@@ -27038,14 +27038,14 @@ exports[`DataTable select with allowSelectAll={false} 2`] = `
           </div>
         </td>
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 bAcCYq"
+              class="StyledText-sc-1sadyjn-0 gIpquo"
             >
               beta
             </span>
@@ -41497,48 +41497,48 @@ exports[`DataTable should render new data when page changes 1`] = `
 
 exports[`DataTable should render new data when page changes 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 iQmOCy"
+  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 eLlRsv StyledDataTable__StyledContainer-sc-xrlyjm-1 ijKmFk"
+    class="StyledBox-sc-13pk1d4-0 RYmEp StyledDataTable__StyledContainer-sc-xrlyjm-1 eqDRet"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 kZxVGb"
+      class="StyledBox-sc-13pk1d4-0 hUfIKl"
     >
       <table
-        class="StyledTable-sc-1m3u5g-6 hItFIU StyledDataTable-sc-xrlyjm-0 bhJXnf"
+        class="StyledTable-sc-1m3u5g-6 gfvJtN StyledDataTable-sc-xrlyjm-0 iySlWL"
       >
         <thead
           class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-5"
         >
           <tr
-            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 hGRSSL"
+            class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 ktKCWw"
           >
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 jabPpn StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksVeQF StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
               id="grommet-data-table-header-a"
               scope="col"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 faLdcD"
+                class="StyledBox-sc-13pk1d4-0 kTYaFZ"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 cejToA"
+                  class="StyledText-sc-1sadyjn-0 iuKlFO"
                 >
                   A
                 </span>
               </div>
             </th>
             <th
-              class="StyledTable__StyledTableCell-sc-1m3u5g-0 jabPpn StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+              class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksVeQF StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
               id="grommet-data-table-header-b"
               scope="col"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 faLdcD"
+                class="StyledBox-sc-13pk1d4-0 kTYaFZ"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 cejToA"
+                  class="StyledText-sc-1sadyjn-0 iuKlFO"
                 >
                   B
                 </span>
@@ -41547,7 +41547,7 @@ exports[`DataTable should render new data when page changes 2`] = `
           </tr>
         </thead>
         <tbody
-          class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 dRPopI"
+          class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 buut"
         >
           .c2 {
   display: flex;
@@ -46908,29 +46908,29 @@ exports[`DataTable should render new data when page changes 2`] = `
       </table>
     </div>
     <div
-      class="StyledBox__StyledBoxGap-sc-13pk1d4-1 cKRbXv"
+      class="StyledBox__StyledBoxGap-sc-13pk1d4-1 fjqMzP"
     />
     <div
-      class="StyledBox-sc-13pk1d4-0 jjMhUu Pagination__StyledPaginationContainer-sc-rnlw6m-0"
+      class="StyledBox-sc-13pk1d4-0 iKrjnc Pagination__StyledPaginationContainer-sc-rnlw6m-0"
     >
       <nav
         aria-label="Pagination Navigation"
-        class="StyledBox-sc-13pk1d4-0 kBbldi"
+        class="StyledBox-sc-13pk1d4-0 kvqQSo"
       >
         <ul
-          class="StyledBox-sc-13pk1d4-0 bPPvCJ"
+          class="StyledBox-sc-13pk1d4-0 fLmLVT"
         >
           <li
-            class="StyledPageControl__StyledContainer-sc-1vlfaez-1 budBqk"
+            class="StyledPageControl__StyledContainer-sc-1vlfaez-1 jLcxjj"
           >
             <button
               aria-label="Go to previous page"
-              class="StyledButtonKind-sc-1vhfpnt-0 bKxNBy StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 gHDXxA"
+              class="StyledButtonKind-sc-1vhfpnt-0 cyhaTC StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iIrhyI"
               type="button"
             >
               <svg
                 aria-label="Previous"
-                class="StyledIcon-sc-ofa7kd-0 cDZJSy"
+                class="StyledIcon-sc-ofa7kd-0 dQGxSn"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -46943,41 +46943,41 @@ exports[`DataTable should render new data when page changes 2`] = `
             </button>
           </li>
           <li
-            class="StyledPageControl__StyledContainer-sc-1vlfaez-1 budBqk"
+            class="StyledPageControl__StyledContainer-sc-1vlfaez-1 jLcxjj"
           >
             <button
               aria-label="Go to page 1"
-              class="StyledButtonKind-sc-1vhfpnt-0 isArty StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 gHDXxA"
+              class="StyledButtonKind-sc-1vhfpnt-0 eQoSrm StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iIrhyI"
               type="button"
             >
               1
             </button>
           </li>
           <li
-            class="StyledPageControl__StyledContainer-sc-1vlfaez-1 budBqk"
+            class="StyledPageControl__StyledContainer-sc-1vlfaez-1 jLcxjj"
           >
             <button
               aria-current="page"
               aria-label="Go to page 2"
-              class="StyledButtonKind-sc-1vhfpnt-0 kgFhFU StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 gHDXxA"
+              class="StyledButtonKind-sc-1vhfpnt-0 ecJohc StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iIrhyI"
               type="button"
             >
               2
             </button>
           </li>
           <li
-            class="StyledPageControl__StyledContainer-sc-1vlfaez-1 budBqk"
+            class="StyledPageControl__StyledContainer-sc-1vlfaez-1 jLcxjj"
           >
             <button
               aria-disabled="true"
               aria-label="Go to next page"
-              class="StyledButtonKind-sc-1vhfpnt-0 coAhHy StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 gHDXxA"
+              class="StyledButtonKind-sc-1vhfpnt-0 kTFFQa StyledPageControl__StyledPaginationButton-sc-1vlfaez-0 iIrhyI"
               disabled=""
               type="button"
             >
               <svg
                 aria-label="Next"
-                class="StyledIcon-sc-ofa7kd-0 fmAnVC"
+                class="StyledIcon-sc-ofa7kd-0 blUuJr"
                 viewBox="0 0 24 24"
               >
                 <path
@@ -51747,36 +51747,36 @@ exports[`DataTable should use theme icons 1`] = `
 
 exports[`DataTable should use theme icons 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 iQmOCy"
+  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 hItFIU StyledDataTable-sc-xrlyjm-0 bhJXnf"
+    class="StyledTable-sc-1m3u5g-6 gfvJtN StyledDataTable-sc-xrlyjm-0 iySlWL"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-5"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 hGRSSL"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 ktKCWw"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 jabPpn StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 ksVeQF StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           id="grommet-data-table-header-a"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 bvGdsN"
+            class="StyledBox-sc-13pk1d4-0 jDPdXr"
           >
             <div
-              class="StyledBox-sc-13pk1d4-0 eeJSdc"
+              class="StyledBox-sc-13pk1d4-0 cyLFae"
             >
               <span
-                class="StyledText-sc-1sadyjn-0 cejToA"
+                class="StyledText-sc-1sadyjn-0 iuKlFO"
               >
                 A
               </span>
             </div>
             <div
-              class="StyledBox__StyledBoxGap-sc-13pk1d4-1 qcwOP"
+              class="StyledBox__StyledBoxGap-sc-13pk1d4-1 izwkgv"
             />
             .c0 {
   display: flex;
@@ -51887,20 +51887,20 @@ exports[`DataTable should use theme icons 2`] = `
       </tr>
     </thead>
     <tbody
-      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 dRPopI"
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 buut"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 bAcCYq"
+              class="StyledText-sc-1sadyjn-0 gIpquo"
             >
               []
             </span>
@@ -55100,35 +55100,35 @@ exports[`DataTable sort null data 1`] = `
 
 exports[`DataTable sort null data 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 iQmOCy"
+  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 hItFIU StyledDataTable-sc-xrlyjm-0 bhJXnf"
+    class="StyledTable-sc-1m3u5g-6 gfvJtN StyledDataTable-sc-xrlyjm-0 iySlWL"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-5"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 hGRSSL"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 ktKCWw"
       >
         <th
           aria-sort="ascending"
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 beksZj StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kzbMTh StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           id="grommet-data-table-header-a"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 faLdcD"
+            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
           >
             <button
-              class="StyledButton-sc-323bzc-0 efbshF Header__StyledHeaderCellButton-sc-1baku5q-0 gRxSZx"
+              class="StyledButton-sc-323bzc-0 gVLKEX Header__StyledHeaderCellButton-sc-1baku5q-0 llZrcE"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 ABJcL"
+                class="StyledBox-sc-13pk1d4-0 bHjtLJ"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 cejToA"
+                  class="StyledText-sc-1sadyjn-0 iuKlFO"
                 >
                   A
                 </span>
@@ -55201,23 +55201,23 @@ exports[`DataTable sort null data 2`] = `
         </th>
         <th
           aria-sort="none"
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 beksZj StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kzbMTh StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           id="grommet-data-table-header-b"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 faLdcD"
+            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
           >
             <button
               aria-label="B, sortable"
-              class="StyledButton-sc-323bzc-0 efbshF Header__StyledHeaderCellButton-sc-1baku5q-0 gRxSZx"
+              class="StyledButton-sc-323bzc-0 gVLKEX Header__StyledHeaderCellButton-sc-1baku5q-0 llZrcE"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 ABJcL"
+                class="StyledBox-sc-13pk1d4-0 bHjtLJ"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 cejToA"
+                  class="StyledText-sc-1sadyjn-0 iuKlFO"
                 >
                   B
                 </span>
@@ -55227,23 +55227,23 @@ exports[`DataTable sort null data 2`] = `
         </th>
         <th
           aria-sort="none"
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 beksZj StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kzbMTh StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           id="grommet-data-table-header-c"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 faLdcD"
+            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
           >
             <button
               aria-label="C, sortable"
-              class="StyledButton-sc-323bzc-0 efbshF Header__StyledHeaderCellButton-sc-1baku5q-0 gRxSZx"
+              class="StyledButton-sc-323bzc-0 gVLKEX Header__StyledHeaderCellButton-sc-1baku5q-0 llZrcE"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 ABJcL"
+                class="StyledBox-sc-13pk1d4-0 bHjtLJ"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 cejToA"
+                  class="StyledText-sc-1sadyjn-0 iuKlFO"
                 >
                   C
                 </span>
@@ -55253,23 +55253,23 @@ exports[`DataTable sort null data 2`] = `
         </th>
         <th
           aria-sort="none"
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 beksZj StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kzbMTh StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           id="grommet-data-table-header-d"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 faLdcD"
+            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
           >
             <button
               aria-label="D, sortable"
-              class="StyledButton-sc-323bzc-0 efbshF Header__StyledHeaderCellButton-sc-1baku5q-0 gRxSZx"
+              class="StyledButton-sc-323bzc-0 gVLKEX Header__StyledHeaderCellButton-sc-1baku5q-0 llZrcE"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 ABJcL"
+                class="StyledBox-sc-13pk1d4-0 bHjtLJ"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 cejToA"
+                  class="StyledText-sc-1sadyjn-0 iuKlFO"
                 >
                   D
                 </span>
@@ -55280,53 +55280,53 @@ exports[`DataTable sort null data 2`] = `
       </tr>
     </thead>
     <tbody
-      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 dRPopI"
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 buut"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           />
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               0
             </span>
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               first
             </span>
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               y
             </span>
@@ -55449,98 +55449,98 @@ exports[`DataTable sort null data 2`] = `
         </td>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 bAcCYq"
+              class="StyledText-sc-1sadyjn-0 gIpquo"
             >
               one
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               1
             </span>
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           />
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           />
         </td>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 bAcCYq"
+              class="StyledText-sc-1sadyjn-0 gIpquo"
             >
               two
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               2
             </span>
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               second
             </span>
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           />
         </td>
       </tr>
@@ -55551,36 +55551,36 @@ exports[`DataTable sort null data 2`] = `
 
 exports[`DataTable sort null data 3`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 iQmOCy"
+  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 hItFIU StyledDataTable-sc-xrlyjm-0 bhJXnf"
+    class="StyledTable-sc-1m3u5g-6 gfvJtN StyledDataTable-sc-xrlyjm-0 iySlWL"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-5"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 hGRSSL"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 ktKCWw"
       >
         <th
           aria-sort="none"
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 beksZj StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kzbMTh StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           id="grommet-data-table-header-a"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 faLdcD"
+            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
           >
             <button
               aria-label="A, sortable"
-              class="StyledButton-sc-323bzc-0 efbshF Header__StyledHeaderCellButton-sc-1baku5q-0 gRxSZx"
+              class="StyledButton-sc-323bzc-0 gVLKEX Header__StyledHeaderCellButton-sc-1baku5q-0 llZrcE"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 ABJcL"
+                class="StyledBox-sc-13pk1d4-0 bHjtLJ"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 cejToA"
+                  class="StyledText-sc-1sadyjn-0 iuKlFO"
                 >
                   A
                 </span>
@@ -55590,23 +55590,23 @@ exports[`DataTable sort null data 3`] = `
         </th>
         <th
           aria-sort="none"
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 beksZj StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kzbMTh StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           id="grommet-data-table-header-b"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 faLdcD"
+            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
           >
             <button
               aria-label="B, sortable"
-              class="StyledButton-sc-323bzc-0 efbshF Header__StyledHeaderCellButton-sc-1baku5q-0 gRxSZx"
+              class="StyledButton-sc-323bzc-0 gVLKEX Header__StyledHeaderCellButton-sc-1baku5q-0 llZrcE"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 ABJcL"
+                class="StyledBox-sc-13pk1d4-0 bHjtLJ"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 cejToA"
+                  class="StyledText-sc-1sadyjn-0 iuKlFO"
                 >
                   B
                 </span>
@@ -55616,22 +55616,22 @@ exports[`DataTable sort null data 3`] = `
         </th>
         <th
           aria-sort="ascending"
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 beksZj StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kzbMTh StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           id="grommet-data-table-header-c"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 faLdcD"
+            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
           >
             <button
-              class="StyledButton-sc-323bzc-0 efbshF Header__StyledHeaderCellButton-sc-1baku5q-0 gRxSZx"
+              class="StyledButton-sc-323bzc-0 gVLKEX Header__StyledHeaderCellButton-sc-1baku5q-0 llZrcE"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 ABJcL"
+                class="StyledBox-sc-13pk1d4-0 bHjtLJ"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 cejToA"
+                  class="StyledText-sc-1sadyjn-0 iuKlFO"
                 >
                   C
                 </span>
@@ -55704,23 +55704,23 @@ exports[`DataTable sort null data 3`] = `
         </th>
         <th
           aria-sort="none"
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 beksZj StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kzbMTh StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           id="grommet-data-table-header-d"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 faLdcD"
+            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
           >
             <button
               aria-label="D, sortable"
-              class="StyledButton-sc-323bzc-0 efbshF Header__StyledHeaderCellButton-sc-1baku5q-0 gRxSZx"
+              class="StyledButton-sc-323bzc-0 gVLKEX Header__StyledHeaderCellButton-sc-1baku5q-0 llZrcE"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 ABJcL"
+                class="StyledBox-sc-13pk1d4-0 bHjtLJ"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 cejToA"
+                  class="StyledText-sc-1sadyjn-0 iuKlFO"
                 >
                   D
                 </span>
@@ -55731,92 +55731,92 @@ exports[`DataTable sort null data 3`] = `
       </tr>
     </thead>
     <tbody
-      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 dRPopI"
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 buut"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 bAcCYq"
+              class="StyledText-sc-1sadyjn-0 gIpquo"
             >
               one
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               1
             </span>
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           />
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           />
         </td>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           />
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               3
             </span>
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           />
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               z
             </span>
@@ -55945,53 +55945,53 @@ exports[`DataTable sort null data 3`] = `
         </td>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 bAcCYq"
+              class="StyledText-sc-1sadyjn-0 gIpquo"
             >
               two
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               2
             </span>
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               second
             </span>
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           />
         </td>
       </tr>
@@ -56002,36 +56002,36 @@ exports[`DataTable sort null data 3`] = `
 
 exports[`DataTable sort null data 4`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 iQmOCy"
+  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 hItFIU StyledDataTable-sc-xrlyjm-0 bhJXnf"
+    class="StyledTable-sc-1m3u5g-6 gfvJtN StyledDataTable-sc-xrlyjm-0 iySlWL"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-5"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 hGRSSL"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 ktKCWw"
       >
         <th
           aria-sort="none"
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 beksZj StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kzbMTh StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           id="grommet-data-table-header-a"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 faLdcD"
+            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
           >
             <button
               aria-label="A, sortable"
-              class="StyledButton-sc-323bzc-0 efbshF Header__StyledHeaderCellButton-sc-1baku5q-0 gRxSZx"
+              class="StyledButton-sc-323bzc-0 gVLKEX Header__StyledHeaderCellButton-sc-1baku5q-0 llZrcE"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 ABJcL"
+                class="StyledBox-sc-13pk1d4-0 bHjtLJ"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 cejToA"
+                  class="StyledText-sc-1sadyjn-0 iuKlFO"
                 >
                   A
                 </span>
@@ -56041,23 +56041,23 @@ exports[`DataTable sort null data 4`] = `
         </th>
         <th
           aria-sort="none"
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 beksZj StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kzbMTh StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           id="grommet-data-table-header-b"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 faLdcD"
+            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
           >
             <button
               aria-label="B, sortable"
-              class="StyledButton-sc-323bzc-0 efbshF Header__StyledHeaderCellButton-sc-1baku5q-0 gRxSZx"
+              class="StyledButton-sc-323bzc-0 gVLKEX Header__StyledHeaderCellButton-sc-1baku5q-0 llZrcE"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 ABJcL"
+                class="StyledBox-sc-13pk1d4-0 bHjtLJ"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 cejToA"
+                  class="StyledText-sc-1sadyjn-0 iuKlFO"
                 >
                   B
                 </span>
@@ -56067,23 +56067,23 @@ exports[`DataTable sort null data 4`] = `
         </th>
         <th
           aria-sort="none"
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 beksZj StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kzbMTh StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           id="grommet-data-table-header-c"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 faLdcD"
+            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
           >
             <button
               aria-label="C, sortable"
-              class="StyledButton-sc-323bzc-0 efbshF Header__StyledHeaderCellButton-sc-1baku5q-0 gRxSZx"
+              class="StyledButton-sc-323bzc-0 gVLKEX Header__StyledHeaderCellButton-sc-1baku5q-0 llZrcE"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 ABJcL"
+                class="StyledBox-sc-13pk1d4-0 bHjtLJ"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 cejToA"
+                  class="StyledText-sc-1sadyjn-0 iuKlFO"
                 >
                   C
                 </span>
@@ -56093,22 +56093,22 @@ exports[`DataTable sort null data 4`] = `
         </th>
         <th
           aria-sort="ascending"
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 beksZj StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kzbMTh StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           id="grommet-data-table-header-d"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 faLdcD"
+            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
           >
             <button
-              class="StyledButton-sc-323bzc-0 efbshF Header__StyledHeaderCellButton-sc-1baku5q-0 gRxSZx"
+              class="StyledButton-sc-323bzc-0 gVLKEX Header__StyledHeaderCellButton-sc-1baku5q-0 llZrcE"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 ABJcL"
+                class="StyledBox-sc-13pk1d4-0 bHjtLJ"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 cejToA"
+                  class="StyledText-sc-1sadyjn-0 iuKlFO"
                 >
                   D
                 </span>
@@ -56182,149 +56182,149 @@ exports[`DataTable sort null data 4`] = `
       </tr>
     </thead>
     <tbody
-      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 dRPopI"
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 buut"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 bAcCYq"
+              class="StyledText-sc-1sadyjn-0 gIpquo"
             >
               one
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               1
             </span>
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           />
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           />
         </td>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 bAcCYq"
+              class="StyledText-sc-1sadyjn-0 gIpquo"
             >
               two
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               2
             </span>
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               second
             </span>
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           />
         </td>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           />
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               0
             </span>
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               first
             </span>
           </div>
         </td>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               y
             </span>
@@ -56816,35 +56816,35 @@ exports[`DataTable sortable 1`] = `
 
 exports[`DataTable sortable 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 iQmOCy"
+  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
 >
   <table
-    class="StyledTable-sc-1m3u5g-6 hItFIU StyledDataTable-sc-xrlyjm-0 bhJXnf"
+    class="StyledTable-sc-1m3u5g-6 gfvJtN StyledDataTable-sc-xrlyjm-0 iySlWL"
   >
     <thead
       class="StyledTable__StyledTableHeader-sc-1m3u5g-4 StyledDataTable__StyledDataTableHeader-sc-xrlyjm-5"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 hGRSSL"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRowHeader-sc-xrlyjm-3 ktKCWw"
       >
         <th
           aria-sort="ascending"
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 beksZj StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kzbMTh StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           id="grommet-data-table-header-a"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 faLdcD"
+            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
           >
             <button
-              class="StyledButton-sc-323bzc-0 efbshF Header__StyledHeaderCellButton-sc-1baku5q-0 gRxSZx"
+              class="StyledButton-sc-323bzc-0 gVLKEX Header__StyledHeaderCellButton-sc-1baku5q-0 llZrcE"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 ABJcL"
+                class="StyledBox-sc-13pk1d4-0 bHjtLJ"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 cejToA"
+                  class="StyledText-sc-1sadyjn-0 iuKlFO"
                 >
                   A
                 </span>
@@ -56917,23 +56917,23 @@ exports[`DataTable sortable 2`] = `
         </th>
         <th
           aria-sort="none"
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 beksZj StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 kzbMTh StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           id="grommet-data-table-header-b"
           scope="col"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 faLdcD"
+            class="StyledBox-sc-13pk1d4-0 kTYaFZ"
           >
             <button
               aria-label="B, sortable"
-              class="StyledButton-sc-323bzc-0 efbshF Header__StyledHeaderCellButton-sc-1baku5q-0 gRxSZx"
+              class="StyledButton-sc-323bzc-0 gVLKEX Header__StyledHeaderCellButton-sc-1baku5q-0 llZrcE"
               type="button"
             >
               <div
-                class="StyledBox-sc-13pk1d4-0 ABJcL"
+                class="StyledBox-sc-13pk1d4-0 bHjtLJ"
               >
                 <span
-                  class="StyledText-sc-1sadyjn-0 cejToA"
+                  class="StyledText-sc-1sadyjn-0 iuKlFO"
                 >
                   B
                 </span>
@@ -56944,33 +56944,33 @@ exports[`DataTable sortable 2`] = `
       </tr>
     </thead>
     <tbody
-      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 dRPopI"
+      class="StyledTable__StyledTableBody-sc-1m3u5g-3 StyledDataTable__StyledDataTableBody-sc-xrlyjm-4 buut"
     >
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 bAcCYq"
+              class="StyledText-sc-1sadyjn-0 gIpquo"
             >
               one
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               1
             </span>
@@ -56978,30 +56978,30 @@ exports[`DataTable sortable 2`] = `
         </td>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 bAcCYq"
+              class="StyledText-sc-1sadyjn-0 gIpquo"
             >
               two
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               2
             </span>
@@ -57009,30 +57009,30 @@ exports[`DataTable sortable 2`] = `
         </td>
       </tr>
       <tr
-        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 joJGOz"
+        class="StyledTable__StyledTableRow-sc-1m3u5g-2 StyledDataTable__StyledDataTableRow-sc-xrlyjm-2 iunPNm"
       >
         <th
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
           scope="row"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 bAcCYq"
+              class="StyledText-sc-1sadyjn-0 gIpquo"
             >
               zero
             </span>
           </div>
         </th>
         <td
-          class="StyledTable__StyledTableCell-sc-1m3u5g-0 cWapjt StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 gokxaP"
+          class="StyledTable__StyledTableCell-sc-1m3u5g-0 bufnLL StyledDataTable__StyledDataTableCell-sc-xrlyjm-7 lnazUs"
         >
           <div
-            class="StyledBox-sc-13pk1d4-0 eLlRsv"
+            class="StyledBox-sc-13pk1d4-0 RYmEp"
           >
             <span
-              class="StyledText-sc-1sadyjn-0 cejToA"
+              class="StyledText-sc-1sadyjn-0 iuKlFO"
             >
               0
             </span>

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.tsx.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.tsx.snap
@@ -3904,6 +3904,7 @@ exports[`DataTable custom theme 1`] = `
             class="c5"
           >
             <button
+              aria-label="A, sortable"
               class="c6 c7"
               type="button"
             >
@@ -4084,6 +4085,7 @@ exports[`DataTable custom theme 2`] = `
             class="StyledBox-sc-13pk1d4-0 eeJSdc"
           >
             <button
+              aria-label="A, sortable"
               class="StyledButton-sc-323bzc-0 efbshF Header__StyledHeaderCellButton-sc-1baku5q-0 dudWar"
               type="button"
             >
@@ -17233,6 +17235,7 @@ exports[`DataTable onSort 1`] = `
             class="c4"
           >
             <button
+              aria-label="A, sortable"
               class="c5 c6"
               type="button"
             >
@@ -17258,6 +17261,7 @@ exports[`DataTable onSort 1`] = `
             class="c4"
           >
             <button
+              aria-label="B, sortable"
               class="c5 c6"
               type="button"
             >
@@ -17487,6 +17491,7 @@ exports[`DataTable onSort 2`] = `
             class="StyledBox-sc-13pk1d4-0 faLdcD"
           >
             <button
+              aria-label="B, sortable"
               class="StyledButton-sc-323bzc-0 efbshF Header__StyledHeaderCellButton-sc-1baku5q-0 gRxSZx"
               type="button"
             >
@@ -17907,6 +17912,7 @@ exports[`DataTable onSort external 1`] = `
             class="c4"
           >
             <button
+              aria-label="B, sortable"
               class="c5 c6"
               type="button"
             >
@@ -18124,6 +18130,7 @@ exports[`DataTable onSort external 2`] = `
             class="StyledBox-sc-13pk1d4-0 faLdcD"
           >
             <button
+              aria-label="B, sortable"
               class="StyledButton-sc-323bzc-0 efbshF Header__StyledHeaderCellButton-sc-1baku5q-0 gRxSZx"
               type="button"
             >
@@ -52207,6 +52214,7 @@ exports[`DataTable sort 1`] = `
             class="c4"
           >
             <button
+              aria-label="B, sortable"
               class="c5 c6"
               type="button"
             >
@@ -52699,6 +52707,7 @@ exports[`DataTable sort controlled 1`] = `
               class="c5"
             >
               <button
+                aria-label="B, sortable"
                 class="c6 c7"
                 type="button"
               >
@@ -53192,6 +53201,7 @@ exports[`DataTable sort controlled 2`] = `
               class="c5"
             >
               <button
+                aria-label="B, sortable"
                 class="c6 c7"
                 type="button"
               >
@@ -53613,6 +53623,7 @@ exports[`DataTable sort external 1`] = `
             class="c4"
           >
             <button
+              aria-label="B, sortable"
               class="c5 c6"
               type="button"
             >
@@ -53993,6 +54004,7 @@ exports[`DataTable sort nested object 1`] = `
             class="c4"
           >
             <button
+              aria-label="A, sortable"
               class="c5 c6"
               type="button"
             >
@@ -54413,6 +54425,7 @@ exports[`DataTable sort nested object with onSort 1`] = `
             class="c4"
           >
             <button
+              aria-label="A, sortable"
               class="c5 c6"
               type="button"
             >
@@ -54789,6 +54802,7 @@ exports[`DataTable sort null data 1`] = `
             class="c4"
           >
             <button
+              aria-label="A, sortable"
               class="c5 c6"
               type="button"
             >
@@ -54814,6 +54828,7 @@ exports[`DataTable sort null data 1`] = `
             class="c4"
           >
             <button
+              aria-label="B, sortable"
               class="c5 c6"
               type="button"
             >
@@ -54839,6 +54854,7 @@ exports[`DataTable sort null data 1`] = `
             class="c4"
           >
             <button
+              aria-label="C, sortable"
               class="c5 c6"
               type="button"
             >
@@ -54864,6 +54880,7 @@ exports[`DataTable sort null data 1`] = `
             class="c4"
           >
             <button
+              aria-label="D, sortable"
               class="c5 c6"
               type="button"
             >
@@ -55192,6 +55209,7 @@ exports[`DataTable sort null data 2`] = `
             class="StyledBox-sc-13pk1d4-0 faLdcD"
           >
             <button
+              aria-label="B, sortable"
               class="StyledButton-sc-323bzc-0 efbshF Header__StyledHeaderCellButton-sc-1baku5q-0 gRxSZx"
               type="button"
             >
@@ -55217,6 +55235,7 @@ exports[`DataTable sort null data 2`] = `
             class="StyledBox-sc-13pk1d4-0 faLdcD"
           >
             <button
+              aria-label="C, sortable"
               class="StyledButton-sc-323bzc-0 efbshF Header__StyledHeaderCellButton-sc-1baku5q-0 gRxSZx"
               type="button"
             >
@@ -55242,6 +55261,7 @@ exports[`DataTable sort null data 2`] = `
             class="StyledBox-sc-13pk1d4-0 faLdcD"
           >
             <button
+              aria-label="D, sortable"
               class="StyledButton-sc-323bzc-0 efbshF Header__StyledHeaderCellButton-sc-1baku5q-0 gRxSZx"
               type="button"
             >
@@ -55552,6 +55572,7 @@ exports[`DataTable sort null data 3`] = `
             class="StyledBox-sc-13pk1d4-0 faLdcD"
           >
             <button
+              aria-label="A, sortable"
               class="StyledButton-sc-323bzc-0 efbshF Header__StyledHeaderCellButton-sc-1baku5q-0 gRxSZx"
               type="button"
             >
@@ -55577,6 +55598,7 @@ exports[`DataTable sort null data 3`] = `
             class="StyledBox-sc-13pk1d4-0 faLdcD"
           >
             <button
+              aria-label="B, sortable"
               class="StyledButton-sc-323bzc-0 efbshF Header__StyledHeaderCellButton-sc-1baku5q-0 gRxSZx"
               type="button"
             >
@@ -55690,6 +55712,7 @@ exports[`DataTable sort null data 3`] = `
             class="StyledBox-sc-13pk1d4-0 faLdcD"
           >
             <button
+              aria-label="D, sortable"
               class="StyledButton-sc-323bzc-0 efbshF Header__StyledHeaderCellButton-sc-1baku5q-0 gRxSZx"
               type="button"
             >
@@ -56000,6 +56023,7 @@ exports[`DataTable sort null data 4`] = `
             class="StyledBox-sc-13pk1d4-0 faLdcD"
           >
             <button
+              aria-label="A, sortable"
               class="StyledButton-sc-323bzc-0 efbshF Header__StyledHeaderCellButton-sc-1baku5q-0 gRxSZx"
               type="button"
             >
@@ -56025,6 +56049,7 @@ exports[`DataTable sort null data 4`] = `
             class="StyledBox-sc-13pk1d4-0 faLdcD"
           >
             <button
+              aria-label="B, sortable"
               class="StyledButton-sc-323bzc-0 efbshF Header__StyledHeaderCellButton-sc-1baku5q-0 gRxSZx"
               type="button"
             >
@@ -56050,6 +56075,7 @@ exports[`DataTable sort null data 4`] = `
             class="StyledBox-sc-13pk1d4-0 faLdcD"
           >
             <button
+              aria-label="C, sortable"
               class="StyledButton-sc-323bzc-0 efbshF Header__StyledHeaderCellButton-sc-1baku5q-0 gRxSZx"
               type="button"
             >
@@ -56643,6 +56669,7 @@ exports[`DataTable sortable 1`] = `
             class="c4"
           >
             <button
+              aria-label="A, sortable"
               class="c5 c6"
               type="button"
             >
@@ -56668,6 +56695,7 @@ exports[`DataTable sortable 1`] = `
             class="c4"
           >
             <button
+              aria-label="B, sortable"
               class="c5 c6"
               type="button"
             >
@@ -56897,6 +56925,7 @@ exports[`DataTable sortable 2`] = `
             class="StyledBox-sc-13pk1d4-0 faLdcD"
           >
             <button
+              aria-label="B, sortable"
               class="StyledButton-sc-323bzc-0 efbshF Header__StyledHeaderCellButton-sc-1baku5q-0 gRxSZx"
               type="button"
             >
@@ -57562,6 +57591,7 @@ exports[`DataTable theme search pad, search text pad, sort gap, and expand size 
               class="c11"
             >
               <button
+                aria-label="A, sortable"
                 class="c12 c13"
                 type="button"
               >
@@ -57606,6 +57636,7 @@ exports[`DataTable theme search pad, search text pad, sort gap, and expand size 
             class="c20"
           >
             <button
+              aria-label="B, sortable"
               class="c12 c13"
               type="button"
             >

--- a/src/js/languages/default.json
+++ b/src/js/languages/default.json
@@ -75,6 +75,7 @@
     "rowsChanged": "Number of rows changed",
     "rowsSingle": "row",
     "searchBy": "Open search by {property}",
+    "sortable": "{label}, sortable",
     "total": "{total} {rows}",
     "totalSingle": "{total} {rows}"
   },


### PR DESCRIPTION
Sortable columns that are not currently sorted were missing `aria-sort="none"`, so AT users couldn't discover that a column is sortable before interacting with it. The unsorted sort indicator icon was also exposed to assistive technology despite being decorative.

- Added `ariaSort = 'none'` in the unsorted-but-sortable branch of Header.js
- Added `aria-hidden={true}` on the sort indicator icon when no `aria-label` is set (unsorted state)

Follows the [WAI-ARIA sortable table pattern](https://www.w3.org/WAI/ARIA/apg/patterns/table/examples/sortable-table/).

Closes #7924