### PR TITLE
Improve Tabs accessibility keyboard support

### DIFF
--- a/src/js/components/DataTableColumns/__tests__/__snapshots__/DataTableColumns-test.tsx.snap
+++ b/src/js/components/DataTableColumns/__tests__/__snapshots__/DataTableColumns-test.tsx.snap
@@ -436,7 +436,7 @@ exports[`DataTableColumns pinned 1`] = `
 <div
   aria-label="Order columns Tab Contents"
   class="c0"
-  id="tabs-panel-_r_4_-1"
+  id="_r_4_"
   role="tabpanel"
 >
   <div
@@ -1327,7 +1327,7 @@ exports[`DataTableColumns remove column 2`] = `
 <div
   aria-label="Select columns Tab Contents"
   class="c0"
-  id="tabs-panel-_r_2_-0"
+  id="_r_2_"
   role="tabpanel"
 >
   <div
@@ -2269,7 +2269,7 @@ exports[`DataTableColumns renders 2`] = `
 <div
   aria-label="Select columns Tab Contents"
   class="c0"
-  id="tabs-panel-_r_0_-0"
+  id="_r_0_"
   role="tabpanel"
 >
   <div
@@ -2383,7 +2383,7 @@ exports[`DataTableColumns renders 3`] = `
 <div
   aria-label="Order columns Tab Contents"
   class="StyledTabs__StyledTabPanel-sc-a4fwxl-1 TIIEM"
-  id="tabs-panel-_r_0_-1"
+  id="_r_0_"
   role="tabpanel"
 >
   <div
@@ -3520,7 +3520,7 @@ exports[`DataTableColumns search 2`] = `
 <div
   aria-label="Select columns Tab Contents"
   class="c0"
-  id="tabs-panel-_r_3_-0"
+  id="_r_3_"
   role="tabpanel"
 >
   <div
@@ -4177,7 +4177,7 @@ exports[`DataTableColumns should use theme icons 1`] = `
 <div
   aria-label="Order columns Tab Contents"
   class="c0"
-  id="tabs-panel-_r_1_-1"
+  id="_r_1_"
   role="tabpanel"
 >
   <div
@@ -4594,7 +4594,7 @@ exports[`DataTableColumns theme tabs pad, selectColumns pad and gap, orderColumn
 <div
   aria-label="Select columns Tab Contents"
   class="c0"
-  id="tabs-panel-_r_5_-0"
+  id="_r_5_"
   role="tabpanel"
 >
   <div
@@ -4741,7 +4741,7 @@ exports[`DataTableColumns theme tabs pad, selectColumns pad and gap, orderColumn
 <div
   aria-label="Order columns Tab Contents"
   class="StyledTabs__StyledTabPanel-sc-a4fwxl-1 TIIEM"
-  id="tabs-panel-_r_5_-1"
+  id="_r_5_"
   role="tabpanel"
 >
   <div

--- a/src/js/components/DataTableColumns/__tests__/__snapshots__/DataTableColumns-test.tsx.snap
+++ b/src/js/components/DataTableColumns/__tests__/__snapshots__/DataTableColumns-test.tsx.snap
@@ -435,7 +435,6 @@ exports[`DataTableColumns pinned 1`] = `
 
 <div
   aria-label="Order columns Tab Contents"
-  aria-labelledby="tabs-tab-_r_4_-1"
   class="c0"
   id="tabs-panel-_r_4_-1"
   role="tabpanel"
@@ -1327,7 +1326,6 @@ exports[`DataTableColumns remove column 2`] = `
 
 <div
   aria-label="Select columns Tab Contents"
-  aria-labelledby="tabs-tab-_r_2_-0"
   class="c0"
   id="tabs-panel-_r_2_-0"
   role="tabpanel"
@@ -2270,7 +2268,6 @@ exports[`DataTableColumns renders 2`] = `
 
 <div
   aria-label="Select columns Tab Contents"
-  aria-labelledby="tabs-tab-_r_0_-0"
   class="c0"
   id="tabs-panel-_r_0_-0"
   role="tabpanel"
@@ -2385,7 +2382,6 @@ exports[`DataTableColumns renders 2`] = `
 exports[`DataTableColumns renders 3`] = `
 <div
   aria-label="Order columns Tab Contents"
-  aria-labelledby="tabs-tab-_r_0_-1"
   class="StyledTabs__StyledTabPanel-sc-a4fwxl-1 TIIEM"
   id="tabs-panel-_r_0_-1"
   role="tabpanel"
@@ -3523,7 +3519,6 @@ exports[`DataTableColumns search 2`] = `
 
 <div
   aria-label="Select columns Tab Contents"
-  aria-labelledby="tabs-tab-_r_3_-0"
   class="c0"
   id="tabs-panel-_r_3_-0"
   role="tabpanel"
@@ -4181,7 +4176,6 @@ exports[`DataTableColumns should use theme icons 1`] = `
 
 <div
   aria-label="Order columns Tab Contents"
-  aria-labelledby="tabs-tab-_r_1_-1"
   class="c0"
   id="tabs-panel-_r_1_-1"
   role="tabpanel"
@@ -4599,7 +4593,6 @@ exports[`DataTableColumns theme tabs pad, selectColumns pad and gap, orderColumn
 
 <div
   aria-label="Select columns Tab Contents"
-  aria-labelledby="tabs-tab-_r_5_-0"
   class="c0"
   id="tabs-panel-_r_5_-0"
   role="tabpanel"
@@ -4747,7 +4740,6 @@ exports[`DataTableColumns theme tabs pad, selectColumns pad and gap, orderColumn
 exports[`DataTableColumns theme tabs pad, selectColumns pad and gap, orderColumns pad 2`] = `
 <div
   aria-label="Order columns Tab Contents"
-  aria-labelledby="tabs-tab-_r_5_-1"
   class="StyledTabs__StyledTabPanel-sc-a4fwxl-1 TIIEM"
   id="tabs-panel-_r_5_-1"
   role="tabpanel"

--- a/src/js/components/DataTableColumns/__tests__/__snapshots__/DataTableColumns-test.tsx.snap
+++ b/src/js/components/DataTableColumns/__tests__/__snapshots__/DataTableColumns-test.tsx.snap
@@ -435,7 +435,9 @@ exports[`DataTableColumns pinned 1`] = `
 
 <div
   aria-label="Order columns Tab Contents"
+  aria-labelledby="tabs-tab-_r_4_-1"
   class="c0"
+  id="tabs-panel-_r_4_-1"
   role="tabpanel"
 >
   <div
@@ -1325,7 +1327,9 @@ exports[`DataTableColumns remove column 2`] = `
 
 <div
   aria-label="Select columns Tab Contents"
+  aria-labelledby="tabs-tab-_r_2_-0"
   class="c0"
+  id="tabs-panel-_r_2_-0"
   role="tabpanel"
 >
   <div
@@ -2266,7 +2270,9 @@ exports[`DataTableColumns renders 2`] = `
 
 <div
   aria-label="Select columns Tab Contents"
+  aria-labelledby="tabs-tab-_r_0_-0"
   class="c0"
+  id="tabs-panel-_r_0_-0"
   role="tabpanel"
 >
   <div
@@ -2379,7 +2385,9 @@ exports[`DataTableColumns renders 2`] = `
 exports[`DataTableColumns renders 3`] = `
 <div
   aria-label="Order columns Tab Contents"
+  aria-labelledby="tabs-tab-_r_0_-1"
   class="StyledTabs__StyledTabPanel-sc-a4fwxl-1 TIIEM"
+  id="tabs-panel-_r_0_-1"
   role="tabpanel"
 >
   <div
@@ -3515,7 +3523,9 @@ exports[`DataTableColumns search 2`] = `
 
 <div
   aria-label="Select columns Tab Contents"
+  aria-labelledby="tabs-tab-_r_3_-0"
   class="c0"
+  id="tabs-panel-_r_3_-0"
   role="tabpanel"
 >
   <div
@@ -4171,7 +4181,9 @@ exports[`DataTableColumns should use theme icons 1`] = `
 
 <div
   aria-label="Order columns Tab Contents"
+  aria-labelledby="tabs-tab-_r_1_-1"
   class="c0"
+  id="tabs-panel-_r_1_-1"
   role="tabpanel"
 >
   <div
@@ -4587,7 +4599,9 @@ exports[`DataTableColumns theme tabs pad, selectColumns pad and gap, orderColumn
 
 <div
   aria-label="Select columns Tab Contents"
+  aria-labelledby="tabs-tab-_r_5_-0"
   class="c0"
+  id="tabs-panel-_r_5_-0"
   role="tabpanel"
 >
   <div
@@ -4733,7 +4747,9 @@ exports[`DataTableColumns theme tabs pad, selectColumns pad and gap, orderColumn
 exports[`DataTableColumns theme tabs pad, selectColumns pad and gap, orderColumns pad 2`] = `
 <div
   aria-label="Order columns Tab Contents"
+  aria-labelledby="tabs-tab-_r_5_-1"
   class="StyledTabs__StyledTabPanel-sc-a4fwxl-1 TIIEM"
+  id="tabs-panel-_r_5_-1"
   role="tabpanel"
 >
   <div

--- a/src/js/components/Tab/Tab.js
+++ b/src/js/components/Tab/Tab.js
@@ -39,10 +39,7 @@ const Tab = forwardRef(
       ref: tabsContextRef,
       tabId,
       onActivate,
-      onNext,
-      onPrevious,
-      onFirst,
-      onLast,
+      onKeyDown: onTabsKeyDown,
       setActiveContent,
       setActiveTitle,
       setFocusIndex,
@@ -117,31 +114,7 @@ const Tab = forwardRef(
     const onKeyDownTab = (event) => {
       if (disabled) return;
 
-      switch (event.key) {
-        case 'ArrowRight':
-          event.preventDefault();
-          onNext();
-          break;
-        case 'ArrowLeft':
-          event.preventDefault();
-          onPrevious();
-          break;
-        case 'Home':
-          event.preventDefault();
-          onFirst();
-          break;
-        case 'End':
-          event.preventDefault();
-          onLast();
-          break;
-        case 'Enter':
-        case ' ':
-        case 'Spacebar':
-          event.preventDefault();
-          onActivate();
-          break;
-        default:
-      }
+      onTabsKeyDown(event);
 
       if (onKeyDown) {
         onKeyDown(event);

--- a/src/js/components/Tab/Tab.js
+++ b/src/js/components/Tab/Tab.js
@@ -33,6 +33,7 @@ const Tab = forwardRef(
     const {
       active,
       activeIndex,
+      focusable,
       index,
       panelId,
       ref: tabsContextRef,
@@ -133,6 +134,12 @@ const Tab = forwardRef(
           event.preventDefault();
           onLast();
           break;
+        case 'Enter':
+        case ' ':
+        case 'Spacebar':
+          event.preventDefault();
+          onActivate();
+          break;
         default:
       }
 
@@ -228,7 +235,7 @@ const Tab = forwardRef(
         plain
         id={tabId}
         role="tab"
-        tabIndex={active ? 0 : -1}
+        tabIndex={focusable ? 0 : -1}
         aria-controls={panelId}
         aria-selected={active}
         disabled={disabled}

--- a/src/js/components/Tab/Tab.js
+++ b/src/js/components/Tab/Tab.js
@@ -16,7 +16,6 @@ const Tab = forwardRef(
       active: activeProp, // don't pass with rest
       disabled,
       children,
-      id: idProp,
       icon,
       plain,
       title,
@@ -38,7 +37,6 @@ const Tab = forwardRef(
       index,
       panelId,
       ref: tabsContextRef,
-      tabId,
       onActivate,
       onKeyDown: onTabsKeyDown,
       setActiveContent,
@@ -207,7 +205,6 @@ const Tab = forwardRef(
       <Button
         ref={tabRef}
         plain
-        id={tabId}
         role="tab"
         tabIndex={focusable ? 0 : -1}
         aria-controls={panelId}

--- a/src/js/components/Tab/Tab.js
+++ b/src/js/components/Tab/Tab.js
@@ -33,8 +33,14 @@ const Tab = forwardRef(
       active,
       activeIndex,
       index,
+      panelId,
       ref: tabsContextRef,
+      tabId,
       onActivate,
+      onNext,
+      onPrevious,
+      onFirst,
+      onLast,
       setActiveContent,
       setActiveTitle,
       setFocusIndex,
@@ -103,6 +109,30 @@ const Tab = forwardRef(
       onActivate();
       if (onClick) {
         onClick(event);
+      }
+    };
+
+    const onKeyDownTab = (event) => {
+      if (disabled) return;
+
+      switch (event.key) {
+        case 'ArrowRight':
+          event.preventDefault();
+          onNext();
+          break;
+        case 'ArrowLeft':
+          event.preventDefault();
+          onPrevious();
+          break;
+        case 'Home':
+          event.preventDefault();
+          onFirst();
+          break;
+        case 'End':
+          event.preventDefault();
+          onLast();
+          break;
+        default:
       }
     };
 
@@ -191,20 +221,23 @@ const Tab = forwardRef(
       <Button
         ref={tabRef}
         plain
+        id={tabId}
         role="tab"
+        tabIndex={active ? 0 : -1}
+        aria-controls={panelId}
         aria-selected={active}
-        aria-expanded={active}
         disabled={disabled}
         {...rest}
         onClick={onClickTab}
+        onKeyDown={onKeyDownTab}
         onMouseOver={onMouseOverTab}
         onMouseOut={onMouseOutTab}
-        onFocus={() => {
-          if (onFocus) onFocus();
+        onFocus={(event) => {
+          if (onFocus) onFocus(event);
           setFocusIndex(index);
         }}
-        onBlur={() => {
-          if (onBlur) onBlur();
+        onBlur={(event) => {
+          if (onBlur) onBlur(event);
           setFocusIndex(-1);
         }}
       >

--- a/src/js/components/Tab/Tab.js
+++ b/src/js/components/Tab/Tab.js
@@ -25,6 +25,7 @@ const Tab = forwardRef(
       onMouseOut,
       reverse,
       onClick,
+      onKeyDown,
       ...rest
     },
     ref,
@@ -133,6 +134,10 @@ const Tab = forwardRef(
           onLast();
           break;
         default:
+      }
+
+      if (onKeyDown) {
+        onKeyDown(event);
       }
     };
 

--- a/src/js/components/Tab/Tab.js
+++ b/src/js/components/Tab/Tab.js
@@ -16,6 +16,7 @@ const Tab = forwardRef(
       active: activeProp, // don't pass with rest
       disabled,
       children,
+      id: idProp,
       icon,
       plain,
       title,

--- a/src/js/components/Tabs/Tabs.js
+++ b/src/js/components/Tabs/Tabs.js
@@ -149,9 +149,8 @@ const Tabs = forwardRef(
       (targetIndex) => {
         if (targetIndex === undefined) return;
         focusTab(targetIndex);
-        activateTab(targetIndex);
       },
-      [activateTab, focusTab],
+      [focusTab],
     );
 
     const moveFocusByKey = useCallback(
@@ -358,6 +357,8 @@ const Tabs = forwardRef(
       (index) => ({
         activeIndex,
         active: activeIndex === index,
+        focusable:
+          focusIndex === -1 ? activeIndex === index : focusIndex === index,
         index,
         panelId: getPanelId(index),
         ref: tabRefs[index],
@@ -373,6 +374,7 @@ const Tabs = forwardRef(
       }),
       [
         activeIndex,
+        focusIndex,
         activateTab,
         getPanelId,
         getTabId,

--- a/src/js/components/Tabs/Tabs.js
+++ b/src/js/components/Tabs/Tabs.js
@@ -75,6 +75,17 @@ const Tabs = forwardRef(
       () => React.Children.map(children, () => React.createRef()),
       [children],
     );
+    const tabIds = useMemo(
+      () =>
+        React.Children.map(children, (child, index) => {
+          if (React.isValidElement(child) && child.props.id) {
+            return child.props.id;
+          }
+
+          return `tabs-tab-${tabsId}-${index}`;
+        }) || [],
+      [children, tabsId],
+    );
     const disabledIndexes = useMemo(
       () =>
         React.Children.map(children, (child) => {
@@ -84,10 +95,7 @@ const Tabs = forwardRef(
       [children],
     );
 
-    const getTabId = useCallback(
-      (index) => `tabs-tab-${tabsId}-${index}`,
-      [tabsId],
-    );
+    const getTabId = useCallback((index) => tabIds[index], [tabIds]);
 
     const getPanelId = useCallback(
       (index) => `tabs-panel-${tabsId}-${index}`,

--- a/src/js/components/Tabs/Tabs.js
+++ b/src/js/components/Tabs/Tabs.js
@@ -6,6 +6,7 @@ import React, {
   useEffect,
   useRef,
   useMemo,
+  useId,
 } from 'react';
 import { Previous } from 'grommet-icons/icons/Previous';
 import { Next } from 'grommet-icons/icons/Next';
@@ -46,6 +47,7 @@ const Tabs = forwardRef(
     const [overflow, setOverflow] = useState();
     const [focusIndex, setFocusIndex] = useState(-1);
     const headerRef = useRef();
+    const tabsId = useId();
     const size = useContext(ResponsiveContext);
     const PreviousIcon = theme.tabs.header?.previousButton?.icon || Previous;
     const NextIcon = theme.tabs.header?.nextButton?.icon || Next;
@@ -73,6 +75,99 @@ const Tabs = forwardRef(
     const tabRefs = useMemo(
       () => React.Children.map(children, () => React.createRef()),
       [children],
+    );
+    const disabledIndexes = useMemo(
+      () =>
+        React.Children.map(children, (child) => {
+          if (!React.isValidElement(child)) return true;
+          return !!child.props.disabled;
+        }) || [],
+      [children],
+    );
+
+    const getTabId = useCallback(
+      (index) => `tabs-tab-${tabsId}-${index}`,
+      [tabsId],
+    );
+
+    const getPanelId = useCallback(
+      (index) => `tabs-panel-${tabsId}-${index}`,
+      [tabsId],
+    );
+
+    const focusTab = useCallback(
+      (index) => {
+        if (index >= 0 && tabRefs[index]?.current) {
+          tabRefs[index].current.focus();
+        }
+      },
+      [tabRefs],
+    );
+
+    const findEnabledIndex = useCallback(
+      (startIndex, direction) => {
+        if (!tabRefs.length) return undefined;
+
+        const normalizeIndex = (index) => {
+          if (index < 0) return tabRefs.length - 1;
+          if (index >= tabRefs.length) return 0;
+          return index;
+        };
+
+        let nextIndex = normalizeIndex(startIndex);
+        let attempts = 0;
+
+        while (attempts < tabRefs.length) {
+          if (!disabledIndexes[nextIndex] && tabRefs[nextIndex]?.current) {
+            return nextIndex;
+          }
+          nextIndex = normalizeIndex(nextIndex + direction);
+          attempts += 1;
+        }
+
+        return undefined;
+      },
+      [disabledIndexes, tabRefs],
+    );
+
+    const activateTab = useCallback(
+      (nextIndex) => {
+        sendAnalytics({
+          type: 'activateTab',
+          element: tabRefs[nextIndex].current,
+        });
+        if (propsActiveIndex === undefined) {
+          setActiveIndex(nextIndex);
+        }
+        if (onActive) {
+          onActive(nextIndex);
+        }
+      },
+      [onActive, propsActiveIndex, sendAnalytics, tabRefs],
+    );
+
+    const moveFocus = useCallback(
+      (targetIndex) => {
+        if (targetIndex === undefined) return;
+        focusTab(targetIndex);
+        activateTab(targetIndex);
+      },
+      [activateTab, focusTab],
+    );
+
+    const moveFocusByKey = useCallback(
+      (currentIndex, direction) => {
+        moveFocus(findEnabledIndex(currentIndex + direction, direction));
+      },
+      [findEnabledIndex, moveFocus],
+    );
+
+    const moveFocusToEdge = useCallback(
+      (direction) => {
+        const startIndex = direction > 0 ? 0 : tabRefs.length - 1;
+        moveFocus(findEnabledIndex(startIndex, direction));
+      },
+      [findEnabledIndex, moveFocus, tabRefs.length],
     );
 
     // check if tab is in view
@@ -261,32 +356,31 @@ const Tabs = forwardRef(
     ]);
 
     const getTabsContext = useCallback(
-      (index) => {
-        const activateTab = (nextIndex) => {
-          sendAnalytics({
-            type: 'activateTab',
-            element: tabRefs[nextIndex].current,
-          });
-          if (propsActiveIndex === undefined) {
-            setActiveIndex(nextIndex);
-          }
-          if (onActive) {
-            onActive(nextIndex);
-          }
-        };
-
-        return {
-          activeIndex,
-          active: activeIndex === index,
-          index,
-          ref: tabRefs[index],
-          onActivate: () => activateTab(index),
-          setActiveContent,
-          setActiveTitle,
-          setFocusIndex,
-        };
-      },
-      [activeIndex, onActive, propsActiveIndex, sendAnalytics, tabRefs],
+      (index) => ({
+        activeIndex,
+        active: activeIndex === index,
+        index,
+        panelId: getPanelId(index),
+        ref: tabRefs[index],
+        tabId: getTabId(index),
+        onActivate: () => activateTab(index),
+        onNext: () => moveFocusByKey(index, 1),
+        onPrevious: () => moveFocusByKey(index, -1),
+        onFirst: () => moveFocusToEdge(1),
+        onLast: () => moveFocusToEdge(-1),
+        setActiveContent,
+        setActiveTitle,
+        setFocusIndex,
+      }),
+      [
+        activeIndex,
+        activateTab,
+        getPanelId,
+        getTabId,
+        moveFocusByKey,
+        moveFocusToEdge,
+        tabRefs,
+      ],
     );
 
     const tabs = React.Children.map(children, (child, index) => (
@@ -338,7 +432,10 @@ const Tabs = forwardRef(
         >
           {overflow && (
             <Button
-              a11yTitle="Previous Tab"
+              a11yTitle={format({
+                id: 'tabs.previousTab',
+                messages,
+              })}
               disabled={disableLeftArrow}
               // removed from tabIndex, button is redundant for keyboard users
               tabIndex={-1}
@@ -373,7 +470,10 @@ const Tabs = forwardRef(
           </StyledTabsHeader>
           {overflow && (
             <Button
-              a11yTitle="Next Tab"
+              a11yTitle={format({
+                id: 'tabs.nextTab',
+                messages,
+              })}
               disabled={disableRightArrow}
               // removed from tabIndex, button is redundant for keyboard users
               tabIndex={-1}
@@ -393,8 +493,10 @@ const Tabs = forwardRef(
         </Box>
 
         <StyledTabPanel
+          id={getPanelId(activeIndex)}
           flex={flex}
           aria-label={tabContentTitle}
+          aria-labelledby={getTabId(activeIndex)}
           role="tabpanel"
           {...passThemeFlag}
         >

--- a/src/js/components/Tabs/Tabs.js
+++ b/src/js/components/Tabs/Tabs.js
@@ -496,7 +496,6 @@ const Tabs = forwardRef(
           id={getPanelId(activeIndex)}
           flex={flex}
           aria-label={tabContentTitle}
-          aria-labelledby={getTabId(activeIndex)}
           role="tabpanel"
           {...passThemeFlag}
         >

--- a/src/js/components/Tabs/Tabs.js
+++ b/src/js/components/Tabs/Tabs.js
@@ -168,6 +168,37 @@ const Tabs = forwardRef(
       [findEnabledIndex, moveFocus, tabRefs.length],
     );
 
+    const handleTabKeyDown = useCallback(
+      (index, event) => {
+        switch (event.key) {
+          case 'ArrowRight':
+            event.preventDefault();
+            moveFocusByKey(index, 1);
+            break;
+          case 'ArrowLeft':
+            event.preventDefault();
+            moveFocusByKey(index, -1);
+            break;
+          case 'Home':
+            event.preventDefault();
+            moveFocusToEdge(1);
+            break;
+          case 'End':
+            event.preventDefault();
+            moveFocusToEdge(-1);
+            break;
+          case 'Enter':
+          case ' ':
+          case 'Spacebar':
+            event.preventDefault();
+            activateTab(index);
+            break;
+          default:
+        }
+      },
+      [activateTab, moveFocusByKey, moveFocusToEdge],
+    );
+
     // check if tab is in view
     const isVisible = useCallback(
       (index) => {
@@ -364,6 +395,7 @@ const Tabs = forwardRef(
         ref: tabRefs[index],
         tabId: getTabId(index),
         onActivate: () => activateTab(index),
+        onKeyDown: (event) => handleTabKeyDown(index, event),
         onNext: () => moveFocusByKey(index, 1),
         onPrevious: () => moveFocusByKey(index, -1),
         onFirst: () => moveFocusToEdge(1),
@@ -378,6 +410,7 @@ const Tabs = forwardRef(
         activateTab,
         getPanelId,
         getTabId,
+        handleTabKeyDown,
         moveFocusByKey,
         moveFocusToEdge,
         tabRefs,

--- a/src/js/components/Tabs/Tabs.js
+++ b/src/js/components/Tabs/Tabs.js
@@ -46,7 +46,7 @@ const Tabs = forwardRef(
     const [overflow, setOverflow] = useState();
     const [focusIndex, setFocusIndex] = useState(-1);
     const headerRef = useRef();
-    const tabsId = useId();
+    const panelId = useId();
     const size = useContext(ResponsiveContext);
     const PreviousIcon = theme.tabs.header?.previousButton?.icon || Previous;
     const NextIcon = theme.tabs.header?.nextButton?.icon || Next;
@@ -75,17 +75,6 @@ const Tabs = forwardRef(
       () => React.Children.map(children, () => React.createRef()),
       [children],
     );
-    const tabIds = useMemo(
-      () =>
-        React.Children.map(children, (child, index) => {
-          if (React.isValidElement(child) && child.props.id) {
-            return child.props.id;
-          }
-
-          return `tabs-tab-${tabsId}-${index}`;
-        }) || [],
-      [children, tabsId],
-    );
     const disabledIndexes = useMemo(
       () =>
         React.Children.map(children, (child) => {
@@ -93,13 +82,6 @@ const Tabs = forwardRef(
           return !!child.props.disabled;
         }) || [],
       [children],
-    );
-
-    const getTabId = useCallback((index) => tabIds[index], [tabIds]);
-
-    const getPanelId = useCallback(
-      (index) => `tabs-panel-${tabsId}-${index}`,
-      [tabsId],
     );
 
     const focusTab = useCallback(
@@ -465,9 +447,8 @@ const Tabs = forwardRef(
             ? resolvedActiveIndex === index
             : focusIndex === index,
         index,
-        panelId: getPanelId(index),
+        panelId,
         ref: tabRefs[index],
-        tabId: getTabId(index),
         onActivate: () => activateTab(index),
         onKeyDown: (event) => handleTabKeyDown(index, event),
         onNext: () => moveFocusByKey(index, 1),
@@ -481,11 +462,10 @@ const Tabs = forwardRef(
       [
         focusIndex,
         activateTab,
-        getPanelId,
-        getTabId,
         handleTabKeyDown,
         moveFocusByKey,
         moveFocusToEdge,
+        panelId,
         resolvedActiveIndex,
         tabRefs,
       ],
@@ -601,7 +581,7 @@ const Tabs = forwardRef(
         </Box>
 
         <StyledTabPanel
-          id={getPanelId(resolvedActiveIndex)}
+          id={panelId}
           flex={flex}
           aria-label={tabContentTitle}
           role="tabpanel"

--- a/src/js/components/Tabs/Tabs.js
+++ b/src/js/components/Tabs/Tabs.js
@@ -105,19 +105,19 @@ const Tabs = forwardRef(
 
     const findEnabledIndex = useCallback(
       (startIndex, direction) => {
-        if (!tabRefs.length) return undefined;
+        if (!disabledIndexes.length) return undefined;
 
         const normalizeIndex = (index) => {
-          if (index < 0) return tabRefs.length - 1;
-          if (index >= tabRefs.length) return 0;
+          if (index < 0) return disabledIndexes.length - 1;
+          if (index >= disabledIndexes.length) return 0;
           return index;
         };
 
         let nextIndex = normalizeIndex(startIndex);
         let attempts = 0;
 
-        while (attempts < tabRefs.length) {
-          if (!disabledIndexes[nextIndex] && tabRefs[nextIndex]?.current) {
+        while (attempts < disabledIndexes.length) {
+          if (!disabledIndexes[nextIndex]) {
             return nextIndex;
           }
           nextIndex = normalizeIndex(nextIndex + direction);
@@ -126,8 +126,55 @@ const Tabs = forwardRef(
 
         return undefined;
       },
-      [disabledIndexes, tabRefs],
+      [disabledIndexes],
     );
+
+    const getClosestEnabledIndex = useCallback(
+      (preferredIndex) => {
+        if (!disabledIndexes.length) return undefined;
+
+        const clampedIndex = Math.min(
+          Math.max(preferredIndex, 0),
+          disabledIndexes.length - 1,
+        );
+
+        if (!disabledIndexes[clampedIndex]) {
+          return clampedIndex;
+        }
+
+        for (let offset = 1; offset < disabledIndexes.length; offset += 1) {
+          const nextIndex = clampedIndex + offset;
+          if (
+            nextIndex < disabledIndexes.length &&
+            !disabledIndexes[nextIndex]
+          ) {
+            return nextIndex;
+          }
+
+          const previousIndex = clampedIndex - offset;
+          if (previousIndex >= 0 && !disabledIndexes[previousIndex]) {
+            return previousIndex;
+          }
+        }
+
+        return undefined;
+      },
+      [disabledIndexes],
+    );
+
+    const resolvedActiveIndex = useMemo(() => {
+      if (!disabledIndexes.length) return undefined;
+
+      if (activeIndex < 0 || activeIndex >= disabledIndexes.length) {
+        return getClosestEnabledIndex(activeIndex);
+      }
+
+      if (disabledIndexes[activeIndex]) {
+        return getClosestEnabledIndex(activeIndex);
+      }
+
+      return activeIndex;
+    }, [activeIndex, disabledIndexes, getClosestEnabledIndex]);
 
     const activateTab = useCallback(
       (nextIndex) => {
@@ -328,11 +375,12 @@ const Tabs = forwardRef(
       if (
         overflow &&
         tabRefs &&
-        tabRefs[activeIndex]?.current &&
-        !isVisible(activeIndex)
+        resolvedActiveIndex !== undefined &&
+        tabRefs[resolvedActiveIndex]?.current &&
+        !isVisible(resolvedActiveIndex)
       )
-        scrollTo(activeIndex, true);
-    }, [overflow, activeIndex, tabRefs, isVisible, scrollTo]);
+        scrollTo(resolvedActiveIndex, true);
+    }, [overflow, resolvedActiveIndex, tabRefs, isVisible, scrollTo]);
 
     useEffect(() => {
       // scroll focus item into view if it is not already visible
@@ -384,12 +432,30 @@ const Tabs = forwardRef(
       updateArrowState,
     ]);
 
+    useLayoutEffect(() => {
+      if (focusIndex === -1 || !headerRef.current) return;
+
+      const { activeElement } = document;
+      if (headerRef.current.contains(activeElement)) return;
+
+      const nextFocusIndex = getClosestEnabledIndex(focusIndex);
+      if (nextFocusIndex === undefined) {
+        setFocusIndex(-1);
+        return;
+      }
+
+      setFocusIndex(nextFocusIndex);
+      focusTab(nextFocusIndex);
+    }, [children, focusIndex, focusTab, getClosestEnabledIndex]);
+
     const getTabsContext = useCallback(
       (index) => ({
-        activeIndex,
-        active: activeIndex === index,
+        activeIndex: resolvedActiveIndex,
+        active: resolvedActiveIndex === index,
         focusable:
-          focusIndex === -1 ? activeIndex === index : focusIndex === index,
+          focusIndex === -1
+            ? resolvedActiveIndex === index
+            : focusIndex === index,
         index,
         panelId: getPanelId(index),
         ref: tabRefs[index],
@@ -405,7 +471,6 @@ const Tabs = forwardRef(
         setFocusIndex,
       }),
       [
-        activeIndex,
         focusIndex,
         activateTab,
         getPanelId,
@@ -413,6 +478,7 @@ const Tabs = forwardRef(
         handleTabKeyDown,
         moveFocusByKey,
         moveFocusToEdge,
+        resolvedActiveIndex,
         tabRefs,
       ],
     );
@@ -425,7 +491,7 @@ const Tabs = forwardRef(
           ? // cloneElement is needed for backward compatibility with custom
             // styled components that rely on props.active. We should reassess
             // if it is still necessary in our next major release.
-            React.cloneElement(child, { active: activeIndex === index })
+            React.cloneElement(child, { active: resolvedActiveIndex === index })
           : child}
       </TabsContext.Provider>
     ));
@@ -527,7 +593,7 @@ const Tabs = forwardRef(
         </Box>
 
         <StyledTabPanel
-          id={getPanelId(activeIndex)}
+          id={getPanelId(resolvedActiveIndex)}
           flex={flex}
           aria-label={tabContentTitle}
           role="tabpanel"

--- a/src/js/components/Tabs/Tabs.js
+++ b/src/js/components/Tabs/Tabs.js
@@ -6,7 +6,6 @@ import React, {
   useEffect,
   useRef,
   useMemo,
-  useId,
 } from 'react';
 import { Previous } from 'grommet-icons/icons/Previous';
 import { Next } from 'grommet-icons/icons/Next';
@@ -17,7 +16,7 @@ import { Button } from '../Button';
 import { TabsContext } from './TabsContext';
 import { ResponsiveContext } from '../../contexts/ResponsiveContext';
 import { StyledTabPanel, StyledTabs, StyledTabsHeader } from './StyledTabs';
-import { normalizeColor } from '../../utils';
+import { normalizeColor, useId } from '../../utils';
 import { MessageContext } from '../../contexts/MessageContext';
 import { TabsPropTypes } from './propTypes';
 import { useAnalytics } from '../../contexts/AnalyticsContext/AnalyticsContext';

--- a/src/js/components/Tabs/__tests__/Tabs-test.tsx
+++ b/src/js/components/Tabs/__tests__/Tabs-test.tsx
@@ -3,9 +3,11 @@ import styled, { css } from 'styled-components';
 import 'jest-styled-components';
 import 'jest-axe/extend-expect';
 import 'regenerator-runtime/runtime';
+import '@testing-library/jest-dom';
 
 import { axe } from 'jest-axe';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { Grommet, Tab, Tabs } from '../..';
 import { ThemeType } from '../../../themes';
@@ -142,6 +144,108 @@ describe('Tabs', () => {
     expect(onActive).toHaveBeenCalledWith(1);
 
     expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test('supports arrow key navigation between tabs', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Grommet>
+        <Tabs>
+          <Tab title="Tab 1">Tab body 1</Tab>
+          <Tab title="Tab 2">Tab body 2</Tab>
+          <Tab title="Tab 3">Tab body 3</Tab>
+        </Tabs>
+      </Grommet>,
+    );
+
+    const firstTab = screen.getByRole('tab', { name: 'Tab 1' });
+    const secondTab = screen.getByRole('tab', { name: 'Tab 2' });
+
+    await user.tab();
+    expect(firstTab).toHaveFocus();
+    expect(firstTab).toHaveAttribute('aria-selected', 'true');
+
+    await user.keyboard('{ArrowRight}');
+
+    expect(secondTab).toHaveFocus();
+    expect(secondTab).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('tabpanel')).toHaveTextContent('Tab body 2');
+  });
+
+  test('supports Home and End keys within the tablist', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Grommet>
+        <Tabs>
+          <Tab title="Tab 1">Tab body 1</Tab>
+          <Tab title="Tab 2">Tab body 2</Tab>
+          <Tab title="Tab 3">Tab body 3</Tab>
+        </Tabs>
+      </Grommet>,
+    );
+
+    const firstTab = screen.getByRole('tab', { name: 'Tab 1' });
+    const thirdTab = screen.getByRole('tab', { name: 'Tab 3' });
+
+    await user.tab();
+    await user.keyboard('{End}');
+
+    expect(thirdTab).toHaveFocus();
+    expect(thirdTab).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('tabpanel')).toHaveTextContent('Tab body 3');
+
+    await user.keyboard('{Home}');
+
+    expect(firstTab).toHaveFocus();
+    expect(firstTab).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('tabpanel')).toHaveTextContent('Tab body 1');
+  });
+
+  test('skips disabled tabs during keyboard navigation', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Grommet>
+        <Tabs>
+          <Tab title="Tab 1">Tab body 1</Tab>
+          <Tab title="Tab 2" disabled>
+            Tab body 2
+          </Tab>
+          <Tab title="Tab 3">Tab body 3</Tab>
+        </Tabs>
+      </Grommet>,
+    );
+
+    const firstTab = screen.getByRole('tab', { name: 'Tab 1' });
+    const thirdTab = screen.getByRole('tab', { name: 'Tab 3' });
+
+    await user.tab();
+    expect(firstTab).toHaveFocus();
+
+    await user.keyboard('{ArrowRight}');
+
+    expect(thirdTab).toHaveFocus();
+    expect(thirdTab).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('tabpanel')).toHaveTextContent('Tab body 3');
+  });
+
+  test('associates the active tab with its tabpanel', () => {
+    render(
+      <Grommet>
+        <Tabs>
+          <Tab title="Tab 1">Tab body 1</Tab>
+          <Tab title="Tab 2">Tab body 2</Tab>
+        </Tabs>
+      </Grommet>,
+    );
+
+    const firstTab = screen.getByRole('tab', { name: 'Tab 1' });
+    const panel = screen.getByRole('tabpanel');
+
+    expect(firstTab).toHaveAttribute('aria-controls', panel.id);
+    expect(panel).toHaveAttribute('aria-labelledby', firstTab.id);
   });
 
   test('set on hover', () => {

--- a/src/js/components/Tabs/__tests__/Tabs-test.tsx
+++ b/src/js/components/Tabs/__tests__/Tabs-test.tsx
@@ -496,4 +496,24 @@ describe('Tabs', () => {
 
     expect(asFragment()).toMatchSnapshot();
   });
+
+  test('onKeyDown', () => {
+    const onKeyDown = jest.fn();
+
+    render(
+      <Grommet>
+        <Tabs>
+          <Tab title="Tab 1">Tab body 1</Tab>
+          <Tab title="Tab 2" onKeyDown={onKeyDown}>
+            Tab body 2
+          </Tab>
+        </Tabs>
+      </Grommet>,
+    );
+
+    const secondTab = screen.getByRole('tab', { name: 'Tab 2' });
+    fireEvent.keyDown(secondTab, { key: 'ArrowLeft' });
+
+    expect(onKeyDown).toHaveBeenCalled();
+  });
 });

--- a/src/js/components/Tabs/__tests__/Tabs-test.tsx
+++ b/src/js/components/Tabs/__tests__/Tabs-test.tsx
@@ -632,4 +632,22 @@ describe('Tabs', () => {
       'Billing Information',
     );
   });
+
+  test('uses a developer-provided tab id', () => {
+    render(
+      <Grommet>
+        <Tabs>
+          <Tab id="custom-tab-id" title="Tab 1">
+            Tab body 1
+          </Tab>
+          <Tab title="Tab 2">Tab body 2</Tab>
+        </Tabs>
+      </Grommet>,
+    );
+
+    expect(screen.getByRole('tab', { name: 'Tab 1' })).toHaveAttribute(
+      'id',
+      'custom-tab-id',
+    );
+  });
 });

--- a/src/js/components/Tabs/__tests__/Tabs-test.tsx
+++ b/src/js/components/Tabs/__tests__/Tabs-test.tsx
@@ -245,7 +245,27 @@ describe('Tabs', () => {
     const panel = screen.getByRole('tabpanel');
 
     expect(firstTab).toHaveAttribute('aria-controls', panel.id);
-    expect(panel).toHaveAttribute('aria-labelledby', firstTab.id);
+    expect(panel).toHaveAttribute('aria-label', 'Tab 1 Tab Contents');
+  });
+
+  test('uses fallback panel label for icon-only tabs', () => {
+    render(
+      <Grommet>
+        <Tabs>
+          <Tab a11yTitle="First tab" icon={<svg />}>
+            Tab body 1
+          </Tab>
+          <Tab a11yTitle="Second tab" icon={<svg />}>
+            Tab body 2
+          </Tab>
+        </Tabs>
+      </Grommet>,
+    );
+
+    expect(screen.getByRole('tabpanel')).toHaveAttribute(
+      'aria-label',
+      '1 Tab Contents',
+    );
   });
 
   test('set on hover', () => {

--- a/src/js/components/Tabs/__tests__/Tabs-test.tsx
+++ b/src/js/components/Tabs/__tests__/Tabs-test.tsx
@@ -633,7 +633,7 @@ describe('Tabs', () => {
     );
   });
 
-  test('uses a developer-provided tab id', () => {
+  test('applies a developer-provided tab id', () => {
     render(
       <Grommet>
         <Tabs>

--- a/src/js/components/Tabs/__tests__/Tabs-test.tsx
+++ b/src/js/components/Tabs/__tests__/Tabs-test.tsx
@@ -566,4 +566,70 @@ describe('Tabs', () => {
     expect(secondTab).toHaveAttribute('aria-selected', 'true');
     expect(screen.getByRole('tabpanel')).toHaveTextContent('Tab body 2');
   });
+
+  test('restores focus to the nearest surviving tab when the focused tab is removed', async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(
+      <Grommet>
+        <Tabs>
+          <Tab title="General">General Information</Tab>
+          <Tab title="Account">Account Information</Tab>
+          <Tab title="Billing">Billing Information</Tab>
+          <Tab title="Notifications">Notifications Information</Tab>
+        </Tabs>
+      </Grommet>,
+    );
+
+    await user.tab();
+    await user.keyboard('{ArrowRight}{ArrowRight}{ArrowRight}');
+
+    const notificationsTab = screen.getByRole('tab', { name: 'Notifications' });
+    expect(notificationsTab).toHaveFocus();
+
+    rerender(
+      <Grommet>
+        <Tabs>
+          <Tab title="General">General Information</Tab>
+          <Tab title="Account">Account Information</Tab>
+          <Tab title="Billing">Billing Information</Tab>
+        </Tabs>
+      </Grommet>,
+    );
+
+    expect(screen.getByRole('tab', { name: 'Billing' })).toHaveFocus();
+  });
+
+  test('uses the nearest surviving tab when a controlled active index no longer maps', () => {
+    const { rerender } = render(
+      <Grommet>
+        <Tabs activeIndex={3} onActive={() => {}}>
+          <Tab title="General">General Information</Tab>
+          <Tab title="Account">Account Information</Tab>
+          <Tab title="Billing">Billing Information</Tab>
+          <Tab title="Notifications">Notifications Information</Tab>
+        </Tabs>
+      </Grommet>,
+    );
+
+    expect(screen.getByRole('tabpanel')).toHaveTextContent(
+      'Notifications Information',
+    );
+
+    rerender(
+      <Grommet>
+        <Tabs activeIndex={3} onActive={() => {}}>
+          <Tab title="General">General Information</Tab>
+          <Tab title="Account">Account Information</Tab>
+          <Tab title="Billing">Billing Information</Tab>
+        </Tabs>
+      </Grommet>,
+    );
+
+    const billingTab = screen.getByRole('tab', { name: 'Billing' });
+    expect(billingTab).toHaveAttribute('aria-selected', 'true');
+    expect(billingTab).toHaveAttribute('tabindex', '0');
+    expect(screen.getByRole('tabpanel')).toHaveTextContent(
+      'Billing Information',
+    );
+  });
 });

--- a/src/js/components/Tabs/__tests__/Tabs-test.tsx
+++ b/src/js/components/Tabs/__tests__/Tabs-test.tsx
@@ -146,7 +146,7 @@ describe('Tabs', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test('supports arrow key navigation between tabs', async () => {
+  test('moves focus with arrow keys without activating a tab', async () => {
     const user = userEvent.setup();
 
     render(
@@ -169,11 +169,13 @@ describe('Tabs', () => {
     await user.keyboard('{ArrowRight}');
 
     expect(secondTab).toHaveFocus();
-    expect(secondTab).toHaveAttribute('aria-selected', 'true');
-    expect(screen.getByRole('tabpanel')).toHaveTextContent('Tab body 2');
+    expect(secondTab).toHaveAttribute('aria-selected', 'false');
+    expect(secondTab).toHaveAttribute('tabindex', '0');
+    expect(firstTab).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('tabpanel')).toHaveTextContent('Tab body 1');
   });
 
-  test('supports Home and End keys within the tablist', async () => {
+  test('supports Home and End keys within the tablist without activating', async () => {
     const user = userEvent.setup();
 
     render(
@@ -193,8 +195,8 @@ describe('Tabs', () => {
     await user.keyboard('{End}');
 
     expect(thirdTab).toHaveFocus();
-    expect(thirdTab).toHaveAttribute('aria-selected', 'true');
-    expect(screen.getByRole('tabpanel')).toHaveTextContent('Tab body 3');
+    expect(thirdTab).toHaveAttribute('aria-selected', 'false');
+    expect(screen.getByRole('tabpanel')).toHaveTextContent('Tab body 1');
 
     await user.keyboard('{Home}');
 
@@ -203,7 +205,7 @@ describe('Tabs', () => {
     expect(screen.getByRole('tabpanel')).toHaveTextContent('Tab body 1');
   });
 
-  test('skips disabled tabs during keyboard navigation', async () => {
+  test('skips disabled tabs during keyboard navigation without activating', async () => {
     const user = userEvent.setup();
 
     render(
@@ -227,8 +229,8 @@ describe('Tabs', () => {
     await user.keyboard('{ArrowRight}');
 
     expect(thirdTab).toHaveFocus();
-    expect(thirdTab).toHaveAttribute('aria-selected', 'true');
-    expect(screen.getByRole('tabpanel')).toHaveTextContent('Tab body 3');
+    expect(thirdTab).toHaveAttribute('aria-selected', 'false');
+    expect(screen.getByRole('tabpanel')).toHaveTextContent('Tab body 1');
   });
 
   test('associates the active tab with its tabpanel', () => {
@@ -535,5 +537,33 @@ describe('Tabs', () => {
     fireEvent.keyDown(secondTab, { key: 'ArrowLeft' });
 
     expect(onKeyDown).toHaveBeenCalled();
+  });
+
+  test('activates the focused tab on Enter', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Grommet>
+        <Tabs>
+          <Tab title="Tab 1">Tab body 1</Tab>
+          <Tab title="Tab 2">Tab body 2</Tab>
+          <Tab title="Tab 3">Tab body 3</Tab>
+        </Tabs>
+      </Grommet>,
+    );
+
+    const firstTab = screen.getByRole('tab', { name: 'Tab 1' });
+    const secondTab = screen.getByRole('tab', { name: 'Tab 2' });
+
+    await user.tab();
+    await user.keyboard('{ArrowRight}');
+
+    expect(firstTab).toHaveAttribute('aria-selected', 'true');
+    expect(secondTab).toHaveAttribute('aria-selected', 'false');
+
+    await user.keyboard('{Enter}');
+
+    expect(secondTab).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('tabpanel')).toHaveTextContent('Tab body 2');
   });
 });

--- a/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.tsx.snap
+++ b/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.tsx.snap
@@ -227,10 +227,12 @@ exports[`Tabs Custom Tab component 1`] = `
         role="tablist"
       >
         <button
-          aria-expanded="true"
+          aria-controls="tabs-panel-_r_7_-0"
           aria-selected="true"
           class="c4"
+          id="tabs-tab-_r_7_-0"
           role="tab"
+          tabindex="0"
           type="button"
         >
           <div
@@ -244,10 +246,12 @@ exports[`Tabs Custom Tab component 1`] = `
           </div>
         </button>
         <button
-          aria-expanded="false"
+          aria-controls="tabs-panel-_r_7_-1"
           aria-selected="false"
           class="c4"
+          id="tabs-tab-_r_7_-1"
           role="tab"
+          tabindex="-1"
           type="button"
         >
           <div
@@ -264,7 +268,9 @@ exports[`Tabs Custom Tab component 1`] = `
     </div>
     <div
       aria-label="Tab 1 Tab Contents"
+      aria-labelledby="tabs-tab-_r_7_-0"
       class="c10"
+      id="tabs-panel-_r_7_-0"
       role="tabpanel"
     >
       Tab body 1
@@ -500,10 +506,12 @@ exports[`Tabs Tab 1`] = `
         role="tablist"
       >
         <button
-          aria-expanded="true"
+          aria-controls="tabs-panel-_r_2_-0"
           aria-selected="true"
           class="c4"
+          id="tabs-tab-_r_2_-0"
           role="tab"
+          tabindex="0"
           type="button"
         >
           <div
@@ -517,10 +525,12 @@ exports[`Tabs Tab 1`] = `
           </div>
         </button>
         <button
-          aria-expanded="false"
+          aria-controls="tabs-panel-_r_2_-2"
           aria-selected="false"
           class="c4"
+          id="tabs-tab-_r_2_-2"
           role="tab"
+          tabindex="-1"
           type="button"
         >
           <div
@@ -537,7 +547,9 @@ exports[`Tabs Tab 1`] = `
     </div>
     <div
       aria-label="Tab 1 Tab Contents"
+      aria-labelledby="tabs-tab-_r_2_-0"
       class="c10"
+      id="tabs-panel-_r_2_-0"
       role="tabpanel"
     >
       Tab body 1
@@ -777,10 +789,12 @@ exports[`Tabs alignControls 1`] = `
         role="tablist"
       >
         <button
-          aria-expanded="true"
+          aria-controls="tabs-panel-_r_6_-0"
           aria-selected="true"
           class="c4"
+          id="tabs-tab-_r_6_-0"
           role="tab"
+          tabindex="0"
           type="button"
         >
           <div
@@ -794,10 +808,12 @@ exports[`Tabs alignControls 1`] = `
           </div>
         </button>
         <button
-          aria-expanded="false"
+          aria-controls="tabs-panel-_r_6_-1"
           aria-selected="false"
           class="c4"
+          id="tabs-tab-_r_6_-1"
           role="tab"
+          tabindex="-1"
           type="button"
         >
           <div
@@ -814,7 +830,9 @@ exports[`Tabs alignControls 1`] = `
     </div>
     <div
       aria-label="Tab 1 Tab Contents"
+      aria-labelledby="tabs-tab-_r_6_-0"
       class="c10"
+      id="tabs-panel-_r_6_-0"
       role="tabpanel"
     >
       Tab body 1
@@ -1050,10 +1068,12 @@ exports[`Tabs change to second tab 1`] = `
         role="tablist"
       >
         <button
-          aria-expanded="true"
+          aria-controls="tabs-panel-_r_8_-0"
           aria-selected="true"
           class="c4"
+          id="tabs-tab-_r_8_-0"
           role="tab"
+          tabindex="0"
           type="button"
         >
           <div
@@ -1067,10 +1087,12 @@ exports[`Tabs change to second tab 1`] = `
           </div>
         </button>
         <button
-          aria-expanded="false"
+          aria-controls="tabs-panel-_r_8_-1"
           aria-selected="false"
           class="c4"
+          id="tabs-tab-_r_8_-1"
           role="tab"
+          tabindex="-1"
           type="button"
         >
           <div
@@ -1087,7 +1109,9 @@ exports[`Tabs change to second tab 1`] = `
     </div>
     <div
       aria-label="Tab 1 Tab Contents"
+      aria-labelledby="tabs-tab-_r_8_-0"
       class="c10"
+      id="tabs-panel-_r_8_-0"
       role="tabpanel"
     >
       Tab body 1
@@ -1111,10 +1135,12 @@ exports[`Tabs change to second tab 2`] = `
         role="tablist"
       >
         <button
-          aria-expanded="false"
+          aria-controls="tabs-panel-_r_8_-0"
           aria-selected="false"
           class="StyledButton-sc-323bzc-0 idJamt"
+          id="tabs-tab-_r_8_-0"
           role="tab"
+          tabindex="-1"
           type="button"
         >
           <div
@@ -1128,10 +1154,12 @@ exports[`Tabs change to second tab 2`] = `
           </div>
         </button>
         <button
-          aria-expanded="true"
+          aria-controls="tabs-panel-_r_8_-1"
           aria-selected="true"
           class="StyledButton-sc-323bzc-0 idJamt"
+          id="tabs-tab-_r_8_-1"
           role="tab"
+          tabindex="0"
           type="button"
         >
           <div
@@ -1148,7 +1176,9 @@ exports[`Tabs change to second tab 2`] = `
     </div>
     <div
       aria-label="Tab 2 Tab Contents"
+      aria-labelledby="tabs-tab-_r_8_-1"
       class="StyledTabs__StyledTabPanel-sc-a4fwxl-1 TIIEM"
+      id="tabs-panel-_r_8_-1"
       role="tabpanel"
     >
       Tab body 2
@@ -1372,10 +1402,12 @@ exports[`Tabs complex title 1`] = `
         role="tablist"
       >
         <button
-          aria-expanded="true"
+          aria-controls="tabs-panel-_r_4_-0"
           aria-selected="true"
           class="c4"
+          id="tabs-tab-_r_4_-0"
           role="tab"
+          tabindex="0"
           type="button"
         >
           <div
@@ -1387,10 +1419,12 @@ exports[`Tabs complex title 1`] = `
           </div>
         </button>
         <button
-          aria-expanded="false"
+          aria-controls="tabs-panel-_r_4_-2"
           aria-selected="false"
           class="c4"
+          id="tabs-tab-_r_4_-2"
           role="tab"
+          tabindex="-1"
           type="button"
         >
           <div
@@ -1405,7 +1439,9 @@ exports[`Tabs complex title 1`] = `
     </div>
     <div
       aria-label="1 Tab Contents"
+      aria-labelledby="tabs-tab-_r_4_-0"
       class="c8"
+      id="tabs-panel-_r_4_-0"
       role="tabpanel"
     >
       Tab body 1
@@ -1588,10 +1624,12 @@ exports[`Tabs no Tab 1`] = `
         role="tablist"
       >
         <button
-          aria-expanded="true"
+          aria-controls="tabs-panel-_r_1_-0"
           aria-selected="true"
           class="c4"
+          id="tabs-tab-_r_1_-0"
           role="tab"
+          tabindex="0"
           type="button"
         >
           <div
@@ -1602,7 +1640,9 @@ exports[`Tabs no Tab 1`] = `
     </div>
     <div
       aria-label="1 Tab Contents"
+      aria-labelledby="tabs-tab-_r_1_-0"
       class="c7"
+      id="tabs-panel-_r_1_-0"
       role="tabpanel"
     />
   </div>
@@ -1740,6 +1780,7 @@ exports[`Tabs no Tabs 1`] = `
   <button
     class="c1"
     role="tab"
+    tabindex="-1"
     type="button"
   >
     <div
@@ -1976,10 +2017,12 @@ exports[`Tabs onClick 1`] = `
         role="tablist"
       >
         <button
-          aria-expanded="true"
+          aria-controls="tabs-panel-_r_k_-0"
           aria-selected="true"
           class="c4"
+          id="tabs-tab-_r_k_-0"
           role="tab"
+          tabindex="0"
           type="button"
         >
           <div
@@ -1993,10 +2036,12 @@ exports[`Tabs onClick 1`] = `
           </div>
         </button>
         <button
-          aria-expanded="false"
+          aria-controls="tabs-panel-_r_k_-1"
           aria-selected="false"
           class="c4"
+          id="tabs-tab-_r_k_-1"
           role="tab"
+          tabindex="-1"
           type="button"
         >
           <div
@@ -2013,7 +2058,9 @@ exports[`Tabs onClick 1`] = `
     </div>
     <div
       aria-label="Tab 1 Tab Contents"
+      aria-labelledby="tabs-tab-_r_k_-0"
       class="c10"
+      id="tabs-panel-_r_k_-0"
       role="tabpanel"
     >
       Tab body 1
@@ -2236,10 +2283,12 @@ exports[`Tabs renders outside grommet wrapper 1`] = `
       role="tablist"
     >
       <button
-        aria-expanded="true"
+        aria-controls="tabs-panel-_r_3_-0"
         aria-selected="true"
         class="c3"
+        id="tabs-tab-_r_3_-0"
         role="tab"
+        tabindex="0"
         type="button"
       >
         <div
@@ -2253,10 +2302,12 @@ exports[`Tabs renders outside grommet wrapper 1`] = `
         </div>
       </button>
       <button
-        aria-expanded="false"
+        aria-controls="tabs-panel-_r_3_-2"
         aria-selected="false"
         class="c3"
+        id="tabs-tab-_r_3_-2"
         role="tab"
+        tabindex="-1"
         type="button"
       >
         <div
@@ -2273,7 +2324,9 @@ exports[`Tabs renders outside grommet wrapper 1`] = `
   </div>
   <div
     aria-label="Tab 1 Tab Contents"
+    aria-labelledby="tabs-tab-_r_3_-0"
     class="c9"
+    id="tabs-panel-_r_3_-0"
     role="tabpanel"
   >
     Tab body 1
@@ -2508,10 +2561,12 @@ exports[`Tabs set on hover 1`] = `
         role="tablist"
       >
         <button
-          aria-expanded="true"
+          aria-controls="tabs-panel-_r_d_-0"
           aria-selected="true"
           class="c4"
+          id="tabs-tab-_r_d_-0"
           role="tab"
+          tabindex="0"
           type="button"
         >
           <div
@@ -2525,10 +2580,12 @@ exports[`Tabs set on hover 1`] = `
           </div>
         </button>
         <button
-          aria-expanded="false"
+          aria-controls="tabs-panel-_r_d_-1"
           aria-selected="false"
           class="c4"
+          id="tabs-tab-_r_d_-1"
           role="tab"
+          tabindex="-1"
           type="button"
         >
           <div
@@ -2545,7 +2602,9 @@ exports[`Tabs set on hover 1`] = `
     </div>
     <div
       aria-label="Tab 1 Tab Contents"
+      aria-labelledby="tabs-tab-_r_d_-0"
       class="c10"
+      id="tabs-panel-_r_d_-0"
       role="tabpanel"
     >
       Tab body 1
@@ -2569,10 +2628,12 @@ exports[`Tabs set on hover 2`] = `
         role="tablist"
       >
         <button
-          aria-expanded="true"
+          aria-controls="tabs-panel-_r_d_-0"
           aria-selected="true"
           class="StyledButton-sc-323bzc-0 idJamt"
+          id="tabs-tab-_r_d_-0"
           role="tab"
+          tabindex="0"
           type="button"
         >
           <div
@@ -2586,10 +2647,12 @@ exports[`Tabs set on hover 2`] = `
           </div>
         </button>
         <button
-          aria-expanded="false"
+          aria-controls="tabs-panel-_r_d_-1"
           aria-selected="false"
           class="StyledButton-sc-323bzc-0 idJamt"
+          id="tabs-tab-_r_d_-1"
           role="tab"
+          tabindex="-1"
           type="button"
         >
           <div
@@ -2606,7 +2669,9 @@ exports[`Tabs set on hover 2`] = `
     </div>
     <div
       aria-label="Tab 1 Tab Contents"
+      aria-labelledby="tabs-tab-_r_d_-0"
       class="StyledTabs__StyledTabPanel-sc-a4fwxl-1 TIIEM"
+      id="tabs-panel-_r_d_-0"
       role="tabpanel"
     >
       Tab body 1
@@ -2630,10 +2695,12 @@ exports[`Tabs set on hover 3`] = `
         role="tablist"
       >
         <button
-          aria-expanded="true"
+          aria-controls="tabs-panel-_r_d_-0"
           aria-selected="true"
           class="StyledButton-sc-323bzc-0 idJamt"
+          id="tabs-tab-_r_d_-0"
           role="tab"
+          tabindex="0"
           type="button"
         >
           <div
@@ -2647,10 +2714,12 @@ exports[`Tabs set on hover 3`] = `
           </div>
         </button>
         <button
-          aria-expanded="false"
+          aria-controls="tabs-panel-_r_d_-1"
           aria-selected="false"
           class="StyledButton-sc-323bzc-0 idJamt"
+          id="tabs-tab-_r_d_-1"
           role="tab"
+          tabindex="-1"
           type="button"
         >
           <div
@@ -2667,7 +2736,9 @@ exports[`Tabs set on hover 3`] = `
     </div>
     <div
       aria-label="Tab 1 Tab Contents"
+      aria-labelledby="tabs-tab-_r_d_-0"
       class="StyledTabs__StyledTabPanel-sc-a4fwxl-1 TIIEM"
+      id="tabs-panel-_r_d_-0"
       role="tabpanel"
     >
       Tab body 1
@@ -2691,10 +2762,12 @@ exports[`Tabs set on hover 4`] = `
         role="tablist"
       >
         <button
-          aria-expanded="true"
+          aria-controls="tabs-panel-_r_d_-0"
           aria-selected="true"
           class="StyledButton-sc-323bzc-0 idJamt"
+          id="tabs-tab-_r_d_-0"
           role="tab"
+          tabindex="0"
           type="button"
         >
           <div
@@ -2708,10 +2781,12 @@ exports[`Tabs set on hover 4`] = `
           </div>
         </button>
         <button
-          aria-expanded="false"
+          aria-controls="tabs-panel-_r_d_-1"
           aria-selected="false"
           class="StyledButton-sc-323bzc-0 idJamt"
+          id="tabs-tab-_r_d_-1"
           role="tab"
+          tabindex="-1"
           type="button"
         >
           <div
@@ -2728,7 +2803,9 @@ exports[`Tabs set on hover 4`] = `
     </div>
     <div
       aria-label="Tab 1 Tab Contents"
+      aria-labelledby="tabs-tab-_r_d_-0"
       class="StyledTabs__StyledTabPanel-sc-a4fwxl-1 TIIEM"
+      id="tabs-panel-_r_d_-0"
       role="tabpanel"
     >
       Tab body 1
@@ -2752,10 +2829,12 @@ exports[`Tabs set on hover 5`] = `
         role="tablist"
       >
         <button
-          aria-expanded="true"
+          aria-controls="tabs-panel-_r_d_-0"
           aria-selected="true"
           class="StyledButton-sc-323bzc-0 idJamt"
+          id="tabs-tab-_r_d_-0"
           role="tab"
+          tabindex="0"
           type="button"
         >
           <div
@@ -2769,10 +2848,12 @@ exports[`Tabs set on hover 5`] = `
           </div>
         </button>
         <button
-          aria-expanded="false"
+          aria-controls="tabs-panel-_r_d_-1"
           aria-selected="false"
           class="StyledButton-sc-323bzc-0 idJamt"
+          id="tabs-tab-_r_d_-1"
           role="tab"
+          tabindex="-1"
           type="button"
         >
           <div
@@ -2789,7 +2870,9 @@ exports[`Tabs set on hover 5`] = `
     </div>
     <div
       aria-label="Tab 1 Tab Contents"
+      aria-labelledby="tabs-tab-_r_d_-0"
       class="StyledTabs__StyledTabPanel-sc-a4fwxl-1 TIIEM"
+      id="tabs-panel-_r_d_-0"
       role="tabpanel"
     >
       Tab body 1
@@ -2990,10 +3073,12 @@ exports[`Tabs should allow to extend tab styles 1`] = `
         role="tablist"
       >
         <button
-          aria-expanded="true"
+          aria-controls="tabs-panel-_r_j_-0"
           aria-selected="true"
           class="c4"
+          id="tabs-tab-_r_j_-0"
           role="tab"
+          tabindex="0"
           type="button"
         >
           <div
@@ -3003,10 +3088,12 @@ exports[`Tabs should allow to extend tab styles 1`] = `
           </div>
         </button>
         <button
-          aria-expanded="false"
+          aria-controls="tabs-panel-_r_j_-1"
           aria-selected="false"
           class="c4"
+          id="tabs-tab-_r_j_-1"
           role="tab"
+          tabindex="-1"
           type="button"
         >
           <div
@@ -3023,7 +3110,9 @@ exports[`Tabs should allow to extend tab styles 1`] = `
     </div>
     <div
       aria-label="Title 1 Tab Contents"
+      aria-labelledby="tabs-tab-_r_j_-0"
       class="c9"
+      id="tabs-panel-_r_j_-0"
       role="tabpanel"
     >
       Some content
@@ -3327,10 +3416,12 @@ exports[`Tabs should apply custom theme disabled style 1`] = `
         role="tablist"
       >
         <button
-          aria-expanded="true"
+          aria-controls="tabs-panel-_r_f_-0"
           aria-selected="true"
           class="c4"
+          id="tabs-tab-_r_f_-0"
           role="tab"
+          tabindex="0"
           type="button"
         >
           <div
@@ -3344,11 +3435,13 @@ exports[`Tabs should apply custom theme disabled style 1`] = `
           </div>
         </button>
         <button
-          aria-expanded="false"
+          aria-controls="tabs-panel-_r_f_-1"
           aria-selected="false"
           class="c8"
           disabled=""
+          id="tabs-tab-_r_f_-1"
           role="tab"
+          tabindex="-1"
           type="button"
         >
           <div
@@ -3366,7 +3459,9 @@ exports[`Tabs should apply custom theme disabled style 1`] = `
     </div>
     <div
       aria-label="Enabled Tab Tab Contents"
+      aria-labelledby="tabs-tab-_r_f_-0"
       class="c12"
+      id="tabs-panel-_r_f_-0"
       role="tabpanel"
     >
       This tab is enabled
@@ -3670,10 +3765,12 @@ exports[`Tabs should apply custom theme disabled style when theme.button.default
         role="tablist"
       >
         <button
-          aria-expanded="true"
+          aria-controls="tabs-panel-_r_g_-0"
           aria-selected="true"
           class="c4"
+          id="tabs-tab-_r_g_-0"
           role="tab"
+          tabindex="0"
           type="button"
         >
           <div
@@ -3687,11 +3784,13 @@ exports[`Tabs should apply custom theme disabled style when theme.button.default
           </div>
         </button>
         <button
-          aria-expanded="false"
+          aria-controls="tabs-panel-_r_g_-1"
           aria-selected="false"
           class="c8"
           disabled=""
+          id="tabs-tab-_r_g_-1"
           role="tab"
+          tabindex="-1"
           type="button"
         >
           <div
@@ -3709,7 +3808,9 @@ exports[`Tabs should apply custom theme disabled style when theme.button.default
     </div>
     <div
       aria-label="Enabled Tab Tab Contents"
+      aria-labelledby="tabs-tab-_r_g_-0"
       class="c12"
+      id="tabs-panel-_r_g_-0"
       role="tabpanel"
     >
       This tab is enabled
@@ -3947,10 +4048,12 @@ exports[`Tabs should apply theme alignSelf to tab controls 1`] = `
           role="tablist"
         >
           <button
-            aria-expanded="true"
+            aria-controls="tabs-panel-_r_l_-0"
             aria-selected="true"
             class="c4"
+            id="tabs-tab-_r_l_-0"
             role="tab"
+            tabindex="0"
             type="button"
           >
             <div
@@ -3964,10 +4067,12 @@ exports[`Tabs should apply theme alignSelf to tab controls 1`] = `
             </div>
           </button>
           <button
-            aria-expanded="false"
+            aria-controls="tabs-panel-_r_l_-1"
             aria-selected="false"
             class="c4"
+            id="tabs-tab-_r_l_-1"
             role="tab"
+            tabindex="-1"
             type="button"
           >
             <div
@@ -3984,7 +4089,9 @@ exports[`Tabs should apply theme alignSelf to tab controls 1`] = `
       </div>
       <div
         aria-label="Tab 1 Tab Contents"
+        aria-labelledby="tabs-tab-_r_l_-0"
         class="c10"
+        id="tabs-panel-_r_l_-0"
         role="tabpanel"
       >
         This tab is first
@@ -4169,11 +4276,13 @@ exports[`Tabs should have no accessibility violations 1`] = `
           role="tablist"
         >
           <button
-            aria-expanded="true"
+            aria-controls="tabs-panel-_r_0_-0"
             aria-label="test"
             aria-selected="true"
             class="c4"
+            id="tabs-tab-_r_0_-0"
             role="tab"
+            tabindex="0"
             type="button"
           >
             <div
@@ -4184,7 +4293,9 @@ exports[`Tabs should have no accessibility violations 1`] = `
       </div>
       <div
         aria-label="1 Tab Contents"
+        aria-labelledby="tabs-tab-_r_0_-0"
         class="c7"
+        id="tabs-panel-_r_0_-0"
         role="tabpanel"
       />
     </div>
@@ -4313,10 +4424,12 @@ exports[`Tabs should have no default styles with plain prop 1`] = `
         role="tablist"
       >
         <button
-          aria-expanded="true"
+          aria-controls="tabs-panel-_r_i_-0"
           aria-selected="true"
           class="c4"
+          id="tabs-tab-_r_i_-0"
           role="tab"
+          tabindex="0"
           type="button"
         >
           <div
@@ -4329,7 +4442,9 @@ exports[`Tabs should have no default styles with plain prop 1`] = `
     </div>
     <div
       aria-label="Title 1 Tab Contents"
+      aria-labelledby="tabs-tab-_r_i_-0"
       class="c6"
+      id="tabs-panel-_r_i_-0"
       role="tabpanel"
     />
   </div>
@@ -4630,10 +4745,12 @@ exports[`Tabs should style as disabled 1`] = `
         role="tablist"
       >
         <button
-          aria-expanded="true"
+          aria-controls="tabs-panel-_r_e_-0"
           aria-selected="true"
           class="c4"
+          id="tabs-tab-_r_e_-0"
           role="tab"
+          tabindex="0"
           type="button"
         >
           <div
@@ -4647,11 +4764,13 @@ exports[`Tabs should style as disabled 1`] = `
           </div>
         </button>
         <button
-          aria-expanded="false"
+          aria-controls="tabs-panel-_r_e_-1"
           aria-selected="false"
           class="c8"
           disabled=""
+          id="tabs-tab-_r_e_-1"
           role="tab"
+          tabindex="-1"
           type="button"
         >
           <div
@@ -4669,7 +4788,9 @@ exports[`Tabs should style as disabled 1`] = `
     </div>
     <div
       aria-label="Enabled Tab Tab Contents"
+      aria-labelledby="tabs-tab-_r_e_-0"
       class="c12"
+      id="tabs-panel-_r_e_-0"
       role="tabpanel"
     >
       This tab is enabled
@@ -4913,10 +5034,12 @@ exports[`Tabs styled component should change tab color when active 1`] = `
         role="tablist"
       >
         <button
-          aria-expanded="false"
+          aria-controls="tabs-panel-_r_h_-0"
           aria-selected="false"
           class="c4 c5"
+          id="tabs-tab-_r_h_-0"
           role="tab"
+          tabindex="-1"
           type="button"
         >
           <div
@@ -4930,10 +5053,12 @@ exports[`Tabs styled component should change tab color when active 1`] = `
           </div>
         </button>
         <button
-          aria-expanded="true"
+          aria-controls="tabs-panel-_r_h_-1"
           aria-selected="true"
           class="c4 c9"
+          id="tabs-tab-_r_h_-1"
           role="tab"
+          tabindex="0"
           type="button"
         >
           <div
@@ -4947,10 +5072,12 @@ exports[`Tabs styled component should change tab color when active 1`] = `
           </div>
         </button>
         <button
-          aria-expanded="false"
+          aria-controls="tabs-panel-_r_h_-2"
           aria-selected="false"
           class="c4 c5"
+          id="tabs-tab-_r_h_-2"
           role="tab"
+          tabindex="-1"
           type="button"
         >
           <div
@@ -4967,7 +5094,9 @@ exports[`Tabs styled component should change tab color when active 1`] = `
     </div>
     <div
       aria-label="Activity Tab Contents"
+      aria-labelledby="tabs-tab-_r_h_-1"
       class="c12"
+      id="tabs-panel-_r_h_-1"
       role="tabpanel"
     />
   </div>
@@ -5218,10 +5347,12 @@ exports[`Tabs theme tab gap 1`] = `
           role="tablist"
         >
           <button
-            aria-expanded="true"
+            aria-controls="tabs-panel-_r_m_-0"
             aria-selected="true"
             class="c4"
+            id="tabs-tab-_r_m_-0"
             role="tab"
+            tabindex="0"
             type="button"
           >
             <div
@@ -5241,10 +5372,12 @@ exports[`Tabs theme tab gap 1`] = `
             </div>
           </button>
           <button
-            aria-expanded="false"
+            aria-controls="tabs-panel-_r_m_-1"
             aria-selected="false"
             class="c4"
+            id="tabs-tab-_r_m_-1"
             role="tab"
+            tabindex="-1"
             type="button"
           >
             <div
@@ -5267,7 +5400,9 @@ exports[`Tabs theme tab gap 1`] = `
       </div>
       <div
         aria-label="Tab 1 Tab Contents"
+        aria-labelledby="tabs-tab-_r_m_-0"
         class="c11"
+        id="tabs-panel-_r_m_-0"
         role="tabpanel"
       >
         Tab body 1
@@ -5520,10 +5655,12 @@ exports[`Tabs with icon + reverse 1`] = `
         role="tablist"
       >
         <button
-          aria-expanded="true"
+          aria-controls="tabs-panel-_r_5_-0"
           aria-selected="true"
           class="c4"
+          id="tabs-tab-_r_5_-0"
           role="tab"
+          tabindex="0"
           type="button"
         >
           <div
@@ -5543,10 +5680,12 @@ exports[`Tabs with icon + reverse 1`] = `
           </div>
         </button>
         <button
-          aria-expanded="false"
+          aria-controls="tabs-panel-_r_5_-1"
           aria-selected="false"
           class="c4"
+          id="tabs-tab-_r_5_-1"
           role="tab"
+          tabindex="-1"
           type="button"
         >
           <div
@@ -5569,7 +5708,9 @@ exports[`Tabs with icon + reverse 1`] = `
     </div>
     <div
       aria-label="Tab 1 Tab Contents"
+      aria-labelledby="tabs-tab-_r_5_-0"
       class="c11"
+      id="tabs-panel-_r_5_-0"
       role="tabpanel"
     >
       Tab body 1

--- a/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.tsx.snap
+++ b/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.tsx.snap
@@ -227,10 +227,9 @@ exports[`Tabs Custom Tab component 1`] = `
         role="tablist"
       >
         <button
-          aria-controls="tabs-panel-_r_7_-0"
+          aria-controls="_r_7_"
           aria-selected="true"
           class="c4"
-          id="tabs-tab-_r_7_-0"
           role="tab"
           tabindex="0"
           type="button"
@@ -246,10 +245,9 @@ exports[`Tabs Custom Tab component 1`] = `
           </div>
         </button>
         <button
-          aria-controls="tabs-panel-_r_7_-1"
+          aria-controls="_r_7_"
           aria-selected="false"
           class="c4"
-          id="tabs-tab-_r_7_-1"
           role="tab"
           tabindex="-1"
           type="button"
@@ -269,7 +267,7 @@ exports[`Tabs Custom Tab component 1`] = `
     <div
       aria-label="Tab 1 Tab Contents"
       class="c10"
-      id="tabs-panel-_r_7_-0"
+      id="_r_7_"
       role="tabpanel"
     >
       Tab body 1
@@ -505,10 +503,9 @@ exports[`Tabs Tab 1`] = `
         role="tablist"
       >
         <button
-          aria-controls="tabs-panel-_r_2_-0"
+          aria-controls="_r_2_"
           aria-selected="true"
           class="c4"
-          id="tabs-tab-_r_2_-0"
           role="tab"
           tabindex="0"
           type="button"
@@ -524,10 +521,9 @@ exports[`Tabs Tab 1`] = `
           </div>
         </button>
         <button
-          aria-controls="tabs-panel-_r_2_-2"
+          aria-controls="_r_2_"
           aria-selected="false"
           class="c4"
-          id="tabs-tab-_r_2_-2"
           role="tab"
           tabindex="-1"
           type="button"
@@ -547,7 +543,7 @@ exports[`Tabs Tab 1`] = `
     <div
       aria-label="Tab 1 Tab Contents"
       class="c10"
-      id="tabs-panel-_r_2_-0"
+      id="_r_2_"
       role="tabpanel"
     >
       Tab body 1
@@ -787,10 +783,9 @@ exports[`Tabs alignControls 1`] = `
         role="tablist"
       >
         <button
-          aria-controls="tabs-panel-_r_6_-0"
+          aria-controls="_r_6_"
           aria-selected="true"
           class="c4"
-          id="tabs-tab-_r_6_-0"
           role="tab"
           tabindex="0"
           type="button"
@@ -806,10 +801,9 @@ exports[`Tabs alignControls 1`] = `
           </div>
         </button>
         <button
-          aria-controls="tabs-panel-_r_6_-1"
+          aria-controls="_r_6_"
           aria-selected="false"
           class="c4"
-          id="tabs-tab-_r_6_-1"
           role="tab"
           tabindex="-1"
           type="button"
@@ -829,7 +823,7 @@ exports[`Tabs alignControls 1`] = `
     <div
       aria-label="Tab 1 Tab Contents"
       class="c10"
-      id="tabs-panel-_r_6_-0"
+      id="_r_6_"
       role="tabpanel"
     >
       Tab body 1
@@ -1065,10 +1059,9 @@ exports[`Tabs change to second tab 1`] = `
         role="tablist"
       >
         <button
-          aria-controls="tabs-panel-_r_8_-0"
+          aria-controls="_r_8_"
           aria-selected="true"
           class="c4"
-          id="tabs-tab-_r_8_-0"
           role="tab"
           tabindex="0"
           type="button"
@@ -1084,10 +1077,9 @@ exports[`Tabs change to second tab 1`] = `
           </div>
         </button>
         <button
-          aria-controls="tabs-panel-_r_8_-1"
+          aria-controls="_r_8_"
           aria-selected="false"
           class="c4"
-          id="tabs-tab-_r_8_-1"
           role="tab"
           tabindex="-1"
           type="button"
@@ -1107,7 +1099,7 @@ exports[`Tabs change to second tab 1`] = `
     <div
       aria-label="Tab 1 Tab Contents"
       class="c10"
-      id="tabs-panel-_r_8_-0"
+      id="_r_8_"
       role="tabpanel"
     >
       Tab body 1
@@ -1131,10 +1123,9 @@ exports[`Tabs change to second tab 2`] = `
         role="tablist"
       >
         <button
-          aria-controls="tabs-panel-_r_8_-0"
+          aria-controls="_r_8_"
           aria-selected="false"
           class="StyledButton-sc-323bzc-0 idJamt"
-          id="tabs-tab-_r_8_-0"
           role="tab"
           tabindex="-1"
           type="button"
@@ -1150,10 +1141,9 @@ exports[`Tabs change to second tab 2`] = `
           </div>
         </button>
         <button
-          aria-controls="tabs-panel-_r_8_-1"
+          aria-controls="_r_8_"
           aria-selected="true"
           class="StyledButton-sc-323bzc-0 idJamt"
-          id="tabs-tab-_r_8_-1"
           role="tab"
           tabindex="0"
           type="button"
@@ -1173,7 +1163,7 @@ exports[`Tabs change to second tab 2`] = `
     <div
       aria-label="Tab 2 Tab Contents"
       class="StyledTabs__StyledTabPanel-sc-a4fwxl-1 TIIEM"
-      id="tabs-panel-_r_8_-1"
+      id="_r_8_"
       role="tabpanel"
     >
       Tab body 2
@@ -1397,10 +1387,9 @@ exports[`Tabs complex title 1`] = `
         role="tablist"
       >
         <button
-          aria-controls="tabs-panel-_r_4_-0"
+          aria-controls="_r_4_"
           aria-selected="true"
           class="c4"
-          id="tabs-tab-_r_4_-0"
           role="tab"
           tabindex="0"
           type="button"
@@ -1414,10 +1403,9 @@ exports[`Tabs complex title 1`] = `
           </div>
         </button>
         <button
-          aria-controls="tabs-panel-_r_4_-2"
+          aria-controls="_r_4_"
           aria-selected="false"
           class="c4"
-          id="tabs-tab-_r_4_-2"
           role="tab"
           tabindex="-1"
           type="button"
@@ -1435,7 +1423,7 @@ exports[`Tabs complex title 1`] = `
     <div
       aria-label="1 Tab Contents"
       class="c8"
-      id="tabs-panel-_r_4_-0"
+      id="_r_4_"
       role="tabpanel"
     >
       Tab body 1
@@ -1618,10 +1606,9 @@ exports[`Tabs no Tab 1`] = `
         role="tablist"
       >
         <button
-          aria-controls="tabs-panel-_r_1_-0"
+          aria-controls="_r_1_"
           aria-selected="true"
           class="c4"
-          id="tabs-tab-_r_1_-0"
           role="tab"
           tabindex="0"
           type="button"
@@ -1635,7 +1622,7 @@ exports[`Tabs no Tab 1`] = `
     <div
       aria-label="1 Tab Contents"
       class="c7"
-      id="tabs-panel-_r_1_-0"
+      id="_r_1_"
       role="tabpanel"
     />
   </div>
@@ -2010,10 +1997,9 @@ exports[`Tabs onClick 1`] = `
         role="tablist"
       >
         <button
-          aria-controls="tabs-panel-_r_l_-0"
+          aria-controls="_r_l_"
           aria-selected="true"
           class="c4"
-          id="tabs-tab-_r_l_-0"
           role="tab"
           tabindex="0"
           type="button"
@@ -2029,10 +2015,9 @@ exports[`Tabs onClick 1`] = `
           </div>
         </button>
         <button
-          aria-controls="tabs-panel-_r_l_-1"
+          aria-controls="_r_l_"
           aria-selected="false"
           class="c4"
-          id="tabs-tab-_r_l_-1"
           role="tab"
           tabindex="-1"
           type="button"
@@ -2052,7 +2037,7 @@ exports[`Tabs onClick 1`] = `
     <div
       aria-label="Tab 1 Tab Contents"
       class="c10"
-      id="tabs-panel-_r_l_-0"
+      id="_r_l_"
       role="tabpanel"
     >
       Tab body 1
@@ -2275,10 +2260,9 @@ exports[`Tabs renders outside grommet wrapper 1`] = `
       role="tablist"
     >
       <button
-        aria-controls="tabs-panel-_r_3_-0"
+        aria-controls="_r_3_"
         aria-selected="true"
         class="c3"
-        id="tabs-tab-_r_3_-0"
         role="tab"
         tabindex="0"
         type="button"
@@ -2294,10 +2278,9 @@ exports[`Tabs renders outside grommet wrapper 1`] = `
         </div>
       </button>
       <button
-        aria-controls="tabs-panel-_r_3_-2"
+        aria-controls="_r_3_"
         aria-selected="false"
         class="c3"
-        id="tabs-tab-_r_3_-2"
         role="tab"
         tabindex="-1"
         type="button"
@@ -2317,7 +2300,7 @@ exports[`Tabs renders outside grommet wrapper 1`] = `
   <div
     aria-label="Tab 1 Tab Contents"
     class="c9"
-    id="tabs-panel-_r_3_-0"
+    id="_r_3_"
     role="tabpanel"
   >
     Tab body 1
@@ -2552,10 +2535,9 @@ exports[`Tabs set on hover 1`] = `
         role="tablist"
       >
         <button
-          aria-controls="tabs-panel-_r_e_-0"
+          aria-controls="_r_e_"
           aria-selected="true"
           class="c4"
-          id="tabs-tab-_r_e_-0"
           role="tab"
           tabindex="0"
           type="button"
@@ -2571,10 +2553,9 @@ exports[`Tabs set on hover 1`] = `
           </div>
         </button>
         <button
-          aria-controls="tabs-panel-_r_e_-1"
+          aria-controls="_r_e_"
           aria-selected="false"
           class="c4"
-          id="tabs-tab-_r_e_-1"
           role="tab"
           tabindex="-1"
           type="button"
@@ -2594,7 +2575,7 @@ exports[`Tabs set on hover 1`] = `
     <div
       aria-label="Tab 1 Tab Contents"
       class="c10"
-      id="tabs-panel-_r_e_-0"
+      id="_r_e_"
       role="tabpanel"
     >
       Tab body 1
@@ -2618,10 +2599,9 @@ exports[`Tabs set on hover 2`] = `
         role="tablist"
       >
         <button
-          aria-controls="tabs-panel-_r_e_-0"
+          aria-controls="_r_e_"
           aria-selected="true"
           class="StyledButton-sc-323bzc-0 idJamt"
-          id="tabs-tab-_r_e_-0"
           role="tab"
           tabindex="0"
           type="button"
@@ -2637,10 +2617,9 @@ exports[`Tabs set on hover 2`] = `
           </div>
         </button>
         <button
-          aria-controls="tabs-panel-_r_e_-1"
+          aria-controls="_r_e_"
           aria-selected="false"
           class="StyledButton-sc-323bzc-0 idJamt"
-          id="tabs-tab-_r_e_-1"
           role="tab"
           tabindex="-1"
           type="button"
@@ -2660,7 +2639,7 @@ exports[`Tabs set on hover 2`] = `
     <div
       aria-label="Tab 1 Tab Contents"
       class="StyledTabs__StyledTabPanel-sc-a4fwxl-1 TIIEM"
-      id="tabs-panel-_r_e_-0"
+      id="_r_e_"
       role="tabpanel"
     >
       Tab body 1
@@ -2684,10 +2663,9 @@ exports[`Tabs set on hover 3`] = `
         role="tablist"
       >
         <button
-          aria-controls="tabs-panel-_r_e_-0"
+          aria-controls="_r_e_"
           aria-selected="true"
           class="StyledButton-sc-323bzc-0 idJamt"
-          id="tabs-tab-_r_e_-0"
           role="tab"
           tabindex="0"
           type="button"
@@ -2703,10 +2681,9 @@ exports[`Tabs set on hover 3`] = `
           </div>
         </button>
         <button
-          aria-controls="tabs-panel-_r_e_-1"
+          aria-controls="_r_e_"
           aria-selected="false"
           class="StyledButton-sc-323bzc-0 idJamt"
-          id="tabs-tab-_r_e_-1"
           role="tab"
           tabindex="-1"
           type="button"
@@ -2726,7 +2703,7 @@ exports[`Tabs set on hover 3`] = `
     <div
       aria-label="Tab 1 Tab Contents"
       class="StyledTabs__StyledTabPanel-sc-a4fwxl-1 TIIEM"
-      id="tabs-panel-_r_e_-0"
+      id="_r_e_"
       role="tabpanel"
     >
       Tab body 1
@@ -2750,10 +2727,9 @@ exports[`Tabs set on hover 4`] = `
         role="tablist"
       >
         <button
-          aria-controls="tabs-panel-_r_e_-0"
+          aria-controls="_r_e_"
           aria-selected="true"
           class="StyledButton-sc-323bzc-0 idJamt"
-          id="tabs-tab-_r_e_-0"
           role="tab"
           tabindex="0"
           type="button"
@@ -2769,10 +2745,9 @@ exports[`Tabs set on hover 4`] = `
           </div>
         </button>
         <button
-          aria-controls="tabs-panel-_r_e_-1"
+          aria-controls="_r_e_"
           aria-selected="false"
           class="StyledButton-sc-323bzc-0 idJamt"
-          id="tabs-tab-_r_e_-1"
           role="tab"
           tabindex="-1"
           type="button"
@@ -2792,7 +2767,7 @@ exports[`Tabs set on hover 4`] = `
     <div
       aria-label="Tab 1 Tab Contents"
       class="StyledTabs__StyledTabPanel-sc-a4fwxl-1 TIIEM"
-      id="tabs-panel-_r_e_-0"
+      id="_r_e_"
       role="tabpanel"
     >
       Tab body 1
@@ -2816,10 +2791,9 @@ exports[`Tabs set on hover 5`] = `
         role="tablist"
       >
         <button
-          aria-controls="tabs-panel-_r_e_-0"
+          aria-controls="_r_e_"
           aria-selected="true"
           class="StyledButton-sc-323bzc-0 idJamt"
-          id="tabs-tab-_r_e_-0"
           role="tab"
           tabindex="0"
           type="button"
@@ -2835,10 +2809,9 @@ exports[`Tabs set on hover 5`] = `
           </div>
         </button>
         <button
-          aria-controls="tabs-panel-_r_e_-1"
+          aria-controls="_r_e_"
           aria-selected="false"
           class="StyledButton-sc-323bzc-0 idJamt"
-          id="tabs-tab-_r_e_-1"
           role="tab"
           tabindex="-1"
           type="button"
@@ -2858,7 +2831,7 @@ exports[`Tabs set on hover 5`] = `
     <div
       aria-label="Tab 1 Tab Contents"
       class="StyledTabs__StyledTabPanel-sc-a4fwxl-1 TIIEM"
-      id="tabs-panel-_r_e_-0"
+      id="_r_e_"
       role="tabpanel"
     >
       Tab body 1
@@ -3059,10 +3032,9 @@ exports[`Tabs should allow to extend tab styles 1`] = `
         role="tablist"
       >
         <button
-          aria-controls="tabs-panel-_r_k_-0"
+          aria-controls="_r_k_"
           aria-selected="true"
           class="c4"
-          id="tabs-tab-_r_k_-0"
           role="tab"
           tabindex="0"
           type="button"
@@ -3074,10 +3046,9 @@ exports[`Tabs should allow to extend tab styles 1`] = `
           </div>
         </button>
         <button
-          aria-controls="tabs-panel-_r_k_-1"
+          aria-controls="_r_k_"
           aria-selected="false"
           class="c4"
-          id="tabs-tab-_r_k_-1"
           role="tab"
           tabindex="-1"
           type="button"
@@ -3097,7 +3068,7 @@ exports[`Tabs should allow to extend tab styles 1`] = `
     <div
       aria-label="Title 1 Tab Contents"
       class="c9"
-      id="tabs-panel-_r_k_-0"
+      id="_r_k_"
       role="tabpanel"
     >
       Some content
@@ -3401,10 +3372,9 @@ exports[`Tabs should apply custom theme disabled style 1`] = `
         role="tablist"
       >
         <button
-          aria-controls="tabs-panel-_r_g_-0"
+          aria-controls="_r_g_"
           aria-selected="true"
           class="c4"
-          id="tabs-tab-_r_g_-0"
           role="tab"
           tabindex="0"
           type="button"
@@ -3420,11 +3390,10 @@ exports[`Tabs should apply custom theme disabled style 1`] = `
           </div>
         </button>
         <button
-          aria-controls="tabs-panel-_r_g_-1"
+          aria-controls="_r_g_"
           aria-selected="false"
           class="c8"
           disabled=""
-          id="tabs-tab-_r_g_-1"
           role="tab"
           tabindex="-1"
           type="button"
@@ -3445,7 +3414,7 @@ exports[`Tabs should apply custom theme disabled style 1`] = `
     <div
       aria-label="Enabled Tab Tab Contents"
       class="c12"
-      id="tabs-panel-_r_g_-0"
+      id="_r_g_"
       role="tabpanel"
     >
       This tab is enabled
@@ -3749,10 +3718,9 @@ exports[`Tabs should apply custom theme disabled style when theme.button.default
         role="tablist"
       >
         <button
-          aria-controls="tabs-panel-_r_h_-0"
+          aria-controls="_r_h_"
           aria-selected="true"
           class="c4"
-          id="tabs-tab-_r_h_-0"
           role="tab"
           tabindex="0"
           type="button"
@@ -3768,11 +3736,10 @@ exports[`Tabs should apply custom theme disabled style when theme.button.default
           </div>
         </button>
         <button
-          aria-controls="tabs-panel-_r_h_-1"
+          aria-controls="_r_h_"
           aria-selected="false"
           class="c8"
           disabled=""
-          id="tabs-tab-_r_h_-1"
           role="tab"
           tabindex="-1"
           type="button"
@@ -3793,7 +3760,7 @@ exports[`Tabs should apply custom theme disabled style when theme.button.default
     <div
       aria-label="Enabled Tab Tab Contents"
       class="c12"
-      id="tabs-panel-_r_h_-0"
+      id="_r_h_"
       role="tabpanel"
     >
       This tab is enabled
@@ -4031,10 +3998,9 @@ exports[`Tabs should apply theme alignSelf to tab controls 1`] = `
           role="tablist"
         >
           <button
-            aria-controls="tabs-panel-_r_m_-0"
+            aria-controls="_r_m_"
             aria-selected="true"
             class="c4"
-            id="tabs-tab-_r_m_-0"
             role="tab"
             tabindex="0"
             type="button"
@@ -4050,10 +4016,9 @@ exports[`Tabs should apply theme alignSelf to tab controls 1`] = `
             </div>
           </button>
           <button
-            aria-controls="tabs-panel-_r_m_-1"
+            aria-controls="_r_m_"
             aria-selected="false"
             class="c4"
-            id="tabs-tab-_r_m_-1"
             role="tab"
             tabindex="-1"
             type="button"
@@ -4073,7 +4038,7 @@ exports[`Tabs should apply theme alignSelf to tab controls 1`] = `
       <div
         aria-label="Tab 1 Tab Contents"
         class="c10"
-        id="tabs-panel-_r_m_-0"
+        id="_r_m_"
         role="tabpanel"
       >
         This tab is first
@@ -4258,11 +4223,10 @@ exports[`Tabs should have no accessibility violations 1`] = `
           role="tablist"
         >
           <button
-            aria-controls="tabs-panel-_r_0_-0"
+            aria-controls="_r_0_"
             aria-label="test"
             aria-selected="true"
             class="c4"
-            id="tabs-tab-_r_0_-0"
             role="tab"
             tabindex="0"
             type="button"
@@ -4276,7 +4240,7 @@ exports[`Tabs should have no accessibility violations 1`] = `
       <div
         aria-label="1 Tab Contents"
         class="c7"
-        id="tabs-panel-_r_0_-0"
+        id="_r_0_"
         role="tabpanel"
       />
     </div>
@@ -4405,10 +4369,9 @@ exports[`Tabs should have no default styles with plain prop 1`] = `
         role="tablist"
       >
         <button
-          aria-controls="tabs-panel-_r_j_-0"
+          aria-controls="_r_j_"
           aria-selected="true"
           class="c4"
-          id="tabs-tab-_r_j_-0"
           role="tab"
           tabindex="0"
           type="button"
@@ -4424,7 +4387,7 @@ exports[`Tabs should have no default styles with plain prop 1`] = `
     <div
       aria-label="Title 1 Tab Contents"
       class="c6"
-      id="tabs-panel-_r_j_-0"
+      id="_r_j_"
       role="tabpanel"
     />
   </div>
@@ -4725,10 +4688,9 @@ exports[`Tabs should style as disabled 1`] = `
         role="tablist"
       >
         <button
-          aria-controls="tabs-panel-_r_f_-0"
+          aria-controls="_r_f_"
           aria-selected="true"
           class="c4"
-          id="tabs-tab-_r_f_-0"
           role="tab"
           tabindex="0"
           type="button"
@@ -4744,11 +4706,10 @@ exports[`Tabs should style as disabled 1`] = `
           </div>
         </button>
         <button
-          aria-controls="tabs-panel-_r_f_-1"
+          aria-controls="_r_f_"
           aria-selected="false"
           class="c8"
           disabled=""
-          id="tabs-tab-_r_f_-1"
           role="tab"
           tabindex="-1"
           type="button"
@@ -4769,7 +4730,7 @@ exports[`Tabs should style as disabled 1`] = `
     <div
       aria-label="Enabled Tab Tab Contents"
       class="c12"
-      id="tabs-panel-_r_f_-0"
+      id="_r_f_"
       role="tabpanel"
     >
       This tab is enabled
@@ -5013,10 +4974,9 @@ exports[`Tabs styled component should change tab color when active 1`] = `
         role="tablist"
       >
         <button
-          aria-controls="tabs-panel-_r_i_-0"
+          aria-controls="_r_i_"
           aria-selected="false"
           class="c4 c5"
-          id="tabs-tab-_r_i_-0"
           role="tab"
           tabindex="-1"
           type="button"
@@ -5032,10 +4992,9 @@ exports[`Tabs styled component should change tab color when active 1`] = `
           </div>
         </button>
         <button
-          aria-controls="tabs-panel-_r_i_-1"
+          aria-controls="_r_i_"
           aria-selected="true"
           class="c4 c9"
-          id="tabs-tab-_r_i_-1"
           role="tab"
           tabindex="0"
           type="button"
@@ -5051,10 +5010,9 @@ exports[`Tabs styled component should change tab color when active 1`] = `
           </div>
         </button>
         <button
-          aria-controls="tabs-panel-_r_i_-2"
+          aria-controls="_r_i_"
           aria-selected="false"
           class="c4 c5"
-          id="tabs-tab-_r_i_-2"
           role="tab"
           tabindex="-1"
           type="button"
@@ -5074,7 +5032,7 @@ exports[`Tabs styled component should change tab color when active 1`] = `
     <div
       aria-label="Activity Tab Contents"
       class="c12"
-      id="tabs-panel-_r_i_-1"
+      id="_r_i_"
       role="tabpanel"
     />
   </div>
@@ -5325,10 +5283,9 @@ exports[`Tabs theme tab gap 1`] = `
           role="tablist"
         >
           <button
-            aria-controls="tabs-panel-_r_n_-0"
+            aria-controls="_r_n_"
             aria-selected="true"
             class="c4"
-            id="tabs-tab-_r_n_-0"
             role="tab"
             tabindex="0"
             type="button"
@@ -5350,10 +5307,9 @@ exports[`Tabs theme tab gap 1`] = `
             </div>
           </button>
           <button
-            aria-controls="tabs-panel-_r_n_-1"
+            aria-controls="_r_n_"
             aria-selected="false"
             class="c4"
-            id="tabs-tab-_r_n_-1"
             role="tab"
             tabindex="-1"
             type="button"
@@ -5379,7 +5335,7 @@ exports[`Tabs theme tab gap 1`] = `
       <div
         aria-label="Tab 1 Tab Contents"
         class="c11"
-        id="tabs-panel-_r_n_-0"
+        id="_r_n_"
         role="tabpanel"
       >
         Tab body 1
@@ -5632,10 +5588,9 @@ exports[`Tabs with icon + reverse 1`] = `
         role="tablist"
       >
         <button
-          aria-controls="tabs-panel-_r_5_-0"
+          aria-controls="_r_5_"
           aria-selected="true"
           class="c4"
-          id="tabs-tab-_r_5_-0"
           role="tab"
           tabindex="0"
           type="button"
@@ -5657,10 +5612,9 @@ exports[`Tabs with icon + reverse 1`] = `
           </div>
         </button>
         <button
-          aria-controls="tabs-panel-_r_5_-1"
+          aria-controls="_r_5_"
           aria-selected="false"
           class="c4"
-          id="tabs-tab-_r_5_-1"
           role="tab"
           tabindex="-1"
           type="button"
@@ -5686,7 +5640,7 @@ exports[`Tabs with icon + reverse 1`] = `
     <div
       aria-label="Tab 1 Tab Contents"
       class="c11"
-      id="tabs-panel-_r_5_-0"
+      id="_r_5_"
       role="tabpanel"
     >
       Tab body 1

--- a/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.tsx.snap
+++ b/src/js/components/Tabs/__tests__/__snapshots__/Tabs-test.tsx.snap
@@ -268,7 +268,6 @@ exports[`Tabs Custom Tab component 1`] = `
     </div>
     <div
       aria-label="Tab 1 Tab Contents"
-      aria-labelledby="tabs-tab-_r_7_-0"
       class="c10"
       id="tabs-panel-_r_7_-0"
       role="tabpanel"
@@ -547,7 +546,6 @@ exports[`Tabs Tab 1`] = `
     </div>
     <div
       aria-label="Tab 1 Tab Contents"
-      aria-labelledby="tabs-tab-_r_2_-0"
       class="c10"
       id="tabs-panel-_r_2_-0"
       role="tabpanel"
@@ -830,7 +828,6 @@ exports[`Tabs alignControls 1`] = `
     </div>
     <div
       aria-label="Tab 1 Tab Contents"
-      aria-labelledby="tabs-tab-_r_6_-0"
       class="c10"
       id="tabs-panel-_r_6_-0"
       role="tabpanel"
@@ -1109,7 +1106,6 @@ exports[`Tabs change to second tab 1`] = `
     </div>
     <div
       aria-label="Tab 1 Tab Contents"
-      aria-labelledby="tabs-tab-_r_8_-0"
       class="c10"
       id="tabs-panel-_r_8_-0"
       role="tabpanel"
@@ -1176,7 +1172,6 @@ exports[`Tabs change to second tab 2`] = `
     </div>
     <div
       aria-label="Tab 2 Tab Contents"
-      aria-labelledby="tabs-tab-_r_8_-1"
       class="StyledTabs__StyledTabPanel-sc-a4fwxl-1 TIIEM"
       id="tabs-panel-_r_8_-1"
       role="tabpanel"
@@ -1439,7 +1434,6 @@ exports[`Tabs complex title 1`] = `
     </div>
     <div
       aria-label="1 Tab Contents"
-      aria-labelledby="tabs-tab-_r_4_-0"
       class="c8"
       id="tabs-panel-_r_4_-0"
       role="tabpanel"
@@ -1640,7 +1634,6 @@ exports[`Tabs no Tab 1`] = `
     </div>
     <div
       aria-label="1 Tab Contents"
-      aria-labelledby="tabs-tab-_r_1_-0"
       class="c7"
       id="tabs-panel-_r_1_-0"
       role="tabpanel"
@@ -2017,10 +2010,10 @@ exports[`Tabs onClick 1`] = `
         role="tablist"
       >
         <button
-          aria-controls="tabs-panel-_r_k_-0"
+          aria-controls="tabs-panel-_r_l_-0"
           aria-selected="true"
           class="c4"
-          id="tabs-tab-_r_k_-0"
+          id="tabs-tab-_r_l_-0"
           role="tab"
           tabindex="0"
           type="button"
@@ -2036,10 +2029,10 @@ exports[`Tabs onClick 1`] = `
           </div>
         </button>
         <button
-          aria-controls="tabs-panel-_r_k_-1"
+          aria-controls="tabs-panel-_r_l_-1"
           aria-selected="false"
           class="c4"
-          id="tabs-tab-_r_k_-1"
+          id="tabs-tab-_r_l_-1"
           role="tab"
           tabindex="-1"
           type="button"
@@ -2058,9 +2051,8 @@ exports[`Tabs onClick 1`] = `
     </div>
     <div
       aria-label="Tab 1 Tab Contents"
-      aria-labelledby="tabs-tab-_r_k_-0"
       class="c10"
-      id="tabs-panel-_r_k_-0"
+      id="tabs-panel-_r_l_-0"
       role="tabpanel"
     >
       Tab body 1
@@ -2324,7 +2316,6 @@ exports[`Tabs renders outside grommet wrapper 1`] = `
   </div>
   <div
     aria-label="Tab 1 Tab Contents"
-    aria-labelledby="tabs-tab-_r_3_-0"
     class="c9"
     id="tabs-panel-_r_3_-0"
     role="tabpanel"
@@ -2561,10 +2552,10 @@ exports[`Tabs set on hover 1`] = `
         role="tablist"
       >
         <button
-          aria-controls="tabs-panel-_r_d_-0"
+          aria-controls="tabs-panel-_r_e_-0"
           aria-selected="true"
           class="c4"
-          id="tabs-tab-_r_d_-0"
+          id="tabs-tab-_r_e_-0"
           role="tab"
           tabindex="0"
           type="button"
@@ -2580,10 +2571,10 @@ exports[`Tabs set on hover 1`] = `
           </div>
         </button>
         <button
-          aria-controls="tabs-panel-_r_d_-1"
+          aria-controls="tabs-panel-_r_e_-1"
           aria-selected="false"
           class="c4"
-          id="tabs-tab-_r_d_-1"
+          id="tabs-tab-_r_e_-1"
           role="tab"
           tabindex="-1"
           type="button"
@@ -2602,9 +2593,8 @@ exports[`Tabs set on hover 1`] = `
     </div>
     <div
       aria-label="Tab 1 Tab Contents"
-      aria-labelledby="tabs-tab-_r_d_-0"
       class="c10"
-      id="tabs-panel-_r_d_-0"
+      id="tabs-panel-_r_e_-0"
       role="tabpanel"
     >
       Tab body 1
@@ -2628,10 +2618,10 @@ exports[`Tabs set on hover 2`] = `
         role="tablist"
       >
         <button
-          aria-controls="tabs-panel-_r_d_-0"
+          aria-controls="tabs-panel-_r_e_-0"
           aria-selected="true"
           class="StyledButton-sc-323bzc-0 idJamt"
-          id="tabs-tab-_r_d_-0"
+          id="tabs-tab-_r_e_-0"
           role="tab"
           tabindex="0"
           type="button"
@@ -2647,10 +2637,10 @@ exports[`Tabs set on hover 2`] = `
           </div>
         </button>
         <button
-          aria-controls="tabs-panel-_r_d_-1"
+          aria-controls="tabs-panel-_r_e_-1"
           aria-selected="false"
           class="StyledButton-sc-323bzc-0 idJamt"
-          id="tabs-tab-_r_d_-1"
+          id="tabs-tab-_r_e_-1"
           role="tab"
           tabindex="-1"
           type="button"
@@ -2669,9 +2659,8 @@ exports[`Tabs set on hover 2`] = `
     </div>
     <div
       aria-label="Tab 1 Tab Contents"
-      aria-labelledby="tabs-tab-_r_d_-0"
       class="StyledTabs__StyledTabPanel-sc-a4fwxl-1 TIIEM"
-      id="tabs-panel-_r_d_-0"
+      id="tabs-panel-_r_e_-0"
       role="tabpanel"
     >
       Tab body 1
@@ -2695,10 +2684,10 @@ exports[`Tabs set on hover 3`] = `
         role="tablist"
       >
         <button
-          aria-controls="tabs-panel-_r_d_-0"
+          aria-controls="tabs-panel-_r_e_-0"
           aria-selected="true"
           class="StyledButton-sc-323bzc-0 idJamt"
-          id="tabs-tab-_r_d_-0"
+          id="tabs-tab-_r_e_-0"
           role="tab"
           tabindex="0"
           type="button"
@@ -2714,10 +2703,10 @@ exports[`Tabs set on hover 3`] = `
           </div>
         </button>
         <button
-          aria-controls="tabs-panel-_r_d_-1"
+          aria-controls="tabs-panel-_r_e_-1"
           aria-selected="false"
           class="StyledButton-sc-323bzc-0 idJamt"
-          id="tabs-tab-_r_d_-1"
+          id="tabs-tab-_r_e_-1"
           role="tab"
           tabindex="-1"
           type="button"
@@ -2736,9 +2725,8 @@ exports[`Tabs set on hover 3`] = `
     </div>
     <div
       aria-label="Tab 1 Tab Contents"
-      aria-labelledby="tabs-tab-_r_d_-0"
       class="StyledTabs__StyledTabPanel-sc-a4fwxl-1 TIIEM"
-      id="tabs-panel-_r_d_-0"
+      id="tabs-panel-_r_e_-0"
       role="tabpanel"
     >
       Tab body 1
@@ -2762,10 +2750,10 @@ exports[`Tabs set on hover 4`] = `
         role="tablist"
       >
         <button
-          aria-controls="tabs-panel-_r_d_-0"
+          aria-controls="tabs-panel-_r_e_-0"
           aria-selected="true"
           class="StyledButton-sc-323bzc-0 idJamt"
-          id="tabs-tab-_r_d_-0"
+          id="tabs-tab-_r_e_-0"
           role="tab"
           tabindex="0"
           type="button"
@@ -2781,10 +2769,10 @@ exports[`Tabs set on hover 4`] = `
           </div>
         </button>
         <button
-          aria-controls="tabs-panel-_r_d_-1"
+          aria-controls="tabs-panel-_r_e_-1"
           aria-selected="false"
           class="StyledButton-sc-323bzc-0 idJamt"
-          id="tabs-tab-_r_d_-1"
+          id="tabs-tab-_r_e_-1"
           role="tab"
           tabindex="-1"
           type="button"
@@ -2803,9 +2791,8 @@ exports[`Tabs set on hover 4`] = `
     </div>
     <div
       aria-label="Tab 1 Tab Contents"
-      aria-labelledby="tabs-tab-_r_d_-0"
       class="StyledTabs__StyledTabPanel-sc-a4fwxl-1 TIIEM"
-      id="tabs-panel-_r_d_-0"
+      id="tabs-panel-_r_e_-0"
       role="tabpanel"
     >
       Tab body 1
@@ -2829,10 +2816,10 @@ exports[`Tabs set on hover 5`] = `
         role="tablist"
       >
         <button
-          aria-controls="tabs-panel-_r_d_-0"
+          aria-controls="tabs-panel-_r_e_-0"
           aria-selected="true"
           class="StyledButton-sc-323bzc-0 idJamt"
-          id="tabs-tab-_r_d_-0"
+          id="tabs-tab-_r_e_-0"
           role="tab"
           tabindex="0"
           type="button"
@@ -2848,10 +2835,10 @@ exports[`Tabs set on hover 5`] = `
           </div>
         </button>
         <button
-          aria-controls="tabs-panel-_r_d_-1"
+          aria-controls="tabs-panel-_r_e_-1"
           aria-selected="false"
           class="StyledButton-sc-323bzc-0 idJamt"
-          id="tabs-tab-_r_d_-1"
+          id="tabs-tab-_r_e_-1"
           role="tab"
           tabindex="-1"
           type="button"
@@ -2870,9 +2857,8 @@ exports[`Tabs set on hover 5`] = `
     </div>
     <div
       aria-label="Tab 1 Tab Contents"
-      aria-labelledby="tabs-tab-_r_d_-0"
       class="StyledTabs__StyledTabPanel-sc-a4fwxl-1 TIIEM"
-      id="tabs-panel-_r_d_-0"
+      id="tabs-panel-_r_e_-0"
       role="tabpanel"
     >
       Tab body 1
@@ -3073,10 +3059,10 @@ exports[`Tabs should allow to extend tab styles 1`] = `
         role="tablist"
       >
         <button
-          aria-controls="tabs-panel-_r_j_-0"
+          aria-controls="tabs-panel-_r_k_-0"
           aria-selected="true"
           class="c4"
-          id="tabs-tab-_r_j_-0"
+          id="tabs-tab-_r_k_-0"
           role="tab"
           tabindex="0"
           type="button"
@@ -3088,10 +3074,10 @@ exports[`Tabs should allow to extend tab styles 1`] = `
           </div>
         </button>
         <button
-          aria-controls="tabs-panel-_r_j_-1"
+          aria-controls="tabs-panel-_r_k_-1"
           aria-selected="false"
           class="c4"
-          id="tabs-tab-_r_j_-1"
+          id="tabs-tab-_r_k_-1"
           role="tab"
           tabindex="-1"
           type="button"
@@ -3110,9 +3096,8 @@ exports[`Tabs should allow to extend tab styles 1`] = `
     </div>
     <div
       aria-label="Title 1 Tab Contents"
-      aria-labelledby="tabs-tab-_r_j_-0"
       class="c9"
-      id="tabs-panel-_r_j_-0"
+      id="tabs-panel-_r_k_-0"
       role="tabpanel"
     >
       Some content
@@ -3416,10 +3401,10 @@ exports[`Tabs should apply custom theme disabled style 1`] = `
         role="tablist"
       >
         <button
-          aria-controls="tabs-panel-_r_f_-0"
+          aria-controls="tabs-panel-_r_g_-0"
           aria-selected="true"
           class="c4"
-          id="tabs-tab-_r_f_-0"
+          id="tabs-tab-_r_g_-0"
           role="tab"
           tabindex="0"
           type="button"
@@ -3435,11 +3420,11 @@ exports[`Tabs should apply custom theme disabled style 1`] = `
           </div>
         </button>
         <button
-          aria-controls="tabs-panel-_r_f_-1"
+          aria-controls="tabs-panel-_r_g_-1"
           aria-selected="false"
           class="c8"
           disabled=""
-          id="tabs-tab-_r_f_-1"
+          id="tabs-tab-_r_g_-1"
           role="tab"
           tabindex="-1"
           type="button"
@@ -3459,9 +3444,8 @@ exports[`Tabs should apply custom theme disabled style 1`] = `
     </div>
     <div
       aria-label="Enabled Tab Tab Contents"
-      aria-labelledby="tabs-tab-_r_f_-0"
       class="c12"
-      id="tabs-panel-_r_f_-0"
+      id="tabs-panel-_r_g_-0"
       role="tabpanel"
     >
       This tab is enabled
@@ -3765,10 +3749,10 @@ exports[`Tabs should apply custom theme disabled style when theme.button.default
         role="tablist"
       >
         <button
-          aria-controls="tabs-panel-_r_g_-0"
+          aria-controls="tabs-panel-_r_h_-0"
           aria-selected="true"
           class="c4"
-          id="tabs-tab-_r_g_-0"
+          id="tabs-tab-_r_h_-0"
           role="tab"
           tabindex="0"
           type="button"
@@ -3784,11 +3768,11 @@ exports[`Tabs should apply custom theme disabled style when theme.button.default
           </div>
         </button>
         <button
-          aria-controls="tabs-panel-_r_g_-1"
+          aria-controls="tabs-panel-_r_h_-1"
           aria-selected="false"
           class="c8"
           disabled=""
-          id="tabs-tab-_r_g_-1"
+          id="tabs-tab-_r_h_-1"
           role="tab"
           tabindex="-1"
           type="button"
@@ -3808,9 +3792,8 @@ exports[`Tabs should apply custom theme disabled style when theme.button.default
     </div>
     <div
       aria-label="Enabled Tab Tab Contents"
-      aria-labelledby="tabs-tab-_r_g_-0"
       class="c12"
-      id="tabs-panel-_r_g_-0"
+      id="tabs-panel-_r_h_-0"
       role="tabpanel"
     >
       This tab is enabled
@@ -4048,10 +4031,10 @@ exports[`Tabs should apply theme alignSelf to tab controls 1`] = `
           role="tablist"
         >
           <button
-            aria-controls="tabs-panel-_r_l_-0"
+            aria-controls="tabs-panel-_r_m_-0"
             aria-selected="true"
             class="c4"
-            id="tabs-tab-_r_l_-0"
+            id="tabs-tab-_r_m_-0"
             role="tab"
             tabindex="0"
             type="button"
@@ -4067,10 +4050,10 @@ exports[`Tabs should apply theme alignSelf to tab controls 1`] = `
             </div>
           </button>
           <button
-            aria-controls="tabs-panel-_r_l_-1"
+            aria-controls="tabs-panel-_r_m_-1"
             aria-selected="false"
             class="c4"
-            id="tabs-tab-_r_l_-1"
+            id="tabs-tab-_r_m_-1"
             role="tab"
             tabindex="-1"
             type="button"
@@ -4089,9 +4072,8 @@ exports[`Tabs should apply theme alignSelf to tab controls 1`] = `
       </div>
       <div
         aria-label="Tab 1 Tab Contents"
-        aria-labelledby="tabs-tab-_r_l_-0"
         class="c10"
-        id="tabs-panel-_r_l_-0"
+        id="tabs-panel-_r_m_-0"
         role="tabpanel"
       >
         This tab is first
@@ -4293,7 +4275,6 @@ exports[`Tabs should have no accessibility violations 1`] = `
       </div>
       <div
         aria-label="1 Tab Contents"
-        aria-labelledby="tabs-tab-_r_0_-0"
         class="c7"
         id="tabs-panel-_r_0_-0"
         role="tabpanel"
@@ -4424,10 +4405,10 @@ exports[`Tabs should have no default styles with plain prop 1`] = `
         role="tablist"
       >
         <button
-          aria-controls="tabs-panel-_r_i_-0"
+          aria-controls="tabs-panel-_r_j_-0"
           aria-selected="true"
           class="c4"
-          id="tabs-tab-_r_i_-0"
+          id="tabs-tab-_r_j_-0"
           role="tab"
           tabindex="0"
           type="button"
@@ -4442,9 +4423,8 @@ exports[`Tabs should have no default styles with plain prop 1`] = `
     </div>
     <div
       aria-label="Title 1 Tab Contents"
-      aria-labelledby="tabs-tab-_r_i_-0"
       class="c6"
-      id="tabs-panel-_r_i_-0"
+      id="tabs-panel-_r_j_-0"
       role="tabpanel"
     />
   </div>
@@ -4745,10 +4725,10 @@ exports[`Tabs should style as disabled 1`] = `
         role="tablist"
       >
         <button
-          aria-controls="tabs-panel-_r_e_-0"
+          aria-controls="tabs-panel-_r_f_-0"
           aria-selected="true"
           class="c4"
-          id="tabs-tab-_r_e_-0"
+          id="tabs-tab-_r_f_-0"
           role="tab"
           tabindex="0"
           type="button"
@@ -4764,11 +4744,11 @@ exports[`Tabs should style as disabled 1`] = `
           </div>
         </button>
         <button
-          aria-controls="tabs-panel-_r_e_-1"
+          aria-controls="tabs-panel-_r_f_-1"
           aria-selected="false"
           class="c8"
           disabled=""
-          id="tabs-tab-_r_e_-1"
+          id="tabs-tab-_r_f_-1"
           role="tab"
           tabindex="-1"
           type="button"
@@ -4788,9 +4768,8 @@ exports[`Tabs should style as disabled 1`] = `
     </div>
     <div
       aria-label="Enabled Tab Tab Contents"
-      aria-labelledby="tabs-tab-_r_e_-0"
       class="c12"
-      id="tabs-panel-_r_e_-0"
+      id="tabs-panel-_r_f_-0"
       role="tabpanel"
     >
       This tab is enabled
@@ -5034,10 +5013,10 @@ exports[`Tabs styled component should change tab color when active 1`] = `
         role="tablist"
       >
         <button
-          aria-controls="tabs-panel-_r_h_-0"
+          aria-controls="tabs-panel-_r_i_-0"
           aria-selected="false"
           class="c4 c5"
-          id="tabs-tab-_r_h_-0"
+          id="tabs-tab-_r_i_-0"
           role="tab"
           tabindex="-1"
           type="button"
@@ -5053,10 +5032,10 @@ exports[`Tabs styled component should change tab color when active 1`] = `
           </div>
         </button>
         <button
-          aria-controls="tabs-panel-_r_h_-1"
+          aria-controls="tabs-panel-_r_i_-1"
           aria-selected="true"
           class="c4 c9"
-          id="tabs-tab-_r_h_-1"
+          id="tabs-tab-_r_i_-1"
           role="tab"
           tabindex="0"
           type="button"
@@ -5072,10 +5051,10 @@ exports[`Tabs styled component should change tab color when active 1`] = `
           </div>
         </button>
         <button
-          aria-controls="tabs-panel-_r_h_-2"
+          aria-controls="tabs-panel-_r_i_-2"
           aria-selected="false"
           class="c4 c5"
-          id="tabs-tab-_r_h_-2"
+          id="tabs-tab-_r_i_-2"
           role="tab"
           tabindex="-1"
           type="button"
@@ -5094,9 +5073,8 @@ exports[`Tabs styled component should change tab color when active 1`] = `
     </div>
     <div
       aria-label="Activity Tab Contents"
-      aria-labelledby="tabs-tab-_r_h_-1"
       class="c12"
-      id="tabs-panel-_r_h_-1"
+      id="tabs-panel-_r_i_-1"
       role="tabpanel"
     />
   </div>
@@ -5347,10 +5325,10 @@ exports[`Tabs theme tab gap 1`] = `
           role="tablist"
         >
           <button
-            aria-controls="tabs-panel-_r_m_-0"
+            aria-controls="tabs-panel-_r_n_-0"
             aria-selected="true"
             class="c4"
-            id="tabs-tab-_r_m_-0"
+            id="tabs-tab-_r_n_-0"
             role="tab"
             tabindex="0"
             type="button"
@@ -5372,10 +5350,10 @@ exports[`Tabs theme tab gap 1`] = `
             </div>
           </button>
           <button
-            aria-controls="tabs-panel-_r_m_-1"
+            aria-controls="tabs-panel-_r_n_-1"
             aria-selected="false"
             class="c4"
-            id="tabs-tab-_r_m_-1"
+            id="tabs-tab-_r_n_-1"
             role="tab"
             tabindex="-1"
             type="button"
@@ -5400,9 +5378,8 @@ exports[`Tabs theme tab gap 1`] = `
       </div>
       <div
         aria-label="Tab 1 Tab Contents"
-        aria-labelledby="tabs-tab-_r_m_-0"
         class="c11"
-        id="tabs-panel-_r_m_-0"
+        id="tabs-panel-_r_n_-0"
         role="tabpanel"
       >
         Tab body 1
@@ -5708,7 +5685,6 @@ exports[`Tabs with icon + reverse 1`] = `
     </div>
     <div
       aria-label="Tab 1 Tab Contents"
-      aria-labelledby="tabs-tab-_r_5_-0"
       class="c11"
       id="tabs-panel-_r_5_-0"
       role="tabpanel"

--- a/src/js/languages/default.json
+++ b/src/js/languages/default.json
@@ -198,6 +198,8 @@
     "skipTo": "Skip To:"
   },
   "tabs": {
+    "nextTab": "Next Tab",
+    "previousTab": "Previous Tab",
     "tabContents": "Tab Contents"
   },
   "tag": {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Adds keyboard support for the Tabs component. Shifts the behavior from using `Tab` keys to using `Arrow` keys. Follows best practices outlined in WCAG standards.

#### Where should the reviewer start?

- src/js/components/Tab/Tab.js
- src/js/components/Tabs/Tabs.js

#### What testing has been done on this PR?

- Manual testing

#### How should this be manually tested?

- Voiceover with Storybook

#### Do Jest tests follow these best practices?

- [x] `screen` is used for querying.
- [x] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

- None

#### What are the relevant issues?

closes https://github.com/grommet/grommet/issues/7962

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

- Maybe not the Grommet docs, but possibly the HPE Design System docs.

#### Should this PR be mentioned in the release notes?

- Most likely, as a bugfix or enhancement.

#### Is this change backwards compatible or is it a breaking change?

- I'm not familiar enough to answer that.
