### PR TITLE
exclude direction props from DOM

### DIFF
--- a/src/js/components/Stepper/StyledStepper.js
+++ b/src/js/components/Stepper/StyledStepper.js
@@ -1,4 +1,7 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import styled, { css } from 'styled-components';
+import isPropValid from '@emotion/is-prop-valid';
 import {
   focusStyle,
   normalizeColor,
@@ -28,7 +31,10 @@ const getConnectorColor = (stepStatus, theme) =>
     theme,
   );
 
-const StyledStepItem = styled.li.withConfig(styledComponentsConfig)`
+const StyledStepItem = styled.li.withConfig({
+  shouldForwardProp: (prop) =>
+    isPropValid(prop) && prop !== 'direction',
+})`
   display: flex;
   position: relative;
   ${(props) => {
@@ -83,7 +89,9 @@ const StyledStepButton = styled.button.withConfig(styledComponentsConfig)`
         `}
 `;
 
-const StyledStepContent = styled.span.withConfig(styledComponentsConfig)`
+const StyledStepContent = styled.span.withConfig({
+  shouldForwardProp: (prop) => isPropValid(prop) && prop !== 'direction',
+})`
   display: flex;
   flex-direction: column;
   ${(props) => {

--- a/src/js/components/Stepper/__tests__/__snapshots__/Stepper-test.js.snap
+++ b/src/js/components/Stepper/__tests__/__snapshots__/Stepper-test.js.snap
@@ -229,7 +229,6 @@ exports[`Stepper renders horizontal steps 1`] = `
   >
     <li
       class="c2"
-      direction="horizontal"
     >
       <button
         aria-current="step"
@@ -259,7 +258,6 @@ exports[`Stepper renders horizontal steps 1`] = `
         </span>
         <span
           class="c7"
-          direction="horizontal"
         >
           <span
             class="c8"
@@ -282,7 +280,6 @@ exports[`Stepper renders horizontal steps 1`] = `
     </li>
     <li
       class="c2"
-      direction="horizontal"
     >
       <button
         aria-label="Step 2 of 3: Step 2"
@@ -296,7 +293,6 @@ exports[`Stepper renders horizontal steps 1`] = `
         />
         <span
           class="c7"
-          direction="horizontal"
         >
           <span
             class="c11"
@@ -319,7 +315,6 @@ exports[`Stepper renders horizontal steps 1`] = `
     </li>
     <li
       class="c2"
-      direction="horizontal"
     >
       <button
         aria-label="Step 3 of 3: Step 3"
@@ -333,7 +328,6 @@ exports[`Stepper renders horizontal steps 1`] = `
         />
         <span
           class="c7"
-          direction="horizontal"
         >
           <span
             class="c11"
@@ -563,7 +557,6 @@ exports[`Stepper renders outside Grommet wrapper 1`] = `
 >
   <li
     class="c1"
-    direction="horizontal"
   >
     <button
       aria-current="step"
@@ -593,7 +586,6 @@ exports[`Stepper renders outside Grommet wrapper 1`] = `
       </span>
       <span
         class="c6"
-        direction="horizontal"
       >
         <span
           class="c7"
@@ -616,7 +608,6 @@ exports[`Stepper renders outside Grommet wrapper 1`] = `
   </li>
   <li
     class="c1"
-    direction="horizontal"
   >
     <button
       aria-label="Step 2 of 3: Step 2"
@@ -630,7 +621,6 @@ exports[`Stepper renders outside Grommet wrapper 1`] = `
       />
       <span
         class="c6"
-        direction="horizontal"
       >
         <span
           class="c10"
@@ -653,7 +643,6 @@ exports[`Stepper renders outside Grommet wrapper 1`] = `
   </li>
   <li
     class="c1"
-    direction="horizontal"
   >
     <button
       aria-label="Step 3 of 3: Step 3"
@@ -667,7 +656,6 @@ exports[`Stepper renders outside Grommet wrapper 1`] = `
       />
       <span
         class="c6"
-        direction="horizontal"
       >
         <span
           class="c10"
@@ -909,7 +897,6 @@ exports[`Stepper renders vertical steps 1`] = `
   >
     <li
       class="c2"
-      direction="vertical"
     >
       <button
         aria-label="Step 1 of 3: Step 1"
@@ -923,7 +910,6 @@ exports[`Stepper renders vertical steps 1`] = `
         />
         <span
           class="c6"
-          direction="vertical"
         >
           <span
             class="c7"
@@ -951,7 +937,6 @@ exports[`Stepper renders vertical steps 1`] = `
     </li>
     <li
       class="c2"
-      direction="vertical"
     >
       <button
         aria-current="step"
@@ -981,7 +966,6 @@ exports[`Stepper renders vertical steps 1`] = `
         </span>
         <span
           class="c6"
-          direction="vertical"
         >
           <span
             class="c12"
@@ -1009,7 +993,6 @@ exports[`Stepper renders vertical steps 1`] = `
     </li>
     <li
       class="c2"
-      direction="vertical"
     >
       <button
         aria-label="Step 3 of 3: Step 3"
@@ -1023,7 +1006,6 @@ exports[`Stepper renders vertical steps 1`] = `
         />
         <span
           class="c6"
-          direction="vertical"
         >
           <span
             class="c7"


### PR DESCRIPTION

#### What does this PR do?
A couple of Stepper styled components are leaking the `direction` prop into the DOM elements as attributes.

This PR excludes those internal props from becoming attributes on the DOM elements.

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
Fixes #8015 

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
No

#### Should this PR be mentioned in the release notes?
No

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible