### PR TITLE
fix edgesize

### DIFF
--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -401,6 +401,7 @@ export interface ThemeType {
       large?: string;
       xlarge?: string;
       responsiveBreakpoint?: string;
+      [x: string]: string | undefined;
     };
     elevation?: {
       light?: {

--- a/src/js/utils/index.d.ts
+++ b/src/js/utils/index.d.ts
@@ -280,6 +280,7 @@ declare const breakpointEdgeSize: {
   medium?: string;
   large?: string;
   xlarge?: string;
+  [x: string]: string | undefined;
 };
 export type BreakpointEdgeSize = typeof breakpointEdgeSize;
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds an index signature (`[x: string]: string | undefined`) to the `breakpointEdgeSize` 
declaration in `utils/index.d.ts` and to the `global.edgeSize` object in `themes/base.d.ts`.

#### Where should the reviewer start?
base.d.ts
#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
https://github.com/grommet/hpe-design-system/pull/6184
#### What are the relevant issues?
https://github.com/grommet/hpe-design-system/pull/6184
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible