### PR TITLE
Clean up Select and SelectMultiple children stories

### DIFF
--- a/src/js/components/Select/stories/ChildrenRender.stories.js
+++ b/src/js/components/Select/stories/ChildrenRender.stories.js
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 
-import { FormClose } from 'grommet-icons';
-import { Box, Button, Select, Text } from 'grommet';
+import { Box, Select, Tag, Text } from 'grommet';
 
 const allSeasons = [
   'S01',
@@ -23,37 +22,16 @@ export const Children = () => {
     setSelected(selected.filter((selectedSeason) => selectedSeason !== season));
   };
 
-  const renderSeason = (season) => (
-    <Button
-      key={`season_tag_${season}`}
-      href="#"
-      onClick={(event) => {
-        event.preventDefault();
-        event.stopPropagation();
-        onRemoveSeason(season);
-      }}
-      onFocus={(event) => event.stopPropagation()}
+  const renderOption = (option, index, options, state) => (
+    <Box
+      pad="small"
+      background={
+        state.selected ? 'brand' : undefined
+      }
     >
-      <Box
-        align="center"
-        direction="row"
-        gap="xsmall"
-        pad={{ vertical: 'xsmall', horizontal: 'small' }}
-        margin="xsmall"
-        background="brand"
-        round="large"
-      >
-        <Text size="small">{season}</Text>
-        <Box round="full" margin={{ left: 'xsmall' }}>
-          <FormClose size="small" style={{ width: '12px', height: '12px' }} />
-        </Box>
-      </Box>
-    </Button>
-  );
-
-  const renderOption = (option, state) => (
-    <Box pad="small" background={state.active ? 'active' : undefined}>
-      {option}
+      <Text color={state.disabled ? 'text-disabled' : 'text-strong'}>
+        {option}
+      </Text>
     </Box>
   );
 
@@ -64,20 +42,33 @@ export const Children = () => {
       <Select
         closeOnChange={false}
         multiple
-        valueLabel={
-          <Box wrap direction="row" width="small">
-            {selected && selected.length ? (
-              selected.map((value) => renderSeason(value))
-            ) : (
-              <Box
-                pad={{ vertical: 'xsmall', horizontal: 'small' }}
-                margin="xsmall"
-              >
-                Select Season
-              </Box>
-            )}
+        placeholder="Select Season"
+        valueLabel={(options) => (
+          <Box
+            wrap
+            direction="row"
+            pad="xsmall"
+            gap="xsmall"
+            cssGap
+            width="small"
+          >
+            {options && options.length ?
+              options.map((season) => (
+                <Tag
+                  key={`season_tag_${season}`}
+                  value={season}
+                  onRemove={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    onRemoveSeason(season);
+                  }}
+                />
+              )) : (
+              <Text color="text-weak">Select Season</Text>
+             )
+            }
           </Box>
-        }
+        )}
         options={allSeasons}
         value={selected}
         disabled={[2, 6]}

--- a/src/js/components/SelectMultiple/stories/typescript/Children.stories.tsx
+++ b/src/js/components/SelectMultiple/stories/typescript/Children.stories.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 
-import { FormClose } from 'grommet-icons';
-import { Box, Button, Text } from 'grommet';
+import { Box, Tag, Text } from 'grommet';
 import { SelectMultiple } from '../../SelectMultiple.js';
 
 const allSeasons = [
@@ -24,35 +23,7 @@ export const Children = () => {
     setSelected(selected.filter((selectedSeason) => selectedSeason !== season));
   };
 
-  const renderSeason = (season) => (
-    <Button
-      key={`season_tag_${season}`}
-      onClick={(event) => {
-        event.preventDefault();
-        event.stopPropagation();
-        onRemoveSeason(season);
-      }}
-      onFocus={(event) => event.stopPropagation()}
-      a11yTitle={season}
-    >
-      <Box
-        align="center"
-        direction="row"
-        gap="xsmall"
-        pad={{ vertical: 'xsmall', horizontal: 'small' }}
-        margin="xsmall"
-        background="light-3"
-        round="large"
-      >
-        <Text size="small">{season}</Text>
-        <Box round="full" margin={{ left: 'xsmall' }}>
-          <FormClose size="small" style={{ width: '12px', height: '12px' }} />
-        </Box>
-      </Box>
-    </Button>
-  );
-
-  const renderOption = (option, state) => (
+  const renderOption = (option, index, options, state) => (
     <Box pad="small" background={state.active ? 'active' : undefined}>
       {option}
     </Box>
@@ -66,25 +37,30 @@ export const Children = () => {
       <SelectMultiple
         sortSelectedOnClose={false}
         showSelectedInline
-        valueLabel={(option) => (
-          <Box wrap direction="row" width="small">
-            {option && option.length ? (
-              <>
-                {option.map((i) => {
-                  console.log(option);
-                  return renderSeason(i);
-                })}
-              </>
-            ) : (
-              <Text color="text-weak">Select Season</Text>
-            )}
+        placeholder="Select Season"
+        valueLabel={(options) => (
+          <Box
+            wrap
+            direction="row"
+            pad="xsmall"
+            gap="xsmall"
+            cssGap
+            width="small"
+          >
+            {options && options.length &&
+              options.map((season) => (
+                <Tag
+                  key={`season_tag_${season}`}
+                  value={season}
+                  onRemove={() => onRemoveSeason(season)}
+                />
+              ))
+            }
           </Box>
         )}
         options={allSeasons}
         value={selected}
-        onChange={({ value }) => {
-          setSelected([...value]);
-        }}
+        onChange={({ value }) => setSelected([...value])}
       >
         {renderOption}
       </SelectMultiple>

--- a/src/js/components/SelectMultiple/stories/typescript/Children.stories.tsx
+++ b/src/js/components/SelectMultiple/stories/typescript/Children.stories.tsx
@@ -17,13 +17,13 @@ const allSeasons = [
 ];
 
 export const Children = () => {
-  const [selected, setSelected] = useState([]);
+  const [selected, setSelected] = useState<string[]>([]);
 
-  const onRemoveSeason = (season) => {
+  const onRemoveSeason = (season: string) => {
     setSelected(selected.filter((selectedSeason) => selectedSeason !== season));
   };
 
-  const renderOption = (option, index, options, state) => (
+  const renderOption = (option: string, _index: number, _options: string[], state: { active: boolean }) => (
     <Box pad="small" background={state.active ? 'active' : undefined}>
       {option}
     </Box>
@@ -38,14 +38,14 @@ export const Children = () => {
         sortSelectedOnClose={false}
         showSelectedInline
         placeholder="Select Season"
-        valueLabel={(options) => (
+        width="medium"
+        valueLabel={(options: any[]) => (
           <Box
             wrap
             direction="row"
             pad="xsmall"
             gap="xsmall"
             cssGap
-            width="small"
           >
             {options && options.length &&
               options.map((season) => (
@@ -60,7 +60,7 @@ export const Children = () => {
         )}
         options={allSeasons}
         value={selected}
-        onChange={({ value }) => setSelected([...value])}
+        onChange={({ value }: { value: any[] }) => setSelected([...value])}
       >
         {renderOption}
       </SelectMultiple>

--- a/src/js/components/SelectMultiple/stories/typescript/ValueLabel.stories.tsx
+++ b/src/js/components/SelectMultiple/stories/typescript/ValueLabel.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 
 import { Box, Tag, Text } from 'grommet';
 import { SelectMultiple } from '../../SelectMultiple.js';
@@ -18,9 +18,23 @@ const tags = [
 
 export const ValueLabel = () => {
   const [selected, setSelected] = useState(tags.slice(0, 3));
-
-  const onRemoveTag = (tag) => {
-    setSelected(selected.filter((selectedTag) => selectedTag !== tag));
+  const valuesRef = useRef(undefined as unknown as HTMLDivElement);
+  const onRemoveTag = (tag: string) => {
+    const nextSelected = selected.filter((selectedTag) => selectedTag !== tag);
+    if (nextSelected.length > 0) {
+      const index = selected.indexOf(tag);
+      // update focus to the next tag's remove button
+      // if there is one, otherwise the previous one
+      const nextFocusIndex = index < nextSelected.length ? index : index - 1;
+      if (nextFocusIndex >= 0 && valuesRef.current) {
+        setTimeout(() => {
+          const element = valuesRef.current as HTMLElement;
+          const buttons = element?.querySelectorAll('button');
+          buttons[nextFocusIndex].focus();
+        }, 200);
+      }
+    }
+    setSelected(nextSelected);
   };
 
   return (
@@ -31,8 +45,9 @@ export const ValueLabel = () => {
       <SelectMultiple
         showSelectedInline
         placeholder="Select tag"
-        valueLabel={(options) => (
+        valueLabel={(options: any[]) => (
           <Box
+            ref={valuesRef}
             wrap
             direction="row"
             pad="xsmall"
@@ -53,7 +68,7 @@ export const ValueLabel = () => {
         )}
         options={tags}
         value={selected}
-        onChange={({ value }) => setSelected([...value])}
+        onChange={({ value }: { value: string[] }) => setSelected([...value])}
       />
     </Box>
     // </Grommet>

--- a/src/js/components/SelectMultiple/stories/typescript/ValueLabel.stories.tsx
+++ b/src/js/components/SelectMultiple/stories/typescript/ValueLabel.stories.tsx
@@ -45,6 +45,7 @@ export const ValueLabel = () => {
       <SelectMultiple
         showSelectedInline
         placeholder="Select tag"
+        width="medium"
         valueLabel={(options: any[]) => (
           <Box
             ref={valuesRef}
@@ -53,7 +54,6 @@ export const ValueLabel = () => {
             pad="xsmall"
             gap="xsmall"
             cssGap
-            width="small"
           >
             {options && options.length &&
               options.map((tag) => (

--- a/src/js/components/SelectMultiple/stories/typescript/ValueLabel.stories.tsx
+++ b/src/js/components/SelectMultiple/stories/typescript/ValueLabel.stories.tsx
@@ -1,0 +1,73 @@
+import React, { useState } from 'react';
+
+import { Box, Tag, Text } from 'grommet';
+import { SelectMultiple } from '../../SelectMultiple.js';
+
+const tags = [
+  'Production',
+  'Test',
+  'Integration',
+  'Analytics',
+  'Development',
+  'Staging',
+  'QA',
+  'UAT',
+  'Performance',
+  'Crash and bash',
+].sort();
+
+export const ValueLabel = () => {
+  const [selected, setSelected] = useState(tags.slice(0, 3));
+
+  const onRemoveTag = (tag) => {
+    setSelected(selected.filter((selectedTag) => selectedTag !== tag));
+  };
+
+  return (
+    // Uncomment <Grommet> lines when using outside of storybook
+    // <Grommet theme={...}>
+    <Box fill align="center" pad="large" gap="large">
+      <Text>SelectMultiple with custom valueLabel</Text>
+      <SelectMultiple
+        showSelectedInline
+        placeholder="Select tag"
+        valueLabel={(options) => (
+          <Box
+            wrap
+            direction="row"
+            pad="xsmall"
+            gap="xsmall"
+            cssGap
+            width="small"
+          >
+            {options && options.length &&
+              options.map((tag) => (
+                <Tag
+                  key={`tag_${tag}`}
+                  value={tag}
+                  onRemove={() => onRemoveTag(tag)}
+                />
+              ))
+            }
+          </Box>
+        )}
+        options={tags}
+        value={selected}
+        onChange={({ value }) => setSelected([...value])}
+      />
+    </Box>
+    // </Grommet>
+  );
+};
+
+ValueLabel.parameters = {
+  chromatic: { disable: true },
+};
+
+ValueLabel.args = {
+  full: true,
+};
+
+export default {
+  title: 'Input/SelectMultiple/Value Label',
+};

--- a/src/js/components/Tag/index.d.ts
+++ b/src/js/components/Tag/index.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { BoxProps } from '../Box';
+import { BoxExtendedProps } from '../Box';
 
 export interface TagProps {
   name?: string;
@@ -22,7 +22,7 @@ export interface TagProps {
   value: string | number;
 }
 
-export interface TagExtendedProps extends BoxProps, TagProps {}
+export interface TagExtendedProps extends Omit<BoxExtendedProps, keyof TagProps>, TagProps {}
 
 // Keep type alias for backwards compatibility.
 export type TagType = TagProps;


### PR DESCRIPTION

[Deploy Preview](https://5d9774839a6eff00203f5cbf-iijjefwoff.chromatic.com/?path=/story/input-selectmultiple-value-label--value-label&globals=theme:hpe)

#### What does this PR do?
This cleans up the `children` and `valueLabel` related stories for Select and SelectMultiple. Both try to show how to use `valueLabel` to render the selected items as tags but with custom versions (pre-Tag existing).

This also adds a separate SelectMultiple->valueLabel story that serves as a better example of doing tags (without the custom children in the drop.)

Finally this corrects a couple of the children render functions which we expecting the wrong arguments and incorrectly interpreting index as state.


#### Where should the reviewer start?
Children.stories.tsx

#### What testing has been done on this PR?
Storybook.

#### How should this be manually tested?
Storybook

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No
#### Is this change backwards compatible or is it a breaking change?
Backwards compatible