### PR TITLE
Add TimeInput component metadata to Storybook stories

### DIFF
--- a/src/js/components/TimeInput/stories/Controlled.stories.tsx
+++ b/src/js/components/TimeInput/stories/Controlled.stories.tsx
@@ -26,4 +26,5 @@ export const Controlled = () => {
 
 export default {
   title: 'Input/TimeInput/Controlled',
+  component: TimeInput,
 };

--- a/src/js/components/TimeInput/stories/Disabled.stories.tsx
+++ b/src/js/components/TimeInput/stories/Disabled.stories.tsx
@@ -10,4 +10,5 @@ export const Disabled = () => (
 
 export default {
   title: 'Input/TimeInput/Disabled',
+  component: TimeInput,
 };

--- a/src/js/components/TimeInput/stories/Form.stories.tsx
+++ b/src/js/components/TimeInput/stories/Form.stories.tsx
@@ -35,4 +35,5 @@ TimeForm.storyName = 'Form';
 
 export default {
   title: 'Input/TimeInput',
+  component: TimeInput,
 };

--- a/src/js/components/TimeInput/stories/ReadOnly.stories.tsx
+++ b/src/js/components/TimeInput/stories/ReadOnly.stories.tsx
@@ -10,4 +10,5 @@ export const ReadOnly = () => (
 
 export default {
   title: 'Input/TimeInput/ReadOnly',
+  component: TimeInput,
 };

--- a/src/js/components/TimeInput/stories/Simple.stories.tsx
+++ b/src/js/components/TimeInput/stories/Simple.stories.tsx
@@ -16,4 +16,5 @@ export const Simple = () => {
 
 export default {
   title: 'Input/TimeInput/Simple',
+  component: TimeInput,
 };

--- a/src/js/components/TimeInput/stories/Step.stories.tsx
+++ b/src/js/components/TimeInput/stories/Step.stories.tsx
@@ -11,4 +11,5 @@ export const Step = () => (
 
 export default {
   title: 'Input/TimeInput/Step',
+  component: TimeInput,
 };

--- a/src/js/components/TimeInput/stories/ThemingLightDark.stories.tsx
+++ b/src/js/components/TimeInput/stories/ThemingLightDark.stories.tsx
@@ -19,4 +19,5 @@ export const ThemingLightDark = () => (
 
 export default {
   title: 'Input/TimeInput/Theming Light Dark',
+  component: TimeInput,
 };

--- a/src/js/components/TimeInput/stories/Uncontrolled.stories.tsx
+++ b/src/js/components/TimeInput/stories/Uncontrolled.stories.tsx
@@ -19,4 +19,5 @@ export const Uncontrolled = () => {
 
 export default {
   title: 'Input/TimeInput/Uncontrolled',
+  component: TimeInput,
 };


### PR DESCRIPTION
## Summary
- add `component: TimeInput` to all `TimeInput` story meta exports
- restore Storybook Controls API visibility for `TimeInput` stories

## Why
During DateTimeInput review we found `TimeInput` Controls were incomplete because story metadata had `title` only and no `component` binding.

## Scope
This PR is intentionally limited to Storybook story metadata for TimeInput and does not change runtime component behavior.
