### PR TITLE
Revert "fix avatar accessibility"

### DIFF
--- a/src/js/components/Avatar/Avatar.js
+++ b/src/js/components/Avatar/Avatar.js
@@ -37,15 +37,11 @@ const Avatar = ({
 
   const AvatarChildren = useCallback(
     () => (
-      <StyledAvatar
-        aria-label={a11yTitle || ariaLabel || undefined}
-        {...avatarProps}
-        {...rest}
-      >
+      <StyledAvatar {...avatarProps} {...rest}>
         {children}
       </StyledAvatar>
     ),
-    [a11yTitle, ariaLabel, avatarProps, children, rest],
+    [avatarProps, children, rest],
   );
 
   if (height || width) {
@@ -55,12 +51,10 @@ const Avatar = ({
   }
 
   let content;
-  let hasImage = false;
   if (typeof children === 'string') {
     content = (
       <StyledAvatarText
         alignSelf="center"
-        aria-hidden={a11yTitle || ariaLabel ? true : undefined}
         size={avatarTextSize}
         {...passThemeFlag}
       >
@@ -68,21 +62,16 @@ const Avatar = ({
       </StyledAvatarText>
     );
   } else if (typeof src === 'string') {
-    hasImage = true;
     content = (
-      <Image
-        alt={a11yTitle || ariaLabel || ''}
-        fit="contain"
-        src={src}
-        {...imageProps}
-      />
+      <Image role="presentation" fit="contain" src={src} {...imageProps} />
     );
   }
 
   if (typeof children === 'string' || typeof src === 'string') {
     return (
       <StyledAvatar
-        aria-label={hasImage ? undefined : a11yTitle || ariaLabel || undefined}
+        role={typeof src === 'string' ? 'figure' : undefined}
+        a11yTitle={a11yTitle || ariaLabel}
         {...avatarProps}
         {...passThemeFlag}
         {...rest}

--- a/src/js/components/Avatar/__tests__/__snapshots__/Avatar-test.tsx.snap
+++ b/src/js/components/Avatar/__tests__/__snapshots__/Avatar-test.tsx.snap
@@ -36,11 +36,13 @@ exports[`Avatar a11yTitle renders 1`] = `
   class="c0"
 >
   <div
+    aria-label="testing for a11ytitle"
     class="c1 StyledAvatar-sc-1suyamb-1"
+    role="figure"
   >
     <img
-      alt="testing for a11ytitle"
       class="c2"
+      role="presentation"
       src="test.png"
     />
   </div>
@@ -85,11 +87,12 @@ exports[`Avatar apply imageProps to avatar 1`] = `
 >
   <div
     class="c1 StyledAvatar-sc-1suyamb-1"
+    role="figure"
   >
     <img
-      alt=""
       aria-label="test image"
       class="c2"
+      role="presentation"
       src="test.png"
     />
   </div>
@@ -373,55 +376,61 @@ exports[`Avatar round renders 1`] = `
 >
   <div
     class="c1 StyledAvatar-sc-1suyamb-1"
+    role="figure"
   >
     <img
-      alt=""
       class="c2"
+      role="presentation"
       src="test.png"
     />
   </div>
   <div
     class="c3 StyledAvatar-sc-1suyamb-1"
+    role="figure"
   >
     <img
-      alt=""
       class="c2"
+      role="presentation"
       src="test.png"
     />
   </div>
   <div
     class="c4 StyledAvatar-sc-1suyamb-1"
+    role="figure"
   >
     <img
-      alt=""
       class="c2"
+      role="presentation"
       src="test.png"
     />
   </div>
   <div
     class="c5 StyledAvatar-sc-1suyamb-1"
+    role="figure"
   >
     <img
-      alt=""
       class="c2"
+      role="presentation"
       src="test.png"
     />
   </div>
   <div
     class="c6 StyledAvatar-sc-1suyamb-1"
+    role="figure"
   >
     <img
-      alt=""
       class="c2"
+      role="presentation"
       src="test.png"
     />
   </div>
   <div
     class="c7 StyledAvatar-sc-1suyamb-1"
+    role="figure"
   >
     <img
-      alt=""
       class="c2"
+      role="presentation"
       src="test.png"
     />
   </div>
@@ -633,82 +642,91 @@ exports[`Avatar size 1`] = `
 >
   <div
     class="c1 StyledAvatar-sc-1suyamb-1"
+    role="figure"
   >
     <img
-      alt=""
       class="c2"
+      role="presentation"
       src="test.png"
     />
   </div>
   <div
     class="c3 StyledAvatar-sc-1suyamb-1"
+    role="figure"
   >
     <img
-      alt=""
       class="c2"
+      role="presentation"
       src="test.png"
     />
   </div>
   <div
     class="c4 StyledAvatar-sc-1suyamb-1"
+    role="figure"
   >
     <img
-      alt=""
       class="c2"
+      role="presentation"
       src="test.png"
     />
   </div>
   <div
     class="c5 StyledAvatar-sc-1suyamb-1"
+    role="figure"
   >
     <img
-      alt=""
       class="c2"
+      role="presentation"
       src="test.png"
     />
   </div>
   <div
     class="c6 StyledAvatar-sc-1suyamb-1"
+    role="figure"
   >
     <img
-      alt=""
       class="c2"
+      role="presentation"
       src="test.png"
     />
   </div>
   <div
     class="c7 StyledAvatar-sc-1suyamb-1"
+    role="figure"
   >
     <img
-      alt=""
       class="c2"
+      role="presentation"
       src="test.png"
     />
   </div>
   <div
     class="c8 StyledAvatar-sc-1suyamb-1"
+    role="figure"
   >
     <img
-      alt=""
       class="c2"
+      role="presentation"
       src="test.png"
     />
   </div>
   <div
     class="c9 StyledAvatar-sc-1suyamb-1"
+    role="figure"
   >
     <img
-      alt=""
       class="c2"
+      role="presentation"
       src="test.png"
     />
   </div>
   <div
     class="c10 StyledAvatar-sc-1suyamb-1"
+    role="figure"
   >
     <img
-      alt=""
       class="c2"
+      role="presentation"
       src="test.png"
     />
   </div>
@@ -900,10 +918,11 @@ exports[`Avatar stack renders 1`] = `
         >
           <div
             class="c5 StyledAvatar-sc-1suyamb-1"
+            role="figure"
           >
             <img
-              alt=""
               class="c6"
+              role="presentation"
               src="test.png"
             />
           </div>
@@ -921,10 +940,11 @@ exports[`Avatar stack renders 1`] = `
     >
       <div
         class="c9 StyledAvatar-sc-1suyamb-1"
+        role="figure"
       >
         <img
-          alt=""
           class="c6"
+          role="presentation"
           src="test.png"
         />
       </div>

--- a/src/js/components/Avatar/stories/Basic.stories.js
+++ b/src/js/components/Avatar/stories/Basic.stories.js
@@ -17,8 +17,8 @@ export const Basic = () => {
       gap="small"
       pad="large"
     >
-      <Avatar src={src} aria-label="Shimi" />
-      <Avatar background="dark-4" aria-label="Favorites">
+      <Avatar src={src} />
+      <Avatar background="dark-4">
         <Favorite color="light-2" />
       </Avatar>
       <Avatar background="dark-2">R</Avatar>

--- a/src/js/components/Avatar/stories/CustomThemed/Themed.stories.js
+++ b/src/js/components/Avatar/stories/CustomThemed/Themed.stories.js
@@ -34,7 +34,7 @@ export const Themed = () => {
         pad="large"
         background="dark-2"
       >
-        <Avatar src={src} aria-label="Shimi" size="myLarge" />
+        <Avatar src={src} size="myLarge" />
         <Avatar size="myLarge" background="accent-4">
           <Favorite color="accent-2" size="36px" />
         </Avatar>

--- a/src/js/components/Avatar/stories/Round.stories.js
+++ b/src/js/components/Avatar/stories/Round.stories.js
@@ -9,12 +9,12 @@ export const Round = () => {
     // Uncomment <Grommet> lines when using outside of storybook
     // <Grommet theme={grommet}>
     <Box direction="row" alignContent="center" gap="small" pad="large">
-      <Avatar size="large" src={src} round={false} aria-label="Shimi" />
-      <Avatar size="large" src={src} round="xsmall" aria-label="Shimi" />
-      <Avatar size="large" src={src} round="small" aria-label="Shimi" />
-      <Avatar size="large" src={src} round="medium" aria-label="Shimi" />
-      <Avatar size="large" src={src} round="large" aria-label="Shimi" />
-      <Avatar size="large" src={src} aria-label="Shimi" />
+      <Avatar size="large" src={src} round={false} />
+      <Avatar size="large" src={src} round="xsmall" />
+      <Avatar size="large" src={src} round="small" />
+      <Avatar size="large" src={src} round="medium" />
+      <Avatar size="large" src={src} round="large" />
+      <Avatar size="large" src={src} />
     </Box>
     // </Grommet>
   );

--- a/src/js/components/Avatar/stories/Sizes.stories.js
+++ b/src/js/components/Avatar/stories/Sizes.stories.js
@@ -9,11 +9,11 @@ export const Sizes = () => {
     // <Grommet theme={grommet}>
     <Box>
       <Box direction="row" pad="large" gap="small">
-        <Avatar size="small" src={src} aria-label="Shimi" />
-        <Avatar size="medium" src={src} aria-label="Shimi" />
-        <Avatar size="large" src={src} aria-label="Shimi" />
-        <Avatar size="xlarge" src={src} aria-label="Shimi" />
-        <Avatar size="2xl" src={src} aria-label="Shimi" />
+        <Avatar size="small" src={src} />
+        <Avatar size="medium" src={src} />
+        <Avatar size="large" src={src} />
+        <Avatar size="xlarge" src={src} />
+        <Avatar size="2xl" src={src} />
       </Box>
       <Box direction="row" pad="large" align="center" gap="small">
         <Avatar background="dark-2" size="small">
@@ -48,9 +48,9 @@ export const Sizes = () => {
           </Avatar>
         </Box>
         <Box direction="row" pad="large" gap="small">
-          <Avatar size="3xl" src={src} aria-label="Shimi" />
-          <Avatar size="4xl" src={src} aria-label="Shimi" />
-          <Avatar size="5xl" src={src} aria-label="Shimi" />
+          <Avatar size="3xl" src={src} />
+          <Avatar size="4xl" src={src} />
+          <Avatar size="5xl" src={src} />
         </Box>
       </Box>
     </Box>

--- a/src/js/components/Avatar/stories/typescript/Stacked.stories.tsx
+++ b/src/js/components/Avatar/stories/typescript/Stacked.stories.tsx
@@ -13,64 +13,36 @@ export const Stacked = () => {
 
   const GroupedGravatar = ({ border }) => (
     <Stack anchor="left">
-      <Avatar src={bryan} border={border} aria-label="Bryan" />
-      <Avatar
-        src={eric}
-        border={border}
-        margin={{ left: 'medium' }}
-        aria-label="Eric"
-      />
-      <Avatar
-        src={shimi}
-        border={border}
-        margin={{ left: 'large' }}
-        aria-label="Shimi"
-      />
+      <Avatar src={bryan} border={border} />
+      <Avatar src={eric} border={border} margin={{ left: 'medium' }} />
+      <Avatar src={shimi} border={border} margin={{ left: 'large' }} />
     </Stack>
   );
 
   const GroupedGravatarCentered = () => (
     <Stack anchor="right" margin={{ left: 'xlarge' }}>
-      <Avatar src={bryan} aria-label="Bryan" />
-      <Avatar src={shimi} margin={{ right: 'large' }} aria-label="Shimi" />
-      <Avatar src={eric} margin={{ right: 'medium' }} aria-label="Eric" />
+      <Avatar src={bryan} />
+      <Avatar src={shimi} margin={{ right: 'large' }} />
+      <Avatar src={eric} margin={{ right: 'medium' }} />
     </Stack>
   );
   const GroupedGravatarRTL = () => (
     <Stack anchor="right" margin={{ left: 'xlarge' }}>
-      <Avatar size="large" src={shimi} aria-label="Shimi" />
-      <Avatar
-        size="large"
-        src={eric}
-        margin={{ right: 'large' }}
-        aria-label="Eric"
-      />
-      <Avatar
-        size="large"
-        src={bryan}
-        margin={{ right: 'xlarge' }}
-        aria-label="Bryan"
-      />
+      <Avatar size="large" src={shimi} />
+      <Avatar size="large" src={eric} margin={{ right: 'large' }} />
+      <Avatar size="large" src={bryan} margin={{ right: 'xlarge' }} />
     </Stack>
   );
 
   const GroupedIcons = () => (
     <Stack anchor="left">
-      <Avatar background="dark-1" aria-label="New user">
+      <Avatar background="dark-1">
         <UserNew color="light-2" />
       </Avatar>
-      <Avatar
-        background="dark-2"
-        margin={{ left: 'medium' }}
-        aria-label="Female user"
-      >
+      <Avatar background="dark-2" margin={{ left: 'medium' }}>
         <UserFemale color="light-1" />
       </Avatar>
-      <Avatar
-        background="dark-4"
-        margin={{ left: 'large' }}
-        aria-label="Favorites"
-      >
+      <Avatar background="dark-4" margin={{ left: 'large' }}>
         <Favorite color="light-2" />
       </Avatar>
     </Stack>
@@ -83,22 +55,17 @@ export const Stacked = () => {
         <Stack anchor="bottom-right">
           <Box>
             <Box direction="row">
-              <Avatar
-                size="xlarge"
-                src={shimi}
-                border={borderSmall}
-                aria-label="Shimi"
-              />
+              <Avatar size="xlarge" src={shimi} border={borderSmall} />
               <Box pad="xxsmall" />
             </Box>
             <Box pad="xxsmall" />
           </Box>
-          <Avatar src={eric} border={borderSmall} aria-label="Eric" />
+          <Avatar src={eric} border={borderSmall} />
         </Stack>
 
         {/* Notification */}
         <Stack anchor="top-right">
-          <Avatar src={shimi} aria-label="Shimi" />
+          <Avatar src={shimi} />
           <Box pad="xsmall" round background="light-1" responsive={false} />
         </Stack>
 

--- a/src/js/components/Sidebar/__tests__/__snapshots__/Sidebar-test.tsx.snap
+++ b/src/js/components/Sidebar/__tests__/__snapshots__/Sidebar-test.tsx.snap
@@ -87,10 +87,11 @@ exports[`Sidebar all 1`] = `
   >
     <div
       class="c2 StyledAvatar-sc-1suyamb-1"
+      role="figure"
     >
       <img
-        alt=""
         class="c3"
+        role="presentation"
         src="test.png"
       />
     </div>
@@ -188,10 +189,11 @@ exports[`Sidebar children 1`] = `
     >
       <div
         class="c3 StyledAvatar-sc-1suyamb-1"
+        role="figure"
       >
         <img
-          alt=""
           class="c4"
+          role="presentation"
           src="test.png"
         />
       </div>
@@ -286,10 +288,11 @@ exports[`Sidebar footer 1`] = `
     />
     <div
       class="c4 StyledAvatar-sc-1suyamb-1"
+      role="figure"
     >
       <img
-        alt=""
         class="c5"
+        role="presentation"
         src="test.png"
       />
     </div>
@@ -376,10 +379,11 @@ exports[`Sidebar header 1`] = `
   >
     <div
       class="c2 StyledAvatar-sc-1suyamb-1"
+      role="figure"
     >
       <img
-        alt=""
         class="c3"
+        role="presentation"
         src="test.png"
       />
     </div>
@@ -568,10 +572,11 @@ exports[`Sidebar theme gap and pad 1`] = `
   >
     <div
       class="c2 StyledAvatar-sc-1suyamb-1"
+      role="figure"
     >
       <img
-        alt=""
         class="c3"
+        role="presentation"
         src="test.png"
       />
     </div>


### PR DESCRIPTION
Reverts grommet/grommet#7917

Reverting due to an accessibility issue flagged by storybook
<img width="1430" height="380" alt="Screenshot 2026-06-04 at 1 58 41 PM" src="https://github.com/user-attachments/assets/26fefb52-8e42-42f3-a518-337b0f1bf835" />
