### PR TITLE
Remove overflow visible from DateInput

### DIFF
--- a/src/js/components/DateInput/DateInput.js
+++ b/src/js/components/DateInput/DateInput.js
@@ -441,7 +441,6 @@ Use the icon prop instead.`,
         input,
         <Drop
           key="drop"
-          overflow="visible"
           id={id ? `${id}__drop` : undefined}
           target={containerRef.current}
           align={{ ...calendarDropdownAlign, ...dropProps }}

--- a/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.tsx.snap
+++ b/src/js/components/DateInput/__tests__/__snapshots__/DateInput-test.tsx.snap
@@ -16471,7 +16471,7 @@ exports[`DateInput select format 3`] = `
   min-width: 0;
   min-height: 0;
   flex-direction: column;
-  overflow: visible;
+  overflow: auto;
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.20);
 }
 
@@ -29076,7 +29076,7 @@ exports[`DateInput select format no timezone 3`] = `
   min-width: 0;
   min-height: 0;
   flex-direction: column;
-  overflow: visible;
+  overflow: auto;
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.20);
 }
 


### PR DESCRIPTION
#### What does this PR do?
Overflow visible was added in [this PR](https://github.com/grommet/grommet/pull/4382) in an effort to prevent the focus indicator from being cut off.
Having focus visible creates the following issue where the Calendar overflows outside it's container when the drop is constrained. Also focus visisble doesn't resolve the focus indicator issue, it gets cut off reguardless.

Before (with focus visible):
<img width="442" height="321" alt="Screenshot 2026-05-28 at 3 16 36 PM" src="https://github.com/user-attachments/assets/c2032f9c-7803-41cc-b334-17f2b66f9782" />

After (without focus visible):
<img width="475" height="308" alt="Screenshot 2026-05-28 at 3 17 09 PM" src="https://github.com/user-attachments/assets/126356a3-e2f8-4831-8051-c7dec313aceb" />

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?
Tested with the DateInput/Format story

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible