### PR TITLE
fix(Cards): use logical OR instead of nullish coalescing in default item renderer

### DIFF
--- a/src/js/components/Cards/Cards.js
+++ b/src/js/components/Cards/Cards.js
@@ -205,8 +205,8 @@ const Cards = React.forwardRef(
             as={!(onOrder || sizeKey) && as === 'ul' ? 'li' : undefined}
           >
             <CardBody>
-              {(typeof item === 'string' && item) ??
-                (typeof item === 'object' && Object.values(item)[0]) ??
+              {(typeof item === 'string' && item) ||
+                (typeof item === 'object' && Object.values(item)[0]) ||
                 index}
             </CardBody>
           </Card>

--- a/src/js/components/Cards/__tests__/__snapshots__/Cards-test.tsx.snap
+++ b/src/js/components/Cards/__tests__/__snapshots__/Cards-test.tsx.snap
@@ -202,14 +202,18 @@ exports[`Cards data objects 1`] = `
     >
       <div
         class="c3"
-      />
+      >
+        one
+      </div>
     </li>
     <li
       class="c2"
     >
       <div
         class="c3"
-      />
+      >
+        two
+      </div>
     </li>
   </ul>
 </div>
@@ -963,14 +967,18 @@ exports[`Cards renders a11yTitle and aria-label 1`] = `
       >
         <div
           class="c3"
-        />
+        >
+          alpha
+        </div>
       </li>
       <li
         class="c2"
       >
         <div
           class="c3"
-        />
+        >
+          beta
+        </div>
       </li>
     </ul>
     <ul
@@ -982,14 +990,18 @@ exports[`Cards renders a11yTitle and aria-label 1`] = `
       >
         <div
           class="c3"
-        />
+        >
+          alpha
+        </div>
       </li>
       <li
         class="c2"
       >
         <div
           class="c3"
-        />
+        >
+          beta
+        </div>
       </li>
     </ul>
   </div>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Fixes a silent rendering bug in `Cards`. 
The default item renderer (used when no `children` render-prop is supplied) chained fallbacks with `??`:

```js
{(typeof item === 'string' && item) ??
  (typeof item === 'object' && Object.values(item)[0]) ??
  index}
```

`??` (nullish coalescing) only falls through when the left operand is `null`/`undefined`. 
For non-string items, `typeof item === 'string' && item` evaluates to the boolean `false` — which is not nullish — so `??` never falls through to the object-handling branch. `Object.values(item)[0]` was unreachable dead code.

Rendering `<Cards data={[{ name: 'Alice' }, { name: 'Bob' }]} />` without a `children` render prop shows nothing: each `CardBody` renders `false` (i.e. no content), and since there's nothing to give the card a height, the whole card collapses to zero size and disappears from the page — with no console error.

So, this PR replaces the `??` chain with `||`, restoring the intended cascading fallback.

#### Where should the reviewer start?

`src/js/components/Cards/Cards.js` (the default item renderer, ~line 208), and the updated snapshots in `src/js/components/Cards/__tests__/__snapshots__/Cards-test.tsx.snap`.

#### What testing has been done on this PR?

 - The existing data objects and renders a11yTitle and aria-label tests already exercised this exact code path (object-array data with no childrenprop), but their snapshots had the bug's empty output baked in as the "expected" result. 
Updated both snapshots to reflect the correct rendered values (e.g. one, two, alpha, beta). 
- Ran the full Cards test suite — all 15 tests passing.
- Manually reproduced in Storybook with a temporary story rendering `<Cards data={[{ name: 'Alice' }, { name: 'Bob' }, { name: 'Carol' }]} />` — confirmed the cards were entirely invisible (zero height, no error) before the fix, and rendered the three names correctly after. (Temporary story was not included in this PR.)

#### How should this be manually tested?

Render <Cards data={[{ name: 'Alice' }, { name: 'Bob' }]} /> with no children prop. Before this fix, nothing appears on screen. After this fix, two cards render showing Alice and Bob.

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [x] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [x] `asFragment()` is used for snapshot testing.

**Note**: no new test was added — the existing data objects / renders a11yTitle and aria-label tests already covered this scenario via container.firstChild + toMatchSnapshot() (the pattern already used throughout this file), so only their snapshots needed updating.

#### Any background context you want to provide?

Found during a broader audit of src/js/components for latent bugs.

#### What are the relevant issues?

N/A

#### Screenshots (if appropriate)

**Before fixed**
<img width="1411" height="601" alt="スクリーンショット 2026-07-30 22 16 15" src="https://github.com/user-attachments/assets/61cc4a66-bc74-4ade-8571-e2d2fcfa796e" />


**After fixed**

<img width="1409" height="612" alt="スクリーンショット 2026-07-30 22 45 44" src="https://github.com/user-attachments/assets/24cc8928-4217-467b-bd4d-14f1e4ef4721" />


#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

Yes.
This is a silent-failure fix for a plausible real-world usage (rendering Cards with plain object data and no custom children renderer), worth calling out.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.
This only fixes broken fallback logic to match the originally-intended behavior; no working usage relied on the ?? short-circuit.
