### PR TITLE
Add dark mode toggle to storybook but default it to light mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "regenerator-runtime": "^0.14.1",
     "simple-git": "^3.36.0",
     "storybook": "^10.4.2",
+    "storybook-dark-mode": "^5.0.0",
     "styled-components": "^6.4.2",
     "tarball-extract": "^0.0.6",
     "testcafe": "^3.7.4",

--- a/storybook/main.js
+++ b/storybook/main.js
@@ -3,6 +3,7 @@ const path = require('path');
 module.exports = {
   addons: [
     '@storybook/addon-a11y',
+    'storybook-dark-mode',
     {
       name: '@storybook/addon-docs',
       options: {

--- a/storybook/preview.js
+++ b/storybook/preview.js
@@ -8,6 +8,7 @@ import { StyleSheetManager } from 'styled-components';
 import { hpe as hpeTheme } from 'grommet-theme-hpe';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import isChromatic from 'chromatic/isChromatic';
+import { useDarkMode } from 'storybook-dark-mode';
 import { Grommet, grommet, hacktoberfest2022, Box, Text } from '../src/js';
 import sizeMapper from './sizeMapper';
 
@@ -37,6 +38,8 @@ const THEMES = {
 export const decorators = [
   (Story, context) => {
     const [rootRef, setRootRef] = useState(null);
+    const isDark = useDarkMode();
+    const themeMode = isDark ? 'dark' : 'light';
     const activeTheme = context.globals.theme || 'grommet';
     const root = context.globals.root || 'document';
     const full = context.allArgs?.full || 'min';
@@ -132,6 +135,7 @@ export const decorators = [
             <StyleSheetManager target={rootRef.shadowRoot}>
               <Grommet
                 theme={THEMES[activeTheme]}
+                themeMode={themeMode}
                 full={full}
                 dir={dir}
                 options={options}
@@ -148,6 +152,7 @@ export const decorators = [
     return (
       <Grommet
         theme={THEMES[activeTheme]}
+        themeMode={themeMode}
         full={full}
         dir={dir}
         options={options}
@@ -159,6 +164,9 @@ export const decorators = [
 ];
 
 export const parameters = {
+  darkMode: {
+    current: 'light',
+  },
   layout: 'fullscreen',
   tags: {
     exclude:

--- a/storybook/preview.js
+++ b/storybook/preview.js
@@ -8,6 +8,7 @@ import { StyleSheetManager } from 'styled-components';
 import { hpe as hpeTheme } from 'grommet-theme-hpe';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import isChromatic from 'chromatic/isChromatic';
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { useDarkMode } from 'storybook-dark-mode';
 import { Grommet, grommet, hacktoberfest2022, Box, Text } from '../src/js';
 import sizeMapper from './sizeMapper';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5567,6 +5567,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/icons@npm:^2.0.1":
+  version: 2.1.0
+  resolution: "@storybook/icons@npm:2.1.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10c0/73614dbb3e9c4756a6838525a6c78f85b24a5a09782512a39f24fe5a435992d6af92591ce18ac7a9a08c14aec10c08b158f68126aa29125058e01169c827bed6
+  languageName: node
+  linkType: hard
+
 "@storybook/icons@npm:^2.0.2":
   version: 2.0.2
   resolution: "@storybook/icons@npm:2.0.2"
@@ -11420,6 +11429,7 @@ __metadata:
     regenerator-runtime: "npm:^0.14.1"
     simple-git: "npm:^3.36.0"
     storybook: "npm:^10.4.2"
+    storybook-dark-mode: "npm:^5.0.0"
     styled-components: "npm:^6.4.2"
     tarball-extract: "npm:^0.0.6"
     testcafe: "npm:^3.7.4"
@@ -14283,6 +14293,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"map-or-similar@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "map-or-similar@npm:1.5.0"
+  checksum: 10c0/33c6ccfdc272992e33e4e99a69541a3e7faed9de3ac5bc732feb2500a9ee71d3f9d098980a70b7746e7eeb7f859ff7dfb8aa9b5ecc4e34170a32ab78cfb18def
+  languageName: node
+  linkType: hard
+
 "markdown-to-jsx@npm:7.4.4":
   version: 7.4.4
   resolution: "markdown-to-jsx@npm:7.4.4"
@@ -14340,6 +14357,15 @@ __metadata:
     tree-dump: "npm:^1.0.1"
     tslib: "npm:^2.0.0"
   checksum: 10c0/2901f69e80e1fbefa8aafe994a253fff6f34eb176d8b80d57476311611e516a11ab4dd93f852c8739fe04f2b57d6a4ca7a1828fa0bd401ce631bcac214b3d58b
+  languageName: node
+  linkType: hard
+
+"memoizerific@npm:^1.11.3":
+  version: 1.11.3
+  resolution: "memoizerific@npm:1.11.3"
+  dependencies:
+    map-or-similar: "npm:^1.5.0"
+  checksum: 10c0/661bf69b7afbfad57f0208f0c63324f4c96087b480708115b78ee3f0237d86c7f91347f6db31528740b2776c2e34c709bcb034e1e910edee2270c9603a0a469e
   languageName: node
   linkType: hard
 
@@ -17426,6 +17452,19 @@ __metadata:
     es-errors: "npm:^1.3.0"
     internal-slot: "npm:^1.1.0"
   checksum: 10c0/de4e45706bb4c0354a4b1122a2b8cc45a639e86206807ce0baf390ee9218d3ef181923fa4d2b67443367c491aa255c5fbaa64bb74648e3c5b48299928af86c09
+  languageName: node
+  linkType: hard
+
+"storybook-dark-mode@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "storybook-dark-mode@npm:5.0.0"
+  dependencies:
+    "@storybook/icons": "npm:^2.0.1"
+    fast-deep-equal: "npm:^3.1.3"
+    memoizerific: "npm:^1.11.3"
+  peerDependencies:
+    storybook: ^10.0.0
+  checksum: 10c0/a098909b63fc6b7d5729c726b9220b4c52538dc99758b7669724bb0c2425a8e07f31889129ec530e2aa730438e4d3be3725c4e660ed6535b6ed03e8e474823ec
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

#### What does this PR do?
This adds a light/dark mode button at the top of storybook (like we have in the aries-core storybook).
The default is set to light mode rather than it defaulting to browser preference. The reason is to avoid some sticker shock and hopefully avoid any issues with chromatic (not sure if it would affect that.)

#### Where should the reviewer start?
preview.js

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
