### PR TITLE
fix file input cancel clears selection

### DIFF
--- a/src/js/components/FileInput/FileInput.js
+++ b/src/js/components/FileInput/FileInput.js
@@ -328,6 +328,9 @@ const FileInput = forwardRef(
             onChange={(event) => {
               event.persist();
               const fileList = event.target.files;
+              // If the user cancelled the file picker, fileList will be empty
+              // and we should not clear any previously selected files.
+              if (!fileList.length && files.length) return;
               const nextFiles = multiple ? [...files] : [];
               for (let i = 0; i < fileList.length; i += 1) {
                 // avoid duplicates

--- a/src/js/components/FileInput/__tests__/FileInput-test.tsx
+++ b/src/js/components/FileInput/__tests__/FileInput-test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import 'jest-styled-components';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 
 import { Grommet } from '../../Grommet';
@@ -237,5 +238,33 @@ describe('FileInput', () => {
     );
 
     expect(asFragment()).toMatchSnapshot();
+  });
+
+  test('cancelling the file picker should not clear an existing file', async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+
+    render(
+      <Grommet>
+        <FileInput onChange={onChange} />
+      </Grommet>,
+    );
+
+    const input = document.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+
+    // Select a file
+    const file = new File(['hello'], 'hello.txt', { type: 'text/plain' });
+    await user.upload(input, file);
+    expect(screen.getByText('hello.txt')).toBeInTheDocument();
+    expect(onChange).toHaveBeenCalledTimes(1);
+
+    // Simulate cancelling the file picker — browser fires change with empty FileList
+    fireEvent.change(input, { target: { files: [] } });
+
+    // File should still be shown and onChange should not have fired again
+    expect(screen.getByText('hello.txt')).toBeInTheDocument();
+    expect(onChange).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fixes a bug where cancelling out of the browser's file picker dialog would clear a previously selected file. When the user opens the file picker and cancels without selecting a new file, the browser fires a `change` event with an empty FileList. The `onChange` handler was processing this and wiping the existing file selection. This PR adds a guard to bail out early in that case.
#### Where should the reviewer start?
fileinput.js
#### What testing has been done on this PR?
locally and added a test
#### How should this be manually tested?
1. Render a FileInput
2. Select a file  confirm filename appears
3. Click Browse again and cancel out of the dialog
4. Confirm the previously selected file is still shown
#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
When the file picker is cancelled, browsers fire a `change` event with `event.target.files` as an empty FileList (length 0). This is browser-native behavior that cannot be suppressed, so the fix handles it in the handler itself.
#### What are the relevant issues?
n/a
#### Screenshots (if appropriate)
n/a
#### Do the grommet docs need to be updated?
n/a
#### Should this PR be mentioned in the release notes?
sure
#### Is this change backwards compatible or is it a breaking change?
backwards compatible