### PR TITLE
Add Stepper and TimeInput messages to Grommet

### DIFF
--- a/src/js/components/Grommet/index.d.ts
+++ b/src/js/components/Grommet/index.d.ts
@@ -220,10 +220,28 @@ export interface GrommetProps {
       skipLinks?: {
         skipTo?: string;
       };
+      stepper?: {
+        progress?: string;
+        step?: string;
+      };
       tabs?: {
         nextTab?: string;
         previousTab?: string;
         tabContents?: string;
+      };
+      timeInput?: {
+        activePeriodValue?: string;
+        activeSection?: string;
+        activeSectionValue?: string;
+        chooseTime?: string;
+        currentValue?: string;
+        inputLabel?: string;
+        invalidTime?: string;
+        openDrop?: string;
+        sectionHours?: string;
+        sectionMeridiem?: string;
+        sectionMinutes?: string;
+        sectionSeconds?: string;
       };
       textInput?: {
         enterSelect?: string;

--- a/src/js/components/Grommet/propTypes.js
+++ b/src/js/components/Grommet/propTypes.js
@@ -214,6 +214,10 @@ if (process.env.NODE_ENV !== 'production') {
         skipLinks: PropTypes.shape({
           skipTo: PropTypes.string,
         }),
+        stepper: PropTypes.shape({
+          progress: PropTypes.string,
+          step: PropTypes.string,
+        }),
         tabs: PropTypes.shape({
           nextTab: PropTypes.string,
           previousTab: PropTypes.string,
@@ -230,6 +234,20 @@ if (process.env.NODE_ENV !== 'production') {
           suggestionsCount: PropTypes.string,
           suggestionsExist: PropTypes.string,
           suggestionIsOpen: PropTypes.string,
+        }),
+        timeInput: PropTypes.shape({
+          activePeriodValue: PropTypes.string,
+          activeSection: PropTypes.string,
+          activeSectionValue: PropTypes.string,
+          chooseTime: PropTypes.string,
+          currentValue: PropTypes.string,
+          inputLabel: PropTypes.string,
+          invalidTime: PropTypes.string,
+          openDrop: PropTypes.string,
+          sectionHours: PropTypes.string,
+          sectionMeridiem: PropTypes.string,
+          sectionMinutes: PropTypes.string,
+          sectionSeconds: PropTypes.string,
         }),
         video: PropTypes.shape({
           audioDescriptions: PropTypes.string,


### PR DESCRIPTION
#### What does this PR do?
Adds messages for Stepper and TimeInput to Grommet proptypes and index.d.ts

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
yes
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
backwards compatible