### PR TITLE
Sync Tabs locale message definitions

### DIFF
--- a/src/js/components/Grommet/index.d.ts
+++ b/src/js/components/Grommet/index.d.ts
@@ -220,6 +220,8 @@ export interface GrommetProps {
         skipTo?: string;
       };
       tabs?: {
+        nextTab?: string;
+        previousTab?: string;
         tabContents?: string;
       };
       textInput?: {

--- a/src/js/components/Grommet/propTypes.js
+++ b/src/js/components/Grommet/propTypes.js
@@ -213,6 +213,8 @@ if (process.env.NODE_ENV !== 'production') {
           skipTo: PropTypes.string,
         }),
         tabs: PropTypes.shape({
+          nextTab: PropTypes.string,
+          previousTab: PropTypes.string,
           tabContents: PropTypes.string,
         }),
         tag: PropTypes.shape({


### PR DESCRIPTION
#### What does this PR do?

Fixes missing message key definitions for Tabs.

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

Quick fix for a recent Tabs enhancement.

#### What are the relevant issues?

https://github.com/grommet/grommet/pull/7967

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
