### PR TITLE
 #7936 Fix NotFoundError on insertBefore when page is translated. 

### DIFF
--- a/src/js/components/Anchor/Anchor.js
+++ b/src/js/components/Anchor/Anchor.js
@@ -80,8 +80,14 @@ const Anchor = forwardRef(
 
     const anchorIcon = useSizedIcon(coloredIcon, sizeProp || size, theme);
 
-    const first = reverse ? label : anchorIcon;
-    const second = reverse ? anchorIcon : label;
+    // Wrap a plain string label in a span so browser translation tools
+    // (e.g. Chrome's Google Translate) replace the text node inside the span
+    // rather than a text node that is a direct sibling of React-managed
+    // elements, which would break React's DOM reconciliation
+    // (NotFoundError on insertBefore).
+    const safeLabel = typeof label === 'string' ? <span>{label}</span> : label;
+    const first = reverse ? safeLabel : anchorIcon;
+    const second = reverse ? anchorIcon : safeLabel;
 
     return (
       <StyledAnchor

--- a/src/js/components/Anchor/__tests__/__snapshots__/Anchor-test.tsx.snap
+++ b/src/js/components/Anchor/__tests__/__snapshots__/Anchor-test.tsx.snap
@@ -33,7 +33,9 @@ exports[`Anchor blur renders 1`] = `
     class="c1"
     href="#"
   >
-    Test
+    <span>
+      Test
+    </span>
   </a>
 </div>
 `;
@@ -125,7 +127,9 @@ exports[`Anchor focus renders 1`] = `
     class="c1"
     href="#"
   >
-    Test
+    <span>
+      Test
+    </span>
   </a>
 </div>
 `;
@@ -213,7 +217,9 @@ exports[`Anchor gap renders 1`] = `
         <span
           class="c3"
         />
-        Theme Gap
+        <span>
+          Theme Gap
+        </span>
       </span>
     </a>
     <a
@@ -229,7 +235,9 @@ exports[`Anchor gap renders 1`] = `
         <span
           class="c4"
         />
-        Small Gap
+        <span>
+          Small Gap
+        </span>
       </span>
     </a>
     <a
@@ -245,7 +253,9 @@ exports[`Anchor gap renders 1`] = `
         <span
           class="c5"
         />
-        Medium Gap
+        <span>
+          Medium Gap
+        </span>
       </span>
     </a>
     <a
@@ -261,7 +271,9 @@ exports[`Anchor gap renders 1`] = `
         <span
           class="c6"
         />
-        Large Gap
+        <span>
+          Large Gap
+        </span>
       </span>
     </a>
     <a
@@ -277,7 +289,9 @@ exports[`Anchor gap renders 1`] = `
         <span
           class="c7"
         />
-        5px Gap
+        <span>
+          5px Gap
+        </span>
       </span>
     </a>
   </div>
@@ -342,7 +356,9 @@ exports[`Anchor icon label renders 1`] = `
         <span
           class="c3"
         />
-        Test
+        <span>
+          Test
+        </span>
       </span>
     </a>
   </div>
@@ -382,7 +398,9 @@ exports[`Anchor is clickable 1`] = `
     class="c1"
     href="#"
   >
-    Test
+    <span>
+      Test
+    </span>
   </a>
 </div>
 `;
@@ -674,7 +692,9 @@ exports[`Anchor matches icon size to size prop when theme.icon.matchSize is true
         <span
           class="c4"
         />
-        Label
+        <span>
+          Label
+        </span>
       </span>
     </a>
     <a
@@ -698,7 +718,9 @@ exports[`Anchor matches icon size to size prop when theme.icon.matchSize is true
         <span
           class="c4"
         />
-        Label
+        <span>
+          Label
+        </span>
       </span>
     </a>
     <a
@@ -722,7 +744,9 @@ exports[`Anchor matches icon size to size prop when theme.icon.matchSize is true
         <span
           class="c4"
         />
-        Label
+        <span>
+          Label
+        </span>
       </span>
     </a>
     <a
@@ -746,7 +770,9 @@ exports[`Anchor matches icon size to size prop when theme.icon.matchSize is true
         <span
           class="c4"
         />
-        Label
+        <span>
+          Label
+        </span>
       </span>
     </a>
     <a
@@ -770,7 +796,9 @@ exports[`Anchor matches icon size to size prop when theme.icon.matchSize is true
         <span
           class="c4"
         />
-        Label
+        <span>
+          Label
+        </span>
       </span>
     </a>
   </div>
@@ -849,14 +877,18 @@ exports[`Anchor renders a11yTitle and aria-label 1`] = `
       class="c1"
       href="#"
     >
-      Test
+      <span>
+        Test
+      </span>
     </a>
     <a
       aria-label="test-2"
       class="c1"
       href="#"
     >
-      Test
+      <span>
+        Test
+      </span>
     </a>
   </div>
 </div>
@@ -1161,7 +1193,9 @@ exports[`Anchor renders size specific theming 1`] = `
       <a
         class="c2"
       >
-        xsmall
+        <span>
+          xsmall
+        </span>
       </a>
       <span
         class="c3"
@@ -1170,7 +1204,9 @@ exports[`Anchor renders size specific theming 1`] = `
         <a
           class="c2"
         >
-          xsmall
+          <span>
+            xsmall
+          </span>
         </a>
          from text.
       </span>
@@ -1181,7 +1217,9 @@ exports[`Anchor renders size specific theming 1`] = `
       <a
         class="c4"
       >
-        small
+        <span>
+          small
+        </span>
       </a>
       <span
         class="c5"
@@ -1190,7 +1228,9 @@ exports[`Anchor renders size specific theming 1`] = `
         <a
           class="c4"
         >
-          small
+          <span>
+            small
+          </span>
         </a>
          from text.
       </span>
@@ -1201,7 +1241,9 @@ exports[`Anchor renders size specific theming 1`] = `
       <a
         class="c6"
       >
-        medium
+        <span>
+          medium
+        </span>
       </a>
       <span
         class="c7"
@@ -1210,7 +1252,9 @@ exports[`Anchor renders size specific theming 1`] = `
         <a
           class="c6"
         >
-          medium
+          <span>
+            medium
+          </span>
         </a>
          from text.
       </span>
@@ -1221,7 +1265,9 @@ exports[`Anchor renders size specific theming 1`] = `
       <a
         class="c8"
       >
-        large
+        <span>
+          large
+        </span>
       </a>
       <span
         class="c9"
@@ -1230,7 +1276,9 @@ exports[`Anchor renders size specific theming 1`] = `
         <a
           class="c8"
         >
-          large
+          <span>
+            large
+          </span>
         </a>
          from text.
       </span>
@@ -1241,7 +1289,9 @@ exports[`Anchor renders size specific theming 1`] = `
       <a
         class="c10"
       >
-        xlarge
+        <span>
+          xlarge
+        </span>
       </a>
       <span
         class="c11"
@@ -1250,7 +1300,9 @@ exports[`Anchor renders size specific theming 1`] = `
         <a
           class="c10"
         >
-          xlarge
+          <span>
+            xlarge
+          </span>
         </a>
          from text.
       </span>
@@ -1261,7 +1313,9 @@ exports[`Anchor renders size specific theming 1`] = `
       <a
         class="c12"
       >
-        xxlarge
+        <span>
+          xxlarge
+        </span>
       </a>
       <span
         class="c13"
@@ -1270,7 +1324,9 @@ exports[`Anchor renders size specific theming 1`] = `
         <a
           class="c12"
         >
-          xxlarge
+          <span>
+            xxlarge
+          </span>
         </a>
          from text.
       </span>
@@ -1282,14 +1338,18 @@ exports[`Anchor renders size specific theming 1`] = `
       <a
         class="c4"
       >
-        small
+        <span>
+          small
+        </span>
       </a>
        from Paragraph.
     </p>
     <a
       class="c15"
     >
-      Default anchor with no size prop should receive medium
+      <span>
+        Default anchor with no size prop should receive medium
+      </span>
     </a>
     <a
       class="c16"
@@ -1312,7 +1372,9 @@ exports[`Anchor renders size specific theming 1`] = `
         <span
           class="c19"
         />
-        Anchor with icon
+        <span>
+          Anchor with icon
+        </span>
       </span>
     </a>
     <a
@@ -1336,7 +1398,9 @@ exports[`Anchor renders size specific theming 1`] = `
         <span
           class="c21"
         />
-        small anchor with icon should receive color on icon
+        <span>
+          small anchor with icon should receive color on icon
+        </span>
       </span>
     </a>
     <a
@@ -1360,7 +1424,9 @@ exports[`Anchor renders size specific theming 1`] = `
         <span
           class="c22"
         />
-        Large anchor with icon should receive color on icon
+        <span>
+          Large anchor with icon should receive color on icon
+        </span>
       </span>
     </a>
   </div>
@@ -1498,7 +1564,9 @@ exports[`Anchor renders specific icon color 1`] = `
         <span
           class="c4"
         />
-        Color prop on icon
+        <span>
+          Color prop on icon
+        </span>
       </span>
     </a>
     <a
@@ -1522,7 +1590,9 @@ exports[`Anchor renders specific icon color 1`] = `
         <span
           class="c4"
         />
-        Anchor with color prop
+        <span>
+          Anchor with color prop
+        </span>
       </span>
     </a>
     <a
@@ -1546,7 +1616,9 @@ exports[`Anchor renders specific icon color 1`] = `
         <span
           class="c4"
         />
-        Anchor using theme
+        <span>
+          Anchor using theme
+        </span>
       </span>
     </a>
   </div>
@@ -1647,7 +1719,9 @@ exports[`Anchor renders specific icon color 1`] = `
         <span
           class="c4"
         />
-        Anchor color
+        <span>
+          Anchor color
+        </span>
       </span>
     </a>
   </div>
@@ -1688,7 +1762,9 @@ exports[`Anchor renders tag 1`] = `
       class="c1"
       href="#"
     >
-      Test
+      <span>
+        Test
+      </span>
     </span>
   </div>
 </div>
@@ -1784,7 +1860,9 @@ exports[`Anchor reverse icon label renders 1`] = `
       <span
         class="c2"
       >
-        Test
+        <span>
+          Test
+        </span>
         <span
           class="c3"
         />
@@ -2192,7 +2270,9 @@ exports[`Anchor warns about invalid label render 1`] = `
     class="c1"
     href="#"
   >
-    Test
+    <span>
+      Test
+    </span>
   </a>
 </div>
 `;
@@ -2351,55 +2431,73 @@ exports[`Anchor weight renders 1`] = `
       class="c1"
       href="#"
     >
-      Normal
+      <span>
+        Normal
+      </span>
     </a>
     <a
       class="c2"
       href="#"
     >
-      Bold
+      <span>
+        Bold
+      </span>
     </a>
     <a
       class="c3"
       href="#"
     >
-      Bold
+      <span>
+        Bold
+      </span>
     </a>
     <a
       class="c4"
       href="#"
     >
-      Lighter
+      <span>
+        Lighter
+      </span>
     </a>
     <a
       class="c5"
       href="#"
     >
-      Bolder
+      <span>
+        Bolder
+      </span>
     </a>
     <a
       class="c6"
       href="#"
     >
-      Inherit
+      <span>
+        Inherit
+      </span>
     </a>
     <a
       class="c7"
       href="#"
     >
-      Initial
+      <span>
+        Initial
+      </span>
     </a>
     <a
       class="c8"
       href="#"
     >
-      Revert
+      <span>
+        Revert
+      </span>
     </a>
     <a
       class="c9"
       href="#"
     >
-      Unset
+      <span>
+        Unset
+      </span>
     </a>
   </div>
 </div>

--- a/src/js/components/Button/Button.js
+++ b/src/js/components/Button/Button.js
@@ -408,8 +408,14 @@ const Button = forwardRef(
 
     const reverse = reverseProp ?? theme.button[kind]?.reverse;
     const domTag = !as && href ? 'a' : as;
-    const first = reverse ? label : buttonIcon;
-    const second = reverse ? buttonIcon : label;
+    // Wrap a plain string label in a span so browser translation tools
+    // (e.g. Chrome's Google Translate) replace the text node inside the span
+    // rather than a text node that is a direct sibling of React-managed
+    // elements, which would break React's DOM reconciliation
+    // (NotFoundError on insertBefore).
+    const safeLabel = typeof label === 'string' ? <span>{label}</span> : label;
+    const first = reverse ? safeLabel : buttonIcon;
+    const second = reverse ? buttonIcon : safeLabel;
 
     let contents;
     if (first && second) {

--- a/src/js/components/Button/__tests__/Button-kind-test.js
+++ b/src/js/components/Button/__tests__/Button-kind-test.js
@@ -420,7 +420,7 @@ describe('Button kind', () => {
 
   test(`disabled state cursor should indicate the button cannot be
   clicked`, () => {
-    const { getByText } = render(
+    const { getByRole } = render(
       <Grommet
         theme={{
           button: { default: {} },
@@ -430,7 +430,7 @@ describe('Button kind', () => {
       </Grommet>,
     );
 
-    const button = getByText('Button');
+    const button = getByRole('button', { name: 'Button' });
     // eslint-disable-next-line no-underscore-dangle
     const cursorStyle = window.getComputedStyle(button)._values.cursor;
     expect(cursorStyle).not.toBe('pointer');

--- a/src/js/components/Button/__tests__/__snapshots__/Button-kind-test.js.snap
+++ b/src/js/components/Button/__tests__/__snapshots__/Button-kind-test.js.snap
@@ -129,7 +129,9 @@ exports[`Button kind badge should align to button container if specified in them
         class="c3"
         type="button"
       >
-        Button
+        <span>
+          Button
+        </span>
       </button>
     </div>
     <div
@@ -284,7 +286,9 @@ exports[`Button kind badge should apply background 1`] = `
         class="c3"
         type="button"
       >
-        Button
+        <span>
+          Button
+        </span>
       </button>
     </div>
     <div
@@ -432,7 +436,9 @@ exports[`Button kind badge should be offset from top-right corner 1`] = `
         class="c3"
         type="button"
       >
-        Button
+        <span>
+          Button
+        </span>
       </button>
     </div>
     <div
@@ -581,7 +587,9 @@ exports[`Button kind badge should display "+" when number is greater than max 1`
         class="c3"
         type="button"
       >
-        Button
+        <span>
+          Button
+        </span>
       </button>
     </div>
     <div
@@ -736,7 +744,9 @@ exports[`Button kind badge should display number content 1`] = `
         class="c3"
         type="button"
       >
-        Button
+        <span>
+          Button
+        </span>
       </button>
     </div>
     <div
@@ -904,7 +914,9 @@ exports[`Button kind badge should render custom element 1`] = `
         class="c3"
         type="button"
       >
-        Button
+        <span>
+          Button
+        </span>
       </button>
     </div>
     <div
@@ -1202,7 +1214,9 @@ exports[`Button kind border on default button 1`] = `
     class="c1"
     type="button"
   >
-    Test
+    <span>
+      Test
+    </span>
   </button>
 </div>
 `;
@@ -1834,7 +1848,9 @@ exports[`Button kind button with transparent background 1`] = `
         class="c2"
         type="button"
       >
-        Test button
+        <span>
+          Test button
+        </span>
       </button>
       <div
         class="c3"
@@ -1843,7 +1859,9 @@ exports[`Button kind button with transparent background 1`] = `
         class="c4"
         type="button"
       >
-        Active Test button
+        <span>
+          Active Test button
+        </span>
       </button>
     </div>
     <div
@@ -1853,7 +1871,9 @@ exports[`Button kind button with transparent background 1`] = `
         class="c6"
         type="button"
       >
-        Test button
+        <span>
+          Test button
+        </span>
       </button>
       <div
         class="c3"
@@ -1862,7 +1882,9 @@ exports[`Button kind button with transparent background 1`] = `
         class="c7"
         type="button"
       >
-        Active Test button
+        <span>
+          Active Test button
+        </span>
       </button>
     </div>
   </div>
@@ -2041,7 +2063,9 @@ exports[`Button kind disabled with hoverIndicator should not hover 1`] = `
     disabled=""
     type="button"
   >
-    Button
+    <span>
+      Button
+    </span>
   </button>
 </div>
 `;
@@ -2055,7 +2079,9 @@ exports[`Button kind disabled with hoverIndicator should not hover 2`] = `
     disabled=""
     type="button"
   >
-    Button
+    <span>
+      Button
+    </span>
   </button>
 </div>
 `;
@@ -2140,7 +2166,9 @@ exports[`Button kind extend on default button 1`] = `
     class="c1"
     type="button"
   >
-    Test
+    <span>
+      Test
+    </span>
   </button>
 </div>
 `;
@@ -2352,19 +2380,25 @@ exports[`Button kind fill 1`] = `
     class="c1"
     type="button"
   >
-    Test
+    <span>
+      Test
+    </span>
   </button>
   <button
     class="c2"
     type="button"
   >
-    Test
+    <span>
+      Test
+    </span>
   </button>
   <button
     class="c3"
     type="button"
   >
-    Test
+    <span>
+      Test
+    </span>
   </button>
 </div>
 `;
@@ -2450,7 +2484,9 @@ exports[`Button kind font on button default 1`] = `
     class="c1"
     type="button"
   >
-    Test
+    <span>
+      Test
+    </span>
   </button>
 </div>
 `;
@@ -2534,7 +2570,9 @@ exports[`Button kind font undefined 1`] = `
     class="c1"
     type="button"
   >
-    Test
+    <span>
+      Test
+    </span>
   </button>
 </div>
 `;
@@ -2619,7 +2657,9 @@ exports[`Button kind hover on default button 1`] = `
     class="c1"
     type="button"
   >
-    Test
+    <span>
+      Test
+    </span>
   </button>
 </div>
 `;
@@ -2710,7 +2750,9 @@ exports[`Button kind hover secondary with color and background 1`] = `
     class="c1"
     type="button"
   >
-    Button
+    <span>
+      Button
+    </span>
   </button>
 </div>
 `;
@@ -2723,7 +2765,9 @@ exports[`Button kind hover secondary with color and background 2`] = `
     class="StyledButtonKind-sc-1vhfpnt-0 czElJO"
     type="button"
   >
-    Button
+    <span>
+      Button
+    </span>
   </button>
 </div>
 `;
@@ -2812,7 +2856,9 @@ exports[`Button kind hoverIndicator with color and background 1`] = `
     class="c1"
     type="button"
   >
-    Button
+    <span>
+      Button
+    </span>
   </button>
 </div>
 `;
@@ -2825,7 +2871,9 @@ exports[`Button kind hoverIndicator with color and background 2`] = `
     class="StyledButtonKind-sc-1vhfpnt-0 gVhrlZ"
     type="button"
   >
-    Button
+    <span>
+      Button
+    </span>
   </button>
 </div>
 `;
@@ -3282,7 +3330,9 @@ exports[`Button kind icon only pad should apply when icon but no label 1`] = `
       class="c3"
       type="button"
     >
-      Add
+      <span>
+        Add
+      </span>
     </button>
     <button
       class="c4"
@@ -3305,7 +3355,9 @@ exports[`Button kind icon only pad should apply when icon but no label 1`] = `
       class="c5"
       type="button"
     >
-      Add
+      <span>
+        Add
+      </span>
     </button>
     <button
       class="c6"
@@ -3328,7 +3380,9 @@ exports[`Button kind icon only pad should apply when icon but no label 1`] = `
       class="c7"
       type="button"
     >
-      Add
+      <span>
+        Add
+      </span>
     </button>
   </div>
 </DocumentFragment>
@@ -3883,7 +3937,9 @@ exports[`Button kind match icon size to size prop when theme.icon.matchSize is t
         <div
           class="c4"
         />
-        Label
+        <span>
+          Label
+        </span>
       </div>
     </button>
     <button
@@ -3908,7 +3964,9 @@ exports[`Button kind match icon size to size prop when theme.icon.matchSize is t
         <div
           class="c4"
         />
-        Label
+        <span>
+          Label
+        </span>
       </div>
     </button>
     <button
@@ -3933,7 +3991,9 @@ exports[`Button kind match icon size to size prop when theme.icon.matchSize is t
         <div
           class="c4"
         />
-        Label
+        <span>
+          Label
+        </span>
       </div>
     </button>
     <button
@@ -3958,7 +4018,9 @@ exports[`Button kind match icon size to size prop when theme.icon.matchSize is t
         <div
           class="c4"
         />
-        Label
+        <span>
+          Label
+        </span>
       </div>
     </button>
     <button
@@ -3983,7 +4045,9 @@ exports[`Button kind match icon size to size prop when theme.icon.matchSize is t
         <div
           class="c4"
         />
-        Label
+        <span>
+          Label
+        </span>
       </div>
     </button>
   </div>
@@ -4144,7 +4208,9 @@ exports[`Button kind mouseOver and mouseOut events 1`] = `
       <div
         class="c4"
       />
-      label
+      <span>
+        label
+      </span>
     </div>
   </button>
 </div>
@@ -4176,7 +4242,9 @@ exports[`Button kind mouseOver and mouseOut events 2`] = `
       <div
         class="StyledBox__StyledBoxGap-sc-13pk1d4-1 jeSzjR"
       />
-      label
+      <span>
+        label
+      </span>
     </div>
   </button>
 </div>
@@ -4262,7 +4330,9 @@ exports[`Button kind no border on default button 1`] = `
     class="c1"
     type="button"
   >
-    Test
+    <span>
+      Test
+    </span>
   </button>
 </div>
 `;
@@ -4348,7 +4418,9 @@ exports[`Button kind no padding on default button 1`] = `
     class="c1"
     type="button"
   >
-    Test
+    <span>
+      Test
+    </span>
   </button>
 </div>
 `;
@@ -4433,7 +4505,9 @@ exports[`Button kind opacity on default button 1`] = `
     class="c1"
     type="button"
   >
-    Test
+    <span>
+      Test
+    </span>
   </button>
 </div>
 `;
@@ -4523,7 +4597,9 @@ exports[`Button kind padding is applied correctly when intelligentPad is false 1
     class="c1"
     type="button"
   >
-    Test
+    <span>
+      Test
+    </span>
   </button>
 </div>
 `;
@@ -4613,7 +4689,9 @@ exports[`Button kind padding is applied correctly when intelligentPad is true 1`
     class="c1"
     type="button"
   >
-    Test
+    <span>
+      Test
+    </span>
   </button>
 </div>
 `;
@@ -4700,7 +4778,9 @@ exports[`Button kind padding on default button 1`] = `
     class="c1"
     type="button"
   >
-    Test
+    <span>
+      Test
+    </span>
   </button>
 </div>
 `;
@@ -5374,7 +5454,9 @@ exports[`Button kind should apply kind direction 1`] = `
         <div
           class="c3"
         />
-        Button
+        <span>
+          Button
+        </span>
       </div>
     </button>
   </div>
@@ -5582,25 +5664,33 @@ exports[`Button kind should apply styling according to theme size definitions 1`
     class="c1"
     type="button"
   >
-    Button
+    <span>
+      Button
+    </span>
   </button>
   <button
     class="c2"
     type="button"
   >
-    Button
+    <span>
+      Button
+    </span>
   </button>
   <button
     class="c2"
     type="button"
   >
-    Button
+    <span>
+      Button
+    </span>
   </button>
   <button
     class="c3"
     type="button"
   >
-    Button
+    <span>
+      Button
+    </span>
   </button>
 </div>
 `;
@@ -5817,13 +5907,17 @@ exports[`Button kind should render elevation 1`] = `
       class="c1"
       type="button"
     >
-      Default
+      <span>
+        Default
+      </span>
     </button>
     <button
       class="c2"
       type="button"
     >
-      Primary
+      <span>
+        Primary
+      </span>
     </button>
     <button
       class="c3"
@@ -6118,7 +6212,9 @@ exports[`Button kind should render pad 1`] = `
         <div
           class="c4"
         />
-        String pad
+        <span>
+          String pad
+        </span>
       </div>
     </button>
     <button
@@ -6144,7 +6240,9 @@ exports[`Button kind should render pad 1`] = `
         <div
           class="c4"
         />
-        Object pad
+        <span>
+          Object pad
+        </span>
       </div>
     </button>
     <button
@@ -6248,7 +6346,9 @@ exports[`Button kind size of default button 1`] = `
     class="c1"
     type="button"
   >
-    Test
+    <span>
+      Test
+    </span>
   </button>
 </div>
 `;
@@ -6492,7 +6592,9 @@ exports[`Button kind theme busy gap 1`] = `
       <div
         class="c11"
       >
-        Loading
+        <span>
+          Loading
+        </span>
       </div>
     </div>
   </button>
@@ -6524,7 +6626,9 @@ exports[`Button kind theme busy gap 1`] = `
       <div
         class="c11"
       >
-        Success
+        <span>
+          Success
+        </span>
       </div>
     </div>
   </button>

--- a/src/js/components/Button/__tests__/__snapshots__/Button-test.tsx.snap
+++ b/src/js/components/Button/__tests__/__snapshots__/Button-test.tsx.snap
@@ -180,7 +180,9 @@ exports[`Button active + primary 1`] = `
     class="c1"
     type="button"
   >
-    Button
+    <span>
+      Button
+    </span>
   </button>
 </div>
 `;
@@ -270,7 +272,9 @@ exports[`Button active 1`] = `
     class="c1"
     type="button"
   >
-    Button
+    <span>
+      Button
+    </span>
   </button>
 </div>
 `;
@@ -497,7 +501,9 @@ exports[`Button badge should apply background 1`] = `
         class="c3"
         type="button"
       >
-        Button
+        <span>
+          Button
+        </span>
       </button>
     </div>
     <div
@@ -645,7 +651,9 @@ exports[`Button badge should be offset from top-right corner 1`] = `
         class="c3"
         type="button"
       >
-        Button
+        <span>
+          Button
+        </span>
       </button>
     </div>
     <div
@@ -794,7 +802,9 @@ exports[`Button badge should display "+" when number is greater than max 1`] = `
         class="c3"
         type="button"
       >
-        Button
+        <span>
+          Button
+        </span>
       </button>
     </div>
     <div
@@ -949,7 +959,9 @@ exports[`Button badge should display number content 1`] = `
         class="c3"
         type="button"
       >
-        Button
+        <span>
+          Button
+        </span>
       </button>
     </div>
     <div
@@ -1117,7 +1129,9 @@ exports[`Button badge should render custom element 1`] = `
         class="c3"
         type="button"
       >
-        Button
+        <span>
+          Button
+        </span>
       </button>
     </div>
     <div
@@ -1408,7 +1422,9 @@ exports[`Button basic 1`] = `
     class="c1"
     type="button"
   >
-    Test
+    <span>
+      Test
+    </span>
   </button>
 </div>
 `;
@@ -1961,25 +1977,33 @@ exports[`Button color 1`] = `
     class="c1"
     type="button"
   >
-    accent-1
+    <span>
+      accent-1
+    </span>
   </button>
   <button
     class="c2"
     type="button"
   >
-    primary accent-1
+    <span>
+      primary accent-1
+    </span>
   </button>
   <button
     class="c3"
     type="button"
   >
-    custom color #1
+    <span>
+      custom color #1
+    </span>
   </button>
   <button
     class="c4"
     type="button"
   >
-    custom color #2
+    <span>
+      custom color #2
+    </span>
   </button>
 </div>
 `;
@@ -2399,28 +2423,36 @@ exports[`Button disabled 1`] = `
     disabled=""
     type="button"
   >
-    Button
+    <span>
+      Button
+    </span>
   </button>
   <button
     class="c1"
     disabled=""
     type="button"
   >
-    Button
+    <span>
+      Button
+    </span>
   </button>
   <button
     class="c3"
     disabled=""
     type="button"
   >
-    Button
+    <span>
+      Button
+    </span>
   </button>
   <button
     class="c1"
     disabled=""
     type="button"
   >
-    Button
+    <span>
+      Button
+    </span>
   </button>
   <button
     class="c4"
@@ -2455,7 +2487,9 @@ exports[`Button disabled 1`] = `
       <div
         class="c8"
       />
-      Button
+      <span>
+        Button
+      </span>
     </div>
   </button>
   <button
@@ -2470,7 +2504,9 @@ exports[`Button disabled 1`] = `
       <div
         class="c8"
       />
-      Button
+      <span>
+        Button
+      </span>
     </div>
   </button>
   <button
@@ -2487,7 +2523,9 @@ exports[`Button disabled 1`] = `
       <div
         class="c8"
       />
-      Button
+      <span>
+        Button
+      </span>
     </div>
   </button>
 </div>
@@ -2777,25 +2815,33 @@ exports[`Button fill 1`] = `
     class="c1"
     type="button"
   >
-    fill
+    <span>
+      fill
+    </span>
   </button>
   <button
     class="c2"
     type="button"
   >
-    fill false
+    <span>
+      fill false
+    </span>
   </button>
   <button
     class="c3"
     type="button"
   >
-    fill horizontal
+    <span>
+      fill horizontal
+    </span>
   </button>
   <button
     class="c4"
     type="button"
   >
-    fill vertical
+    <span>
+      fill vertical
+    </span>
   </button>
 </div>
 `;
@@ -2879,7 +2925,9 @@ exports[`Button focus 1`] = `
     class="c1"
     type="button"
   >
-    Test focus
+    <span>
+      Test focus
+    </span>
   </button>
 </div>
 `;
@@ -3307,7 +3355,9 @@ exports[`Button href 1`] = `
     class="c1"
     href="test"
   >
-    Button as link
+    <span>
+      Button as link
+    </span>
   </a>
 </div>
 `;
@@ -3421,7 +3471,9 @@ exports[`Button icon label 1`] = `
       <div
         class="c3"
       />
-      Test
+      <span>
+        Test
+      </span>
     </div>
   </button>
 </div>
@@ -3513,7 +3565,9 @@ exports[`Button primary 1`] = `
     class="c1"
     type="button"
   >
-    Primary Button
+    <span>
+      Primary Button
+    </span>
   </button>
 </div>
 `;
@@ -3588,7 +3642,9 @@ exports[`Button render without grommet wrapper 1`] = `
   class="c0"
   type="button"
 >
-  Test
+  <span>
+    Test
+  </span>
 </button>
 `;
 
@@ -3695,7 +3751,9 @@ exports[`Button reverse icon label 1`] = `
     <div
       class="c2"
     >
-      Test
+      <span>
+        Test
+      </span>
       <div
         class="c3"
       />
@@ -3919,13 +3977,17 @@ exports[`Button should render elevation 1`] = `
       class="c1"
       type="button"
     >
-      Default
+      <span>
+        Default
+      </span>
     </button>
     <button
       class="c2"
       type="button"
     >
-      Primary
+      <span>
+        Primary
+      </span>
     </button>
     <button
       class="c3"
@@ -4216,7 +4278,9 @@ exports[`Button should render pad 1`] = `
         <div
           class="c4"
         />
-        String pad
+        <span>
+          String pad
+        </span>
       </div>
     </button>
     <button
@@ -4242,7 +4306,9 @@ exports[`Button should render pad 1`] = `
         <div
           class="c4"
         />
-        Object pad
+        <span>
+          Object pad
+        </span>
       </div>
     </button>
     <button
@@ -4827,49 +4893,65 @@ exports[`Button size 1`] = `
     class="c1"
     type="button"
   >
-    Small
+    <span>
+      Small
+    </span>
   </button>
   <button
     class="c2"
     type="button"
   >
-    Medium
+    <span>
+      Medium
+    </span>
   </button>
   <button
     class="c2"
     type="button"
   >
-    Default
+    <span>
+      Default
+    </span>
   </button>
   <button
     class="c3"
     type="button"
   >
-    Large
+    <span>
+      Large
+    </span>
   </button>
   <button
     class="c4"
     type="button"
   >
-    Small
+    <span>
+      Small
+    </span>
   </button>
   <button
     class="c5"
     type="button"
   >
-    Medium
+    <span>
+      Medium
+    </span>
   </button>
   <button
     class="c5"
     type="button"
   >
-    Default
+    <span>
+      Default
+    </span>
   </button>
   <button
     class="c6"
     type="button"
   >
-    Large
+    <span>
+      Large
+    </span>
   </button>
   <button
     class="c7"
@@ -4946,7 +5028,9 @@ exports[`Button size 1`] = `
     <div
       class="c9"
     >
-      Small
+      <span>
+        Small
+      </span>
       <div
         class="c10"
       />
@@ -4971,7 +5055,9 @@ exports[`Button size 1`] = `
     <div
       class="c9"
     >
-      Medium
+      <span>
+        Medium
+      </span>
       <div
         class="c10"
       />
@@ -4996,7 +5082,9 @@ exports[`Button size 1`] = `
     <div
       class="c9"
     >
-      Default
+      <span>
+        Default
+      </span>
       <div
         class="c10"
       />
@@ -5021,7 +5109,9 @@ exports[`Button size 1`] = `
     <div
       class="c9"
     >
-      Large
+      <span>
+        Large
+      </span>
       <div
         class="c10"
       />
@@ -5150,7 +5240,9 @@ exports[`Button tip 1`] = `
     class="c1"
     type="button"
   >
-    Default Tip
+    <span>
+      Default Tip
+    </span>
   </button>
 </div>
 `;
@@ -5312,7 +5404,9 @@ exports[`Button warns about invalid label 1`] = `
     class="c1"
     type="button"
   >
-    Test
+    <span>
+      Test
+    </span>
   </button>
 </div>
 `;

--- a/src/js/components/Data/__tests__/__snapshots__/Data-test.tsx.snap
+++ b/src/js/components/Data/__tests__/__snapshots__/Data-test.tsx.snap
@@ -1594,7 +1594,9 @@ exports[`Data onView 1`] = `
             class="c6"
             type="submit"
           >
-            Apply filters
+            <span>
+              Apply filters
+            </span>
           </button>
         </footer>
       </div>
@@ -4740,7 +4742,9 @@ exports[`Data should render property label and return property value to view whe
               class="c33"
               type="submit"
             >
-              Apply filters
+              <span>
+                Apply filters
+              </span>
             </button>
           </footer>
         </div>
@@ -11140,7 +11144,9 @@ exports[`Data view property range 1`] = `
               class="c17"
               type="button"
             >
-              Clear filters
+              <span>
+                Clear filters
+              </span>
             </button>
           </div>
         </div>

--- a/src/js/components/DataClearFilters/__tests__/__snapshots__/DataClearFilters-test.tsx.snap
+++ b/src/js/components/DataClearFilters/__tests__/__snapshots__/DataClearFilters-test.tsx.snap
@@ -536,7 +536,9 @@ exports[`DataClearFilters clears filters when clicked 1`] = `
         class="c3"
         type="button"
       >
-        Clear filters
+        <span>
+          Clear filters
+        </span>
       </button>
     </div>
   </div>
@@ -641,7 +643,9 @@ exports[`DataClearFilters renders 1`] = `
         class="c2"
         type="button"
       >
-        Clear filters
+        <span>
+          Clear filters
+        </span>
       </button>
     </div>
   </div>
@@ -1058,7 +1062,9 @@ exports[`DataClearFilters renders custom message 1`] = `
         class="c12"
         type="button"
       >
-        Remove all filters
+        <span>
+          Remove all filters
+        </span>
       </button>
     </div>
   </div>

--- a/src/js/components/DataFilter/__tests__/__snapshots__/DataFilter-test.tsx.snap
+++ b/src/js/components/DataFilter/__tests__/__snapshots__/DataFilter-test.tsx.snap
@@ -776,7 +776,9 @@ exports[`DataFilter children 1`] = `
             class="c11"
             type="submit"
           >
-            Apply filters
+            <span>
+              Apply filters
+            </span>
           </button>
         </footer>
       </div>
@@ -1291,7 +1293,9 @@ exports[`DataFilter options 1`] = `
             class="c16"
             type="submit"
           >
-            Apply filters
+            <span>
+              Apply filters
+            </span>
           </button>
         </footer>
       </div>
@@ -1743,7 +1747,9 @@ exports[`DataFilter range Data 1`] = `
             class="c20"
             type="submit"
           >
-            Apply filters
+            <span>
+              Apply filters
+            </span>
           </button>
         </footer>
       </div>
@@ -2195,7 +2201,9 @@ exports[`DataFilter range prop 1`] = `
             class="c20"
             type="submit"
           >
-            Apply filters
+            <span>
+              Apply filters
+            </span>
           </button>
         </footer>
       </div>
@@ -2883,7 +2891,9 @@ exports[`DataFilter renders 1`] = `
             class="c27"
             type="submit"
           >
-            Apply filters
+            <span>
+              Apply filters
+            </span>
           </button>
         </footer>
       </div>
@@ -3287,7 +3297,9 @@ exports[`DataFilter select multiple options 1`] = `
             class="c11"
             type="button"
           >
-            Clear filters
+            <span>
+              Clear filters
+            </span>
           </button>
         </div>
       </div>
@@ -3837,7 +3849,9 @@ exports[`DataFilter should allow filtering on multiple sub-properties from same 
             class="c11"
             type="button"
           >
-            Clear filters
+            <span>
+              Clear filters
+            </span>
           </button>
         </div>
       </div>
@@ -4550,7 +4564,9 @@ exports[`DataFilter theme rangeSelector size and round, selectMultiple dropHeigh
               class="c30"
               type="submit"
             >
-              Apply filters
+              <span>
+                Apply filters
+              </span>
             </button>
           </footer>
         </div>
@@ -5074,7 +5090,9 @@ exports[`DataFilter theme rangeSelector size and round, selectMultiple dropHeigh
           class="c8"
           type="button"
         >
-          Select All
+          <span>
+            Select All
+          </span>
         </button>
       </div>
       <div

--- a/src/js/components/DataFilters/__tests__/__snapshots__/DataFilters-test.tsx.snap
+++ b/src/js/components/DataFilters/__tests__/__snapshots__/DataFilters-test.tsx.snap
@@ -404,7 +404,9 @@ exports[`DataFilters clear 1`] = `
             class="c18"
             type="submit"
           >
-            Apply filters
+            <span>
+              Apply filters
+            </span>
           </button>
         </footer>
       </div>
@@ -937,7 +939,9 @@ exports[`DataFilters drop badge 1`] = `
           class="c11"
           type="button"
         >
-          Clear filters
+          <span>
+            Clear filters
+          </span>
         </button>
       </div>
     </div>
@@ -1794,7 +1798,9 @@ exports[`DataFilters layer 2`] = `
               class="c25"
               type="submit"
             >
-              Apply filters
+              <span>
+                Apply filters
+              </span>
             </button>
           </footer>
         </div>
@@ -2205,7 +2211,9 @@ exports[`DataFilters properties array 1`] = `
             class="c16"
             type="submit"
           >
-            Apply filters
+            <span>
+              Apply filters
+            </span>
           </button>
         </footer>
       </div>
@@ -2577,7 +2585,9 @@ exports[`DataFilters properties object 1`] = `
             class="c16"
             type="submit"
           >
-            Apply filters
+            <span>
+              Apply filters
+            </span>
           </button>
         </footer>
       </div>
@@ -2949,7 +2959,9 @@ exports[`DataFilters renders 1`] = `
             class="c16"
             type="submit"
           >
-            Apply filters
+            <span>
+              Apply filters
+            </span>
           </button>
         </footer>
       </div>
@@ -3461,7 +3473,9 @@ exports[`DataFilters should display all filter options regardless of result set 
               class="c16"
               type="submit"
             >
-              Apply filters
+              <span>
+                Apply filters
+              </span>
             </button>
           </footer>
         </div>
@@ -4461,7 +4475,9 @@ exports[`DataFilters sub objects 1`] = `
             class="c29"
             type="submit"
           >
-            Apply filters
+            <span>
+              Apply filters
+            </span>
           </button>
         </footer>
       </div>
@@ -4918,7 +4934,9 @@ exports[`DataFilters sub objects with rangeSelector 1`] = `
             class="c11"
             type="button"
           >
-            Clear filters
+            <span>
+              Clear filters
+            </span>
           </button>
         </div>
       </div>
@@ -5332,7 +5350,9 @@ exports[`DataFilters theme footer actions margin and gap 1`] = `
               class="c18"
               type="submit"
             >
-              Apply filters
+              <span>
+                Apply filters
+              </span>
             </button>
           </footer>
         </div>

--- a/src/js/components/DataSearch/__tests__/__snapshots__/DataSearch-test.tsx.snap
+++ b/src/js/components/DataSearch/__tests__/__snapshots__/DataSearch-test.tsx.snap
@@ -690,7 +690,9 @@ exports[`DataSearch renders 1`] = `
             class="c13"
             type="submit"
           >
-            Apply filters
+            <span>
+              Apply filters
+            </span>
           </button>
         </footer>
       </div>

--- a/src/js/components/DataSort/__tests__/__snapshots__/DataSort-test.tsx.snap
+++ b/src/js/components/DataSort/__tests__/__snapshots__/DataSort-test.tsx.snap
@@ -1023,7 +1023,9 @@ exports[`DataSort renders 1`] = `
             class="c25"
             type="submit"
           >
-            Apply filters
+            <span>
+              Apply filters
+            </span>
           </button>
         </footer>
       </div>

--- a/src/js/components/DataSummary/__tests__/__snapshots__/DataSummary-test.tsx.snap
+++ b/src/js/components/DataSummary/__tests__/__snapshots__/DataSummary-test.tsx.snap
@@ -173,7 +173,9 @@ exports[`DataSummary renders 1`] = `
             class="c7"
             type="submit"
           >
-            Apply filters
+            <span>
+              Apply filters
+            </span>
           </button>
         </footer>
       </div>
@@ -356,7 +358,9 @@ exports[`DataSummary renders filtered message correctly when 0 results but only 
               class="c7"
               type="submit"
             >
-              Apply filters
+              <span>
+                Apply filters
+              </span>
             </button>
           </footer>
         </div>
@@ -540,7 +544,9 @@ exports[`DataSummary renders total message correctly when only 1 item 1`] = `
               class="c7"
               type="submit"
             >
-              Apply filters
+              <span>
+                Apply filters
+              </span>
             </button>
           </footer>
         </div>
@@ -985,7 +991,9 @@ exports[`DataSummary theme separator margin and dataSummary margin 1`] = `
               class="c9"
               type="submit"
             >
-              Apply filters
+              <span>
+                Apply filters
+              </span>
             </button>
           </footer>
         </div>

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.tsx.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.tsx.snap
@@ -52630,7 +52630,9 @@ exports[`DataTable sort controlled 1`] = `
       class="c1"
       type="button"
     >
-      Sort data
+      <span>
+        Sort data
+      </span>
     </button>
     <table
       class="c2 c3"
@@ -53122,7 +53124,9 @@ exports[`DataTable sort controlled 2`] = `
       class="c1"
       type="button"
     >
-      Sort data
+      <span>
+        Sort data
+      </span>
     </button>
     <table
       class="c2 c3"

--- a/src/js/components/DataTableColumns/__tests__/__snapshots__/DataTableColumns-test.tsx.snap
+++ b/src/js/components/DataTableColumns/__tests__/__snapshots__/DataTableColumns-test.tsx.snap
@@ -1856,7 +1856,9 @@ exports[`DataTableColumns renders 1`] = `
               class="c8"
               type="submit"
             >
-              Apply filters
+              <span>
+                Apply filters
+              </span>
             </button>
           </footer>
         </div>

--- a/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.tsx.snap
+++ b/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.tsx.snap
@@ -1779,7 +1779,9 @@ exports[`DateInput controlled format inline 1`] = `
     class="c23"
     type="button"
   >
-    first
+    <span>
+      first
+    </span>
   </button>
 </div>
 `;
@@ -2733,7 +2735,9 @@ exports[`DateInput controlled format inline 2`] = `
     class="StyledButton-sc-323bzc-0 eJnOht"
     type="button"
   >
-    first
+    <span>
+      first
+    </span>
   </button>
 </div>
 `;
@@ -4262,7 +4266,9 @@ exports[`DateInput controlled format inline without timezone 1`] = `
       class="c23"
       type="button"
     >
-      first
+      <span>
+        first
+      </span>
     </button>
   </div>
 </DocumentFragment>
@@ -5792,7 +5798,9 @@ exports[`DateInput controlled format inline without timezone 2`] = `
       class="c23"
       type="button"
     >
-      first
+      <span>
+        first
+      </span>
     </button>
   </div>
 </DocumentFragment>

--- a/src/js/components/DropButton/__tests__/__snapshots__/DropButton-test.tsx.snap
+++ b/src/js/components/DropButton/__tests__/__snapshots__/DropButton-test.tsx.snap
@@ -84,7 +84,9 @@ exports[`DropButton close by clicking outside 1`] = `
     class="c1"
     type="button"
   >
-    Dropper
+    <span>
+      Dropper
+    </span>
   </button>
 </div>
 `;
@@ -187,7 +189,9 @@ exports[`DropButton closed 1`] = `
     class="c1"
     type="button"
   >
-    Dropper
+    <span>
+      Dropper
+    </span>
   </button>
 </div>
 `;
@@ -263,7 +267,9 @@ exports[`DropButton closed outside grommet wrapper 1`] = `
   class="c0"
   type="button"
 >
-  Dropper
+  <span>
+    Dropper
+  </span>
 </button>
 `;
 
@@ -350,7 +356,9 @@ exports[`DropButton disabled 1`] = `
     disabled=""
     type="button"
   >
-    Dropper
+    <span>
+      Dropper
+    </span>
   </button>
 </div>
 `;
@@ -439,7 +447,9 @@ exports[`DropButton open and close 1`] = `
     class="c1"
     type="button"
   >
-    Dropper
+    <span>
+      Dropper
+    </span>
   </button>
 </div>
 `;
@@ -546,7 +556,9 @@ exports[`DropButton opened 1`] = `
     class="c1"
     type="button"
   >
-    Dropper
+    <span>
+      Dropper
+    </span>
   </button>
 </div>
 `;
@@ -639,7 +651,9 @@ exports[`DropButton opened ref 1`] = `
     class="c1"
     type="button"
   >
-    Dropper
+    <span>
+      Dropper
+    </span>
   </button>
 </div>
 `;
@@ -746,7 +760,9 @@ exports[`DropButton ref function 1`] = `
     class="c1"
     type="button"
   >
-    Dropper
+    <span>
+      Dropper
+    </span>
   </button>
 </div>
 `;
@@ -849,14 +865,18 @@ exports[`DropButton rendersr a11yTitle and aria-label 1`] = `
     class="c1"
     type="button"
   >
-    Dropper
+    <span>
+      Dropper
+    </span>
   </button>
   <button
     aria-label="Test Label-2"
     class="c1"
     type="button"
   >
-    Dropper
+    <span>
+      Dropper
+    </span>
   </button>
 </div>
 `;

--- a/src/js/components/FileInput/__tests__/__snapshots__/FileInput-test.tsx.snap
+++ b/src/js/components/FileInput/__tests__/__snapshots__/FileInput-test.tsx.snap
@@ -170,7 +170,9 @@ exports[`FileInput accept 1`] = `
         class="c6"
         tabindex="-1"
       >
-        browse
+        <span>
+          browse
+        </span>
       </a>
     </div>
   </div>
@@ -348,7 +350,9 @@ exports[`FileInput background 1`] = `
         class="c6"
         tabindex="-1"
       >
-        browse
+        <span>
+          browse
+        </span>
       </a>
     </div>
   </div>
@@ -524,7 +528,9 @@ exports[`FileInput basic 1`] = `
         class="c6"
         tabindex="-1"
       >
-        browse
+        <span>
+          browse
+        </span>
       </a>
     </div>
   </div>
@@ -687,7 +693,9 @@ exports[`FileInput basic outside grommet wrapper 1`] = `
       class="c5"
       tabindex="-1"
     >
-      browse
+      <span>
+        browse
+      </span>
     </a>
   </div>
 </div>
@@ -862,7 +870,9 @@ exports[`FileInput border 1`] = `
         class="c6"
         tabindex="-1"
       >
-        browse
+        <span>
+          browse
+        </span>
       </a>
     </div>
   </div>
@@ -1037,7 +1047,9 @@ exports[`FileInput custom theme input font size 1`] = `
         class="c6"
         tabindex="-1"
       >
-        browse
+        <span>
+          browse
+        </span>
       </a>
     </div>
   </div>
@@ -1216,7 +1228,9 @@ exports[`FileInput disabled 1`] = `
         disabled=""
         tabindex="-1"
       >
-        browse
+        <span>
+          browse
+        </span>
       </a>
     </div>
   </div>
@@ -1595,7 +1609,9 @@ exports[`FileInput disabled with file selected 1`] = `
                 disabled=""
                 tabindex="-1"
               >
-                browse
+                <span>
+                  browse
+                </span>
               </a>
             </div>
           </div>
@@ -1782,7 +1798,9 @@ exports[`FileInput margin 1`] = `
         class="c6"
         tabindex="-1"
       >
-        browse
+        <span>
+          browse
+        </span>
       </a>
     </div>
   </div>
@@ -1958,7 +1976,9 @@ exports[`FileInput maxSize 1`] = `
         class="c6"
         tabindex="-1"
       >
-        browse
+        <span>
+          browse
+        </span>
       </a>
     </div>
   </div>
@@ -2134,7 +2154,9 @@ exports[`FileInput messages 1`] = `
         class="c6"
         tabindex="-1"
       >
-        test browse
+        <span>
+          test browse
+        </span>
       </a>
     </div>
   </div>
@@ -2311,7 +2333,9 @@ exports[`FileInput multiple 1`] = `
         class="c6"
         tabindex="-1"
       >
-        browse
+        <span>
+          browse
+        </span>
       </a>
     </div>
   </div>
@@ -2488,7 +2512,9 @@ exports[`FileInput multiple aggregateThreshold 1`] = `
         class="c6"
         tabindex="-1"
       >
-        browse
+        <span>
+          browse
+        </span>
       </a>
     </div>
   </div>
@@ -2665,7 +2691,9 @@ exports[`FileInput multiple max 1`] = `
         class="c6"
         tabindex="-1"
       >
-        browse
+        <span>
+          browse
+        </span>
       </a>
     </div>
   </div>
@@ -2848,7 +2876,9 @@ exports[`FileInput pad 1`] = `
         class="c6"
         tabindex="-1"
       >
-        browse
+        <span>
+          browse
+        </span>
       </a>
     </div>
   </div>
@@ -3253,7 +3283,9 @@ exports[`FileInput should use theme icons 1`] = `
                 class="c14"
                 tabindex="-1"
               >
-                browse
+                <span>
+                  browse
+                </span>
               </a>
             </div>
           </div>
@@ -3434,7 +3466,9 @@ exports[`FileInput theme anchor margin and label gap 1`] = `
           class="c6"
           tabindex="-1"
         >
-          browse
+          <span>
+            browse
+          </span>
         </a>
       </div>
     </div>

--- a/src/js/components/Form/__tests__/Form-test-uncontrolled.tsx
+++ b/src/js/components/Form/__tests__/Form-test-uncontrolled.tsx
@@ -655,48 +655,53 @@ describe('Form uncontrolled', () => {
   test('validate on blur', async () => {
     jest.useFakeTimers();
     const onFocus = jest.fn();
-    const { getByText, getByPlaceholderText, queryAllByText, queryByText } =
-      render(
-        <Grommet>
-          <Form validate="blur">
-            <FormField
-              onFocus={onFocus}
-              label="Name"
-              name="name"
-              placeholder="name"
-              required
-              validate={[
-                { regexp: /^[a-z]/i },
-                (name) => {
-                  if (name && name.length === 1) return 'must be >1 character';
-                  return undefined;
-                },
-                (name) => {
-                  if (name === 'good')
-                    return {
-                      message: 'good',
-                      status: 'info',
-                    };
-                  return undefined;
-                },
-              ]}
-            />
+    const {
+      getByRole,
+      getByText,
+      getByPlaceholderText,
+      queryAllByText,
+      queryByText,
+    } = render(
+      <Grommet>
+        <Form validate="blur">
+          <FormField
+            onFocus={onFocus}
+            label="Name"
+            name="name"
+            placeholder="name"
+            required
+            validate={[
+              { regexp: /^[a-z]/i },
+              (name) => {
+                if (name && name.length === 1) return 'must be >1 character';
+                return undefined;
+              },
+              (name) => {
+                if (name === 'good')
+                  return {
+                    message: 'good',
+                    status: 'info',
+                  };
+                return undefined;
+              },
+            ]}
+          />
 
-            <FormField onFocus={onFocus} label="Email" name="email" required>
-              <TextInput
-                a11yTitle="test"
-                name="email"
-                type="email"
-                placeholder="email"
-              />
-            </FormField>
-            <Button onFocus={onFocus} label="submit" type="submit" />
-          </Form>
-        </Grommet>,
-      );
+          <FormField onFocus={onFocus} label="Email" name="email" required>
+            <TextInput
+              a11yTitle="test"
+              name="email"
+              type="email"
+              placeholder="email"
+            />
+          </FormField>
+          <Button onFocus={onFocus} label="submit" type="submit" />
+        </Form>
+      </Grommet>,
+    );
 
     // both fields have required error message
-    act(() => getByText('submit').focus());
+    act(() => getByRole('button', { name: 'submit' }).focus());
     fireEvent.click(getByText('submit'));
     expect(queryAllByText('required')).toHaveLength(2);
 
@@ -705,7 +710,7 @@ describe('Form uncontrolled', () => {
     fireEvent.change(getByPlaceholderText('name'), {
       target: { value: 'Input has changed' },
     });
-    act(() => getByText('submit').focus());
+    act(() => getByRole('button', { name: 'submit' }).focus());
     act(() => jest.advanceTimersByTime(200)); // allow validations to run
     expect(queryAllByText('required')).toHaveLength(1);
 
@@ -714,7 +719,7 @@ describe('Form uncontrolled', () => {
     fireEvent.change(getByPlaceholderText('name'), {
       target: { value: 'a' },
     });
-    act(() => getByText('submit').focus());
+    act(() => getByRole('button', { name: 'submit' }).focus());
     act(() => jest.advanceTimersByTime(200)); // allow validations to run
     expect(queryByText('required')).toBeTruthy();
     expect(queryByText('must be >1 character')).toBeTruthy();
@@ -760,7 +765,9 @@ describe('Form uncontrolled', () => {
     act(() => jest.advanceTimersByTime(200)); // allow validations to run
     expect(screen.queryAllByText('required')).toHaveLength(0);
 
-    act(() => screen.getByText('submit').focus());
+    act(() =>
+      screen.getByRole('button', { name: 'submit', hidden: true }).focus(),
+    );
     act(() => jest.advanceTimersByTime(200)); // allow validations to run
     expect(screen.queryAllByText('required')).toHaveLength(1);
 

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-controlled.tsx.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-controlled.tsx.snap
@@ -187,7 +187,9 @@ exports[`Form controlled controlled 1`] = `
       class="c5"
       type="submit"
     >
-      Submit
+      <span>
+        Submit
+      </span>
     </button>
   </form>
 </div>
@@ -221,7 +223,9 @@ exports[`Form controlled controlled 2`] = `
       class="StyledButton-sc-323bzc-0 sqHMX"
       type="submit"
     >
-      Submit
+      <span>
+        Submit
+      </span>
     </button>
   </form>
 </div>
@@ -255,7 +259,9 @@ exports[`Form controlled controlled 3`] = `
       class="StyledButton-sc-323bzc-0 sqHMX"
       type="submit"
     >
-      Submit
+      <span>
+        Submit
+      </span>
     </button>
   </form>
 </div>
@@ -566,7 +572,9 @@ exports[`Form controlled controlled Array of Form Fields 1`] = `
       class="c6"
       type="submit"
     >
-      Submit
+      <span>
+        Submit
+      </span>
     </button>
   </form>
 </div>
@@ -707,7 +715,9 @@ exports[`Form controlled controlled Array of Form Fields 2`] = `
       class="StyledButton-sc-323bzc-0 sqHMX"
       type="submit"
     >
-      Submit
+      <span>
+        Submit
+      </span>
     </button>
   </form>
 </div>
@@ -848,7 +858,9 @@ exports[`Form controlled controlled Array of Form Fields 3`] = `
       class="StyledButton-sc-323bzc-0 sqHMX"
       type="submit"
     >
-      Submit
+      <span>
+        Submit
+      </span>
     </button>
   </form>
 </div>
@@ -1117,7 +1129,9 @@ exports[`Form controlled controlled Array of Form Fields onValidate 1`] = `
       class="c6"
       type="submit"
     >
-      Submit
+      <span>
+        Submit
+      </span>
     </button>
   </form>
 </div>
@@ -1270,7 +1284,9 @@ exports[`Form controlled controlled Array of Form Fields onValidate 2`] = `
       class="StyledButton-sc-323bzc-0 sqHMX"
       type="submit"
     >
-      Submit
+      <span>
+        Submit
+      </span>
     </button>
   </form>
 </div>
@@ -1539,7 +1555,9 @@ exports[`Form controlled controlled Array of Form Fields onValidate custom error
       class="c6"
       type="submit"
     >
-      Submit
+      <span>
+        Submit
+      </span>
     </button>
   </form>
 </div>
@@ -1665,7 +1683,9 @@ exports[`Form controlled controlled Array of Form Fields onValidate custom error
       class="StyledButton-sc-323bzc-0 sqHMX"
       type="submit"
     >
-      Submit
+      <span>
+        Submit
+      </span>
     </button>
   </form>
 </div>
@@ -1874,7 +1894,9 @@ exports[`Form controlled controlled FormField deprecated 1`] = `
       class="c6"
       type="submit"
     >
-      Submit
+      <span>
+        Submit
+      </span>
     </button>
   </form>
 </div>
@@ -1915,7 +1937,9 @@ exports[`Form controlled controlled FormField deprecated 2`] = `
       class="StyledButton-sc-323bzc-0 sqHMX"
       type="submit"
     >
-      Submit
+      <span>
+        Submit
+      </span>
     </button>
   </form>
 </div>
@@ -1956,7 +1980,9 @@ exports[`Form controlled controlled FormField deprecated 3`] = `
       class="StyledButton-sc-323bzc-0 sqHMX"
       type="submit"
     >
-      Submit
+      <span>
+        Submit
+      </span>
     </button>
   </form>
 </div>
@@ -2149,7 +2175,9 @@ exports[`Form controlled controlled input 1`] = `
       class="c5"
       type="submit"
     >
-      Submit
+      <span>
+        Submit
+      </span>
     </button>
   </form>
 </div>
@@ -2183,7 +2211,9 @@ exports[`Form controlled controlled input 2`] = `
       class="StyledButton-sc-323bzc-0 sqHMX"
       type="submit"
     >
-      Submit
+      <span>
+        Submit
+      </span>
     </button>
   </form>
 </div>
@@ -2217,7 +2247,9 @@ exports[`Form controlled controlled input 3`] = `
       class="StyledButton-sc-323bzc-0 sqHMX"
       type="submit"
     >
-      Submit
+      <span>
+        Submit
+      </span>
     </button>
   </form>
 </div>
@@ -2410,7 +2442,9 @@ exports[`Form controlled controlled input lazy 1`] = `
       class="c5"
       type="submit"
     >
-      Submit
+      <span>
+        Submit
+      </span>
     </button>
   </form>
 </div>
@@ -2444,7 +2478,9 @@ exports[`Form controlled controlled input lazy 2`] = `
       class="StyledButton-sc-323bzc-0 sqHMX"
       type="submit"
     >
-      Submit
+      <span>
+        Submit
+      </span>
     </button>
   </form>
 </div>
@@ -2478,7 +2514,9 @@ exports[`Form controlled controlled input lazy 3`] = `
       class="StyledButton-sc-323bzc-0 sqHMX"
       type="submit"
     >
-      Submit
+      <span>
+        Submit
+      </span>
     </button>
   </form>
 </div>
@@ -2671,7 +2709,9 @@ exports[`Form controlled controlled lazy 1`] = `
       class="c5"
       type="submit"
     >
-      Submit
+      <span>
+        Submit
+      </span>
     </button>
   </form>
 </div>
@@ -2705,7 +2745,9 @@ exports[`Form controlled controlled lazy 2`] = `
       class="StyledButton-sc-323bzc-0 sqHMX"
       type="submit"
     >
-      Submit
+      <span>
+        Submit
+      </span>
     </button>
   </form>
 </div>
@@ -2739,7 +2781,9 @@ exports[`Form controlled controlled lazy 3`] = `
       class="StyledButton-sc-323bzc-0 sqHMX"
       type="submit"
     >
-      Submit
+      <span>
+        Submit
+      </span>
     </button>
   </form>
 </div>
@@ -2932,7 +2976,9 @@ exports[`Form controlled controlled onChange touched 1`] = `
       class="c5"
       type="submit"
     >
-      Submit
+      <span>
+        Submit
+      </span>
     </button>
   </form>
 </div>
@@ -3125,7 +3171,9 @@ exports[`Form controlled controlled onValidate 1`] = `
       class="c5"
       type="submit"
     >
-      Submit
+      <span>
+        Submit
+      </span>
     </button>
   </form>
 </div>
@@ -3186,7 +3234,9 @@ exports[`Form controlled controlled onValidate 2`] = `
       class="StyledButton-sc-323bzc-0 sqHMX"
       type="submit"
     >
-      Submit
+      <span>
+        Submit
+      </span>
     </button>
   </form>
 </div>
@@ -3379,7 +3429,9 @@ exports[`Form controlled controlled onValidate custom error 1`] = `
       class="c5"
       type="submit"
     >
-      Submit
+      <span>
+        Submit
+      </span>
     </button>
   </form>
 </div>
@@ -3440,7 +3492,9 @@ exports[`Form controlled controlled onValidate custom error 2`] = `
       class="StyledButton-sc-323bzc-0 sqHMX"
       type="submit"
     >
-      Submit
+      <span>
+        Submit
+      </span>
     </button>
   </form>
 </div>
@@ -3633,7 +3687,9 @@ exports[`Form controlled controlled onValidate custom info 1`] = `
       class="c5"
       type="submit"
     >
-      Submit
+      <span>
+        Submit
+      </span>
     </button>
   </form>
 </div>
@@ -3690,7 +3746,9 @@ exports[`Form controlled controlled onValidate custom info 2`] = `
       class="StyledButton-sc-323bzc-0 sqHMX"
       type="submit"
     >
-      Submit
+      <span>
+        Submit
+      </span>
     </button>
   </form>
 </div>
@@ -4246,7 +4304,9 @@ exports[`Form controlled dynamicly removed fields using blur validation\\n  don'
       class="c11"
       type="submit"
     >
-      Submit
+      <span>
+        Submit
+      </span>
     </button>
   </form>
 </div>
@@ -4474,7 +4534,9 @@ exports[`Form controlled dynamicly removed fields using blur validation\\n  don'
       class="StyledButton-sc-323bzc-0 sqHMX"
       type="submit"
     >
-      Submit
+      <span>
+        Submit
+      </span>
     </button>
   </form>
 </div>
@@ -4535,7 +4597,9 @@ exports[`Form controlled dynamicly removed fields using blur validation\\n  don'
       class="StyledButton-sc-323bzc-0 sqHMX"
       type="submit"
     >
-      Submit
+      <span>
+        Submit
+      </span>
     </button>
   </form>
 </div>
@@ -4702,13 +4766,17 @@ exports[`Form controlled lazy value 1`] = `
       class="c3"
       type="button"
     >
-      set
+      <span>
+        set
+      </span>
     </button>
     <button
       class="c3"
       type="submit"
     >
-      submit
+      <span>
+        submit
+      </span>
     </button>
   </form>
 </div>

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.tsx.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.tsx.snap
@@ -1115,7 +1115,9 @@ exports[`Form uncontrolled dynamically removed fields should be removed from for
       class="c11"
       type="submit"
     >
-      Submit
+      <span>
+        Submit
+      </span>
     </button>
   </form>
 </div>
@@ -1175,7 +1177,9 @@ exports[`Form uncontrolled dynamically removed fields should be removed from for
       class="StyledButton-sc-323bzc-0 sqHMX"
       type="submit"
     >
-      Submit
+      <span>
+        Submit
+      </span>
     </button>
   </form>
 </div>
@@ -1489,7 +1493,9 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation\\n  do
       class="c11"
       type="submit"
     >
-      Submit
+      <span>
+        Submit
+      </span>
     </button>
   </form>
 </div>
@@ -1715,7 +1721,9 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation\\n  do
       class="StyledButton-sc-323bzc-0 sqHMX"
       type="submit"
     >
-      Submit
+      <span>
+        Submit
+      </span>
     </button>
   </form>
 </div>
@@ -1775,7 +1783,9 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation\\n  do
       class="StyledButton-sc-323bzc-0 sqHMX"
       type="submit"
     >
-      Submit
+      <span>
+        Submit
+      </span>
     </button>
   </form>
 </div>
@@ -2929,7 +2939,9 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 1`] =
       class="c28"
       type="reset"
     >
-      Reset
+      <span>
+        Reset
+      </span>
     </button>
   </form>
 </div>
@@ -3148,7 +3160,9 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
       class="StyledButton-sc-323bzc-0 sqHMX"
       type="reset"
     >
-      Reset
+      <span>
+        Reset
+      </span>
     </button>
   </form>
 </div>
@@ -3340,7 +3354,9 @@ exports[`Form uncontrolled uncontrolled 1`] = `
       class="c5"
       type="submit"
     >
-      Submit
+      <span>
+        Submit
+      </span>
     </button>
   </form>
 </div>
@@ -3373,7 +3389,9 @@ exports[`Form uncontrolled uncontrolled 2`] = `
       class="StyledButton-sc-323bzc-0 sqHMX"
       type="submit"
     >
-      Submit
+      <span>
+        Submit
+      </span>
     </button>
   </form>
 </div>
@@ -3406,7 +3424,9 @@ exports[`Form uncontrolled uncontrolled 3`] = `
       class="StyledButton-sc-323bzc-0 sqHMX"
       type="submit"
     >
-      Submit
+      <span>
+        Submit
+      </span>
     </button>
   </form>
 </div>
@@ -3598,7 +3618,9 @@ exports[`Form uncontrolled uncontrolled onValidate 1`] = `
       class="c5"
       type="submit"
     >
-      Submit
+      <span>
+        Submit
+      </span>
     </button>
   </form>
 </div>
@@ -3658,7 +3680,9 @@ exports[`Form uncontrolled uncontrolled onValidate 2`] = `
       class="StyledButton-sc-323bzc-0 sqHMX"
       type="submit"
     >
-      Submit
+      <span>
+        Submit
+      </span>
     </button>
   </form>
 </div>
@@ -3850,7 +3874,9 @@ exports[`Form uncontrolled uncontrolled onValidate custom error 1`] = `
       class="c5"
       type="submit"
     >
-      Submit
+      <span>
+        Submit
+      </span>
     </button>
   </form>
 </div>
@@ -3910,7 +3936,9 @@ exports[`Form uncontrolled uncontrolled onValidate custom error 2`] = `
       class="StyledButton-sc-323bzc-0 sqHMX"
       type="submit"
     >
-      Submit
+      <span>
+        Submit
+      </span>
     </button>
   </form>
 </div>
@@ -4102,7 +4130,9 @@ exports[`Form uncontrolled uncontrolled onValidate custom info 1`] = `
       class="c5"
       type="submit"
     >
-      Submit
+      <span>
+        Submit
+      </span>
     </button>
   </form>
 </div>
@@ -4158,7 +4188,9 @@ exports[`Form uncontrolled uncontrolled onValidate custom info 2`] = `
       class="StyledButton-sc-323bzc-0 sqHMX"
       type="submit"
     >
-      Submit
+      <span>
+        Submit
+      </span>
     </button>
   </form>
 </div>
@@ -4368,7 +4400,9 @@ exports[`Form uncontrolled update 1`] = `
       class="c5"
       type="submit"
     >
-      Submit
+      <span>
+        Submit
+      </span>
     </button>
   </form>
 </div>

--- a/src/js/components/List/__tests__/__snapshots__/List-test.tsx.snap
+++ b/src/js/components/List/__tests__/__snapshots__/List-test.tsx.snap
@@ -17967,7 +17967,9 @@ exports[`List onOrder with action Render 1`] = `
             class="c9"
             type="button"
           >
-            Action
+            <span>
+              Action
+            </span>
           </button>
         </div>
         <div
@@ -18050,7 +18052,9 @@ exports[`List onOrder with action Render 1`] = `
             class="c9"
             type="button"
           >
-            Action
+            <span>
+              Action
+            </span>
           </button>
         </div>
         <div

--- a/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
+++ b/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
@@ -1943,7 +1943,9 @@ exports[`Menu custom theme with default button 1`] = `
     <div
       class="c2"
     >
-      Test Menu
+      <span>
+        Test Menu
+      </span>
       <div
         class="c3"
       />

--- a/src/js/components/Notification/__tests__/__snapshots__/Notification-test.tsx.snap
+++ b/src/js/components/Notification/__tests__/__snapshots__/Notification-test.tsx.snap
@@ -1440,14 +1440,18 @@ exports[`Notification multi actions 1`] = `
               class="c9 c10"
               href="/some-link"
             >
-              Renew Subscription
+              <span>
+                Renew Subscription
+              </span>
             </a>
              
             <a
               class="c9 c10"
               href="/link"
             >
-              View More
+              <span>
+                View More
+              </span>
             </a>
              
           </p>
@@ -6589,14 +6593,18 @@ exports[`Notification theme actions margin, gap, and message text margin 1`] = `
               class="c9 c10"
               href="/link1"
             >
-              Action 1
+              <span>
+                Action 1
+              </span>
             </a>
              
             <a
               class="c9 c10"
               href="/link2"
             >
-              Action 2
+              <span>
+                Action 2
+              </span>
             </a>
              
           </p>
@@ -6648,7 +6656,9 @@ exports[`Notification theme actions margin, gap, and message text margin 1`] = `
               class="c9 c10"
               href="/link3"
             >
-              Action 3
+              <span>
+                Action 3
+              </span>
             </a>
              
           </p>

--- a/src/js/components/PageHeader/__tests__/__snapshots__/PageHeader-test.tsx.snap
+++ b/src/js/components/PageHeader/__tests__/__snapshots__/PageHeader-test.tsx.snap
@@ -218,7 +218,9 @@ exports[`PageHeader basic 1`] = `
           <a
             class="c4"
           >
-            Parent Page
+            <span>
+              Parent Page
+            </span>
           </a>
         </div>
         <div
@@ -248,7 +250,9 @@ exports[`PageHeader basic 1`] = `
             class="c10"
             type="button"
           >
-            Get Started
+            <span>
+              Get Started
+            </span>
           </button>
         </div>
       </div>
@@ -462,7 +466,9 @@ exports[`PageHeader basic renders outside grommet wrapper 1`] = `
         <a
           class="c3"
         >
-          Parent Page
+          <span>
+            Parent Page
+          </span>
         </a>
       </div>
       <div
@@ -492,7 +498,9 @@ exports[`PageHeader basic renders outside grommet wrapper 1`] = `
           class="c9"
           type="button"
         >
-          Get Started
+          <span>
+            Get Started
+          </span>
         </button>
       </div>
     </div>
@@ -728,7 +736,9 @@ exports[`PageHeader custom theme 1`] = `
           <a
             class="c4"
           >
-            Settings
+            <span>
+              Settings
+            </span>
           </a>
         </div>
         <div
@@ -759,7 +769,9 @@ exports[`PageHeader custom theme 1`] = `
               class="c11"
               type="button"
             >
-              Edit
+              <span>
+                Edit
+              </span>
             </button>
           </div>
         </div>
@@ -987,7 +999,9 @@ exports[`PageHeader level - 1 1`] = `
           <a
             class="c4"
           >
-            Parent Page
+            <span>
+              Parent Page
+            </span>
           </a>
         </div>
         <div
@@ -1017,7 +1031,9 @@ exports[`PageHeader level - 1 1`] = `
             class="c10"
             type="button"
           >
-            Get Started
+            <span>
+              Get Started
+            </span>
           </button>
         </div>
       </div>
@@ -1244,7 +1260,9 @@ exports[`PageHeader level - 1 2`] = `
           <a
             class="c4"
           >
-            Parent Page
+            <span>
+              Parent Page
+            </span>
           </a>
         </div>
         <div
@@ -1274,7 +1292,9 @@ exports[`PageHeader level - 1 2`] = `
             class="c10"
             type="button"
           >
-            Get Started
+            <span>
+              Get Started
+            </span>
           </button>
         </div>
       </div>
@@ -1501,7 +1521,9 @@ exports[`PageHeader level - 2 1`] = `
           <a
             class="c4"
           >
-            Parent Page
+            <span>
+              Parent Page
+            </span>
           </a>
         </div>
         <div
@@ -1531,7 +1553,9 @@ exports[`PageHeader level - 2 1`] = `
             class="c10"
             type="button"
           >
-            Get Started
+            <span>
+              Get Started
+            </span>
           </button>
         </div>
       </div>
@@ -1758,7 +1782,9 @@ exports[`PageHeader level - 2 2`] = `
           <a
             class="c4"
           >
-            Parent Page
+            <span>
+              Parent Page
+            </span>
           </a>
         </div>
         <div
@@ -1788,7 +1814,9 @@ exports[`PageHeader level - 2 2`] = `
             class="c10"
             type="button"
           >
-            Get Started
+            <span>
+              Get Started
+            </span>
           </button>
         </div>
       </div>
@@ -2015,7 +2043,9 @@ exports[`PageHeader level - 3 1`] = `
           <a
             class="c4"
           >
-            Parent Page
+            <span>
+              Parent Page
+            </span>
           </a>
         </div>
         <div
@@ -2045,7 +2075,9 @@ exports[`PageHeader level - 3 1`] = `
             class="c10"
             type="button"
           >
-            Get Started
+            <span>
+              Get Started
+            </span>
           </button>
         </div>
       </div>
@@ -2272,7 +2304,9 @@ exports[`PageHeader level - 3 2`] = `
           <a
             class="c4"
           >
-            Parent Page
+            <span>
+              Parent Page
+            </span>
           </a>
         </div>
         <div
@@ -2302,7 +2336,9 @@ exports[`PageHeader level - 3 2`] = `
             class="c10"
             type="button"
           >
-            Get Started
+            <span>
+              Get Started
+            </span>
           </button>
         </div>
       </div>
@@ -2529,7 +2565,9 @@ exports[`PageHeader level - 4 1`] = `
           <a
             class="c4"
           >
-            Parent Page
+            <span>
+              Parent Page
+            </span>
           </a>
         </div>
         <div
@@ -2559,7 +2597,9 @@ exports[`PageHeader level - 4 1`] = `
             class="c10"
             type="button"
           >
-            Get Started
+            <span>
+              Get Started
+            </span>
           </button>
         </div>
       </div>
@@ -2786,7 +2826,9 @@ exports[`PageHeader level - 4 2`] = `
           <a
             class="c4"
           >
-            Parent Page
+            <span>
+              Parent Page
+            </span>
           </a>
         </div>
         <div
@@ -2816,7 +2858,9 @@ exports[`PageHeader level - 4 2`] = `
             class="c10"
             type="button"
           >
-            Get Started
+            <span>
+              Get Started
+            </span>
           </button>
         </div>
       </div>
@@ -3043,7 +3087,9 @@ exports[`PageHeader level - 5 1`] = `
           <a
             class="c4"
           >
-            Parent Page
+            <span>
+              Parent Page
+            </span>
           </a>
         </div>
         <div
@@ -3073,7 +3119,9 @@ exports[`PageHeader level - 5 1`] = `
             class="c10"
             type="button"
           >
-            Get Started
+            <span>
+              Get Started
+            </span>
           </button>
         </div>
       </div>
@@ -3300,7 +3348,9 @@ exports[`PageHeader level - 5 2`] = `
           <a
             class="c4"
           >
-            Parent Page
+            <span>
+              Parent Page
+            </span>
           </a>
         </div>
         <div
@@ -3330,7 +3380,9 @@ exports[`PageHeader level - 5 2`] = `
             class="c10"
             type="button"
           >
-            Get Started
+            <span>
+              Get Started
+            </span>
           </button>
         </div>
       </div>
@@ -3557,7 +3609,9 @@ exports[`PageHeader level - 6 1`] = `
           <a
             class="c4"
           >
-            Parent Page
+            <span>
+              Parent Page
+            </span>
           </a>
         </div>
         <div
@@ -3587,7 +3641,9 @@ exports[`PageHeader level - 6 1`] = `
             class="c10"
             type="button"
           >
-            Get Started
+            <span>
+              Get Started
+            </span>
           </button>
         </div>
       </div>
@@ -3814,7 +3870,9 @@ exports[`PageHeader level - 6 2`] = `
           <a
             class="c4"
           >
-            Parent Page
+            <span>
+              Parent Page
+            </span>
           </a>
         </div>
         <div
@@ -3844,7 +3902,9 @@ exports[`PageHeader level - 6 2`] = `
             class="c10"
             type="button"
           >
-            Get Started
+            <span>
+              Get Started
+            </span>
           </button>
         </div>
       </div>
@@ -4071,7 +4131,9 @@ exports[`PageHeader size - large 1`] = `
           <a
             class="c4"
           >
-            Parent Page
+            <span>
+              Parent Page
+            </span>
           </a>
         </div>
         <div
@@ -4101,7 +4163,9 @@ exports[`PageHeader size - large 1`] = `
             class="c10"
             type="button"
           >
-            Get Started
+            <span>
+              Get Started
+            </span>
           </button>
         </div>
       </div>
@@ -4328,7 +4392,9 @@ exports[`PageHeader size - medium 1`] = `
           <a
             class="c4"
           >
-            Parent Page
+            <span>
+              Parent Page
+            </span>
           </a>
         </div>
         <div
@@ -4358,7 +4424,9 @@ exports[`PageHeader size - medium 1`] = `
             class="c10"
             type="button"
           >
-            Get Started
+            <span>
+              Get Started
+            </span>
           </button>
         </div>
       </div>
@@ -4585,7 +4653,9 @@ exports[`PageHeader size - small 1`] = `
           <a
             class="c4"
           >
-            Parent Page
+            <span>
+              Parent Page
+            </span>
           </a>
         </div>
         <div
@@ -4615,7 +4685,9 @@ exports[`PageHeader size - small 1`] = `
             class="c10"
             type="button"
           >
-            Get Started
+            <span>
+              Get Started
+            </span>
           </button>
         </div>
       </div>

--- a/src/js/components/RoutedAnchor/__tests__/__snapshots__/RoutedAnchor-test.js.snap
+++ b/src/js/components/RoutedAnchor/__tests__/__snapshots__/RoutedAnchor-test.js.snap
@@ -34,7 +34,9 @@ exports[`RoutedAnchor renders 1`] = `
       class="c1"
       href="/"
     >
-      Test
+      <span>
+        Test
+      </span>
     </a>
   </div>
 </div>

--- a/src/js/components/RoutedButton/__tests__/__snapshots__/RoutedButton-test.js.snap
+++ b/src/js/components/RoutedButton/__tests__/__snapshots__/RoutedButton-test.js.snap
@@ -84,7 +84,9 @@ exports[`RoutedButton renders 1`] = `
       class="c1"
       href="/"
     >
-      Test
+      <span>
+        Test
+      </span>
     </a>
   </div>
 </div>

--- a/src/js/components/SelectMultiple/__tests__/__snapshots__/SelectMultiple-test.tsx.snap
+++ b/src/js/components/SelectMultiple/__tests__/__snapshots__/SelectMultiple-test.tsx.snap
@@ -6553,7 +6553,9 @@ exports[`SelectMultiple with portal renders custom listbox styling 1`] = `
         class="c7"
         type="button"
       >
-        Select All
+        <span>
+          Select All
+        </span>
       </button>
     </div>
     <div
@@ -7913,7 +7915,9 @@ exports[`SelectMultiple with portal theme selectMultiple test 1`] = `
             class="c22"
             type="button"
           >
-            + 1 more
+            <span>
+              + 1 more
+            </span>
           </button>
         </div>
       </div>
@@ -8635,7 +8639,9 @@ exports[`SelectMultiple with portal theme selectMultiple test 2`] = `
           class="c8"
           type="button"
         >
-          Clear All
+          <span>
+            Clear All
+          </span>
         </button>
       </div>
       <div

--- a/src/js/components/Skeleton/__tests__/__snapshots__/Skeleton-test.tsx.snap
+++ b/src/js/components/Skeleton/__tests__/__snapshots__/Skeleton-test.tsx.snap
@@ -138,7 +138,9 @@ exports[`Skeleton Box skeleton loaded 1`] = `
         class="c5"
         type="button"
       >
-        Button
+        <span>
+          Button
+        </span>
       </button>
     </div>
   </div>

--- a/src/js/components/StarRating/__tests__/__snapshots__/StarRating-tests.tsx.snap
+++ b/src/js/components/StarRating/__tests__/__snapshots__/StarRating-tests.tsx.snap
@@ -1582,7 +1582,9 @@ exports[`StarRating value for rating 1`] = `
       class="c11"
       type="submit"
     >
-      submit
+      <span>
+        submit
+      </span>
     </button>
   </form>
 </div>

--- a/src/js/components/Tab/Tab.js
+++ b/src/js/components/Tab/Tab.js
@@ -174,8 +174,20 @@ const Tab = forwardRef(
       normalizedIcon = renderIcon(icon);
     }
 
-    const first = reverse ? normalizedTitle : normalizedIcon;
-    const second = reverse ? normalizedIcon : normalizedTitle;
+    // Wrap a plain string title in a span so browser translation tools
+    // (e.g. Chrome's Google Translate) replace the text node inside the span
+    // rather than a text node that is a direct sibling of React-managed
+    // elements, which would break React's DOM reconciliation
+    // (NotFoundError on insertBefore). Only relevant when plain={true},
+    // since otherwise normalizedTitle is already wrapped in <Text>.
+    const safeTitle =
+      typeof normalizedTitle === 'string' ? (
+        <span>{normalizedTitle}</span>
+      ) : (
+        normalizedTitle
+      );
+    const first = reverse ? safeTitle : normalizedIcon;
+    const second = reverse ? normalizedIcon : safeTitle;
 
     let withIconStyles;
     if (first && second) {

--- a/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.tsx.snap
+++ b/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.tsx.snap
@@ -2999,7 +2999,9 @@ exports[`Tabs should allow to extend tab styles 1`] = `
           <div
             class="c1 c5"
           >
-            Title 1
+            <span>
+              Title 1
+            </span>
           </div>
         </button>
         <button
@@ -4322,7 +4324,9 @@ exports[`Tabs should have no default styles with plain prop 1`] = `
           <div
             class="c1 c5"
           >
-            Title 1
+            <span>
+              Title 1
+            </span>
           </div>
         </button>
       </div>

--- a/src/js/components/ThumbsRating/__tests__/__snapshots__/ThumbsRating.tsx.snap
+++ b/src/js/components/ThumbsRating/__tests__/__snapshots__/ThumbsRating.tsx.snap
@@ -856,7 +856,9 @@ exports[`ThumbsRating value for thumbs 1`] = `
       class="c11"
       type="submit"
     >
-      submit
+      <span>
+        submit
+      </span>
     </button>
   </form>
 </div>

--- a/src/js/components/Tip/__tests__/__snapshots__/Tip-test.tsx.snap
+++ b/src/js/components/Tip/__tests__/__snapshots__/Tip-test.tsx.snap
@@ -188,7 +188,9 @@ exports[`Tip focus and blur events on the Tip's child 1`] = `
     class="c1"
     type="button"
   >
-    Test Events
+    <span>
+      Test Events
+    </span>
   </button>
 </div>
 `;
@@ -201,7 +203,9 @@ exports[`Tip focus and blur events on the Tip's child 2`] = `
     class="StyledButton-sc-323bzc-0 eJnOht"
     type="button"
   >
-    Test Events
+    <span>
+      Test Events
+    </span>
   </button>
 </div>
 `;

--- a/src/js/components/ToggleGroup/__tests__/__snapshots__/ToggleGroup-test.tsx.snap
+++ b/src/js/components/ToggleGroup/__tests__/__snapshots__/ToggleGroup-test.tsx.snap
@@ -169,7 +169,9 @@ exports[`ToggleGroup Should call onToggle in uncontrolled scenarios 1`] = `
           tabindex="0"
           type="button"
         >
-          one
+          <span>
+            one
+          </span>
         </button>
       </div>
       <div
@@ -182,7 +184,9 @@ exports[`ToggleGroup Should call onToggle in uncontrolled scenarios 1`] = `
           tabindex="-1"
           type="button"
         >
-          two
+          <span>
+            two
+          </span>
         </button>
       </div>
       <div
@@ -195,7 +199,9 @@ exports[`ToggleGroup Should call onToggle in uncontrolled scenarios 1`] = `
           tabindex="-1"
           type="button"
         >
-          three
+          <span>
+            three
+          </span>
         </button>
       </div>
     </div>
@@ -371,7 +377,9 @@ exports[`ToggleGroup Should call onToggle in uncontrolled scenarios with multipl
           tabindex="0"
           type="button"
         >
-          one
+          <span>
+            one
+          </span>
         </button>
       </div>
       <div
@@ -383,7 +391,9 @@ exports[`ToggleGroup Should call onToggle in uncontrolled scenarios with multipl
           tabindex="-1"
           type="button"
         >
-          two
+          <span>
+            two
+          </span>
         </button>
       </div>
       <div
@@ -395,7 +405,9 @@ exports[`ToggleGroup Should call onToggle in uncontrolled scenarios with multipl
           tabindex="-1"
           type="button"
         >
-          three
+          <span>
+            three
+          </span>
         </button>
       </div>
     </div>
@@ -635,7 +647,9 @@ exports[`ToggleGroup Should put tab focus on active button when value 1`] = `
           tabindex="-1"
           type="button"
         >
-          one
+          <span>
+            one
+          </span>
         </button>
       </div>
       <div
@@ -648,7 +662,9 @@ exports[`ToggleGroup Should put tab focus on active button when value 1`] = `
           tabindex="-1"
           type="button"
         >
-          two
+          <span>
+            two
+          </span>
         </button>
       </div>
       <div
@@ -661,7 +677,9 @@ exports[`ToggleGroup Should put tab focus on active button when value 1`] = `
           tabindex="0"
           type="button"
         >
-          three
+          <span>
+            three
+          </span>
         </button>
       </div>
     </div>
@@ -967,7 +985,9 @@ exports[`ToggleGroup Should put tab focus on active button when value with multi
           tabindex="-1"
           type="button"
         >
-          one
+          <span>
+            one
+          </span>
         </button>
       </div>
       <div
@@ -979,7 +999,9 @@ exports[`ToggleGroup Should put tab focus on active button when value with multi
           tabindex="0"
           type="button"
         >
-          two
+          <span>
+            two
+          </span>
         </button>
       </div>
       <div
@@ -991,7 +1013,9 @@ exports[`ToggleGroup Should put tab focus on active button when value with multi
           tabindex="-1"
           type="button"
         >
-          three
+          <span>
+            three
+          </span>
         </button>
       </div>
     </div>
@@ -1229,7 +1253,9 @@ exports[`ToggleGroup Should put tab focus on first button when no value 1`] = `
           tabindex="0"
           type="button"
         >
-          one
+          <span>
+            one
+          </span>
         </button>
       </div>
       <div
@@ -1242,7 +1268,9 @@ exports[`ToggleGroup Should put tab focus on first button when no value 1`] = `
           tabindex="-1"
           type="button"
         >
-          two
+          <span>
+            two
+          </span>
         </button>
       </div>
       <div
@@ -1255,7 +1283,9 @@ exports[`ToggleGroup Should put tab focus on first button when no value 1`] = `
           tabindex="-1"
           type="button"
         >
-          three
+          <span>
+            three
+          </span>
         </button>
       </div>
     </div>
@@ -1492,7 +1522,9 @@ exports[`ToggleGroup Should put tab focus on first button when no value with mul
           tabindex="0"
           type="button"
         >
-          one
+          <span>
+            one
+          </span>
         </button>
       </div>
       <div
@@ -1504,7 +1536,9 @@ exports[`ToggleGroup Should put tab focus on first button when no value with mul
           tabindex="-1"
           type="button"
         >
-          two
+          <span>
+            two
+          </span>
         </button>
       </div>
       <div
@@ -1516,7 +1550,9 @@ exports[`ToggleGroup Should put tab focus on first button when no value with mul
           tabindex="-1"
           type="button"
         >
-          three
+          <span>
+            three
+          </span>
         </button>
       </div>
     </div>
@@ -1681,7 +1717,9 @@ exports[`ToggleGroup Should render when options is array of objects with multipl
           tabindex="0"
           type="button"
         >
-          One
+          <span>
+            One
+          </span>
         </button>
       </div>
       <div
@@ -1693,7 +1731,9 @@ exports[`ToggleGroup Should render when options is array of objects with multipl
           tabindex="-1"
           type="button"
         >
-          Two
+          <span>
+            Two
+          </span>
         </button>
       </div>
     </div>
@@ -1867,7 +1907,9 @@ exports[`ToggleGroup custom theme with hover green 1`] = `
           tabindex="0"
           type="button"
         >
-          one
+          <span>
+            one
+          </span>
         </button>
       </div>
       <div
@@ -1880,7 +1922,9 @@ exports[`ToggleGroup custom theme with hover green 1`] = `
           tabindex="-1"
           type="button"
         >
-          two
+          <span>
+            two
+          </span>
         </button>
       </div>
     </div>
@@ -2054,7 +2098,9 @@ exports[`ToggleGroup custom theme with hover green 2`] = `
           tabindex="0"
           type="button"
         >
-          one
+          <span>
+            one
+          </span>
         </button>
       </div>
       <div
@@ -2067,7 +2113,9 @@ exports[`ToggleGroup custom theme with hover green 2`] = `
           tabindex="-1"
           type="button"
         >
-          two
+          <span>
+            two
+          </span>
         </button>
       </div>
     </div>
@@ -2634,7 +2682,9 @@ exports[`ToggleGroup object options 1`] = `
           tabindex="0"
           type="button"
         >
-          One
+          <span>
+            One
+          </span>
         </button>
       </div>
       <div
@@ -2647,7 +2697,9 @@ exports[`ToggleGroup object options 1`] = `
           tabindex="-1"
           type="button"
         >
-          Two
+          <span>
+            Two
+          </span>
         </button>
       </div>
     </div>
@@ -2855,7 +2907,9 @@ exports[`ToggleGroup should allow divider to be set to false 1`] = `
           tabindex="0"
           type="button"
         >
-          one
+          <span>
+            one
+          </span>
         </button>
       </div>
       <div
@@ -2868,7 +2922,9 @@ exports[`ToggleGroup should allow divider to be set to false 1`] = `
           tabindex="-1"
           type="button"
         >
-          two
+          <span>
+            two
+          </span>
         </button>
       </div>
     </div>
@@ -3020,7 +3076,9 @@ exports[`ToggleGroup should allow rounding on individual buttons 1`] = `
           tabindex="0"
           type="button"
         >
-          one
+          <span>
+            one
+          </span>
         </button>
       </div>
       <div
@@ -3033,7 +3091,9 @@ exports[`ToggleGroup should allow rounding on individual buttons 1`] = `
           tabindex="-1"
           type="button"
         >
-          two
+          <span>
+            two
+          </span>
         </button>
       </div>
     </div>
@@ -3174,7 +3234,9 @@ exports[`ToggleGroup should allow toggleGroup.button.kind as string 1`] = `
           tabindex="0"
           type="button"
         >
-          one
+          <span>
+            one
+          </span>
         </button>
       </div>
       <div
@@ -3187,7 +3249,9 @@ exports[`ToggleGroup should allow toggleGroup.button.kind as string 1`] = `
           tabindex="-1"
           type="button"
         >
-          two
+          <span>
+            two
+          </span>
         </button>
       </div>
     </div>
@@ -3364,7 +3428,9 @@ exports[`ToggleGroup should have no accessibility violations 1`] = `
           tabindex="0"
           type="button"
         >
-          Option 1
+          <span>
+            Option 1
+          </span>
         </button>
       </div>
       <div
@@ -3377,7 +3443,9 @@ exports[`ToggleGroup should have no accessibility violations 1`] = `
           tabindex="-1"
           type="button"
         >
-          Option 2
+          <span>
+            Option 2
+          </span>
         </button>
       </div>
       <div
@@ -3390,7 +3458,9 @@ exports[`ToggleGroup should have no accessibility violations 1`] = `
           tabindex="-1"
           type="button"
         >
-          Option 3
+          <span>
+            Option 3
+          </span>
         </button>
       </div>
     </div>
@@ -3556,7 +3626,9 @@ exports[`ToggleGroup string options 1`] = `
           tabindex="0"
           type="button"
         >
-          one
+          <span>
+            one
+          </span>
         </button>
       </div>
       <div
@@ -3569,7 +3641,9 @@ exports[`ToggleGroup string options 1`] = `
           tabindex="-1"
           type="button"
         >
-          two
+          <span>
+            two
+          </span>
         </button>
       </div>
     </div>
@@ -3734,7 +3808,9 @@ exports[`ToggleGroup string options with multiple prop 1`] = `
           tabindex="0"
           type="button"
         >
-          one
+          <span>
+            one
+          </span>
         </button>
       </div>
       <div
@@ -3746,7 +3822,9 @@ exports[`ToggleGroup string options with multiple prop 1`] = `
           tabindex="-1"
           type="button"
         >
-          two
+          <span>
+            two
+          </span>
         </button>
       </div>
     </div>

--- a/src/js/components/Toolbar/__tests__/__snapshots__/Toolbar-test.js.snap
+++ b/src/js/components/Toolbar/__tests__/__snapshots__/Toolbar-test.js.snap
@@ -533,7 +533,9 @@ exports[`DataFilters renders 1`] = `
               class="c21"
               type="submit"
             >
-              Apply filters
+              <span>
+                Apply filters
+              </span>
             </button>
           </footer>
         </div>
@@ -1057,7 +1059,9 @@ exports[`DataFilters renders outside grommet wrapper 1`] = `
             class="c20"
             type="submit"
           >
-            Apply filters
+            <span>
+              Apply filters
+            </span>
           </button>
         </footer>
       </div>
@@ -1600,7 +1604,9 @@ exports[`DataFilters theme gap 1`] = `
                 class="c21"
                 type="submit"
               >
-                Apply filters
+                <span>
+                  Apply filters
+                </span>
               </button>
             </footer>
           </div>

--- a/src/js/themes/__tests__/__snapshots__/theme-test.js.snap
+++ b/src/js/themes/__tests__/__snapshots__/theme-test.js.snap
@@ -35,7 +35,9 @@ exports[`Grommet ThemeContext theme 1`] = `
   <a
     class="c1"
   >
-    Hello
+    <span>
+      Hello
+    </span>
   </a>
 </div>
 `;
@@ -339,7 +341,9 @@ exports[`Grommet custom theme 1`] = `
         <span
           class="c5"
         />
-        Add
+        <span>
+          Add
+        </span>
       </span>
     </a>
     <a
@@ -363,7 +367,9 @@ exports[`Grommet custom theme 1`] = `
         <span
           class="c5"
         />
-        Add
+        <span>
+          Add
+        </span>
       </span>
     </a>
   </div>
@@ -391,7 +397,9 @@ exports[`Grommet custom theme 1`] = `
         <span
           class="c5"
         />
-        Add
+        <span>
+          Add
+        </span>
       </span>
     </a>
     <a
@@ -415,7 +423,9 @@ exports[`Grommet custom theme 1`] = `
         <span
           class="c5"
         />
-        Add
+        <span>
+          Add
+        </span>
       </span>
     </a>
   </div>
@@ -1506,13 +1516,17 @@ exports[`Grommet grommet theme 1`] = `
     class="c1"
     type="button"
   >
-    test
+    <span>
+      test
+    </span>
   </button>
   <button
     class="c2"
     type="button"
   >
-    test
+    <span>
+      test
+    </span>
   </button>
 </div>
 `;


### PR DESCRIPTION
#### What does this PR do?

Fixes a runtime crash that occurs in Anchor, Button and Tab when the page is translated by the browser (most commonly Chrome's Google Translate). When a component renders a plain string as a direct sibling of other React-managed elements (e.g. {icon}{label} inside a Box), the translator replaces the raw text node with a new node. React still holds a reference to the original text node and later calls insertBefore against it, throwing NotFoundError: Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.

Impacted root components :
- Anchor
- Button
- Tab

The fix wraps the plain string label (and title for Tab) in a <span>. Translators replace the text node inside the span, but the span itself remains stable, so React's child references stay valid.

#### Where should the reviewer start?

- src/js/components/Button/Button.js — original reported bug.
- src/js/components/Anchor/Anchor.js  — same pattern (string label/title rendered as a sibling of an icon).
- src/js/components/Tab/Tab.js — same pattern (string label/title rendered as a sibling of an icon).

Other components were audited (Menu, Notification, AccordionPanel, RadioButton, CheckBox, NameValuePair, Card, FormField, Heading, Text, Avatar) and either already wrap their string children in protective elements (e.g. <Text>, <Heading>, <Message>) or render the string as the only child, so they are not affected.

#### What testing has been done on this PR?

- Full Jest suite passes (1756 tests, 99 suites, 1968 snapshots).
- Snapshots that include the affected components were regenerated to reflect the added <span> wrapper.
- Two existing tests were updated to use accessibility-first queries (getByRole('button', { name: ... })) instead of getByText('label'), which previously returned the <button> element directly but now returns the inner <span>. The user-facing behavior (focus on click/tab, cursor inheritance) is unchanged

#### How should this be manually tested?

See issue here and associated code sandbox : https://github.com/grommet/grommet/issues/7936

#### Do Jest tests follow these best practices?

- [ X ] `screen` is used for querying.
- [ X ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ X ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

This is a well-known React + Google Translate interaction issue. When a text node is a direct sibling of React-managed elements, the translator's DOM mutations invalidate React's internal references. 
The standard, community-recommended workaround is to wrap text nodes in an inert element (typically a  <span>), which acts as a stable anchor while the translator only swaps out the inner text.

Components like Menu, AccordionPanel, Notification, RadioButton, CheckBox, etc. were already wrapping their string content in <Text>, <Heading>, <Message> or similar elements, so they were already protected.

#### What are the relevant issues?

https://github.com/grommet/grommet/issues/7936

#### Screenshots (if appropriate)

N/A

#### Do the grommet docs need to be updated?

No

#### Should this PR be mentioned in the release notes?

Yes — bug fix affecting users whose pages may be translated by the browser (e.g. multilingual audiences using Chrome's Google Translate).

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.
The only observable change is an extra inline <span> element wrapping the label text in the rendered DOM. This may affect:
  - Snapshot tests in downstream consumers (the wrapper element appears in serialized output).
  - Test queries that rely on getByText('label') to retrieve the parent button/anchor element — these should be migrated to getByRole('button', { name: 'label' }) (the Testing Library recommended approach).

No public API or prop signature changes.