### PR TITLE
Add support for children in Tag

### DIFF
--- a/src/js/components/Tag/Tag.js
+++ b/src/js/components/Tag/Tag.js
@@ -11,7 +11,16 @@ import { MessageContext } from '../../contexts/MessageContext';
 
 const Tag = forwardRef(
   (
-    { name, value, size = 'medium', onRemove, onClick, messages, ...rest },
+    {
+      children,
+      name,
+      value,
+      size = 'medium',
+      onRemove,
+      onClick,
+      messages,
+      ...rest
+    },
     ref,
   ) => {
     const { format } = useContext(MessageContext);
@@ -36,7 +45,7 @@ const Tag = forwardRef(
       round: theme.tag.size?.[size]?.round || theme.tag.round,
       ...rest,
     };
-    const contents = (
+    const contents = children || (
       <Box
         width={{ min: 'min-content' }}
         pad={theme.tag.size?.[size]?.pad || theme.tag.pad}

--- a/src/js/components/Tag/__tests__/Tag-test.tsx
+++ b/src/js/components/Tag/__tests__/Tag-test.tsx
@@ -8,7 +8,7 @@ import 'jest-axe/extend-expect';
 import 'regenerator-runtime/runtime';
 import '@testing-library/jest-dom';
 
-import { Grommet, Tag } from '../..';
+import { Box, Grommet, Tag } from '../..';
 import { grommet } from '../../../themes/grommet';
 import { deepMerge } from '../../../utils';
 import { ThemeType } from '../../../themes';
@@ -36,6 +36,17 @@ describe('Tag', () => {
 
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+
+  test('renders children when provided', () => {
+    const { asFragment } = render(
+      <Grommet>
+        <Tag value="Value">
+          <Box>Custom Child</Box>
+        </Tag>
+      </Grommet>,
+    );
+    expect(asFragment()).toMatchSnapshot();
   });
 
   test('basic', () => {

--- a/src/js/components/Tag/__tests__/Tag-test.tsx
+++ b/src/js/components/Tag/__tests__/Tag-test.tsx
@@ -59,6 +59,16 @@ describe('Tag', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  test('renders node name and value', () => {
+    const { asFragment } = render(
+      <Grommet>
+        <Tag name={<Box>Custom name</Box>} value={<Box>Custom value</Box>} />
+      </Grommet>,
+    );
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+
   test('basic outside grommet wrapper', () => {
     const { container } = render(<Tag name="Name" value="Value" />);
 

--- a/src/js/components/Tag/__tests__/__snapshots__/Tag-test.tsx.snap
+++ b/src/js/components/Tag/__tests__/__snapshots__/Tag-test.tsx.snap
@@ -1632,6 +1632,135 @@ exports[`Tag renders default remove icon 1`] = `
 </div>
 `;
 
+exports[`Tag renders node name and value 1`] = `
+<DocumentFragment>
+  .c1 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: center;
+  border: solid 1px rgba(0, 0, 0, 0.33);
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  min-width: min-content;
+  flex: 0 0 auto;
+  border-radius: 48px;
+}
+
+.c2 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  min-width: min-content;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c4 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.c3 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c5 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: 600;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+@media only screen and (max-width: 768px) {
+  .c1 {
+    border: solid 1px rgba(0, 0, 0, 0.33);
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c1 {
+    border-radius: 24px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    padding-left: 6px;
+    padding-right: 6px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c2 {
+    padding-top: 3px;
+    padding-bottom: 3px;
+  }
+}
+
+<div
+    class="c0"
+  >
+    <div
+      class="c1"
+    >
+      <div
+        class="c2"
+      >
+        <span
+          class="c3"
+        >
+          <span
+            class="c3"
+          >
+             
+            <div
+              class="c4"
+            >
+              Custom name
+            </div>
+          </span>
+          <span
+            class="c3"
+          >
+             : 
+          </span>
+          <span
+            class="c5"
+          >
+            <div
+              class="c4"
+            >
+              Custom value
+            </div>
+          </span>
+        </span>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`Tag size 1`] = `
 .c1 {
   display: flex;

--- a/src/js/components/Tag/__tests__/__snapshots__/Tag-test.tsx.snap
+++ b/src/js/components/Tag/__tests__/__snapshots__/Tag-test.tsx.snap
@@ -572,6 +572,69 @@ exports[`Tag onRemove 1`] = `
 </div>
 `;
 
+exports[`Tag renders children when provided 1`] = `
+<DocumentFragment>
+  .c1 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  align-items: center;
+  border: solid 1px rgba(0, 0, 0, 0.33);
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  min-width: min-content;
+  flex: 0 0 auto;
+  border-radius: 48px;
+}
+
+.c2 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+@media only screen and (max-width: 768px) {
+  .c1 {
+    border: solid 1px rgba(0, 0, 0, 0.33);
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c1 {
+    border-radius: 24px;
+  }
+}
+
+<div
+    class="c0"
+  >
+    <div
+      class="c1"
+    >
+      <div
+        class="c2"
+      >
+        Custom Child
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`Tag renders custom remove button kind and size 1`] = `
 <DocumentFragment>
   .c1 {

--- a/src/js/components/Tag/index.d.ts
+++ b/src/js/components/Tag/index.d.ts
@@ -3,7 +3,7 @@ import { BoxProps } from '../Box';
 
 export interface TagProps {
   children?: React.ReactNode;
-  name?: string;
+  name?: string | React.ReactNode;
   onClick?: (...args: any[]) => any;
   onRemove?: (...args: any[]) => any;
   messages?: {
@@ -20,7 +20,7 @@ export interface TagProps {
     | 'xlarge'
     | 'xxlarge'
     | string;
-  value: string | number;
+  value: string | number | React.ReactNode;
 }
 
 export interface TagExtendedProps extends BoxProps, TagProps {}

--- a/src/js/components/Tag/index.d.ts
+++ b/src/js/components/Tag/index.d.ts
@@ -20,7 +20,7 @@ export interface TagProps {
     | 'xlarge'
     | 'xxlarge'
     | string;
-  value: string | number | React.ReactNode;
+  value?: string | number | React.ReactNode;
 }
 
 export interface TagExtendedProps extends BoxProps, TagProps {}

--- a/src/js/components/Tag/index.d.ts
+++ b/src/js/components/Tag/index.d.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { BoxProps } from '../Box';
 
 export interface TagProps {
+  children?: React.ReactNode;
   name?: string;
   onClick?: (...args: any[]) => any;
   onRemove?: (...args: any[]) => any;

--- a/src/js/components/Tag/propTypes.js
+++ b/src/js/components/Tag/propTypes.js
@@ -5,7 +5,7 @@ if (process.env.NODE_ENV !== 'production') {
   PropType = {
     children: PropTypes.node,
     name: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
-    value: PropTypes.oneOfType([PropTypes.node, PropTypes.string]).isRequired,
+    value: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
     onClick: PropTypes.func,
     onRemove: PropTypes.func,
     messages: PropTypes.shape({

--- a/src/js/components/Tag/propTypes.js
+++ b/src/js/components/Tag/propTypes.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 let PropType = {};
 if (process.env.NODE_ENV !== 'production') {
   PropType = {
+    children: PropTypes.node,
     name: PropTypes.string,
     value: PropTypes.string.isRequired,
     onClick: PropTypes.func,

--- a/src/js/components/Tag/propTypes.js
+++ b/src/js/components/Tag/propTypes.js
@@ -4,8 +4,8 @@ let PropType = {};
 if (process.env.NODE_ENV !== 'production') {
   PropType = {
     children: PropTypes.node,
-    name: PropTypes.string,
-    value: PropTypes.string.isRequired,
+    name: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
+    value: PropTypes.oneOfType([PropTypes.node, PropTypes.string]).isRequired,
     onClick: PropTypes.func,
     onRemove: PropTypes.func,
     messages: PropTypes.shape({

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -1026,6 +1026,7 @@ exports[`Components loads 1`] = `
   "Tag": {
     "$$typeof": Symbol(react.forward_ref),
     "prototype": {
+      "children": [Function],
       "messages": [Function],
       "name": [Function],
       "onClick": [Function],


### PR DESCRIPTION
#### What does this PR do?
Adds children prop to tag component to allow for customization of the tag

Also added node type to name and value

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes https://github.com/grommet/grommet/issues/7951

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
Yes
#### Should this PR be mentioned in the release notes?
Yes
#### Is this change backwards compatible or is it a breaking change?
Backwards compatible