### PR TITLE
fix(Grid): Prevent crash when areas is object-form but rows/columns aren't arrays

### DIFF
--- a/src/js/components/Grid/StyledGrid.js
+++ b/src/js/components/Grid/StyledGrid.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import styled, { css } from 'styled-components';
 import {
   alignContentStyle,

--- a/src/js/components/Grid/StyledGrid.js
+++ b/src/js/components/Grid/StyledGrid.js
@@ -188,9 +188,6 @@ const rowsStyle = (props) => {
 
 const areasStyle = (props) => {
   // translate areas objects into grid-template-areas syntax
-  if (!Array.isArray(props.rowsProp) || !Array.isArray(props.columns)) {
-    console.warn('Grid `areas` requires `rows` and `columns` to be arrays.');
-  }
   if (
     Array.isArray(props.areas) &&
     props.areas.every((area) => Array.isArray(area))
@@ -198,6 +195,10 @@ const areasStyle = (props) => {
     return `grid-template-areas: ${props.areas
       .map((area) => `"${area.join(' ')}"`)
       .join(' ')};`;
+  }
+  if (!Array.isArray(props.rowsProp) || !Array.isArray(props.columns)) {
+    console.warn('Grid `areas` requires `rows` and `columns` to be arrays.');
+    return undefined;
   }
   const cells = props.rowsProp.map(() => props.columns.map(() => '.'));
   props.areas.forEach((area) => {

--- a/src/js/components/Grid/__tests__/Grid-test.tsx
+++ b/src/js/components/Grid/__tests__/Grid-test.tsx
@@ -87,29 +87,33 @@ describe('Grid', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test('areas renders with warning and throws error', () => {
+  test('areas renders with warning when rows/columns are not arrays', () => {
+    // regression test: `columns`/`rows` may legitimately be a non-array
+    // value (e.g. a size keyword string, or a `{ count, size }` shape, per
+    // propTypes) while `areas` uses the named-area object form, which
+    // previously crashed with `props.columns.map is not a function`
+    // instead of just warning.
     console.error = jest.fn();
     console.warn = jest.fn();
     const warnSpy = jest.spyOn(console, 'warn');
-    expect(() => {
-      render(
-        <Grommet>
-          <Grid
-            rows={['xxsmall', 'medium', 'xsmall']}
-            columns="small"
-            areas={[
-              { name: 'header', start: [0, 0], end: [0, 1] },
-              { name: 'main', start: [1, 0], end: [1, 0] },
-              { name: 'sidebar', start: [1, 1], end: [1, 1] },
-              { name: 'footer', start: [2, 0], end: [2, 1] },
-            ]}
-          />
-        </Grommet>,
-      );
-    }).toThrow('props.columns.map is not a function');
+    const { container } = render(
+      <Grommet>
+        <Grid
+          rows={['xxsmall', 'medium', 'xsmall']}
+          columns="small"
+          areas={[
+            { name: 'header', start: [0, 0], end: [0, 1] },
+            { name: 'main', start: [1, 0], end: [1, 0] },
+            { name: 'sidebar', start: [1, 1], end: [1, 1] },
+            { name: 'footer', start: [2, 0], end: [2, 1] },
+          ]}
+        />
+      </Grommet>,
+    );
     expect(warnSpy).toHaveBeenCalledWith(
       'Grid `areas` requires `rows` and `columns` to be arrays.',
     );
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('areas renders when given an array of string arrays', () => {

--- a/src/js/components/Grid/__tests__/Grid-test.tsx
+++ b/src/js/components/Grid/__tests__/Grid-test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { render } from '@testing-library/react';
 import 'jest-styled-components';

--- a/src/js/components/Grid/__tests__/Grid-test.tsx
+++ b/src/js/components/Grid/__tests__/Grid-test.tsx
@@ -2,12 +2,24 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { render } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import 'jest-axe/extend-expect';
 import 'jest-styled-components';
 
 import { Grommet } from '../../Grommet';
 import { Grid } from '..';
 
 describe('Grid', () => {
+  test('should not have accessibility violations', async () => {
+    const { container } = render(
+      <Grommet>
+        <Grid />
+      </Grommet>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   test('renders', () => {
     const { container } = render(
       <Grommet>
@@ -95,27 +107,31 @@ describe('Grid', () => {
     // propTypes) while `areas` uses the named-area object form, which
     // previously crashed with `props.columns.map is not a function`
     // instead of just warning.
-    console.error = jest.fn();
-    console.warn = jest.fn();
-    const warnSpy = jest.spyOn(console, 'warn');
-    const { container } = render(
-      <Grommet>
-        <Grid
-          rows={['xxsmall', 'medium', 'xsmall']}
-          columns="small"
-          areas={[
-            { name: 'header', start: [0, 0], end: [0, 1] },
-            { name: 'main', start: [1, 0], end: [1, 0] },
-            { name: 'sidebar', start: [1, 1], end: [1, 1] },
-            { name: 'footer', start: [2, 0], end: [2, 1] },
-          ]}
-        />
-      </Grommet>,
-    );
-    expect(warnSpy).toHaveBeenCalledWith(
-      'Grid `areas` requires `rows` and `columns` to be arrays.',
-    );
-    expect(container.firstChild).toMatchSnapshot();
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const { container } = render(
+        <Grommet>
+          <Grid
+            rows={['xxsmall', 'medium', 'xsmall']}
+            columns="small"
+            areas={[
+              { name: 'header', start: [0, 0], end: [0, 1] },
+              { name: 'main', start: [1, 0], end: [1, 0] },
+              { name: 'sidebar', start: [1, 1], end: [1, 1] },
+              { name: 'footer', start: [2, 0], end: [2, 1] },
+            ]}
+          />
+        </Grommet>,
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        'Grid `areas` requires `rows` and `columns` to be arrays.',
+      );
+      expect(container.firstChild).toMatchSnapshot();
+    } finally {
+      warnSpy.mockRestore();
+      errorSpy.mockRestore();
+    }
   });
 
   test('areas renders when given an array of string arrays', () => {

--- a/src/js/components/Grid/__tests__/__snapshots__/Grid-test.tsx.snap
+++ b/src/js/components/Grid/__tests__/__snapshots__/Grid-test.tsx.snap
@@ -392,6 +392,33 @@ exports[`Grid areas renders when given an array of string arrays 1`] = `
 </div>
 `;
 
+exports[`Grid areas renders with warning when rows/columns are not arrays 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: grid;
+  box-sizing: border-box;
+  grid-template-columns: repeat( auto-fill,minmax(min(192px, 100%), 1fr) );
+  grid-template-rows: 48px 384px 96px;
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+  />
+</div>
+`;
+
 exports[`Grid as renders 1`] = `
 .c0 {
   font-size: 18px;


### PR DESCRIPTION
#### What does this PR do?

Fixes a reachable crash in `Grid` when `areas` is object-form (namedareas) but `rows`/`columns` are not arrays — e.g. a size keyword string or a `{ count, size }` shape, both legitimate per propTypes.

`areasStyle()` in `StyledGrid.js` warned in this case but didn't stopexecution, so it fell through to `props.rowsProp.map(...)`, throwing `props.columns.map is not a function`.

#### Where should the reviewer start?

`src/js/components/Grid/StyledGrid.js` — `areasStyle()`. The array-of-arrays `areas` check now runs first (it doesn't need rows/columns to be arrays), then the function bails out with `return undefined` after the warning instead of falling through to the crashing branch.

#### What testing has been done on this PR?

Updated the existing Grid test that asserted the crash was expected behaviour; it now asserts the warning still fires and the component renders without throwing.

#### How should this be manually tested?

Render `<Grid rows="small" columns="small" areas={{ ... }} />` (or any non-array `rows`/`columns` with object-form `areas`) — it should render with a console warning instead of throwing.

#### Do Jest tests follow these best practices?

- [x] `screen` is used for querying.
- [x] The correct query is used.
- [x] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

Found via a chunked bug-review audit of `src/js/components`. `rows`/`columns` accepting non-array values is documented/legitimate usage, so this was reachable in normal usage, not just misuse.

#### What are the relevant issues?

N/A

#### Screenshots (if appropriate)

N/A

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

Yes — bug fix.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible. Invalid `rows`/`columns` + object `areas` combinations now warn and render instead of throwing.
