### PR TITLE
fix: `clearTimeout` to `clearInterval` for auto-play timer cleanup in Carousel

### DIFF
--- a/src/js/components/Carousel/Carousel.js
+++ b/src/js/components/Carousel/Carousel.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, {
   Children,
   useCallback,

--- a/src/js/components/Carousel/Carousel.js
+++ b/src/js/components/Carousel/Carousel.js
@@ -162,7 +162,7 @@ const Carousel = ({
       timerRef.current = timer;
 
       return () => {
-        clearTimeout(timer);
+        clearInterval(timer);
       };
     }
     return () => {};


### PR DESCRIPTION

### What does this PR do?                                                                                                                         
- Fixes incorrect use of `clearTimeout` instead of `clearInterval` for the auto-play timer cleanup in the Carousel component. - The auto-play timer is created with `setInterval`, so it must be cleared with `clearInterval`. 

### Where should the reviewer start?                                                                                                              
`src/js/components/Carousel/Carousel.js` — the `useEffect` hook that handles auto-playing slides.  
  
### What testing has been done on this PR?                                                                                                        
Verified that the auto-play interval is properly cleared on unmount and when dependencies change.

### How should this be manually tested?                                                                                                           
  1. Render a Carousel with the `play` prop set (e.g., `play={3000}`).
  2. Navigate away or unmount the component while auto-play is active.
  3. Confirm the interval stops and no console warnings about state updates on unmounted components appear.

### Do Jest tests follow these best practices?

- [x] `screen` is used for querying.
- [x] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority)) 
- [x] `asFragment()` is used for snapshot testing.

### Any background context you want to provide?                                                                                                   
- `clearTimeout` does not cancel timers created by `setInterval`. 
- This mismatch caused the interval to continue running after cleanup, leading to memory leaks and potential state updates on unmounted components.

### What are the relevant issues? 

### Screenshots (if appropriate)

### Do the grommet docs need to be updated?

### Should this PR be mentioned in the release notes?                                                                                             
Yes

### Is this change backwards compatible or is it a breaking change?