### PR TITLE
clean up timeinput theme

### DIFF
--- a/src/js/components/TimeInput/TimeInputPopup.js
+++ b/src/js/components/TimeInput/TimeInputPopup.js
@@ -75,9 +75,6 @@ const PopupOption = styled.div`
   &:focus-visible {
     ${focusStyle({ inset: true })}
   }
-
-  ${(props) =>
-    props.$selected && props.theme.timeInput?.drop?.option?.selected?.extend}
 `;
 
 const optionKey = (label, option) => `${label.toLowerCase()}-${option}`;

--- a/src/js/components/TimeInput/__tests__/TimeInput-test.tsx
+++ b/src/js/components/TimeInput/__tests__/TimeInput-test.tsx
@@ -14,6 +14,7 @@ import '@testing-library/jest-dom';
 
 import { AnnounceContext } from '../../../contexts/AnnounceContext';
 import { createPortal } from '../../../utils/portal';
+import { ThemeType } from '../../../themes';
 import { Form } from '../../Form';
 import { FormField } from '../../FormField';
 import { Grommet } from '../../Grommet';
@@ -1671,5 +1672,99 @@ describe('TimeInput', () => {
         );
       }
     }
+  });
+
+  test('applies timeInput theme tokens across container, active segment, and drop options', async () => {
+    const user = userEvent.setup();
+
+    const customTheme: ThemeType = {
+      timeInput: {
+        button: {
+          margin: { right: 'large' },
+        },
+        container: {
+          round: 'large',
+        },
+        active: {
+          background: '#FFD700',
+          pad: 'large',
+          indicator: {
+            color: '#FF0000',
+            size: 'large',
+          },
+        },
+        drop: {
+          option: {
+            background: '#EEEEEE',
+            hover: {
+              background: '#CCCCCC',
+            },
+            selected: {
+              background: '#0000FF',
+              color: '#FFFFFF',
+              hover: {
+                background: '#00FF00',
+              },
+            },
+          },
+        },
+      },
+    };
+
+    render(
+      <Grommet theme={customTheme}>
+        <TimeInput format="24" defaultValue="10:15:20" />
+      </Grommet>,
+    );
+
+    // container.round
+    const container = screen.getByRole('group').parentElement
+      ?.parentElement as HTMLElement;
+    expect(container).toHaveStyleRule('border-radius', '48px');
+
+    // button.margin
+    const trigger = screen.getByRole('button', { name: 'Choose time' });
+    expect(trigger).toHaveStyleRule('margin-right', '48px');
+
+    // active.pad applies to every segment, active or not
+    const hourSegment = getSegment('hours');
+    expect(hourSegment).toHaveStyleRule('padding-inline', '48px');
+
+    // active.background and active.indicator only render on the
+    // currently focused/active segment
+    await user.click(hourSegment);
+    expect(hourSegment).toHaveStyleRule('background-color', '#FFD700', {
+      modifier: '::before',
+    });
+    expect(hourSegment).toHaveStyleRule('background-color', '#FF0000', {
+      modifier: '::after',
+    });
+    expect(hourSegment).toHaveStyleRule('height', '12px', {
+      modifier: '::after',
+    });
+
+    // open the drop to check drop.option theme tokens
+    await user.keyboard('{Alt>}{ArrowDown}{/Alt}');
+
+    const hourList = screen.getByRole('listbox', { name: 'hour' });
+    const selectedOption = within(hourList).getByRole('option', {
+      name: '10 hours',
+    });
+    const unselectedOption = within(hourList).getByRole('option', {
+      name: '11 hours',
+    });
+
+    expect(unselectedOption).toHaveStyleRule('background', '#EEEEEE');
+    expect(selectedOption).toHaveStyleRule('background', '#0000FF');
+    expect(unselectedOption).toHaveStyleRule('background', '#CCCCCC', {
+      modifier: ':hover',
+    });
+    expect(selectedOption).toHaveStyleRule('background', '#00FF00', {
+      modifier: ':hover',
+    });
+    expect(within(selectedOption).getByText('10')).toHaveStyleRule(
+      'color',
+      '#FFFFFF',
+    );
   });
 });

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -1025,41 +1025,6 @@ export interface ThemeType {
       size?: string;
     };
   };
-  timeInput?: {
-    button?: {
-      margin?: string;
-    };
-    container?: {
-      round?: RoundType;
-    };
-    active?: {
-      background?: ColorType;
-      pad?: string;
-      indicator?: {
-        color?: ColorType;
-        size?: string;
-      };
-    };
-    drop?: {
-      option?: {
-        background?: ColorType;
-        hover?: {
-          background?: ColorType;
-        };
-        selected?: {
-          background?: ColorType;
-          color?: ColorType;
-          hover?: {
-            background?: ColorType;
-          };
-          extend?: ExtendType;
-        };
-      };
-    };
-    icon?: {
-      clock?: React.ReactNode | Icon;
-    };
-  };
   dataTable?: {
     body?: {
       extend?: ExtendType;
@@ -2376,6 +2341,45 @@ export interface ThemeType {
     };
     suggestions?: {
       extend?: ExtendType;
+    };
+  };
+  timeInput?: {
+    button?: {
+      margin?: MarginType;
+    };
+    container?: {
+      round?: RoundType;
+    };
+    active?: {
+      background?: ColorType;
+      pad?: string;
+      indicator?: {
+        color?: ColorType;
+        size?: string;
+      };
+    };
+    drop?: {
+      width?: string;
+      minHeight?: string;
+      column?: {
+        maxHeight?: string;
+      };
+      option?: {
+        background?: ColorType;
+        hover?: {
+          background?: ColorType;
+        };
+        selected?: {
+          background?: ColorType;
+          color?: ColorType;
+          hover?: {
+            background?: ColorType;
+          };
+        };
+      };
+    };
+    icon?: {
+      clock?: React.ReactNode | Icon;
     };
   };
   tip?: {

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -2360,6 +2360,7 @@ export interface ThemeType {
     };
     drop?: {
       option?: {
+        background?: ColorType;
         hover?: {
           background?: ColorType;
         };

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -2359,11 +2359,6 @@ export interface ThemeType {
       };
     };
     drop?: {
-      width?: string;
-      minHeight?: string;
-      column?: {
-        maxHeight?: string;
-      };
       option?: {
         background?: ColorType;
         hover?: {

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -2360,7 +2360,6 @@ export interface ThemeType {
     };
     drop?: {
       option?: {
-        background?: ColorType;
         hover?: {
           background?: ColorType;
         };

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1052,40 +1052,6 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         size: 'medium',
       },
     },
-    timeInput: {
-      button: {
-        margin: { right: 'small' },
-      },
-      container: {
-        round: 'xxsmall',
-      },
-      active: {
-        background: 'active-background',
-        pad: 'xxsmall',
-        indicator: {
-          color: { dark: 'white', light: 'black' },
-          size: 'small',
-        },
-      },
-      drop: {
-        option: {
-          hover: {
-            background: 'active-background',
-          },
-          selected: {
-            background: 'selected',
-            color: 'white',
-            hover: {
-              // background: undefined,
-            },
-            // extend: undefined,
-          },
-        },
-      },
-      icon: {
-        // clock: undefined,
-      },
-    },
     dataSearch: {
       // icons: {
       //   search: undefined,
@@ -2628,6 +2594,39 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       // icons: {
       //   copy: undefined,
       // },
+    },
+    timeInput: {
+      button: {
+        margin: { right: 'small' },
+      },
+      container: {
+        round: 'xxsmall',
+      },
+      active: {
+        background: 'active-background',
+        pad: 'xxsmall',
+        indicator: {
+          color: { dark: 'white', light: 'black' },
+          size: 'small',
+        },
+      },
+      drop: {
+        option: {
+          hover: {
+            background: 'active-background',
+          },
+          selected: {
+            background: 'selected',
+            color: 'white',
+            hover: {
+              // background: undefined,
+            },
+          },
+        },
+      },
+      icon: {
+        // clock: undefined,
+      },
     },
     tip: {
       content: {

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -2612,6 +2612,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       },
       drop: {
         option: {
+          // background: undefined,
           hover: {
             background: 'active-background',
           },


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Removes the `extend` override from `theme.timeInput.drop.option.selected` — this is no longer needed since we're referencing HPE theme tokens directly instead of manually inverting/re-computing colors. Also fixes a TypeScript error on `theme.timeInput.button.margin` (was typed as `string`, now correctly typed as `MarginType` to match how it's actually used with `{ right: 'small' }`), and moves the `timeInput` block to alphabetical order in both `base.js` and `base.d.ts`

Also added a new Jest theme test (`applies timeInput theme tokens across container, active segment, and drop options`) covering `button.margin`, `container.round`, `active.pad`/`active.background`/`active.indicator`, and `drop.option` background/hover/selected states modeled on the existing Calendar theme test pattern.
#### Where should the reviewer start?
base theme
#### What testing has been done on this PR?
locally and added a test 

we no longer need extend 
https://github.com/grommet/grommet-theme-hpe/pull/614
#### How should this be manually tested?
can make a story with the values in theme
#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
`theme.timeInput.drop.option.selected.extend` was originally added to allow inverting `text-onSelectedPrimaryStrong`-style colors for HPE theming, but we are now using the tokens directly. 

 Also fixes a TypeScript error on `theme.timeInput.button.margin`
#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
yes
#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
backwards compatible since its still in beta