### PR TITLE
fix: use clearInterval instead of clearTimeout for setInterval timer in Carousel

### DIFF
--- a/src/js/components/Carousel/Carousel.js
+++ b/src/js/components/Carousel/Carousel.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, {
   Children,
   useCallback,
@@ -162,7 +164,7 @@ const Carousel = ({
       timerRef.current = timer;
 
       return () => {
-        clearTimeout(timer);
+        clearInterval(timer);
       };
     }
     return () => {};


### PR DESCRIPTION
#### What does this PR do?

Fixes the auto-play timer cleanup in `Carousel`. The autoplay effect stores the id returned by `setInterval` in `timer`, but its cleanup called `clearTimeout(timer)` instead of `clearInterval(timer)`.
Mixing the two timer APIs happens to work in some environments but isn't guaranteed, so the interval could keep firing after the effect cleanup ran (e.g. on prop changes or unmount), continuing to auto-advance the Carousel unexpectedly.

#### Where should the reviewer start?

`src/js/components/Carousel/Carousel.js` — the auto-play `useEffect` cleanup function.

#### What testing has been done on this PR?

Manual review of the timer lifecycle. No behavioral test added since this is a one-line API correction with no observable difference in the environments where `clearTimeout`/`clearInterval` happen to be interchangeable.

#### How should this be manually tested?

Render a `Carousel` with `play` set, then change props that re-trigger the effect (e.g. `wrap`) or unmount the component while autoplay is active — the interval should stop cleanly instead of potentially continuing to fire.

#### Do Jest tests follow these best practices?

N/A

#### Any background context you want to provide?

Found via a chunked bug-review audit of `src/js/components`.

#### What are the relevant issues?

N/A

#### Screenshots (if appropriate)

N/A
#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

Yes — bug fix.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.
