### PR TITLE
Create a couple AI skills and an agent for creating new components

### DIFF
--- a/.github/agents/grommet-component.agent.md
+++ b/.github/agents/grommet-component.agent.md
@@ -1,0 +1,53 @@
+---
+description: "Use when creating, modifying, reviewing, styling, or testing Grommet React components. Routes to the grommet-component-contribution skill for full component workflows, grommet-component-styling for theme and styled-components work, or grommet-component-testing for tests and Storybook stories. Covers forwardRef, displayName, useThemeValue, FormContext, onChange shape, accessibility, i18n, and the full component directory structure."
+tools: [read, edit, search]
+---
+
+You are an expert Grommet React contributor. You know Grommet's component architecture, theming system, accessibility requirements, and testing practices inside out.
+
+## Component Directory Structure
+
+Every Grommet component follows this layout:
+
+```
+src/js/components/<ComponentName>/
+├── ComponentName.js              # Component implementation
+├── ComponentNameContext.js       # Context provider (if needed)
+├── StyledComponentName.js        # styled-components
+├── propTypes.js                  # Runtime prop validation (dev only)
+├── index.d.ts                    # TypeScript declarations
+├── index.js                      # Public exports
+├── README.md                     # Component overview
+├── __tests__/
+│   └── ComponentName-test.tsx
+└── stories/
+    └── FeatureName.stories.tsx
+```
+
+## Routing — Which Skill to Load
+
+| Task | Load skill |
+|------|-----------|
+| New component from scratch, full contribution workflow, PR prep | `/grommet-component-contribution` |
+| Adding or modifying `StyledComponent.js`, theme tokens in `base.js`/`base.d.ts`, styling patterns | `/grommet-component-styling` |
+| Writing `__tests__/*.tsx`, Storybook stories, axe checks | `/grommet-component-testing` |
+
+When the task spans multiple areas (e.g., implementing a new component end-to-end), load `/grommet-component-contribution` — it links to the specialized references for styling, accessibility, forms, and i18n.
+
+## Always Apply
+
+Regardless of which skill is active:
+
+- `React.forwardRef` + `displayName` — always required
+- `useThemeValue()` — never `useContext(ThemeContext)` directly
+- `onChange({ value })` for structured inputs; `onChange(event)` for native wrappers
+- `disabledStyle()` / `readOnlyStyle()` helpers — no custom CSS for those states
+- No hardcoded English strings — use `MessageContext`
+- Accessibility with `<Keyboard>` for key handling and `AnnounceContext` for screen reader announcements
+
+## When Unsure
+
+1. Read the nearest similar component in `src/js/components/`.
+2. Check `src/js/themes/base.js` for existing theme token patterns.
+3. Check `src/js/utils/` for shared utilities.
+4. Ask before inventing a new pattern or API shape.

--- a/.github/instructions/grommet-component.instructions.md
+++ b/.github/instructions/grommet-component.instructions.md
@@ -1,0 +1,60 @@
+---
+description: "Core rules for Grommet React component development. Always applied when editing component source files. Covers required implementation patterns, onChange shape, theme access, accessibility, i18n, and the most common anti-patterns."
+applyTo: "src/js/components/**"
+---
+
+## Required Patterns
+
+- `React.forwardRef` + `displayName` on every component — no exceptions
+- `useForwardedRef(refArg)` when the component needs internal access to the DOM node
+- `const { theme, passThemeFlag } = useThemeValue()` — never `useContext(ThemeContext)` directly
+- Spread `{...passThemeFlag}` on every styled component instance
+- Spread `...rest` on the root DOM element
+
+## onChange Shape
+
+| Component type | Correct callback |
+|---|---|
+| Native element wrapper (TextInput, CheckBox) | `onChange(event)` — standard React synthetic event |
+| Structured input that owns a parsed value (DateInput, Select) | `onChange({ value })` — Grommet object payload |
+
+Never call `onChange(value)` — always wrap in an object or pass the event.
+
+## Theme & Styling
+
+- Theme tokens live at `theme.<componentName>` — never `theme.global.myComponent`
+- Use `disabledStyle()` and `readOnlyStyle()` from `../../utils` for those states — no custom CSS
+- No inline `style={{}}` attributes; no hardcoded pixel values when a theme token exists
+- Use `styledComponentsConfig` (not custom `shouldForwardProp`) for styled components
+
+## Controlled / Uncontrolled State
+
+- Input components must support both `value` (controlled) and `defaultValue` (uncontrolled)
+- Use `formContext.useFormInput({ name, value, initialValue })` — not raw `useState`
+- This wires the component into `Form` submit/reset automatically
+
+## Accessibility
+
+- Use `<Keyboard>` for declarative key handling (not raw `onKeyDown`)
+- Always handle Escape on overlays, drops, and layers
+- Restore focus to the trigger element when closing a Drop or Layer: `requestAnimationFrame(() => ref.current?.focus())`
+- Use `aria-label` directly — do not add `a11yTitle` to new component APIs
+
+## Internationalization
+
+- No hardcoded English strings for user-visible text — use `MessageContext.format({ id, messages })`
+- Add defaults to `src/js/languages/default.json` under a namespaced key
+- Use `AnnounceContext` for screen reader announcements; prefer `'polite'` over `'assertive'`
+
+## Anti-Patterns
+
+| Never | Use instead |
+|-------|-------------|
+| `useContext(ThemeContext)` | `useThemeValue()` |
+| `onChange(value)` | `onChange({ value })` or `onChange(event)` |
+| `import styled from 'styled-components/macro'` | `import styled from 'styled-components'` |
+| Custom disabled/readOnly CSS | `disabledStyle()` / `readOnlyStyle()` |
+| `theme.global.myComponent` | `theme.myComponent` |
+| `useEffect` to sync controlled value | `formContext.useFormInput(...)` |
+| `React.createContext` in `src/js/contexts/` | Context file in the component's own directory |
+| `onSelect` / `onValueChange` / `onUpdate` | `onChange` |

--- a/.github/instructions/grommet-tests.instructions.md
+++ b/.github/instructions/grommet-tests.instructions.md
@@ -1,0 +1,50 @@
+---
+description: "Rules for writing tests and Storybook stories for Grommet components. Always applied when editing test or story files. Covers jest-axe, @testing-library/react, userEvent, query priority, Grommet wrapper, CSF-3 story format, and required story types."
+applyTo: ["src/js/components/**/__tests__/**", "src/js/components/**/stories/**"]
+---
+
+## Test File Rules
+
+- **axe check must be the first test** in every file — use `jest-axe` wrapped in `<Grommet>`
+- **Wrap all renders in `<Grommet>`** so theme tokens and contexts evaluate correctly; omit only when explicitly testing unwrapped behavior
+- **File extension**: `.tsx` for all new test files
+- **Target ≥85% coverage** for state logic, prop handling, and keyboard navigation
+
+## Interactions
+
+```tsx
+// Preferred — simulates full browser event sequences:
+const user = userEvent.setup();
+await user.click(element);
+await user.type(input, 'value');
+await user.keyboard('{Escape}');
+
+// Only for synthetic events userEvent cannot produce:
+fireEvent.custom(element, { detail: ... });
+```
+
+Never use `fireEvent.click` for standard user interactions — use `userEvent`.
+
+## DOM Query Priority
+
+1. `screen.getByRole('button', { name: /label/i })` — first choice; reflects semantics
+2. `screen.getByLabelText('Email')` — for labeled inputs
+3. `screen.getByText('Submit')` — last resort
+
+Avoid `getByTestId` and `querySelector`.
+
+## Snapshots
+
+Use `asFragment()`, not `container.innerHTML`:
+```tsx
+expect(asFragment()).toMatchSnapshot();
+```
+
+## Storybook Story Rules
+
+- **One story per file**, CSF-3 format
+- **Title format**: `'ComponentCategory/ComponentName/StoryName'`
+- **File extension**: `.tsx` for new story files
+- **Always include**: basic uncontrolled and/or controlled usage when the component has a value contract
+- **Always include**: `Form` + `FormField` integration story when the component participates in forms
+- **Only add** a `CustomThemed` story when the component introduces new theme tokens

--- a/.github/prompts/scaffold-component.prompt.md
+++ b/.github/prompts/scaffold-component.prompt.md
@@ -1,0 +1,74 @@
+---
+description: "Scaffold all required files for a new Grommet React component following the official directory structure, archetype patterns, and contribution conventions."
+argument-hint: "Component name and one-sentence purpose (e.g. RangeSlider — dual-handle range input)"
+agent: "agent"
+---
+
+Scaffold a complete new Grommet component. Read [.github/skills/grommet-component-contribution/SKILL.md](.github/skills/grommet-component-contribution/SKILL.md) before starting, and reference [.github/skills/grommet-component-contribution/EXAMPLES.md](.github/skills/grommet-component-contribution/EXAMPLES.md) to choose the right archetype.
+
+## Step 1 — Identify the Component
+
+Confirm:
+- **Name**: PascalCase (e.g. `RangeSlider`)
+- **Purpose**: one sentence
+- **Archetype**: which pattern fits best?
+  - **Simple Input** — edits one committed value (like `TextInput`, `CheckBox`)
+  - **Drop or Modal** — opens a selection surface (like `Select`, `DateInput`)
+  - **Display Only** — renders content, no value (like `Text`, `Anchor`, `Button`)
+  - **Layout / Composition** — arranges children (like `Box`, `Grid`)
+
+Read 1-2 similar existing components before writing any code.
+
+## Step 2 — Scaffold the Directory
+
+Create `src/js/components/<ComponentName>/` with all required files:
+
+### `ComponentName.js`
+- `React.forwardRef` with `displayName`
+- `useForwardedRef(refArg)` for internal ref
+- `const { theme, passThemeFlag } = useThemeValue()`
+- `formContext.useFormInput(...)` if the component participates in forms
+- `...rest` spread on the root DOM element
+- `process.env.NODE_ENV !== 'production'` guard for propTypes
+
+### `StyledComponentName.js`
+- `styled.element.withConfig(styledComponentsConfig)`
+- Theme values via `props.theme.<componentName>.*`
+- `${genericStyles}` appended last
+- `disabledStyle()` / `readOnlyStyle()` if needed
+
+### `propTypes.js`
+- `PropTypes` for every public prop
+
+### `index.d.ts`
+- TypeScript declarations matching the prop shape
+
+### `index.js`
+- Named export only: `export { ComponentName } from './ComponentName';`
+
+### `README.md`
+- Component name, one-sentence description, and basic usage example
+
+### `__tests__/ComponentName-test.tsx`
+- axe check as the **first** test
+- Renders wrapped in `<Grommet>`
+- Key interaction and prop tests with `userEvent`
+
+### `stories/Default.stories.tsx`
+- CSF-3 format, one story
+- Title: `'ComponentCategory/ComponentName/Default'`
+
+## Step 3 — Register Exports
+
+- Add named export to `src/js/components/index.js` (alphabetical)
+- Add type export to `src/js/index.d.ts`
+- Add i18n keys to `src/js/languages/default.json` if the component has user-visible strings
+- Add theme tokens to `src/js/themes/base.js` and `base.d.ts` if the component introduces new tokens
+
+## Step 4 — Validate
+
+After all files are created:
+- Confirm `displayName` is set
+- Confirm the axe test is the first test
+- Confirm `onChange` shape matches the archetype contract
+- Confirm theme namespace is at the top level (`theme.<componentName>`, not `theme.global.<componentName>`)

--- a/.github/skills/grommet-component-contribution/EXAMPLES.md
+++ b/.github/skills/grommet-component-contribution/EXAMPLES.md
@@ -1,0 +1,100 @@
+# Grommet Component Contribution Examples
+
+Use these examples to match the component archetype before adding new props or behavior. The goal is to keep the public API aligned with how Grommet components already work.
+The snippets are intentionally abbreviated. Adapt the event payload and commit flow to the component's actual contract.
+
+## 1. Simple Input
+
+Use when the component edits one committed value with little or no transient display state. Native element wrappers should emit the standard React synthetic event.
+
+Examples: `TextInput`, `CheckBox`, `RadioButton`
+
+```js
+const MyInput = forwardRef(({ value: valueProp, defaultValue, onChange, name, disabled, ...rest }, refArg) => {
+  const [value, setValue] = useControlled({
+    prop: valueProp,
+    defaultProp: defaultValue,
+  });
+
+  return (
+    <input
+      ref={refArg}
+      name={name}
+      disabled={disabled}
+      value={value}
+      onChange={(event) => {
+        setValue(event.target.value);
+        onChange?.(event);  // Emit standard React synthetic event
+      }}
+      {...rest}
+    />
+  );
+});
+```
+
+Rules:
+- Keep the API focused on the value contract.
+- Emit the standard React synthetic event `onChange(event)` for native element wrappers.
+- Do not add extra transient state for simple inputs; add transient display state only when formatting or validation requires it.
+
+## 2. Drop or Modal
+
+Use when the component opens a drop, popup, calendar, or selection surface.
+
+Examples: `Select`, `DateInput`, `DropButton`
+
+```js
+const MyDropButton = forwardRef(({ value, defaultValue, onChange, ...rest }, refArg) => {
+  const ref = useForwardedRef(refArg);
+  const { useFormInput } = useContext(FormContext);
+  const [committedValue, setCommittedValue] = useFormInput({
+    value: value,
+    initialValue: defaultValue,
+  });
+  const [open, setOpen] = useState(false);
+
+  const commit = (nextValue) => {
+    setCommittedValue(nextValue);
+    onChange?.({ value: nextValue });
+    setOpen(false);
+    // Restore focus to the trigger element after closing
+    requestAnimationFrame(() => {
+      ref.current?.focus();
+    });
+  };
+
+  return (
+    <button ref={ref} onClick={() => setOpen((next) => !next)} {...rest}>
+      {/* Render the drop/modal surface here and call commit(nextValue) when the selection is confirmed. */}
+    </button>
+  );
+});
+```
+
+Rules:
+- Keep open state internal unless there is a clear need for a controlled open prop.
+- Use `FormContext.useFormInput()` to integrate with forms and manage the committed value.
+- Keep transient UI state internal; do not expose internal state in the public API.
+- Restore focus to the trigger element on close.
+
+## 3. Display Only
+
+Use when the component renders content but does not own a value.
+
+Examples: `Text`, `Heading`, `Anchor`
+
+```js
+import styled from 'styled-components';
+
+const StyledBox = styled.div`
+  // component styling
+`;
+
+const MyDisplay = forwardRef(({ 'aria-label': ariaLabel, children, ...rest }, refArg) => {
+  return (
+    <StyledBox ref={refArg} aria-label={ariaLabel} {...rest}>
+      {children}
+    </StyledBox>
+  );
+});
+```

--- a/.github/skills/grommet-component-contribution/REFERENCE.md
+++ b/.github/skills/grommet-component-contribution/REFERENCE.md
@@ -1,0 +1,100 @@
+# Grommet Component Contribution Reference
+
+This file contains the detailed rules behind the main skill. Keep the main `SKILL.md` concise and use this reference when you need implementation detail.
+
+## 1. Grommet Philosophy
+
+- Composition over monoliths: build small focused primitives and compose them.
+- Browser APIs first: prefer `Intl.DateTimeFormat`, `Intl.NumberFormat`, and similar browser primitives over custom parsing/formatting when possible.
+- Escape hatches via theme: customization belongs in theme tokens, not per-instance props.
+- Standard form semantics:
+  - Native element wrappers emit standard React synthetic events via `onChange(event)`.
+  - Structured inputs that manage parsed/formatted values emit `onChange({ value })`.
+- Accessibility is mandatory: semantic HTML, keyboard support, ARIA, and screen-reader compatibility are required.
+- `...rest` spreading: pass unknown props to the root DOM element unless there is a strong reason not to.
+
+## 2. Directory Structure
+
+```
+src/js/components/<ComponentName>/
+├── ComponentName.js
+├── ComponentNameContext.js
+├── StyledComponentName.js
+├── propTypes.js
+├── index.d.ts
+├── index.js
+├── README.md
+├── __tests__/ComponentName-test.tsx
+└── stories/FeatureName.stories.{js,tsx}
+```
+
+Rules:
+- Subcomponents are peer directories, not nested.
+- Context files live in the component directory, not in `src/js/contexts/`.
+- Test files live in `__tests__/` and should use `.tsx`.
+- Story files live in `stories/` and should match the local component convention (`.js` or `.tsx`).
+
+## 3. Component Implementation
+
+Required pattern:
+
+```js
+import React, { forwardRef } from 'react';
+import { useForwardedRef } from '../../utils';
+import { useThemeValue } from '../../utils/useThemeValue';
+import { MyComponentPropTypes } from './propTypes';
+
+const MyComponent = forwardRef(({ 'aria-label': ariaLabel, id, name, ...rest }, refArg) => {
+  const { theme, passThemeFlag } = useThemeValue();
+  const ref = useForwardedRef(refArg);
+  return <div ref={ref} aria-label={ariaLabel} {...rest} />;
+});
+
+MyComponent.displayName = 'MyComponent';
+
+if (process.env.NODE_ENV !== 'production') {
+  MyComponent.propTypes = MyComponentPropTypes;
+}
+
+export { MyComponent };
+```
+
+Checklist:
+- Use `React.forwardRef` and set `displayName`.
+- Use `useForwardedRef(refArg)` instead of a raw ref.
+- Access theme with `const { theme, passThemeFlag } = useThemeValue()`.
+- Integrate forms through `FormContext` and `useFormInput` when the component participates in forms.
+- Keep `value` + `defaultValue` + `onChange` patterns consistent.
+- Spread `...rest` on the root DOM element.
+
+## 4. Props API Design
+
+Start with the minimum viable API:
+
+Component shapes differ. Do not apply input defaults to non-input components.
+
+| Category | Core MVP Props | Defer |
+|---|---|---|
+| All components | `aria-label`, `id`, `...rest` | `margin`, `alignSelf`, `gridArea` via `genericProps` |
+| Input components | `value`, `defaultValue`, `onChange`, `name`, `disabled` | `onBlur`, `onFocus`, `plain`, `readOnlyCopy` |
+| Drop or Modal | internal open state + trigger | `inline`, `openOnFocus`, `dropProps`, `buttonProps` |
+| Constrained values | `bounds` or `options` | Separate `min`/`max`, `step` |
+| Formatted display | derive from `Intl` or locale | Custom format strings |
+| Customization | theme only | per-instance `icon`, `size` |
+
+Recommended interpretation:
+- Universal props belong in the first row only.
+- `value`, `defaultValue`, `onChange`, and `name` are input-component defaults, not universal defaults.
+- `disabled` applies to interactive components that support user interaction; non-interactive display components (Text, Heading, Anchor) do not include it.
+- Use the row that matches the component archetype before adding any API.
+
+Do not:
+- Copy input defaults onto display-only components.
+- Expose `dropProps`, `buttonProps`, or `openOnFocus` unless the component is actually a drop/modal surface.
+- Add per-instance style props when a theme token already exists.
+- Invent a custom value contract when the nearest Grommet component already establishes one.
+
+### onChange Semantics
+
+- Native element wrappers: fire on every meaningful interaction via standard React synthetic event `onChange(event)`.
+- Structured inputs: fire only when the composed value is valid via `onChange({ value })`.

--- a/.github/skills/grommet-component-contribution/SKILL.md
+++ b/.github/skills/grommet-component-contribution/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: grommet-component-contribution
+description: "Build and contribute Grommet React components following official team conventions. Use when creating a new component from scratch, refactoring a component to align with Grommet conventions, preparing a PR for Grommet core contribution, or reviewing a component against acceptance criteria. Covers scaffolding, forwardRef, displayName, useThemeValue, FormContext, propTypes, TypeScript declarations, accessibility, i18n, and testing."
+argument-hint: "Describe the component or task (e.g. 'create a RangeSlider dual-handle input component')"
+---
+
+# Grommet Component Contribution Skill
+
+## Use When
+- Building a new Grommet component from scratch
+- Refactoring a component to align with Grommet conventions
+- Preparing a PR for Grommet core contribution
+- Reviewing a component against the Grommet acceptance criteria
+
+## Workflow
+1. Discover: read the closest existing component, its tests, propTypes, types, and stories.
+2. Plan: define the value contract, commit model, minimum props, and composition boundaries.
+3. Scaffold: create the component files, register exports, and add docs/tests/stories.
+4. Implement: build pure utilities first, then the component with `forwardRef`, `useForwardedRef`, `useThemeValue`, and `FormContext` integration.
+5. Test: start with accessibility, then value emission, form integration, keyboard, and edge cases.
+6. Stories: controlled usage, `FormField` integration, and `CustomThemed` only if new theme tokens exist.
+7. Validate: lint, full tests, and top-level `grommet` export coverage.
+
+## Non-Negotiable Principles
+- Compose small primitives before building a monolith.
+- Prefer native browser APIs such as `Intl` over custom format/parse logic.
+- Put customization in theme tokens, not instance props.
+- Keep accessibility, semantic HTML, and keyboard support mandatory.
+- Use `onChange` with the `{ value }` shape for structured inputs.
+  - Native element wrappers (TextInput, CheckBox) emit the standard React synthetic event via `onChange(event)`.
+  - Structured inputs that own a parsed/formatted value (DateInput) emit `onChange({ value })`.
+- Simple inputs emit on every meaningful interaction; structured inputs emit only when the composed value is valid.
+- Spread `...rest` onto the root DOM element, though some components may be selective about placement.
+
+## Default API Shape
+- Start with only truly universal props: `aria-label`, `id`, and `...rest`.
+- Apply `disabled` only to value-input components (TextInput, CheckBox, Select, DateInput, etc.).
+- Do NOT add `disabled` to non-interactive display components (Text, Heading, Anchor).
+- Use `genericProps` for layout and style passthrough.
+- See [REFERENCE.md](./REFERENCE.md) for component-specific API shapes.
+
+## Implementation Checklist
+- `React.forwardRef` plus `displayName`
+- `useForwardedRef(refArg)` instead of raw refs
+- `const { theme, passThemeFlag } = useThemeValue()`
+- `FormContext` integration via `useFormInput` when the component participates in forms
+- TypeScript declarations in `index.d.ts`
+- `propTypes.js` guarded for production
+- Component barrel export and top-level export registration
+- Theme defaults live under a dedicated `theme.<componentName>` namespace
+- Stories in CSF-3 format
+- Tests use `@testing-library/user-event`, `jest-axe`, and `<Grommet>` wrappers
+
+## When Unsure
+1. Check the nearest similar component.
+2. Check existing theme tokens.
+3. Check shared utilities or `FormContext`.
+4. Ask before inventing a new pattern.
+5. Read [REFERENCE.md](./REFERENCE.md) before making implementation decisions.
+6. Review [EXAMPLES.md](./EXAMPLES.md) for a matching archetype before drafting new APIs.
+
+## Detailed Reference
+- [REFERENCE.md](./REFERENCE.md) — anti-hallucination rules, implementation patterns, PR checklist, decision tree, and anti-patterns
+- [EXAMPLES.md](./EXAMPLES.md) — archetype code examples for all 4 component types (Simple Input, Drop/Modal, Display Only, Layout)
+- [references/architecture.md](./references/architecture.md) — forwardRef, useForwardedRef, useThemeValue, FormContext/useFormInput, directory structure, propTypes, TypeScript declarations
+- [references/styling.md](./references/styling.md) — styled-components, styledComponentsConfig, theme token namespace, disabledStyle/readOnlyStyle, t-shirt sizing
+- [references/accessibility.md](./references/accessibility.md) — Keyboard component, focus restore, aria-label, Escape handling, semantic HTML rules
+- [references/forms.md](./references/forms.md) — FormContext.useFormInput(), FormField error surfacing, non-destructive UX
+- [references/i18n.md](./references/i18n.md) — MessageContext string keys, AnnounceContext live regions, polite vs assertive

--- a/.github/skills/grommet-component-contribution/references/accessibility.md
+++ b/.github/skills/grommet-component-contribution/references/accessibility.md
@@ -1,0 +1,57 @@
+# Accessibility Reference
+
+## Semantic HTML First
+
+- Use `<Button />` for actions, `<Anchor />` for navigation
+- When `onClick` must go on a `<div>` or other non-interactive element, add `role="button"` and `onKeyDown` to preserve the same semantic contract a native element provides
+- New components use `aria-label` directly — do **not** add `a11yTitle` to new component APIs
+
+```jsx
+// Correct — new component API:
+<MyComponent aria-label="Close dialog" />
+
+// Backwards-compatible only — existing components:
+// a11yTitle maps to aria-label but should not be added to new APIs
+```
+
+## Keyboard Handling with `<Keyboard>`
+
+Use the declarative `<Keyboard>` component for key handling. Do not write raw `onKeyDown` handlers when `<Keyboard>` covers the case:
+
+```jsx
+import { Keyboard } from '../Keyboard';
+
+<Keyboard
+  onEnter={handleEnter}
+  onSpace={handleSpace}
+  onEscape={handleClose}
+  onUp={handleUp}
+  onDown={handleDown}
+>
+  <button ref={ref} onClick={handleClick}>
+    {children}
+  </button>
+</Keyboard>
+```
+
+For hook-level detection (e.g., deciding whether focus should be restored when closing a drop): `useKeyboard()` from `../../utils`.
+
+## Opening Drops & Layers
+
+- Open on Space or Enter keypress — **not** on focus alone
+- Always handle Escape to close overlays, drops, layers, and selects
+
+## Focus Restoration
+
+When a Drop or Layer closes and focus was inside it, restore focus to the trigger element:
+
+```js
+const handleClose = () => {
+  setOpen(false);
+  requestAnimationFrame(() => {
+    triggerRef.current?.focus();
+  });
+};
+```
+
+Only restore focus if the overlay was closed while focus was actually inside it — do not restore focus if the drop was dismissed without the user ever entering it.

--- a/.github/skills/grommet-component-contribution/references/architecture.md
+++ b/.github/skills/grommet-component-contribution/references/architecture.md
@@ -1,0 +1,154 @@
+# Architecture & Implementation Reference
+
+## Directory Structure
+
+```
+src/js/components/<ComponentName>/
+├── ComponentName.js              # Component implementation
+├── ComponentNameContext.js       # Context provider (if needed)
+├── StyledComponentName.js        # Styled-components
+├── propTypes.js                  # Runtime prop validation
+├── index.d.ts                    # TypeScript declarations
+├── index.js                      # Public exports
+├── README.md                     # Component overview
+├── __tests__/
+│   └── ComponentName-test.tsx    # Tests
+└── stories/
+    └── FeatureName.stories.tsx   # One story per file (CSF-3)
+```
+
+- Subcomponents are **peer directories**, not nested (`CardBody` sits beside `Card`, not inside it)
+- Context files belong in the component directory, not `src/js/contexts/`
+- Test files use `.tsx` extension
+- Story files use `.tsx` extension
+
+## Component Shell
+
+```js
+import React, { forwardRef, useContext } from 'react';
+import { useForwardedRef } from '../../utils';
+import { useThemeValue } from '../../utils/useThemeValue';
+import { FormContext } from '../../contexts/FormContext';
+import { MyComponentPropTypes } from './propTypes';
+
+const MyComponent = forwardRef(
+  ({ 'aria-label': ariaLabel, id, ...rest }, refArg) => {
+    const ref = useForwardedRef(refArg);
+    const { theme, passThemeFlag } = useThemeValue();
+
+    return (
+      <div
+        ref={ref}
+        aria-label={ariaLabel}
+        id={id}
+        {...passThemeFlag}
+        {...rest}
+      />
+    );
+  },
+);
+
+MyComponent.displayName = 'MyComponent';
+
+if (process.env.NODE_ENV !== 'production') {
+  MyComponent.propTypes = MyComponentPropTypes;
+}
+
+export { MyComponent };
+```
+
+- Always `React.forwardRef` — required for ref forwarding and `FormField` integration
+- Always assign `displayName` — used by React DevTools, error stacks, and `FormField` to identify wrapped children
+- `useForwardedRef(refArg)` — use when the component needs internal access to the DOM node
+- `useThemeValue()` — the only correct way to access the theme; never `useContext(ThemeContext)` directly
+- Spread `{...passThemeFlag}` on styled components so theme propagation works correctly
+- Spread `...rest` on the root DOM element
+
+## Exports
+
+In `ComponentName/index.js`:
+```js
+export { MyComponent } from './MyComponent';
+```
+
+In `src/js/components/index.js` (alphabetical order):
+```js
+export { MyComponent } from './MyComponent';
+```
+
+Also update `src/js/index.d.ts` and `src/js/languages/default.json` for any i18n keys the component uses.
+
+## Controlled / Uncontrolled Pattern
+
+Input components must support both controlled (`value`) and uncontrolled (`defaultValue`) usage via `FormContext.useFormInput`:
+
+```js
+const formContext = useContext(FormContext);
+const [value, setValue] = formContext.useFormInput({
+  name,
+  value: valueProp,           // controlled prop
+  initialValue: defaultValue, // uncontrolled fallback
+});
+```
+
+- `onChange` for structured inputs: `onChange?.({ value: nextValue })`
+- `onChange` for native element wrappers: `onChange?.(event)`
+- Do not use raw `useControlled` — `formContext.useFormInput` is the established pattern across the codebase
+
+## propTypes.js
+
+```js
+import PropTypes from 'prop-types';
+
+const MyComponentPropTypes = {
+  'aria-label': PropTypes.string,
+  id: PropTypes.string,
+  // ...
+};
+
+export { MyComponentPropTypes };
+```
+
+Assign inside the component file, guarded by the `process.env` check so propTypes are stripped in production:
+
+```js
+if (process.env.NODE_ENV !== 'production') {
+  MyComponent.propTypes = MyComponentPropTypes;
+}
+```
+
+## TypeScript (index.d.ts)
+
+Types live in `.d.ts` declaration files, not inline TypeScript source. Follow the shape of nearby components in the codebase. Keep the JavaScript source as-is and update only the declaration file.
+
+## Context & Named Hooks
+
+When a parent needs to share state with deeply nested children, create a React context. Export a **named hook** as the public API — not the context object directly:
+
+```js
+// MyComponentContext.js
+import React, { useContext } from 'react';
+
+const MyComponentContext = React.createContext({});
+
+const useMyComponent = () => useContext(MyComponentContext);
+
+export { MyComponentContext, useMyComponent };
+```
+
+Context files live in the component directory alongside the component, not in `src/js/contexts/`.
+
+## Drop / Layer Draft Pattern
+
+Keep a draft value separate from the committed value. The draft only becomes committed when the user confirms:
+
+```js
+const [open, setOpen] = useState(false);
+const [draftValue, setDraftValue] = useState(value ?? defaultValue ?? null);
+```
+
+Keep open state internal unless a controlled `open` prop is explicitly required.
+
+## Escape Hatch Props
+
+Expose `{underlying}Props` (e.g., `buttonProps`, `dropProps`) only where there is a clearly demonstrated need. Do not add them speculatively.

--- a/.github/skills/grommet-component-contribution/references/forms.md
+++ b/.github/skills/grommet-component-contribution/references/forms.md
@@ -1,0 +1,43 @@
+# Forms Integration Reference
+
+## FormContext.useFormInput()
+
+Connect any input component to Grommet's `Form` / `FormField` system via `useFormInput`. This handles controlled/uncontrolled state and wires the component into `Form`'s submit and reset lifecycle automatically:
+
+```js
+import { useContext } from 'react';
+import { FormContext } from '../../contexts/FormContext';
+
+const MyInput = forwardRef(
+  ({ value: valueProp, defaultValue, name, onChange, ...rest }, refArg) => {
+    const formContext = useContext(FormContext);
+    const [value, setValue] = formContext.useFormInput({
+      name,
+      value: valueProp,           // controlled prop
+      initialValue: defaultValue, // uncontrolled fallback
+    });
+
+    return (
+      <input
+        name={name}
+        value={value}
+        onChange={(event) => {
+          setValue(event.target.value);
+          onChange?.({ value: event.target.value });
+        }}
+        {...rest}
+      />
+    );
+  },
+);
+```
+
+Do not use raw `useState` for the committed value of an input component — always go through `formContext.useFormInput` so the component participates in `Form`'s submit/reset.
+
+## Surfacing Errors via FormField
+
+Do not write custom error display logic. `FormField` owns the visual error display and links errors to inputs via ARIA. Surface validation state through `FormField`'s `error` prop — the component itself does not need to render error messages.
+
+## Non-Destructive Validation UX
+
+**Never** erase or revert the user's draft when it fails validation. For example, do not clear a text field on blur if the value is invalid. Keep the draft visible and show the error state alongside it so the user can correct their own input.

--- a/.github/skills/grommet-component-contribution/references/i18n.md
+++ b/.github/skills/grommet-component-contribution/references/i18n.md
@@ -1,0 +1,62 @@
+# Internationalization (i18n) Reference
+
+## MessageContext — User-Visible Strings
+
+Any user-visible string that may need translation must use `MessageContext` instead of a hardcoded English literal:
+
+```js
+import { useContext } from 'react';
+import { MessageContext } from '../../contexts/MessageContext';
+
+const MyComponent = forwardRef(({ messages, ...rest }, ref) => {
+  const { format } = useContext(MessageContext);
+
+  const label = format({
+    id: 'myComponent.openLabel',
+    messages, // allow per-instance overrides
+  });
+
+  return <button aria-label={label} ref={ref} {...rest} />;
+});
+```
+
+Add the default English string to `src/js/languages/default.json` under a namespaced key (alphabetical within the namespace):
+
+```json
+{
+  "myComponent": {
+    "openLabel": "Open",
+    "closeLabel": "Close"
+  }
+}
+```
+
+## AnnounceContext — Screen Reader Live Regions
+
+Use `AnnounceContext` to push announcements to screen readers at the right urgency level:
+
+```js
+import { useContext } from 'react';
+import { AnnounceContext } from '../../contexts/AnnounceContext';
+
+const MyComponent = () => {
+  const announce = useContext(AnnounceContext);
+
+  const handleResultsLoaded = (count) => {
+    // Non-urgent: user is not waiting for this
+    announce(`${count} results loaded`, 'polite');
+  };
+
+  const handleCriticalError = () => {
+    // Urgent: requires immediate attention
+    announce('Session expired. Please log in again.', 'assertive');
+  };
+};
+```
+
+| Mode | When to use |
+|------|-------------|
+| `'polite'` | Non-urgent updates: results loaded, selection changed, item added. **Default choice.** |
+| `'assertive'` | Critical, time-sensitive announcements that interrupt the user. Use sparingly. |
+
+When in doubt, use `'polite'`.

--- a/.github/skills/grommet-component-contribution/references/styling.md
+++ b/.github/skills/grommet-component-contribution/references/styling.md
@@ -1,0 +1,99 @@
+# Styling & Theming Reference
+
+## Accessing the Theme
+
+```js
+// Inside the component:
+const { theme, passThemeFlag } = useThemeValue();
+
+// Spread passThemeFlag onto every styled component instance:
+<StyledMyComponent {...passThemeFlag} {...rest} />
+```
+
+Never use `useContext(ThemeContext)` directly — always use `useThemeValue()`.
+
+## Styled Component Pattern
+
+```js
+import styled, { css } from 'styled-components';
+import {
+  genericStyles,
+  styledComponentsConfig,
+  normalizeColor,
+} from '../../utils';
+import { disabledStyle, readOnlyStyle } from '../../utils';
+
+const StyledMyComponent = styled.div.withConfig(styledComponentsConfig)`
+  color: ${({ theme }) => normalizeColor(theme.myComponent.color, theme)};
+  padding: ${({ theme }) => theme.global.edgeSize[theme.myComponent.pad]};
+
+  ${({ disabled }) => disabled && css`${disabledStyle}`}
+  ${({ readOnly }) => readOnly && css`${readOnlyStyle}`}
+
+  ${genericStyles}
+`;
+```
+
+- `styledComponentsConfig` — import from `../../utils`; prevents non-DOM props from leaking to the DOM element
+- `genericStyles` — appended **last**; adds layout props (`margin`, `alignSelf`, `gridArea`) when the component uses `genericProps`
+- `normalizeColor(color, theme)` — resolves a Grommet color name or hex string to a CSS value
+- `css` template tag — use for conditional style blocks to maintain proper interpolation
+
+## Theme Token Namespace
+
+Add tokens under `theme.<componentName>` at the **top level** of `base.js` (alphabetical order):
+
+```js
+// src/js/themes/base.js — add in alphabetical position
+myComponent: {
+  color: 'text',
+  pad: 'small',
+  border: {
+    color: 'border',
+    size: 'xsmall',
+  },
+},
+```
+
+Mirror the shape in `base.d.ts` as a TypeScript interface.
+
+**Do not** nest under `theme.global.myComponent` — all component tokens live at the top level.
+
+**Do not** add hardcoded fallbacks (`theme.foo ?? '#000'`) — this silently hides missing tokens from users with custom themes. Only add a fallback when explicitly migrating from an older token shape.
+
+## Disabled & ReadOnly States
+
+```js
+import { disabledStyle, readOnlyStyle } from '../../utils';
+
+// In a styled component:
+${({ disabled }) => disabled && disabledStyle()}
+${({ readOnly }) => readOnly && readOnlyStyle()}
+```
+
+Never write custom CSS for disabled or readOnly — always use these helpers for consistency.
+
+## Global Focus Styling
+
+Global focus styles come from `theme.global.focus.focusStyle`. Do not write custom focus CSS in component-level styled components.
+
+## Sizing & Spacing
+
+- T-shirt sizes: `xsmall`, `small`, `medium`, `large`, `xlarge` — reference theme tokens, not hardcoded pixels
+- Use `pad` (not `padding`) and `margin` as prop names
+- Object syntax for complex spacing: `pad={{ horizontal: 'small', vertical: 'medium' }}`
+- Use `background` (not `backgroundColor`); use `color` for text/icon colors
+
+## Composing with Grommet Primitives
+
+Prefer Grommet's existing atoms over raw HTML:
+
+| Need | Use |
+|------|-----|
+| Layout / wrapping | `<Box>` |
+| Typography | `<Text>` |
+| Interactive control | `<Button>` |
+| Navigation | `<Anchor>` |
+| Iconography | `grommet-icons` package |
+
+Do not use raw `<svg>` elements or inline `style={{}}` attributes. Always allow icon override via theme token.

--- a/.github/skills/grommet-component-styling/REFERENCE.md
+++ b/.github/skills/grommet-component-styling/REFERENCE.md
@@ -1,0 +1,138 @@
+# Grommet Component Styling Reference
+
+## Accessing the Theme in a Component
+
+```js
+import { useThemeValue } from '../../utils/useThemeValue';
+
+const MyComponent = forwardRef(({ ...rest }, ref) => {
+  const { theme, passThemeFlag } = useThemeValue();
+
+  return (
+    <StyledMyComponent
+      ref={ref}
+      {...passThemeFlag}  // required — propagates theme to styled component
+      {...rest}
+    />
+  );
+});
+```
+
+## Styled Component Pattern
+
+```js
+import styled, { css } from 'styled-components';
+import {
+  genericStyles,
+  normalizeColor,
+  styledComponentsConfig,
+} from '../../utils';
+import { disabledStyle, readOnlyStyle } from '../../utils';
+
+const StyledMyComponent = styled.div.withConfig(styledComponentsConfig)`
+  box-sizing: border-box;
+
+  color: ${({ theme }) => normalizeColor(theme.myComponent.color, theme)};
+  background: ${({ theme }) =>
+    normalizeColor(theme.myComponent.background, theme)};
+
+  ${({ size, theme }) => {
+    const data = theme.myComponent.size?.[size] ?? theme.myComponent.size?.medium;
+    return data ? css`font-size: ${data.size}; line-height: ${data.height};` : '';
+  }}
+
+  ${({ disabled }) => disabled && disabledStyle()}
+  ${({ readOnly }) => readOnly && readOnlyStyle()}
+
+  &:hover {
+    ${({ theme }) => css`
+      color: ${normalizeColor(theme.myComponent.hover?.color, theme)};
+    `}
+  }
+
+  ${genericStyles}
+`;
+```
+
+Key points:
+- `styledComponentsConfig` — prevents non-DOM props (`colorProp`, `hasIcon`, custom booleans) from leaking to the DOM
+- `genericStyles` — **always last**; injects `margin`, `alignSelf`, `gridArea` when the component accepts layout props
+- `normalizeColor(value, theme)` — resolves Grommet color names (`'brand'`, `'text-weak'`) and hex values to CSS
+- `css` template tag — use for conditional style blocks to preserve styled-components' interpolation semantics
+
+## Theme Token Registration
+
+### base.js (alphabetical position)
+
+```js
+myComponent: {
+  background: 'background-front',
+  color: 'text',
+  pad: 'small',
+  border: {
+    color: 'border',
+    size: 'xsmall',
+    radius: '4px',
+  },
+  hover: {
+    color: 'text-strong',
+  },
+  size: {
+    small: { size: '14px', height: '20px' },
+    medium: { size: '18px', height: '24px' },
+    large: { size: '22px', height: '28px' },
+  },
+},
+```
+
+### base.d.ts (mirror the shape)
+
+```ts
+myComponent?: {
+  background?: BackgroundType;
+  color?: ColorType;
+  pad?: PadType;
+  border?: BorderType;
+  hover?: { color?: ColorType };
+  size?: {
+    [key: string]: { size?: string; height?: string };
+  };
+};
+```
+
+## Disabled & ReadOnly States
+
+Import and use the helpers — never write custom CSS for these:
+
+```js
+import { disabledStyle, readOnlyStyle } from '../../utils';
+
+// In a styled component:
+${({ disabled }) => disabled && disabledStyle()}
+${({ readOnly }) => readOnly && readOnlyStyle()}
+```
+
+## T-Shirt Sizing
+
+Reference theme tokens instead of hardcoded pixels:
+
+```js
+// Correct:
+padding: ${({ theme }) => theme.global.edgeSize[theme.myComponent.pad]};
+font-size: ${({ size, theme }) => theme.text[size ?? 'medium'].size};
+
+// Incorrect:
+padding: 8px;
+font-size: 14px;
+```
+
+## Composing with Grommet Primitives
+
+| Avoid | Prefer |
+|-------|--------|
+| `<div>` for layout | `<Box>` |
+| `<span>` for text | `<Text>` |
+| `<button>` for actions | `<Button>` |
+| `<a>` for navigation | `<Anchor>` |
+| Raw `<svg>` elements | `grommet-icons` |
+| `style={{}}` | Styled-component props |

--- a/.github/skills/grommet-component-styling/SKILL.md
+++ b/.github/skills/grommet-component-styling/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: grommet-component-styling
+description: "Style Grommet components using styled-components and the Grommet theme system. Use when creating or modifying StyledComponentName.js files, adding or updating theme tokens in base.js and base.d.ts, applying disabledStyle or readOnlyStyle helpers, choosing t-shirt sizing values, or composing UI with Grommet primitives. Covers useThemeValue, styledComponentsConfig, passThemeFlag, normalizeColor, genericStyles, and theme namespace conventions."
+argument-hint: "Describe the styling task (e.g. 'add theme tokens for a new RangeSlider component')"
+---
+
+# Grommet Component Styling Skill
+
+## When to Use
+- Creating or modifying a `StyledComponentName.js` file
+- Adding or extending theme tokens in `src/js/themes/base.js` and `base.d.ts`
+- Applying disabled or readOnly visual states to a component
+- Choosing sizing and spacing values
+- Composing UI using Grommet primitives (`Box`, `Text`, `Button`, etc.)
+- Troubleshooting why a theme value is not applying, or why a styled component is leaking props to the DOM
+
+## Workflow
+
+1. **Read the theme** — check `src/js/themes/base.js` for the component's existing namespace (`theme.<componentName>`) or the nearest related component's namespace.
+2. **Create the styled component** — use `styled.element.withConfig(styledComponentsConfig)`. Import `styledComponentsConfig`, `genericStyles`, `normalizeColor`, and any state helpers from `../../utils`.
+3. **Wire to the component** — call `useThemeValue()` in the React component and spread `{...passThemeFlag}` on every styled component instance so the theme propagates correctly.
+4. **Add theme tokens** — add the namespace to `base.js` in alphabetical order. Mirror the exact shape in `base.d.ts`.
+5. **Apply state styles** — use `disabledStyle()` for disabled states and `readOnlyStyle()` for readOnly states. Never write custom CSS for these.
+6. **Size with t-shirt values** — reference theme tokens (`xsmall`, `small`, `medium`, `large`, `xlarge`) rather than hardcoded pixel values.
+7. **Compose with primitives** — prefer Grommet atoms (`Box`, `Text`, `Button`) over raw HTML elements for layout and typography.
+
+## Key Rules
+- `const { theme, passThemeFlag } = useThemeValue()` — always; never `useContext(ThemeContext)` directly
+- Spread `{...passThemeFlag}` on every styled component instance
+- Theme namespace: `theme.<componentName>` at the **top level** of `base.js` (not `theme.global.myComponent`)
+- No inline `style={{}}` attributes or CSS class names
+- No hardcoded fallbacks: `theme.foo ?? '#000'` silently hides missing tokens from custom theme users
+- Use `background` not `backgroundColor`; use `color` for text and icon colors
+- Icons: `grommet-icons` package only; always allow icon override via theme token
+
+## See Also
+- [REFERENCE.md](./REFERENCE.md) — complete code examples for styledComponentsConfig, normalizeColor, genericStyles, disabledStyle, readOnlyStyle, and theme token registration

--- a/.github/skills/grommet-component-testing/REFERENCE.md
+++ b/.github/skills/grommet-component-testing/REFERENCE.md
@@ -1,0 +1,181 @@
+# Grommet Component Testing Reference
+
+## Test File Structure
+
+```tsx
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import 'jest-styled-components';
+import 'jest-axe/extend-expect';
+import 'regenerator-runtime/runtime';
+
+import { axe } from 'jest-axe';
+
+import { Grommet } from '../../Grommet';
+import { MyComponent } from '..';
+
+describe('MyComponent', () => {
+  // ALWAYS FIRST: axe accessibility check
+  test('should have no accessibility violations', async () => {
+    const { container } = render(
+      <Grommet>
+        <MyComponent aria-label="my component" />
+      </Grommet>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+    expect(container).toMatchSnapshot();
+  });
+
+  test('renders', () => {
+    const { container } = render(
+      <Grommet>
+        <MyComponent />
+      </Grommet>,
+    );
+    expect(container).toMatchSnapshot();
+  });
+});
+```
+
+## userEvent Pattern (preferred for interactions)
+
+```tsx
+test('calls onChange when value changes', async () => {
+  const user = userEvent.setup();
+  const onChange = jest.fn();
+
+  render(
+    <Grommet>
+      <MyComponent onChange={onChange} />
+    </Grommet>,
+  );
+
+  const input = screen.getByRole('textbox');
+  await user.type(input, 'hello');
+
+  expect(onChange).toHaveBeenCalledWith({ value: 'hello' });
+});
+```
+
+Use `fireEvent` only for synthetic or low-level events that `userEvent` cannot produce (e.g., custom DOM events, `dragover`).
+
+## Keyboard Navigation Test
+
+```tsx
+test('closes on Escape', async () => {
+  const user = userEvent.setup();
+
+  render(
+    <Grommet>
+      <MyComponent />
+    </Grommet>,
+  );
+
+  const trigger = screen.getByRole('button', { name: /open/i });
+  await user.click(trigger);
+
+  // Confirm open state
+  expect(screen.getByRole('listbox')).toBeInTheDocument();
+
+  await user.keyboard('{Escape}');
+
+  // Confirm closed
+  expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+});
+```
+
+## DOM Query Priority
+
+1. `screen.getByRole('button', { name: /label/i })` — reflects accessibility semantics
+2. `screen.getByLabelText('Email')` — for form inputs with associated labels
+3. `screen.getByText('Submit')` — last resort for text content
+
+Avoid `getByTestId` and `querySelector` in favour of queries that reflect what the user and assistive technology see.
+
+## Snapshot Usage
+
+Use `asFragment()` for snapshot assertions:
+
+```tsx
+test('renders with custom theme', () => {
+  const { asFragment } = render(
+    <Grommet theme={{ myComponent: { color: 'brand' } }}>
+      <MyComponent />
+    </Grommet>,
+  );
+  expect(asFragment()).toMatchSnapshot();
+});
+```
+
+## Storybook — CSF-3 Format
+
+```tsx
+// stories/Default.stories.tsx
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Grommet } from 'grommet';
+import { MyComponent } from 'grommet';
+
+const meta: Meta<typeof MyComponent> = {
+  title: 'Input/MyComponent/Default',
+  component: MyComponent,
+};
+
+export default meta;
+type Story = StoryObj<typeof MyComponent>;
+
+export const Simple: Story = {
+  render: () => (
+    <Grommet>
+      <MyComponent />
+    </Grommet>
+  ),
+};
+```
+
+One story per file. Title format: `'ComponentCategory/ComponentName/StoryName'`.
+
+## FormField Integration Story
+
+Include whenever the component participates in forms:
+
+```tsx
+// stories/FormField.stories.tsx
+export const WithFormField: Story = {
+  render: () => (
+    <Grommet>
+      <Form>
+        <FormField name="myField" label="My Field" required>
+          <MyComponent name="myField" />
+        </FormField>
+        <Button type="submit" label="Submit" />
+      </Form>
+    </Grommet>
+  ),
+};
+```
+
+## CustomThemed Story
+
+Add **only** when the component introduces new theme tokens:
+
+```tsx
+// stories/CustomThemed.stories.tsx
+const customTheme = {
+  myComponent: {
+    color: 'brand',
+    pad: 'medium',
+  },
+};
+
+export const CustomThemed: Story = {
+  render: () => (
+    <Grommet theme={customTheme}>
+      <MyComponent />
+    </Grommet>
+  ),
+};
+```

--- a/.github/skills/grommet-component-testing/SKILL.md
+++ b/.github/skills/grommet-component-testing/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: grommet-component-testing
+description: "Write tests and Storybook stories for Grommet components. Use when writing unit tests with @testing-library/react and jest-axe, setting up userEvent interactions, querying the DOM, or creating CSF-3 Storybook stories. Covers required axe accessibility checks as the first test, userEvent vs fireEvent guidance, query priority (getByRole first), Grommet wrapper requirement, snapshot usage, coverage targets, story file format, FormField integration stories, and CustomThemed stories."
+argument-hint: "Describe what needs testing or which stories to write (e.g. 'write tests for a RangeSlider component')"
+---
+
+# Grommet Component Testing Skill
+
+## When to Use
+- Writing a new `__tests__/ComponentName-test.tsx` file
+- Adding test cases to an existing test file
+- Creating Storybook story files in `stories/`
+- Reviewing tests against Grommet's coverage and accessibility requirements
+
+## Workflow
+
+### Tests
+1. **axe first** — the very first test in every file must be an axe accessibility check wrapped in `<Grommet>`.
+2. **Queries** — query via `screen.getByRole` → `getByLabelText` → `getByText`. Use `getByRole` whenever a semantic role is available.
+3. **Interactions** — use `userEvent.setup()` for all user interactions (click, type, keyboard). Use `fireEvent` only for low-level synthetic events that `userEvent` cannot produce.
+4. **Snapshots** — use `asFragment()` for snapshot assertions, not `container.innerHTML`.
+5. **Wrappers** — wrap renders in `<Grommet>` by default. Omit only when explicitly testing unwrapped/unstyled behavior.
+6. **Coverage** — target ≥85% for state logic, prop handling, and keyboard navigation.
+
+### Stories
+1. One story per file, CSF-3 format.
+2. Title: `'ComponentCategory/ComponentName/StoryName'`.
+3. Always include a basic controlled and/or uncontrolled usage story when the component has a value contract.
+4. Include a `Form` + `FormField` integration story when the component participates in forms.
+5. Add a `CustomThemed` story **only** when the component introduces new theme tokens.
+
+## Key Rules
+- File extension: `.tsx` for both test files and new story files
+- Test files live in `__tests__/`, story files live in `stories/`
+- `userEvent.setup()` not `fireEvent` for simulating user interactions
+- `screen.getByRole` as the first query choice — it reflects actual accessibility semantics
+- Every test file starts with an axe check
+- Wrap all renders in `<Grommet>` unless testing unwrapped behavior explicitly
+
+## See Also
+- [REFERENCE.md](./REFERENCE.md) — full code examples for test structure, axe setup, userEvent patterns, story CSF-3 format, and FormField integration


### PR DESCRIPTION

#### What does this PR do?

This PR adds some AI skills and context information to provide a `grommet-component` agent. This agent shows up in vscode as an agent choice:

<img width="333" height="184" alt="image" src="https://github.com/user-attachments/assets/07d87e02-0654-4c63-9910-63391725e1ca" />

It also provides some `/` commands to use in chat also:
<img width="505" height="282" alt="image" src="https://github.com/user-attachments/assets/a4aba241-5a7a-4b84-a846-47c121017001" />

Much of the initial skill content comes from [Srinivas' work on a skill](https://github.com/hpe-cds/OpsRampDSSkills/pull/2) for creating a grommet component.

## What was created

**skills** (new — this is the valid location VS Code scans):

| File | What it does |
|------|-------------|
| `grommet-component-contribution/SKILL.md` | Fixed frontmatter (removed `globs`/`alwaysApply`), updated Detailed Reference section linking all 7 sub-references |
| `grommet-component-contribution/REFERENCE.md` | Full implementation patterns & API design (preserved from your original) |
| `grommet-component-contribution/EXAMPLES.md` | Archetype code examples (preserved from your original) |
| `grommet-component-contribution/references/architecture.md` | `forwardRef`, `useForwardedRef`, controlled/uncontrolled, exports, context hooks |
| `grommet-component-contribution/references/styling.md` | `styledComponentsConfig`, `passThemeFlag`, `normalizeColor`, theme namespace, `disabledStyle`/`readOnlyStyle` |
| `grommet-component-contribution/references/accessibility.md` | `<Keyboard>`, focus restore, `aria-label`, Escape handling |
| `grommet-component-contribution/references/forms.md` | `FormContext.useFormInput`, `FormField` error surfacing, non-destructive UX |
| `grommet-component-contribution/references/i18n.md` | `MessageContext`, `AnnounceContext`, polite vs assertive |
| `grommet-component-styling/SKILL.md` + REFERENCE.md | Focused styling skill with code examples for `base.js`/`base.d.ts` registration, `styledComponentsConfig`, `normalizeColor` |
| `grommet-component-testing/SKILL.md` + REFERENCE.md | Focused testing skill with full test file structure, `userEvent` patterns, CSF-3 stories |

**grommet-component.agent.md** — "Grommet Component" in the agent picker; routes contributors to the right skill

**instructions** (auto-attach baseline):
- `grommet-component.instructions.md` → loads for all `src/js/components/**` files
- `grommet-tests.instructions.md` → loads for `__tests__/**` and `stories/**` files

**scaffold-component.prompt.md** → `/scaffold-component` slash command

---

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?
One simple example you can test is to create a RangeSlider component. With the `grommet-component` agent chosen, try the prompt: "Create a RangeSlider component"

It will create a decent range slider component that is themed from the theme via styled-components, has a basic storybook example and tests.

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
closes https://github.com/grommet/hpe-design-system/issues/6281
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
