### PR TITLE
Stepper - fix html structure and styling cleanups

### DIFF
--- a/src/js/components/Stepper/StepConnector.js
+++ b/src/js/components/Stepper/StepConnector.js
@@ -1,79 +1,37 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
-
+import styled, { css } from 'styled-components';
+import isPropValid from '@emotion/is-prop-valid';
 import { useThemeValue } from '../../utils/useThemeValue';
 import { StyledConnector } from './StyledStepper';
 
+const StyledStepConnectorGroup = styled.div.withConfig({
+  shouldForwardProp: (prop) => isPropValid(prop) && prop !== 'direction',
+})`
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  flex: 1;
+  overflow: visible;
+  ${(props) => {
+    if (props.direction === 'horizontal') {
+      return css`
+        align-items: center;
+      `;
+    }
+
+    return css`
+      justify-content: flex-start;
+    `;
+  }}
+`;
+
 export const StepConnector = ({ step, direction, children }) => {
-  const { theme, passThemeFlag } = useThemeValue();
-
-  const indicatorSize =
-    theme.stepper?.indicator?.size &&
-    theme.global?.edgeSize?.[theme.stepper.indicator.size]
-      ? theme.global.edgeSize[theme.stepper.indicator.size]
-      : theme.global?.edgeSize?.medium || '24px';
-  const childGap = theme.global?.edgeSize?.xsmall || '8px';
-  const childPadTop = theme.global?.edgeSize?.medium || '24px';
-  const minConnectorInlineSize = theme.global?.edgeSize?.small || '12px';
-
-  const directionStyle =
-    direction === 'horizontal'
-      ? {
-          alignItems: 'center',
-          minWidth: minConnectorInlineSize,
-        }
-      : {
-          justifyContent: 'flex-start',
-          minHeight: minConnectorInlineSize,
-        };
-
-  const renderChildren = () => {
-    if (!children) return null;
-
-    const childIndent = `calc(${indicatorSize} + ${
-      theme.global?.edgeSize?.small || '12px'
-    })`;
-
-    return direction === 'horizontal' ? (
-      <span
-        style={{
-          display: 'flex',
-          flexDirection: 'row',
-          alignItems: 'center',
-          gap: childGap,
-          paddingTop: childPadTop,
-          maxWidth: '100%',
-          flexWrap: 'wrap',
-          justifyContent: 'center',
-        }}
-      >
-        {children}
-      </span>
-    ) : (
-      <ol
-        style={{
-          listStyle: 'none',
-          padding: `0 0 0 ${childIndent}`,
-          margin: 0,
-        }}
-      >
-        {children}
-      </ol>
-    );
-  };
+  const { passThemeFlag } = useThemeValue();
 
   return (
-    <li
-      role="presentation"
-      aria-hidden={children ? undefined : 'true'}
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        position: 'relative',
-        flex: 1,
-        overflow: 'visible',
-        ...directionStyle,
-      }}
-    >
+    <StyledStepConnectorGroup direction={direction} {...passThemeFlag}>
       <StyledConnector
         direction={direction}
         status={step.status}
@@ -81,7 +39,7 @@ export const StepConnector = ({ step, direction, children }) => {
         isBetween
         {...passThemeFlag}
       />
-      {renderChildren()}
-    </li>
+      {children}
+    </StyledStepConnectorGroup>
   );
 };

--- a/src/js/components/Stepper/StepConnector.js
+++ b/src/js/components/Stepper/StepConnector.js
@@ -14,17 +14,11 @@ const StyledStepConnectorGroup = styled.div.withConfig({
   position: relative;
   flex: 1;
   overflow: visible;
-  ${(props) => {
-    if (props.direction === 'horizontal') {
-      return css`
-        align-items: center;
-      `;
-    }
-
-    return css`
-      justify-content: flex-start;
-    `;
-  }}
+  ${(props) =>
+    props.direction === 'horizontal' &&
+    css`
+      align-items: center;
+    `}
 `;
 
 export const StepConnector = ({ step, direction, children }) => {

--- a/src/js/components/Stepper/Stepper.js
+++ b/src/js/components/Stepper/Stepper.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, {
   forwardRef,
   useCallback,
@@ -13,7 +15,6 @@ import { MessageContext } from '../../contexts/MessageContext';
 
 import { Keyboard } from '../Keyboard';
 
-import { StepConnector } from './StepConnector';
 import { StepperContext } from './StepperContext';
 import { StepperStep } from './StepperStep';
 import { StepperPropTypes } from './propTypes';
@@ -336,7 +337,7 @@ const Stepper = forwardRef(
             isLast={isLastParent}
             showConnector={
               direction === 'horizontal'
-                ? false
+                ? !isLastParent
                 : !isLastParent || !!childElements
             }
             direction={direction}
@@ -346,19 +347,9 @@ const Stepper = forwardRef(
             onFocusStep={updateFocusedIndex}
             stepsRef={stepsRef}
             stepRefs={stepRefs}
+            subSteps={childElements}
           />,
         );
-        if (!isLastParent || (childElements && direction === 'vertical')) {
-          elements.push(
-            <StepConnector
-              key={`${step.id}-connector`}
-              step={step}
-              direction={direction}
-            >
-              {childElements}
-            </StepConnector>,
-          );
-        }
       });
       return elements;
     };

--- a/src/js/components/Stepper/StepperStep.js
+++ b/src/js/components/Stepper/StepperStep.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext, useMemo } from 'react';
 import { MessageContext } from '../../contexts/MessageContext';
 import { useThemeValue } from '../../utils/useThemeValue';
@@ -6,11 +8,13 @@ import { StepperIndicator } from './StepperIndicator';
 import { StepperLabel } from './StepperLabel';
 import { StepperDescription } from './StepperDescription';
 import { StepperError, StepperDisabledReason } from './StepperHelperText';
+import { StepConnector } from './StepConnector';
 import {
   StyledStepItem,
   StyledStepButton,
   StyledStepContent,
   StyledConnector,
+  StyledSubStepsList,
 } from './StyledStepper';
 
 export const StepperStep = ({
@@ -22,6 +26,7 @@ export const StepperStep = ({
   focusedIndex,
   index: indexProp,
   isSubStep,
+  subSteps,
   onFocusStep,
   stepsRef,
   stepRefs,
@@ -142,13 +147,21 @@ export const StepperStep = ({
             <StepperDisabledReason />
           </StyledStepContent>
         </StyledStepButton>
-        {(showConnector !== undefined ? showConnector : !isLast) && (
-          <StyledConnector
-            direction={direction}
-            status={step.status}
-            aria-hidden="true"
-            {...passThemeFlag}
-          />
+        {(showConnector !== undefined ? showConnector : !isLast) &&
+          !subSteps?.length && (
+            <StyledConnector
+              direction={direction}
+              status={step.status}
+              aria-hidden="true"
+              {...passThemeFlag}
+            />
+          )}
+        {!!subSteps?.length && (
+          <StepConnector step={step} direction={direction}>
+            <StyledSubStepsList direction={direction} {...passThemeFlag}>
+              {subSteps}
+            </StyledSubStepsList>
+          </StepConnector>
         )}
       </StyledStepItem>
     </StepItemContext.Provider>

--- a/src/js/components/Stepper/StepperStep.js
+++ b/src/js/components/Stepper/StepperStep.js
@@ -110,6 +110,8 @@ export const StepperStep = ({
       <StyledStepItem
         direction={direction}
         isSubStep={isSubStep}
+        isLast={isLast}
+        hasSubSteps={!!subSteps?.length}
         {...passThemeFlag}
       >
         <StyledStepButton

--- a/src/js/components/Stepper/StyledStepper.js
+++ b/src/js/components/Stepper/StyledStepper.js
@@ -32,8 +32,7 @@ const getConnectorColor = (stepStatus, theme) =>
   );
 
 const StyledStepItem = styled.li.withConfig({
-  shouldForwardProp: (prop) =>
-    isPropValid(prop) && prop !== 'direction',
+  shouldForwardProp: (prop) => isPropValid(prop) && prop !== 'direction',
 })`
   display: flex;
   position: relative;
@@ -60,7 +59,7 @@ const StyledStepItem = styled.li.withConfig({
       align-items: center;
       flex: 1;
       min-width: 0;
-      overflow: hidden;
+      overflow: visible;
     `;
   }}
 `;
@@ -251,6 +250,8 @@ const StyledConnector = styled.span.withConfig(styledComponentsConfig)`
             left: calc(${props.isBetween ? '-' : ''}50% + ${connectorOffset});
             right: calc(-50% + ${connectorOffset});
             height: ${connectorThickness};
+            margin-left: ${props.theme.global.borderSize.medium};
+            margin-right: ${props.theme.global.borderSize.medium};
           `
         : css`
             left: calc(
@@ -262,11 +263,31 @@ const StyledConnector = styled.span.withConfig(styledComponentsConfig)`
               : `calc(${parentSize} + ${buttonPad} * 3)`};
             bottom: 0;
             width: ${connectorThickness};
+            margin-top: ${props.theme.global.borderSize.medium};
+            margin-bottom: ${props.theme.global.borderSize.medium};
           `}
     `;
   }}
   position: absolute;
   background: ${(props) => getConnectorColor(props.status, props.theme)};
+`;
+
+const StyledSubStepsList = styled.ol.withConfig(styledComponentsConfig)`
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  ${(props) => {
+    if (props.direction !== 'vertical') return '';
+
+    const indicatorSizeToken = props.theme.stepper?.indicator?.size || 'medium';
+    const indicatorSize = getMetricSize(props.theme, indicatorSizeToken);
+    const textGap = props.theme.global?.edgeSize?.small || '12px';
+    const buttonPad = props.theme.global?.edgeSize?.xxsmall || '4px';
+
+    return css`
+      padding-inline-start: calc(${indicatorSize} + ${textGap} + ${buttonPad});
+    `;
+  }}
 `;
 
 export {
@@ -275,4 +296,5 @@ export {
   StyledStepContent,
   StyledIndicator,
   StyledConnector,
+  StyledSubStepsList,
 };

--- a/src/js/components/Stepper/StyledStepper.js
+++ b/src/js/components/Stepper/StyledStepper.js
@@ -69,7 +69,9 @@ const StyledStepItem = styled.li.withConfig({
   }}
 `;
 
-const StyledStepButton = styled.button.withConfig(styledComponentsConfig)`
+const StyledStepButton = styled.button.withConfig({
+  shouldForwardProp: (prop) => isPropValid(prop) && prop !== 'direction',
+})`
   display: flex;
   background: none;
   border: none;
@@ -268,10 +270,7 @@ const StyledConnector = styled.span.withConfig(styledComponentsConfig)`
             left: calc(${props.isBetween ? '-' : ''}50% + ${connectorOffset});
             right: calc(-50% + ${connectorOffset});
             height: ${connectorThickness};
-            margin-left: ${props.theme.global.edgeSize[
-              props.theme.stepper?.horizontal?.connector?.margin || 'xxsmall'
-            ]};
-            margin-right: ${props.theme.global.edgeSize[
+            margin-inline: ${props.theme.global.edgeSize[
               props.theme.stepper?.horizontal?.connector?.margin || 'xxsmall'
             ]};
           `
@@ -281,17 +280,13 @@ const StyledConnector = styled.span.withConfig(styledComponentsConfig)`
                 ${connectorThickness} / 2
             );
             top: ${props.isBetween ? 0 : nonBetweenTop};
-            ${props.isBetween
-              ? css`
-                  bottom: 0;
-                `
-              : css`
-                  bottom: 0;
-                  min-height: 12px;
-                `}
+            bottom: 0;
+            ${!props.isBetween &&
+            css`
+              min-height: 12px;
+            `}
             width: ${connectorThickness};
-            margin-top: 0;
-            margin-bottom: 0;
+            margin-block: 0;
           `}
     `;
   }}
@@ -299,7 +294,9 @@ const StyledConnector = styled.span.withConfig(styledComponentsConfig)`
   background: ${(props) => getConnectorColor(props.status, props.theme)};
 `;
 
-const StyledSubStepsList = styled.ol.withConfig(styledComponentsConfig)`
+const StyledSubStepsList = styled.ol.withConfig({
+  shouldForwardProp: (prop) => isPropValid(prop) && prop !== 'direction',
+})`
   list-style: none;
   margin: 0;
   padding: 0;

--- a/src/js/components/Stepper/StyledStepper.js
+++ b/src/js/components/Stepper/StyledStepper.js
@@ -38,10 +38,15 @@ const StyledStepItem = styled.li.withConfig({
   position: relative;
   ${(props) => {
     if (props.direction === 'vertical') {
+      let paddingBottom = '0px';
+      if (!props.isSubStep && !props.isLast && !props.hasSubSteps) {
+        paddingBottom = `${props.theme.global.edgeSize.medium}`;
+      }
+
       return css`
         flex-direction: column;
         align-items: flex-start;
-        padding-bottom: ${props.theme.global?.edgeSize?.xxsmall || '4px'};
+        padding-bottom: ${paddingBottom};
       `;
     }
     if (props.isSubStep) {
@@ -68,7 +73,10 @@ const StyledStepButton = styled.button.withConfig(styledComponentsConfig)`
   display: flex;
   background: none;
   border: none;
-  padding: ${(props) => props.theme.global?.edgeSize?.xxsmall || '4px'};
+  padding: ${(props) =>
+    props.theme.global?.edgeSize?.[
+      props.theme.stepper?.button?.pad || 'xxsmall'
+    ]};
   cursor: ${(props) => (props.isClickable ? 'pointer' : 'default')};
   outline: none;
   ${(props) =>
@@ -76,13 +84,17 @@ const StyledStepButton = styled.button.withConfig(styledComponentsConfig)`
       ? css`
           flex-direction: row;
           align-items: flex-start;
-          gap: ${props.theme.global?.edgeSize?.small};
+          gap: ${props.theme.global?.edgeSize?.[
+            props.theme.stepper?.vertical?.button?.gap || 'small'
+          ]};
           text-align: left;
         `
       : css`
           flex-direction: column;
           align-items: center;
-          gap: ${props.theme.global?.edgeSize?.xxsmall};
+          gap: ${props.theme.global?.edgeSize?.[
+            props.theme.stepper?.horizontal?.button?.gap || 'xxsmall'
+          ]};
           text-align: center;
           width: 100%;
         `}
@@ -234,13 +246,19 @@ const StyledConnector = styled.span.withConfig(styledComponentsConfig)`
       theme,
       theme.stepper?.indicator?.border?.width || '2px',
     );
-    const buttonPad = theme.global?.edgeSize?.xxsmall || '4px';
+    const buttonPad =
+      props.theme.global?.edgeSize?.[
+        props.theme.stepper?.button?.pad || 'xxsmall'
+      ];
     const connectorThickness =
       theme.stepper?.connector?.stroke?.width ||
       theme.global?.borderSize?.small ||
       '2px';
     const connectorRadius = theme.global?.edgeSize?.xsmall || '4px';
     const connectorOffset = `calc(${parentSize} / 2 + ${buttonPad})`;
+    const connectorGap = '4px';
+    const nonBetweenTop = `calc(${parentSize} + ${buttonPad} +
+      (${indicatorBorderWidth} * 2) + ${connectorGap})`;
 
     return css`
       border-radius: ${connectorRadius};
@@ -250,21 +268,30 @@ const StyledConnector = styled.span.withConfig(styledComponentsConfig)`
             left: calc(${props.isBetween ? '-' : ''}50% + ${connectorOffset});
             right: calc(-50% + ${connectorOffset});
             height: ${connectorThickness};
-            margin-left: ${props.theme.global.borderSize.medium};
-            margin-right: ${props.theme.global.borderSize.medium};
+            margin-left: ${props.theme.global.edgeSize[
+              props.theme.stepper?.horizontal?.connector?.margin || 'xxsmall'
+            ]};
+            margin-right: ${props.theme.global.edgeSize[
+              props.theme.stepper?.horizontal?.connector?.margin || 'xxsmall'
+            ]};
           `
         : css`
             left: calc(
               ${connectorOffset} + ${indicatorBorderWidth} -
                 ${connectorThickness} / 2
             );
-            top: ${props.isBetween
-              ? 0
-              : `calc(${parentSize} + ${buttonPad} * 3)`};
-            bottom: 0;
+            top: ${props.isBetween ? 0 : nonBetweenTop};
+            ${props.isBetween
+              ? css`
+                  bottom: 0;
+                `
+              : css`
+                  bottom: 0;
+                  min-height: 12px;
+                `}
             width: ${connectorThickness};
-            margin-top: ${props.theme.global.borderSize.medium};
-            margin-bottom: ${props.theme.global.borderSize.medium};
+            margin-top: 0;
+            margin-bottom: 0;
           `}
     `;
   }}
@@ -281,9 +308,14 @@ const StyledSubStepsList = styled.ol.withConfig(styledComponentsConfig)`
 
     const indicatorSizeToken = props.theme.stepper?.indicator?.size || 'medium';
     const indicatorSize = getMetricSize(props.theme, indicatorSizeToken);
-    const textGap = props.theme.global?.edgeSize?.small || '12px';
-    const buttonPad = props.theme.global?.edgeSize?.xxsmall || '4px';
-
+    const textGap =
+      props.theme.global?.edgeSize?.[
+        props.theme.stepper?.vertical?.button?.gap || 'small'
+      ];
+    const buttonPad =
+      props.theme.global?.edgeSize?.[
+        props.theme.stepper?.button?.pad || 'xxsmall'
+      ];
     return css`
       padding-inline-start: calc(${indicatorSize} + ${textGap} + ${buttonPad});
     `;

--- a/src/js/components/Stepper/__tests__/__snapshots__/Stepper-test.js.snap
+++ b/src/js/components/Stepper/__tests__/__snapshots__/Stepper-test.js.snap
@@ -203,6 +203,8 @@ exports[`Stepper renders horizontal steps 1`] = `
   left: calc(50% + calc(24px / 2 + 3px));
   right: calc(-50% + calc(24px / 2 + 3px));
   height: 2px;
+  margin-left: 4px;
+  margin-right: 4px;
   position: absolute;
   background: rgba(0, 0, 0, 0.33);
 }
@@ -522,6 +524,8 @@ exports[`Stepper renders outside Grommet wrapper 1`] = `
   left: calc(50% + calc(24px / 2 + 3px));
   right: calc(-50% + calc(24px / 2 + 3px));
   height: 2px;
+  margin-left: 4px;
+  margin-right: 4px;
   position: absolute;
   background: rgba(0, 0, 0, 0.33);
 }
@@ -837,6 +841,8 @@ exports[`Stepper renders vertical steps 1`] = `
   top: calc(24px + 3px * 3);
   bottom: 0;
   width: 2px;
+  margin-top: 4px;
+  margin-bottom: 4px;
   position: absolute;
   background: rgba(0, 0, 0, 0.33);
 }

--- a/src/js/components/Stepper/__tests__/__snapshots__/Stepper-test.js.snap
+++ b/src/js/components/Stepper/__tests__/__snapshots__/Stepper-test.js.snap
@@ -83,7 +83,7 @@ exports[`Stepper renders horizontal steps 1`] = `
   align-items: center;
   flex: 1;
   min-width: 0;
-  overflow: hidden;
+  overflow: visible;
 }
 
 .c4 {
@@ -200,7 +200,7 @@ exports[`Stepper renders horizontal steps 1`] = `
 .c9 {
   border-radius: 6px;
   top: calc(24px / 2 + 3px);
-  left: calc(-50% + calc(24px / 2 + 3px));
+  left: calc(50% + calc(24px / 2 + 3px));
   right: calc(-50% + calc(24px / 2 + 3px));
   height: 2px;
   position: absolute;
@@ -266,12 +266,6 @@ exports[`Stepper renders horizontal steps 1`] = `
           </span>
         </span>
       </button>
-    </li>
-    <li
-      aria-hidden="true"
-      role="presentation"
-      style="display: flex; flex-direction: column; position: relative; flex: 1; overflow: visible; align-items: center; min-width: 12px;"
-    >
       <span
         aria-hidden="true"
         class="c9"
@@ -301,12 +295,6 @@ exports[`Stepper renders horizontal steps 1`] = `
           </span>
         </span>
       </button>
-    </li>
-    <li
-      aria-hidden="true"
-      role="presentation"
-      style="display: flex; flex-direction: column; position: relative; flex: 1; overflow: visible; align-items: center; min-width: 12px;"
-    >
       <span
         aria-hidden="true"
         class="c9"
@@ -414,7 +402,7 @@ exports[`Stepper renders outside Grommet wrapper 1`] = `
   align-items: center;
   flex: 1;
   min-width: 0;
-  overflow: hidden;
+  overflow: visible;
 }
 
 .c3 {
@@ -531,7 +519,7 @@ exports[`Stepper renders outside Grommet wrapper 1`] = `
 .c8 {
   border-radius: 6px;
   top: calc(24px / 2 + 3px);
-  left: calc(-50% + calc(24px / 2 + 3px));
+  left: calc(50% + calc(24px / 2 + 3px));
   right: calc(-50% + calc(24px / 2 + 3px));
   height: 2px;
   position: absolute;
@@ -594,12 +582,6 @@ exports[`Stepper renders outside Grommet wrapper 1`] = `
         </span>
       </span>
     </button>
-  </li>
-  <li
-    aria-hidden="true"
-    role="presentation"
-    style="display: flex; flex-direction: column; position: relative; flex: 1; overflow: visible; align-items: center; min-width: 12px;"
-  >
     <span
       aria-hidden="true"
       class="c8"
@@ -629,12 +611,6 @@ exports[`Stepper renders outside Grommet wrapper 1`] = `
         </span>
       </span>
     </button>
-  </li>
-  <li
-    aria-hidden="true"
-    role="presentation"
-    style="display: flex; flex-direction: column; position: relative; flex: 1; overflow: visible; align-items: center; min-width: 12px;"
-  >
     <span
       aria-hidden="true"
       class="c8"
@@ -682,7 +658,7 @@ exports[`Stepper renders vertical steps 1`] = `
   overflow: hidden;
 }
 
-.c11 {
+.c10 {
   display: inline-block;
   flex: 0 0 auto;
   width: 24px;
@@ -691,25 +667,25 @@ exports[`Stepper renders vertical steps 1`] = `
   stroke: currentColor;
 }
 
-.c11 g {
+.c10 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c11 *:not([stroke])[fill='none'] {
+.c10 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c11 *[stroke*='#'],
-.c11 *[STROKE*='#'] {
+.c10 *[stroke*='#'],
+.c10 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c11 *[fill-rule],
-.c11 *[FILL-RULE],
-.c11 *[fill*='#'],
-.c11 *[FILL*='#'] {
+.c10 *[fill-rule],
+.c10 *[FILL-RULE],
+.c10 *[fill*='#'],
+.c10 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -720,7 +696,7 @@ exports[`Stepper renders vertical steps 1`] = `
   color: #444444;
 }
 
-.c12 {
+.c11 {
   font-size: 18px;
   line-height: 24px;
   color: #7D4CDB;
@@ -809,7 +785,7 @@ exports[`Stepper renders vertical steps 1`] = `
   color: color-mix(in srgb, #000000 80%, black);
 }
 
-.c10 {
+.c9 {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -825,31 +801,31 @@ exports[`Stepper renders vertical steps 1`] = `
   border-color: #7D4CDB;
 }
 
-.c3:focus-visible .c10 {
+.c3:focus-visible .c9 {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus-visible .c10 >circle,
-.c3:focus-visible .c10 >ellipse,
-.c3:focus-visible .c10 >line,
-.c3:focus-visible .c10 >path,
-.c3:focus-visible .c10 >polygon,
-.c3:focus-visible .c10 >polyline,
-.c3:focus-visible .c10 >rect {
+.c3:focus-visible .c9 >circle,
+.c3:focus-visible .c9 >ellipse,
+.c3:focus-visible .c9 >line,
+.c3:focus-visible .c9 >path,
+.c3:focus-visible .c9 >polygon,
+.c3:focus-visible .c9 >polyline,
+.c3:focus-visible .c9 >rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus-visible .c10 ::-moz-focus-inner {
+.c3:focus-visible .c9 ::-moz-focus-inner {
   border: 0;
 }
 
-.c3:not([aria-disabled]):active .c10 {
+.c3:not([aria-disabled]):active .c9 {
   transform: scale(0.95);
 }
 
-.c3:not([aria-disabled]):hover .c10 {
+.c3:not([aria-disabled]):hover .c9 {
   background: color-mix(in srgb, #7D4CDB 80%, black);
   border-color: color-mix(in srgb, #7D4CDB 80%, black);
   color: #FFFFFF;
@@ -859,16 +835,6 @@ exports[`Stepper renders vertical steps 1`] = `
   border-radius: 6px;
   left: calc( calc(24px / 2 + 3px) + 2px - 2px / 2 );
   top: calc(24px + 3px * 3);
-  bottom: 0;
-  width: 2px;
-  position: absolute;
-  background: rgba(0, 0, 0, 0.33);
-}
-
-.c9 {
-  border-radius: 6px;
-  left: calc( calc(24px / 2 + 3px) + 2px - 2px / 2 );
-  top: 0;
   bottom: 0;
   width: 2px;
   position: absolute;
@@ -925,17 +891,6 @@ exports[`Stepper renders vertical steps 1`] = `
       />
     </li>
     <li
-      aria-hidden="true"
-      role="presentation"
-      style="display: flex; flex-direction: column; position: relative; flex: 1; overflow: visible; justify-content: flex-start; min-height: 12px;"
-    >
-      <span
-        aria-hidden="true"
-        class="c9"
-        direction="vertical"
-      />
-    </li>
-    <li
       class="c2"
     >
       <button
@@ -947,12 +902,12 @@ exports[`Stepper renders vertical steps 1`] = `
         type="button"
       >
         <span
-          class="c10"
+          class="c9"
         >
           <svg
             aria-hidden="true"
             aria-label="Status is okay"
-            class="c11"
+            class="c10"
             viewBox="0 0 12 12"
           >
             <circle
@@ -968,7 +923,7 @@ exports[`Stepper renders vertical steps 1`] = `
           class="c6"
         >
           <span
-            class="c12"
+            class="c11"
           >
             Step 2
           </span>
@@ -977,17 +932,6 @@ exports[`Stepper renders vertical steps 1`] = `
       <span
         aria-hidden="true"
         class="c8"
-        direction="vertical"
-      />
-    </li>
-    <li
-      aria-hidden="true"
-      role="presentation"
-      style="display: flex; flex-direction: column; position: relative; flex: 1; overflow: visible; justify-content: flex-start; min-height: 12px;"
-    >
-      <span
-        aria-hidden="true"
-        class="c9"
         direction="vertical"
       />
     </li>

--- a/src/js/components/Stepper/__tests__/__snapshots__/Stepper-test.js.snap
+++ b/src/js/components/Stepper/__tests__/__snapshots__/Stepper-test.js.snap
@@ -203,8 +203,7 @@ exports[`Stepper renders horizontal steps 1`] = `
   left: calc(50% + calc(24px / 2 + 3px));
   right: calc(-50% + calc(24px / 2 + 3px));
   height: 2px;
-  margin-left: 3px;
-  margin-right: 3px;
+  margin-inline: 3px;
   position: absolute;
   background: rgba(0, 0, 0, 0.33);
 }
@@ -236,7 +235,6 @@ exports[`Stepper renders horizontal steps 1`] = `
         aria-current="step"
         aria-label="Step 1 of 3: Step 1"
         class="c3 c4"
-        direction="horizontal"
         tabindex="0"
         type="button"
       >
@@ -280,7 +278,6 @@ exports[`Stepper renders horizontal steps 1`] = `
       <button
         aria-label="Step 2 of 3: Step 2"
         class="c3 c4"
-        direction="horizontal"
         tabindex="-1"
         type="button"
       >
@@ -309,7 +306,6 @@ exports[`Stepper renders horizontal steps 1`] = `
       <button
         aria-label="Step 3 of 3: Step 3"
         class="c3 c4"
-        direction="horizontal"
         tabindex="-1"
         type="button"
       >
@@ -524,8 +520,7 @@ exports[`Stepper renders outside Grommet wrapper 1`] = `
   left: calc(50% + calc(24px / 2 + 3px));
   right: calc(-50% + calc(24px / 2 + 3px));
   height: 2px;
-  margin-left: 3px;
-  margin-right: 3px;
+  margin-inline: 3px;
   position: absolute;
   background: rgba(0, 0, 0, 0.33);
 }
@@ -554,7 +549,6 @@ exports[`Stepper renders outside Grommet wrapper 1`] = `
       aria-current="step"
       aria-label="Step 1 of 3: Step 1"
       class="c2 c3"
-      direction="horizontal"
       tabindex="0"
       type="button"
     >
@@ -598,7 +592,6 @@ exports[`Stepper renders outside Grommet wrapper 1`] = `
     <button
       aria-label="Step 2 of 3: Step 2"
       class="c2 c3"
-      direction="horizontal"
       tabindex="-1"
       type="button"
     >
@@ -627,7 +620,6 @@ exports[`Stepper renders outside Grommet wrapper 1`] = `
     <button
       aria-label="Step 3 of 3: Step 3"
       class="c2 c3"
-      direction="horizontal"
       tabindex="-1"
       type="button"
     >
@@ -850,8 +842,7 @@ exports[`Stepper renders vertical steps 1`] = `
   bottom: 0;
   min-height: 12px;
   width: 2px;
-  margin-top: 0;
-  margin-bottom: 0;
+  margin-block: 0;
   position: absolute;
   background: rgba(0, 0, 0, 0.33);
 }
@@ -882,7 +873,6 @@ exports[`Stepper renders vertical steps 1`] = `
       <button
         aria-label="Step 1 of 3: Step 1"
         class="c3 c4"
-        direction="vertical"
         tabindex="-1"
         type="button"
       >
@@ -912,7 +902,6 @@ exports[`Stepper renders vertical steps 1`] = `
         aria-current="step"
         aria-label="Step 2 of 3: Step 2"
         class="c3 c4"
-        direction="vertical"
         tabindex="0"
         type="button"
       >
@@ -956,7 +945,6 @@ exports[`Stepper renders vertical steps 1`] = `
       <button
         aria-label="Step 3 of 3: Step 3"
         class="c3 c4"
-        direction="vertical"
         tabindex="-1"
         type="button"
       >

--- a/src/js/components/Stepper/__tests__/__snapshots__/Stepper-test.js.snap
+++ b/src/js/components/Stepper/__tests__/__snapshots__/Stepper-test.js.snap
@@ -95,7 +95,7 @@ exports[`Stepper renders horizontal steps 1`] = `
   outline: none;
   flex-direction: column;
   align-items: center;
-  gap: 3px;
+  gap: 6px;
   text-align: center;
   width: 100%;
 }
@@ -203,8 +203,8 @@ exports[`Stepper renders horizontal steps 1`] = `
   left: calc(50% + calc(24px / 2 + 3px));
   right: calc(-50% + calc(24px / 2 + 3px));
   height: 2px;
-  margin-left: 4px;
-  margin-right: 4px;
+  margin-left: 3px;
+  margin-right: 3px;
   position: absolute;
   background: rgba(0, 0, 0, 0.33);
 }
@@ -416,7 +416,7 @@ exports[`Stepper renders outside Grommet wrapper 1`] = `
   outline: none;
   flex-direction: column;
   align-items: center;
-  gap: 3px;
+  gap: 6px;
   text-align: center;
   width: 100%;
 }
@@ -524,8 +524,8 @@ exports[`Stepper renders outside Grommet wrapper 1`] = `
   left: calc(50% + calc(24px / 2 + 3px));
   right: calc(-50% + calc(24px / 2 + 3px));
   height: 2px;
-  margin-left: 4px;
-  margin-right: 4px;
+  margin-left: 3px;
+  margin-right: 3px;
   position: absolute;
   background: rgba(0, 0, 0, 0.33);
 }
@@ -721,7 +721,15 @@ exports[`Stepper renders vertical steps 1`] = `
   position: relative;
   flex-direction: column;
   align-items: flex-start;
-  padding-bottom: 3px;
+  padding-bottom: 24px;
+}
+
+.c12 {
+  display: flex;
+  position: relative;
+  flex-direction: column;
+  align-items: flex-start;
+  padding-bottom: 0px;
 }
 
 .c4 {
@@ -838,11 +846,12 @@ exports[`Stepper renders vertical steps 1`] = `
 .c8 {
   border-radius: 6px;
   left: calc( calc(24px / 2 + 3px) + 2px - 2px / 2 );
-  top: calc(24px + 3px * 3);
+  top: calc(24px + 3px +       (2px * 2) + 4px);
   bottom: 0;
+  min-height: 12px;
   width: 2px;
-  margin-top: 4px;
-  margin-bottom: 4px;
+  margin-top: 0;
+  margin-bottom: 0;
   position: absolute;
   background: rgba(0, 0, 0, 0.33);
 }
@@ -942,7 +951,7 @@ exports[`Stepper renders vertical steps 1`] = `
       />
     </li>
     <li
-      class="c2"
+      class="c12"
     >
       <button
         aria-label="Step 3 of 3: Step 3"

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import {
   FlattenInterpolation,
   FlattenSimpleInterpolation,
@@ -2160,6 +2162,22 @@ export interface ThemeType {
     helperText?: {
       size?: string;
       color?: ColorType;
+    };
+    button?: {
+      pad?: EdgeSizeType;
+    };
+    horizontal?: {
+      connector?: {
+        margin?: EdgeSizeType;
+      };
+      button?: {
+        gap?: GapType;
+      };
+    };
+    vertical?: {
+      button?: {
+        gap?: GapType;
+      };
     };
     hover?: {
       background?: BackgroundType;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Actions } from 'grommet-icons/icons/Actions';
 import { AssistListening } from 'grommet-icons/icons/AssistListening';
 import { CircleInformation } from 'grommet-icons/icons/CircleInformation';
@@ -2349,6 +2351,22 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       helperText: {
         size: 'xsmall',
         color: 'text-weak',
+      },
+      button: {
+        pad: 'xxsmall',
+      },
+      horizontal: {
+        connector: {
+          margin: 'xxsmall',
+        },
+        button: {
+          gap: 'xsmall',
+        },
+      },
+      vertical: {
+        button: {
+          gap: 'small',
+        },
       },
       // States: [component].[state].[element].[property]
       pending: {


### PR DESCRIPTION
#### What does this PR do?
Fixes the HTML structure of the stepper component and cleans up some of the styling (the styling cleanup doesn't fix everything but is a small incremental change moving us towards the direction we want to go).

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?
Yes
#### Is this change backwards compatible or is it a breaking change?
backwards compatible