### PR TITLE
6425 opsramp textinput password affordance

### DIFF
--- a/package.json
+++ b/package.json
@@ -215,7 +215,7 @@
   "bundlesize": [
     {
       "path": "./dist/grommet.min.js",
-      "maxSize": "215 kB"
+      "maxSize": "216 kB"
     }
   ],
   "keywords": [

--- a/src/js/components/Data/__tests__/__snapshots__/Data-test.tsx.snap
+++ b/src/js/components/Data/__tests__/__snapshots__/Data-test.tsx.snap
@@ -582,7 +582,7 @@ exports[`Data controlled search 2`] = `
             <input
               aria-label="Search"
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 dvidct"
+              class="StyledTextInput-sc-1x30a0s-0 jUTnOB"
               id="data--search"
               name="_search"
               type="search"
@@ -6812,7 +6812,7 @@ exports[`Data uncontrolled search 2`] = `
             <input
               aria-label="Search"
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 dvidct"
+              class="StyledTextInput-sc-1x30a0s-0 jUTnOB"
               id="data--search"
               name="_search"
               type="search"
@@ -7915,7 +7915,7 @@ exports[`Data uncontrolled, when paginated, search should return to page 1 2`] =
             <input
               aria-label="Search"
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 dvidct"
+              class="StyledTextInput-sc-1x30a0s-0 jUTnOB"
               id="data--search"
               name="_search"
               type="search"
@@ -8276,7 +8276,7 @@ exports[`Data uncontrolled, when paginated, search should return to page 1 3`] =
             <input
               aria-label="Search"
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 dvidct"
+              class="StyledTextInput-sc-1x30a0s-0 jUTnOB"
               id="data--search"
               name="_search"
               type="search"

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-controlled.tsx.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-controlled.tsx.snap
@@ -209,7 +209,7 @@ exports[`Form controlled controlled 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 iKSay"
+            class="StyledTextInput-sc-1x30a0s-0 eaXSmi"
             name="test"
             placeholder="test input"
             value="v"
@@ -243,7 +243,7 @@ exports[`Form controlled controlled 3`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 iKSay"
+            class="StyledTextInput-sc-1x30a0s-0 eaXSmi"
             name="test"
             placeholder="test input"
             value="v"
@@ -591,7 +591,7 @@ exports[`Form controlled controlled Array of Form Fields 2`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 iKSay"
+              class="StyledTextInput-sc-1x30a0s-0 eaXSmi"
               name="phones[0].number"
               placeholder="number test input 1"
               value=""
@@ -610,7 +610,7 @@ exports[`Form controlled controlled Array of Form Fields 2`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 iKSay"
+              class="StyledTextInput-sc-1x30a0s-0 eaXSmi"
               name="phones[0].ext"
               placeholder="ext test input 1"
               value=""
@@ -633,7 +633,7 @@ exports[`Form controlled controlled Array of Form Fields 2`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 iKSay"
+              class="StyledTextInput-sc-1x30a0s-0 eaXSmi"
               name="phones[1].number"
               placeholder="number test input 2"
               value="123456789"
@@ -652,7 +652,7 @@ exports[`Form controlled controlled Array of Form Fields 2`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 iKSay"
+              class="StyledTextInput-sc-1x30a0s-0 eaXSmi"
               name="phones[1].ext"
               placeholder="ext test input 2"
               value=""
@@ -675,7 +675,7 @@ exports[`Form controlled controlled Array of Form Fields 2`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 iKSay"
+              class="StyledTextInput-sc-1x30a0s-0 eaXSmi"
               name="phones[2].number"
               placeholder="number test input 3"
               value=""
@@ -694,7 +694,7 @@ exports[`Form controlled controlled Array of Form Fields 2`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 iKSay"
+              class="StyledTextInput-sc-1x30a0s-0 eaXSmi"
               name="phones[2].ext"
               placeholder="ext test input 3"
               value="999"
@@ -732,7 +732,7 @@ exports[`Form controlled controlled Array of Form Fields 3`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 iKSay"
+              class="StyledTextInput-sc-1x30a0s-0 eaXSmi"
               name="phones[0].number"
               placeholder="number test input 1"
               value=""
@@ -751,7 +751,7 @@ exports[`Form controlled controlled Array of Form Fields 3`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 iKSay"
+              class="StyledTextInput-sc-1x30a0s-0 eaXSmi"
               name="phones[0].ext"
               placeholder="ext test input 1"
               value=""
@@ -774,7 +774,7 @@ exports[`Form controlled controlled Array of Form Fields 3`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 iKSay"
+              class="StyledTextInput-sc-1x30a0s-0 eaXSmi"
               name="phones[1].number"
               placeholder="number test input 2"
               value="123456789"
@@ -793,7 +793,7 @@ exports[`Form controlled controlled Array of Form Fields 3`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 iKSay"
+              class="StyledTextInput-sc-1x30a0s-0 eaXSmi"
               name="phones[1].ext"
               placeholder="ext test input 2"
               value=""
@@ -816,7 +816,7 @@ exports[`Form controlled controlled Array of Form Fields 3`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 iKSay"
+              class="StyledTextInput-sc-1x30a0s-0 eaXSmi"
               name="phones[2].number"
               placeholder="number test input 3"
               value=""
@@ -835,7 +835,7 @@ exports[`Form controlled controlled Array of Form Fields 3`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 iKSay"
+              class="StyledTextInput-sc-1x30a0s-0 eaXSmi"
               name="phones[2].ext"
               placeholder="ext test input 3"
               value="999"
@@ -1143,7 +1143,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate 2`] = `
             <input
               aria-invalid="true"
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 iKSay"
+              class="StyledTextInput-sc-1x30a0s-0 eaXSmi"
               name="phones[0].number"
               placeholder="number test input 1"
               value=""
@@ -1189,7 +1189,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate 2`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 iKSay"
+              class="StyledTextInput-sc-1x30a0s-0 eaXSmi"
               name="phones[0].ext"
               placeholder="ext test input 1"
               value=""
@@ -1213,7 +1213,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate 2`] = `
             <input
               aria-invalid="true"
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 iKSay"
+              class="StyledTextInput-sc-1x30a0s-0 eaXSmi"
               name="phones[1].number"
               placeholder="number test input 2"
               value=""
@@ -1259,7 +1259,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate 2`] = `
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 iKSay"
+              class="StyledTextInput-sc-1x30a0s-0 eaXSmi"
               name="phones[1].ext"
               placeholder="ext test input 2"
               value=""
@@ -1566,7 +1566,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate custom error
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 iKSay"
+              class="StyledTextInput-sc-1x30a0s-0 eaXSmi"
               name="phones[0].number"
               placeholder="number test input 1"
               value=""
@@ -1585,7 +1585,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate custom error
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 iKSay"
+              class="StyledTextInput-sc-1x30a0s-0 eaXSmi"
               name="phones[0].ext"
               placeholder="ext test input 1"
               value=""
@@ -1609,7 +1609,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate custom error
             <input
               aria-invalid="true"
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 iKSay"
+              class="StyledTextInput-sc-1x30a0s-0 eaXSmi"
               name="phones[1].number"
               placeholder="number test input 2"
               value="sadasd"
@@ -1655,7 +1655,7 @@ exports[`Form controlled controlled Array of Form Fields onValidate custom error
           >
             <input
               autocomplete="off"
-              class="StyledTextInput-sc-1x30a0s-0 iKSay"
+              class="StyledTextInput-sc-1x30a0s-0 eaXSmi"
               name="phones[1].ext"
               placeholder="ext test input 2"
               value=""
@@ -1906,7 +1906,7 @@ exports[`Form controlled controlled FormField deprecated 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 iKSay"
+            class="StyledTextInput-sc-1x30a0s-0 eaXSmi"
             id="test"
             name="test"
             value="v"
@@ -1947,7 +1947,7 @@ exports[`Form controlled controlled FormField deprecated 3`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 iKSay"
+            class="StyledTextInput-sc-1x30a0s-0 eaXSmi"
             id="test"
             name="test"
             value="v"
@@ -2174,7 +2174,7 @@ exports[`Form controlled controlled input 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 iKSay"
+            class="StyledTextInput-sc-1x30a0s-0 eaXSmi"
             name="test"
             placeholder="test input"
             value="v"
@@ -2208,7 +2208,7 @@ exports[`Form controlled controlled input 3`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 iKSay"
+            class="StyledTextInput-sc-1x30a0s-0 eaXSmi"
             name="test"
             placeholder="test input"
             value="v"
@@ -2435,7 +2435,7 @@ exports[`Form controlled controlled input lazy 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 iKSay"
+            class="StyledTextInput-sc-1x30a0s-0 eaXSmi"
             name="test"
             placeholder="test input"
             value="v"
@@ -2469,7 +2469,7 @@ exports[`Form controlled controlled input lazy 3`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 iKSay"
+            class="StyledTextInput-sc-1x30a0s-0 eaXSmi"
             name="test"
             placeholder="test input"
             value="v"
@@ -2696,7 +2696,7 @@ exports[`Form controlled controlled lazy 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 iKSay"
+            class="StyledTextInput-sc-1x30a0s-0 eaXSmi"
             name="test"
             placeholder="test input"
             value="v"
@@ -2730,7 +2730,7 @@ exports[`Form controlled controlled lazy 3`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 iKSay"
+            class="StyledTextInput-sc-1x30a0s-0 eaXSmi"
             name="test"
             placeholder="test input"
             value="v"
@@ -3151,7 +3151,7 @@ exports[`Form controlled controlled onValidate 2`] = `
           <input
             aria-invalid="true"
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 iKSay"
+            class="StyledTextInput-sc-1x30a0s-0 eaXSmi"
             name="test"
             placeholder="test input"
             value=""
@@ -3406,7 +3406,7 @@ exports[`Form controlled controlled onValidate custom error 2`] = `
           <input
             aria-invalid="true"
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 iKSay"
+            class="StyledTextInput-sc-1x30a0s-0 eaXSmi"
             name="test"
             placeholder="test input"
             value=""
@@ -3660,7 +3660,7 @@ exports[`Form controlled controlled onValidate custom info 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 iKSay"
+            class="StyledTextInput-sc-1x30a0s-0 eaXSmi"
             name="test"
             placeholder="test input"
             value=""
@@ -4273,7 +4273,7 @@ exports[`Form controlled dynamicly removed fields using blur validation\\n  don'
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 iKSay"
+            class="StyledTextInput-sc-1x30a0s-0 eaXSmi"
             name="name"
             placeholder="test name"
             value=""
@@ -4501,7 +4501,7 @@ exports[`Form controlled dynamicly removed fields using blur validation\\n  don'
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 iKSay"
+            class="StyledTextInput-sc-1x30a0s-0 eaXSmi"
             name="name"
             placeholder="test name"
             value=""

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.tsx.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.tsx.snap
@@ -1137,7 +1137,7 @@ exports[`Form uncontrolled dynamically removed fields should be removed from for
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 iKSay"
+            class="StyledTextInput-sc-1x30a0s-0 eaXSmi"
             name="name"
             placeholder="test name"
           />
@@ -1511,7 +1511,7 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation\\n  do
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 iKSay"
+            class="StyledTextInput-sc-1x30a0s-0 eaXSmi"
             name="name"
             placeholder="test name"
           />
@@ -1737,7 +1737,7 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation\\n  do
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 iKSay"
+            class="StyledTextInput-sc-1x30a0s-0 eaXSmi"
             name="name"
             placeholder="test name"
           />
@@ -2972,7 +2972,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
               >
                 <input
                   autocomplete="off"
-                  class="StyledTextInput-sc-1x30a0s-0 hVXjBt StyledSelect__SelectTextInput-sc-znp66n-4 hQtXQL"
+                  class="StyledTextInput-sc-1x30a0s-0 dzhDdt StyledSelect__SelectTextInput-sc-znp66n-4 hQtXQL"
                   id="test-select__input"
                   inert=""
                   name="test-select"
@@ -3362,7 +3362,7 @@ exports[`Form uncontrolled uncontrolled 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 iKSay"
+            class="StyledTextInput-sc-1x30a0s-0 eaXSmi"
             name="test"
             placeholder="test input"
           />
@@ -3395,7 +3395,7 @@ exports[`Form uncontrolled uncontrolled 3`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 iKSay"
+            class="StyledTextInput-sc-1x30a0s-0 eaXSmi"
             name="test"
             placeholder="test input"
           />
@@ -3621,7 +3621,7 @@ exports[`Form uncontrolled uncontrolled onValidate 2`] = `
           <input
             aria-invalid="true"
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 iKSay"
+            class="StyledTextInput-sc-1x30a0s-0 eaXSmi"
             name="test"
             placeholder="test input"
           />
@@ -3874,7 +3874,7 @@ exports[`Form uncontrolled uncontrolled onValidate custom error 2`] = `
           <input
             aria-invalid="true"
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 iKSay"
+            class="StyledTextInput-sc-1x30a0s-0 eaXSmi"
             name="test"
             placeholder="test input"
           />
@@ -4126,7 +4126,7 @@ exports[`Form uncontrolled uncontrolled onValidate custom info 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 iKSay"
+            class="StyledTextInput-sc-1x30a0s-0 eaXSmi"
             name="test"
             placeholder="test input"
           />

--- a/src/js/components/Grommet/index.d.ts
+++ b/src/js/components/Grommet/index.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import * as React from 'react';
 import { ThemeType } from '../../themes';
 import { BackgroundType } from '../../utils';
@@ -245,6 +247,10 @@ export interface GrommetProps {
       };
       textInput?: {
         enterSelect?: string;
+        hidePassword?: string;
+        showPassword?: string;
+        hidePassword?: string;
+        showPassword?: string;
         suggestionsCount?: string;
         suggestionsExist?: string;
         suggestionIsOpen?: string;

--- a/src/js/components/Grommet/index.d.ts
+++ b/src/js/components/Grommet/index.d.ts
@@ -250,7 +250,6 @@ export interface GrommetProps {
         enterSelect?: string;
         hidePassword?: string;
         showPassword?: string;
-        showPassword?: string;
         suggestionsCount?: string;
         suggestionsExist?: string;
         suggestionIsOpen?: string;

--- a/src/js/components/Grommet/index.d.ts
+++ b/src/js/components/Grommet/index.d.ts
@@ -250,7 +250,6 @@ export interface GrommetProps {
         enterSelect?: string;
         hidePassword?: string;
         showPassword?: string;
-        hidePassword?: string;
         showPassword?: string;
         suggestionsCount?: string;
         suggestionsExist?: string;

--- a/src/js/components/Select/__tests__/__snapshots__/Select-multiple-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-multiple-test.js.snap
@@ -5048,7 +5048,7 @@ exports[`Select Controlled multiple values 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 hVXjBt StyledSelect__SelectTextInput-sc-znp66n-4 hQtXQL"
+            class="StyledTextInput-sc-1x30a0s-0 dzhDdt StyledSelect__SelectTextInput-sc-znp66n-4 hQtXQL"
             id="test-select__input"
             inert=""
             placeholder="test select"

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -3283,7 +3283,7 @@ exports[`Select complex options and children 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 hVXjBt StyledSelect__SelectTextInput-sc-znp66n-4 hQtXQL"
+            class="StyledTextInput-sc-1x30a0s-0 dzhDdt StyledSelect__SelectTextInput-sc-znp66n-4 hQtXQL"
             id="test-select__input"
             inert=""
             placeholder="test select"
@@ -4962,7 +4962,7 @@ exports[`Select disabled 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 hVXjBt StyledSelect__SelectTextInput-sc-znp66n-4 hznfdb"
+            class="StyledTextInput-sc-1x30a0s-0 dzhDdt StyledSelect__SelectTextInput-sc-znp66n-4 hznfdb"
             id="test-select__input"
             inert=""
             placeholder="test select"
@@ -12222,7 +12222,7 @@ exports[`Select prop: onOpen 2`] = `
       >
         <input
           autocomplete="off"
-          class="StyledTextInput-sc-1x30a0s-0 hVXjBt StyledSelect__SelectTextInput-sc-znp66n-4 hQtXQL"
+          class="StyledTextInput-sc-1x30a0s-0 dzhDdt StyledSelect__SelectTextInput-sc-znp66n-4 hQtXQL"
           id="test-select__input"
           inert=""
           placeholder="test select"
@@ -14047,7 +14047,7 @@ exports[`Select renders custom up and down icons 2`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 hVXjBt StyledSelect__SelectTextInput-sc-znp66n-4 hQtXQL"
+            class="StyledTextInput-sc-1x30a0s-0 dzhDdt StyledSelect__SelectTextInput-sc-znp66n-4 hQtXQL"
             inert=""
             placeholder="Select..."
             readonly=""
@@ -16145,7 +16145,7 @@ exports[`Select search 4`] = `
 <input
   aria-label="Search options"
   autocomplete="off"
-  class="StyledTextInput-sc-1x30a0s-0 dRUTkt"
+  class="StyledTextInput-sc-1x30a0s-0 htWCMt"
   type="search"
   value=""
 />
@@ -16155,7 +16155,7 @@ exports[`Select search 5`] = `
 <input
   aria-label="Search options"
   autocomplete="off"
-  class="StyledTextInput-sc-1x30a0s-0 dRUTkt"
+  class="StyledTextInput-sc-1x30a0s-0 htWCMt"
   type="search"
   value="o"
 />
@@ -16817,7 +16817,7 @@ exports[`Select search and select 4`] = `
 <input
   aria-label="Search options"
   autocomplete="off"
-  class="StyledTextInput-sc-1x30a0s-0 dRUTkt"
+  class="StyledTextInput-sc-1x30a0s-0 htWCMt"
   type="search"
   value=""
 />
@@ -16827,7 +16827,7 @@ exports[`Select search and select 5`] = `
 <input
   aria-label="Search options"
   autocomplete="off"
-  class="StyledTextInput-sc-1x30a0s-0 dRUTkt"
+  class="StyledTextInput-sc-1x30a0s-0 htWCMt"
   type="search"
   value="t"
 />
@@ -18574,7 +18574,7 @@ exports[`Select select option by typing should not break if caller passes JSX 2`
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 hVXjBt StyledSelect__SelectTextInput-sc-znp66n-4 hQtXQL"
+            class="StyledTextInput-sc-1x30a0s-0 dzhDdt StyledSelect__SelectTextInput-sc-znp66n-4 hQtXQL"
             id="test-select__input"
             inert=""
             placeholder="test select"

--- a/src/js/components/SelectMultiple/__tests__/__snapshots__/SelectMultiple-test.tsx.snap
+++ b/src/js/components/SelectMultiple/__tests__/__snapshots__/SelectMultiple-test.tsx.snap
@@ -7037,7 +7037,7 @@ exports[`SelectMultiple with portal select all and clear 3`] = `
       >
         <input
           autocomplete="off"
-          class="StyledTextInput-sc-1x30a0s-0 hVXjBt StyledSelect__SelectTextInput-sc-znp66n-4 hQtXQL"
+          class="StyledTextInput-sc-1x30a0s-0 dzhDdt StyledSelect__SelectTextInput-sc-znp66n-4 hQtXQL"
           id="test-select__drop__input"
           inert=""
           readonly=""

--- a/src/js/components/TextInput/StyledTextInput.js
+++ b/src/js/components/TextInput/StyledTextInput.js
@@ -13,22 +13,12 @@ import {
   widthStyle,
   styledComponentsConfig,
 } from '../../utils';
-import { inputPadForIcon } from '../../utils/styles';
+import { getInputIconPad, inputPadForIcon } from '../../utils/styles';
 import { readOnlyStyle } from '../../utils/readOnly';
 
-const getInputIconPad = (props) => {
-  if (props.theme?.icon?.matchSize) {
-    return `${
-      parseMetricToNum(props.theme.icon?.size?.[props?.size || 'medium']) +
-      parseMetricToNum(props.theme.global.edgeSize.medium)
-    }px`;
-  }
-  return props.theme.global.edgeSize.large;
-};
-
 const getInlineButtonPad = (props) => {
-  const rightInset = parseMetricToNum(getInputPadBySide(props, 'right'));
-  const iconPad = parseMetricToNum(getInputIconPad(props));
+  const rightInset = Number.parseFloat(getInputPadBySide(props, 'right'));
+  const iconPad = Number.parseFloat(getInputIconPad(props));
   // Reserve both the icon space and the control's edge inset so text clears
   // the flush-right password toggle.
   return `${iconPad + rightInset}px`;

--- a/src/js/components/TextInput/StyledTextInput.js
+++ b/src/js/components/TextInput/StyledTextInput.js
@@ -19,9 +19,10 @@ import { readOnlyStyle } from '../../utils/readOnly';
 const getInlineButtonPad = (props) => {
   const rightInset = Number.parseFloat(getInputPadBySide(props, 'right'));
   const iconPad = Number.parseFloat(getInputIconPad(props));
+  const trailingIconPad = props.hasTrailingIcon ? iconPad : 0;
   // Reserve both the icon space and the control's edge inset so text clears
-  // the flush-right password toggle.
-  return `${iconPad + rightInset}px`;
+  // the flush-right password toggle, and the reversed icon when both coexist.
+  return `${iconPad + trailingIconPad + rightInset}px`;
 };
 
 const getPlainStyle = (plain) => {
@@ -128,6 +129,13 @@ const StyledInlineButton = styled.div.withConfig(styledComponentsConfig)`
   z-index: 1;
 `;
 
+const StyledInlineIcon = styled.div.withConfig(styledComponentsConfig)`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+`;
+
 const StyledSuggestions = styled.ol.withConfig(styledComponentsConfig)`
   border-top-left-radius: 0;
   border-top-right-radius: 0;
@@ -147,5 +155,6 @@ export {
   StyledPlaceholder,
   StyledIcon,
   StyledInlineButton,
+  StyledInlineIcon,
   StyledSuggestions,
 };

--- a/src/js/components/TextInput/StyledTextInput.js
+++ b/src/js/components/TextInput/StyledTextInput.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import styled, { css } from 'styled-components';
 
 import {
@@ -14,6 +16,24 @@ import {
 import { inputPadForIcon } from '../../utils/styles';
 import { readOnlyStyle } from '../../utils/readOnly';
 
+const getInputIconPad = (props) => {
+  if (props.theme?.icon?.matchSize) {
+    return `${
+      parseMetricToNum(props.theme.icon?.size?.[props?.size || 'medium']) +
+      parseMetricToNum(props.theme.global.edgeSize.medium)
+    }px`;
+  }
+  return props.theme.global.edgeSize.large;
+};
+
+const getInlineButtonPad = (props) => {
+  const rightInset = parseMetricToNum(getInputPadBySide(props, 'right'));
+  const iconPad = parseMetricToNum(getInputIconPad(props));
+  // Reserve both the icon space and the control's edge inset so text clears
+  // the flush-right password toggle.
+  return `${iconPad + rightInset}px`;
+};
+
 const getPlainStyle = (plain) => {
   if (plain === 'full') {
     return css`
@@ -25,14 +45,18 @@ const getPlainStyle = (plain) => {
 
 const StyledTextInput = styled.input.withConfig(styledComponentsConfig)`
   ${inputStyle}
+  ${(props) => (props.hasButton || props.readOnlyCopy) && 'flex: 1 1 auto;'}
+  ${(props) => (props.hasButton || props.readOnlyCopy) && 'min-width: 0;'}
   ${(props) =>
-    props.readOnlyCopy
+    props.readOnlyCopy || props.hasButton
       ? `padding-${props.reverse ? 'left' : 'right'}: 0px;`
       : ''}
   // readOnly border is handled by StyledTextInputContainer
   ${(props) => props.readOnly && `border: none;`}
   ${(props) => getPlainStyle(props.plain)}
   ${(props) => props.icon && inputPadForIcon}
+  ${(props) =>
+    props.hasInlineButton && `padding-right: ${getInlineButtonPad(props)};`}
   ${(props) =>
     props.disabled &&
     disabledStyle(
@@ -58,11 +82,12 @@ const StyledTextInputContainer = styled.div.withConfig(styledComponentsConfig)`
   ${(props) => props.readOnlyProp && !props.plain && controlBorderStyle};
 
   ${(props) =>
-    props.readOnlyCopy &&
+    (props.readOnlyCopy || props.hasButton) &&
     `
     box-sizing: border-box;
     flex-direction: row;
     display: flex;
+    align-items: stretch;
   `};
 
   ${(props) => props.readOnlyProp && !props.plain && readOnlyStyle(props.theme)}
@@ -103,6 +128,16 @@ const StyledIcon = styled.div.withConfig(styledComponentsConfig)`
       : `left: ${getInputPadBySide(props, 'left')};`}
 `;
 
+const StyledInlineButton = styled.div.withConfig(styledComponentsConfig)`
+  position: absolute;
+  display: flex;
+  align-items: stretch;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 1;
+`;
+
 const StyledSuggestions = styled.ol.withConfig(styledComponentsConfig)`
   border-top-left-radius: 0;
   border-top-right-radius: 0;
@@ -121,5 +156,6 @@ export {
   StyledTextInputContainer,
   StyledPlaceholder,
   StyledIcon,
+  StyledInlineButton,
   StyledSuggestions,
 };

--- a/src/js/components/TextInput/TextInput.js
+++ b/src/js/components/TextInput/TextInput.js
@@ -548,7 +548,6 @@ const TextInput = forwardRef(
         aria-label={
           passwordRevealed ? hidePasswordMessage : showPasswordMessage
         }
-        {...passThemeFlag}
       />
     ) : undefined;
 

--- a/src/js/components/TextInput/TextInput.js
+++ b/src/js/components/TextInput/TextInput.js
@@ -58,6 +58,13 @@ const stringLabel = (suggestion) => {
   return suggestion;
 };
 
+const renderIcon = (iconValue) => {
+  if (React.isValidElement(iconValue)) return iconValue;
+
+  const IconComponent = iconValue;
+  return IconComponent ? <IconComponent /> : undefined;
+};
+
 const ContainerBox = styled(Box)`
   ${(props) =>
     props.dropHeight
@@ -505,12 +512,14 @@ const TextInput = forwardRef(
     // primarily for tests.
 
     const textInputIcon = useSizedIcon(icon, rest.size, theme);
-    const ShowPasswordIcon = theme.textInput?.icons?.showPassword || View;
-    const HidePasswordIcon = theme.textInput?.icons?.hidePassword || Hide;
+    const showPasswordIcon = theme.textInput?.icons?.showPassword || View;
+    const hidePasswordIcon = theme.textInput?.icons?.hidePassword || Hide;
     let inputType = typeProp;
     if (passwordToggle) {
       inputType = passwordRevealed ? 'text' : 'password';
     }
+    const showTextInputIcon =
+      !!textInputIcon && !readOnlyCopy && !(passwordToggle && reverse);
 
     const ReadOnlyCopyButton = (
       <CopyButton
@@ -527,7 +536,11 @@ const TextInput = forwardRef(
       <Button
         disabled={disabled}
         kind="toolbar"
-        icon={passwordRevealed ? <ShowPasswordIcon /> : <HidePasswordIcon />}
+        icon={
+          passwordRevealed
+            ? renderIcon(showPasswordIcon)
+            : renderIcon(hidePasswordIcon)
+        }
         onClick={() => setPasswordRevealed((current) => !current)}
         aria-label={
           passwordRevealed ? hidePasswordMessage : showPasswordMessage
@@ -555,7 +568,7 @@ const TextInput = forwardRef(
             {placeholder}
           </StyledPlaceholder>
         )}
-        {textInputIcon && !readOnlyCopy && (
+        {showTextInputIcon && (
           <StyledIcon reverse={reverse} theme={theme}>
             {textInputIcon}
           </StyledIcon>
@@ -572,7 +585,7 @@ const TextInput = forwardRef(
             placeholder={
               typeof placeholder === 'string' ? placeholder : undefined
             }
-            icon={!readOnlyCopy && icon}
+            icon={showTextInputIcon ? icon : undefined}
             reverse={reverse}
             focus={focus}
             hasButton={!!textInputButton}

--- a/src/js/components/TextInput/TextInput.js
+++ b/src/js/components/TextInput/TextInput.js
@@ -11,7 +11,6 @@ import React, {
 } from 'react';
 
 import styled from 'styled-components';
-import { Hide, View } from 'grommet-icons';
 
 import { Box } from '../Box';
 import { Button } from '../Button';
@@ -512,8 +511,8 @@ const TextInput = forwardRef(
     // primarily for tests.
 
     const textInputIcon = useSizedIcon(icon, rest.size, theme);
-    const showPasswordIcon = theme.textInput?.icons?.showPassword || View;
-    const hidePasswordIcon = theme.textInput?.icons?.hidePassword || Hide;
+    const showPasswordIcon = theme.textInput?.icons?.showPassword;
+    const hidePasswordIcon = theme.textInput?.icons?.hidePassword;
     let inputType = typeProp;
     if (passwordToggle) {
       inputType = passwordRevealed ? 'text' : 'password';

--- a/src/js/components/TextInput/TextInput.js
+++ b/src/js/components/TextInput/TextInput.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, {
   forwardRef,
   useCallback,
@@ -9,6 +11,7 @@ import React, {
 } from 'react';
 
 import styled from 'styled-components';
+import { Hide, View } from 'grommet-icons';
 
 import { Box } from '../Box';
 import { Button } from '../Button';
@@ -30,6 +33,7 @@ import {
   StyledTextInputContainer,
   StyledPlaceholder,
   StyledIcon,
+  StyledInlineButton,
   StyledSuggestions,
 } from './StyledTextInput';
 import { MessageContext } from '../../contexts/MessageContext';
@@ -94,11 +98,13 @@ const TextInput = forwardRef(
       onSuggestionsOpen,
       placeholder,
       plain,
+      showPasswordToggle,
       readOnly: readOnlyProp,
       readOnlyCopy,
       reverse,
       suggestions,
       textAlign,
+      type: typeProp,
       value: valueProp,
       width: widthProp,
       ...rest
@@ -122,6 +128,7 @@ const TextInput = forwardRef(
 
     const [focus, setFocus] = useState();
     const [showDrop, setShowDrop] = useState(false);
+    const [passwordRevealed, setPasswordRevealed] = useState(false);
 
     const handleSuggestionSelect = useMemo(
       () => (onSelect && !onSuggestionSelect ? onSelect : onSuggestionSelect),
@@ -144,6 +151,14 @@ const TextInput = forwardRef(
     });
 
     const [tip, setTip] = useState(readOnlyCopyPrompt);
+    const showPasswordMessage = format({
+      id: 'textInput.showPassword',
+      messages,
+    });
+    const hidePasswordMessage = format({
+      id: 'textInput.hidePassword',
+      messages,
+    });
 
     const onClickCopy = () => {
       navigator.clipboard.writeText(value);
@@ -154,6 +169,14 @@ const TextInput = forwardRef(
     const onBlurCopy = () => {
       if (tip === readOnlyCopyValidation) setTip(readOnlyCopyPrompt);
     };
+
+    const passwordToggle =
+      showPasswordToggle && typeProp === 'password' && !readOnlyCopy;
+
+    useEffect(() => {
+      // When the toggle stops applying, return the input to its authored type.
+      if (!passwordToggle) setPasswordRevealed(false);
+    }, [passwordToggle]);
 
     const openDrop = useCallback(() => {
       setShowDrop(true);
@@ -483,6 +506,12 @@ const TextInput = forwardRef(
     // primarily for tests.
 
     const textInputIcon = useSizedIcon(icon, rest.size, theme);
+    const ShowPasswordIcon = theme.textInput?.icons?.showPassword || View;
+    const HidePasswordIcon = theme.textInput?.icons?.hidePassword || Hide;
+    let inputType = typeProp;
+    if (passwordToggle) {
+      inputType = passwordRevealed ? 'text' : 'password';
+    }
 
     const ReadOnlyCopyButton = (
       <CopyButton
@@ -495,8 +524,24 @@ const TextInput = forwardRef(
       />
     );
 
+    const PasswordToggleButton = passwordToggle ? (
+      <Button
+        disabled={disabled}
+        kind="toolbar"
+        icon={passwordRevealed ? <ShowPasswordIcon /> : <HidePasswordIcon />}
+        onClick={() => setPasswordRevealed((current) => !current)}
+        aria-label={
+          passwordRevealed ? hidePasswordMessage : showPasswordMessage
+        }
+        {...passThemeFlag}
+      />
+    ) : undefined;
+
+    const textInputButton = readOnlyCopy ? ReadOnlyCopyButton : undefined;
+
     return (
       <StyledTextInputContainer
+        hasButton={!!textInputButton}
         readOnlyProp={readOnly} // readOnlyProp to avoid passing to DOM
         readOnlyCopy={readOnlyCopy}
         plain={plain}
@@ -505,7 +550,7 @@ const TextInput = forwardRef(
         onMouseMove={() => setMouseMovedSinceLastKey(true)}
         {...passThemeFlag}
       >
-        {reverse && readOnlyCopy && ReadOnlyCopyButton}
+        {reverse && textInputButton}
         {showStyledPlaceholder && (
           <StyledPlaceholder {...passThemeFlag}>
             {placeholder}
@@ -531,8 +576,11 @@ const TextInput = forwardRef(
             icon={!readOnlyCopy && icon}
             reverse={reverse}
             focus={focus}
+            hasButton={!!textInputButton}
+            hasInlineButton={passwordToggle}
             focusIndicator={focusIndicator}
             textAlign={textAlign}
+            type={inputType}
             widthProp={widthProp}
             {...passThemeFlag}
             {...rest}
@@ -591,7 +639,12 @@ const TextInput = forwardRef(
             }
           />
         </Keyboard>
-        {!reverse && readOnlyCopy && ReadOnlyCopyButton}
+        {PasswordToggleButton && !readOnlyCopy && (
+          <StyledInlineButton {...passThemeFlag}>
+            {PasswordToggleButton}
+          </StyledInlineButton>
+        )}
+        {!reverse && textInputButton}
         {!readOnly && drop}
       </StyledTextInputContainer>
     );

--- a/src/js/components/TextInput/TextInput.js
+++ b/src/js/components/TextInput/TextInput.js
@@ -96,9 +96,9 @@ const TextInput = forwardRef(
       onSuggestionSelect,
       onSuggestionsClose,
       onSuggestionsOpen,
+      password,
       placeholder,
       plain,
-      showPasswordToggle,
       readOnly: readOnlyProp,
       readOnlyCopy,
       reverse,
@@ -170,8 +170,7 @@ const TextInput = forwardRef(
       if (tip === readOnlyCopyValidation) setTip(readOnlyCopyPrompt);
     };
 
-    const passwordToggle =
-      showPasswordToggle && typeProp === 'password' && !readOnlyCopy;
+    const passwordToggle = password && typeProp === 'password' && !readOnlyCopy;
 
     useEffect(() => {
       // When the toggle stops applying, return the input to its authored type.

--- a/src/js/components/TextInput/TextInput.js
+++ b/src/js/components/TextInput/TextInput.js
@@ -176,7 +176,9 @@ const TextInput = forwardRef(
       if (tip === readOnlyCopyValidation) setTip(readOnlyCopyPrompt);
     };
 
-    const passwordToggle = password && typeProp === 'password' && !readOnlyCopy;
+    const authoredType = typeProp || (password ? 'password' : undefined);
+    const passwordToggle =
+      password && authoredType === 'password' && !readOnlyCopy;
 
     useEffect(() => {
       // When the toggle stops applying, return the input to its authored type.
@@ -513,7 +515,7 @@ const TextInput = forwardRef(
     const textInputIcon = useSizedIcon(icon, rest.size, theme);
     const showPasswordIcon = theme.textInput?.icons?.showPassword;
     const hidePasswordIcon = theme.textInput?.icons?.hidePassword;
-    let inputType = typeProp;
+    let inputType = authoredType;
     if (passwordToggle) {
       inputType = passwordRevealed ? 'text' : 'password';
     }

--- a/src/js/components/TextInput/TextInput.js
+++ b/src/js/components/TextInput/TextInput.js
@@ -33,6 +33,7 @@ import {
   StyledPlaceholder,
   StyledIcon,
   StyledInlineButton,
+  StyledInlineIcon,
   StyledSuggestions,
 } from './StyledTextInput';
 import { MessageContext } from '../../contexts/MessageContext';
@@ -519,8 +520,9 @@ const TextInput = forwardRef(
     if (passwordToggle) {
       inputType = passwordRevealed ? 'text' : 'password';
     }
-    const showTextInputIcon =
-      !!textInputIcon && !readOnlyCopy && !(passwordToggle && reverse);
+    const showTextInputIcon = !!textInputIcon && !readOnlyCopy;
+    const showLeadingIcon = showTextInputIcon && !reverse;
+    const showTrailingIcon = showTextInputIcon && reverse;
 
     const ReadOnlyCopyButton = (
       <CopyButton
@@ -569,7 +571,7 @@ const TextInput = forwardRef(
             {placeholder}
           </StyledPlaceholder>
         )}
-        {showTextInputIcon && (
+        {showLeadingIcon && (
           <StyledIcon reverse={reverse} theme={theme}>
             {textInputIcon}
           </StyledIcon>
@@ -591,6 +593,7 @@ const TextInput = forwardRef(
             focus={focus}
             hasButton={!!textInputButton}
             hasInlineButton={passwordToggle}
+            hasTrailingIcon={showTrailingIcon}
             focusIndicator={focusIndicator}
             textAlign={textAlign}
             type={inputType}
@@ -654,8 +657,18 @@ const TextInput = forwardRef(
         </Keyboard>
         {PasswordToggleButton && !readOnlyCopy && (
           <StyledInlineButton {...passThemeFlag}>
+            {showTrailingIcon && (
+              <StyledInlineIcon {...passThemeFlag}>
+                {textInputIcon}
+              </StyledInlineIcon>
+            )}
             {PasswordToggleButton}
           </StyledInlineButton>
+        )}
+        {showTrailingIcon && !PasswordToggleButton && (
+          <StyledIcon reverse={reverse} theme={theme}>
+            {textInputIcon}
+          </StyledIcon>
         )}
         {!reverse && textInputButton}
         {!readOnly && drop}

--- a/src/js/components/TextInput/__tests__/TextInput-test.tsx
+++ b/src/js/components/TextInput/__tests__/TextInput-test.tsx
@@ -65,6 +65,48 @@ describe('TextInput', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  test('supports password reveal toggle', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Grommet>
+        <TextInput aria-label="Password" type="password" showPasswordToggle />
+      </Grommet>,
+    );
+
+    expect(screen.getByLabelText('Password')).toHaveAttribute(
+      'type',
+      'password',
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Show password' }));
+
+    expect(screen.getByLabelText('Password')).toHaveAttribute('type', 'text');
+    expect(
+      screen.getByRole('button', { name: 'Hide password' }),
+    ).toBeInTheDocument();
+  });
+
+  test('supports password toggle theme icons', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Grommet
+        theme={{
+          textInput: { icons: { showPassword: Add, hidePassword: Search } },
+        }}
+      >
+        <TextInput aria-label="Password" type="password" showPasswordToggle />
+      </Grommet>,
+    );
+
+    expect(screen.getByLabelText('Search')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Show password' }));
+
+    expect(screen.getByLabelText('Add')).toBeInTheDocument();
+  });
+
   test('suggestions', (done) => {
     const onChange = jest.fn();
     const onFocus = jest.fn();

--- a/src/js/components/TextInput/__tests__/TextInput-test.tsx
+++ b/src/js/components/TextInput/__tests__/TextInput-test.tsx
@@ -72,7 +72,7 @@ describe('TextInput', () => {
 
     render(
       <Grommet>
-        <TextInput aria-label="Password" type="password" showPasswordToggle />
+        <TextInput aria-label="Password" type="password" password />
       </Grommet>,
     );
 
@@ -98,7 +98,7 @@ describe('TextInput', () => {
           textInput: { icons: { showPassword: Add, hidePassword: Search } },
         }}
       >
-        <TextInput aria-label="Password" type="password" showPasswordToggle />
+        <TextInput aria-label="Password" type="password" password />
       </Grommet>,
     );
 

--- a/src/js/components/TextInput/__tests__/TextInput-test.tsx
+++ b/src/js/components/TextInput/__tests__/TextInput-test.tsx
@@ -172,7 +172,7 @@ describe('TextInput', () => {
     ).toBeInTheDocument();
   });
 
-  test('suppresses reverse icon when password toggle is active', () => {
+  test('supports reverse icon when password toggle is active', () => {
     render(
       <Grommet>
         <TextInput
@@ -185,7 +185,7 @@ describe('TextInput', () => {
       </Grommet>,
     );
 
-    expect(screen.queryByLabelText('Search')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Search')).toBeInTheDocument();
     expect(
       screen.getByRole('button', { name: 'Show password' }),
     ).toBeInTheDocument();

--- a/src/js/components/TextInput/__tests__/TextInput-test.tsx
+++ b/src/js/components/TextInput/__tests__/TextInput-test.tsx
@@ -109,6 +109,47 @@ describe('TextInput', () => {
     expect(screen.getByLabelText('Add')).toBeInTheDocument();
   });
 
+  test('supports password toggle theme icon elements', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Grommet
+        theme={{
+          textInput: {
+            icons: { showPassword: <Add />, hidePassword: <Search /> },
+          },
+        }}
+      >
+        <TextInput aria-label="Password" type="password" password />
+      </Grommet>,
+    );
+
+    expect(screen.getByLabelText('Search')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Show password' }));
+
+    expect(screen.getByLabelText('Add')).toBeInTheDocument();
+  });
+
+  test('suppresses reverse icon when password toggle is active', () => {
+    render(
+      <Grommet>
+        <TextInput
+          aria-label="Password"
+          type="password"
+          password
+          reverse
+          icon={<Search />}
+        />
+      </Grommet>,
+    );
+
+    expect(screen.queryByLabelText('Search')).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Show password' }),
+    ).toBeInTheDocument();
+  });
+
   test('suggestions', (done) => {
     const onChange = jest.fn();
     const onFocus = jest.fn();

--- a/src/js/components/TextInput/__tests__/TextInput-test.tsx
+++ b/src/js/components/TextInput/__tests__/TextInput-test.tsx
@@ -131,6 +131,28 @@ describe('TextInput', () => {
     expect(screen.getByLabelText('Add')).toBeInTheDocument();
   });
 
+  test('supports password toggle with matchSize and custom size', () => {
+    render(
+      <Grommet
+        theme={{
+          icon: {
+            matchSize: true,
+          },
+        }}
+      >
+        <TextInput aria-label="Password" type="password" password size="16px" />
+      </Grommet>,
+    );
+
+    expect(screen.getByLabelText('Password')).toHaveAttribute(
+      'type',
+      'password',
+    );
+    expect(
+      screen.getByRole('button', { name: 'Show password' }),
+    ).toBeInTheDocument();
+  });
+
   test('suppresses reverse icon when password toggle is active', () => {
     render(
       <Grommet>

--- a/src/js/components/TextInput/__tests__/TextInput-test.tsx
+++ b/src/js/components/TextInput/__tests__/TextInput-test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import 'jest-styled-components';
 import 'regenerator-runtime/runtime';

--- a/src/js/components/TextInput/__tests__/TextInput-test.tsx
+++ b/src/js/components/TextInput/__tests__/TextInput-test.tsx
@@ -89,6 +89,25 @@ describe('TextInput', () => {
     ).toBeInTheDocument();
   });
 
+  test('uses password type when password is set without type', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Grommet>
+        <TextInput aria-label="Password" password />
+      </Grommet>,
+    );
+
+    expect(screen.getByLabelText('Password')).toHaveAttribute(
+      'type',
+      'password',
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Show password' }));
+
+    expect(screen.getByLabelText('Password')).toHaveAttribute('type', 'text');
+  });
+
   test('supports password toggle theme icons', async () => {
     const user = userEvent.setup();
 

--- a/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.tsx.snap
+++ b/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.tsx.snap
@@ -477,16 +477,16 @@ exports[`TextInput calls onSuggestionsClose 3`] = `""`;
 
 exports[`TextInput calls onSuggestionsClose 4`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
+  class="StyledGrommet-sc-19lkkz7-0 chFqZQ"
 >
   <div
-    class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kJJhJg"
+    class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 OvUNf"
   >
     <input
       aria-autocomplete="list"
       aria-expanded="false"
       autocomplete="off"
-      class="StyledTextInput-sc-1x30a0s-0 ddCwRo"
+      class="StyledTextInput-sc-1x30a0s-0 hzItmP"
       data-testid="test-input"
       id="item"
       name="item"
@@ -984,16 +984,16 @@ exports[`TextInput close suggestion drop 3`] = `""`;
 
 exports[`TextInput close suggestion drop 4`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
+  class="StyledGrommet-sc-19lkkz7-0 chFqZQ"
 >
   <div
-    class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kJJhJg"
+    class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 OvUNf"
   >
     <input
       aria-autocomplete="list"
       aria-expanded="false"
       autocomplete="off"
-      class="StyledTextInput-sc-1x30a0s-0 ddCwRo"
+      class="StyledTextInput-sc-1x30a0s-0 hzItmP"
       data-testid="test-input"
       id="item"
       name="item"
@@ -1566,14 +1566,14 @@ exports[`TextInput handles next and previous without suggestion 1`] = `
 
 exports[`TextInput handles next and previous without suggestion 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
+  class="StyledGrommet-sc-19lkkz7-0 chFqZQ"
 >
   <div
-    class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kJJhJg"
+    class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 OvUNf"
   >
     <input
       autocomplete="off"
-      class="StyledTextInput-sc-1x30a0s-0 ddCwRo"
+      class="StyledTextInput-sc-1x30a0s-0 hzItmP"
       data-testid="test-input"
       id="item"
       name="item"
@@ -4798,16 +4798,16 @@ exports[`TextInput select suggestion 3`] = `""`;
 
 exports[`TextInput select suggestion 4`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
+  class="StyledGrommet-sc-19lkkz7-0 chFqZQ"
 >
   <div
-    class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kJJhJg"
+    class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 OvUNf"
   >
     <input
       aria-autocomplete="list"
       aria-expanded="false"
       autocomplete="off"
-      class="StyledTextInput-sc-1x30a0s-0 ejoMQd"
+      class="StyledTextInput-sc-1x30a0s-0 fopLRC"
       data-testid="test-input"
       id="item"
       name="item"
@@ -5396,14 +5396,14 @@ exports[`TextInput should only show default placeholder when placeholder is a\\n
 
 exports[`TextInput should only show default placeholder when placeholder is a\\n  string 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
+  class="StyledGrommet-sc-19lkkz7-0 chFqZQ"
 >
   <div
-    class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kJJhJg"
+    class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 OvUNf"
   >
     <input
       autocomplete="off"
-      class="StyledTextInput-sc-1x30a0s-0 ddCwRo"
+      class="StyledTextInput-sc-1x30a0s-0 hzItmP"
       data-testid="placeholder"
       id="placeholder"
       name="placeholder"

--- a/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.tsx.snap
+++ b/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.tsx.snap
@@ -477,16 +477,16 @@ exports[`TextInput calls onSuggestionsClose 3`] = `""`;
 
 exports[`TextInput calls onSuggestionsClose 4`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 chFqZQ"
+  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
 >
   <div
-    class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 OvUNf"
+    class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kJJhJg"
   >
     <input
       aria-autocomplete="list"
       aria-expanded="false"
       autocomplete="off"
-      class="StyledTextInput-sc-1x30a0s-0 NbgCz"
+      class="StyledTextInput-sc-1x30a0s-0 ddCwRo"
       data-testid="test-input"
       id="item"
       name="item"
@@ -984,16 +984,16 @@ exports[`TextInput close suggestion drop 3`] = `""`;
 
 exports[`TextInput close suggestion drop 4`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 chFqZQ"
+  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
 >
   <div
-    class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 OvUNf"
+    class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kJJhJg"
   >
     <input
       aria-autocomplete="list"
       aria-expanded="false"
       autocomplete="off"
-      class="StyledTextInput-sc-1x30a0s-0 NbgCz"
+      class="StyledTextInput-sc-1x30a0s-0 ddCwRo"
       data-testid="test-input"
       id="item"
       name="item"
@@ -1566,14 +1566,14 @@ exports[`TextInput handles next and previous without suggestion 1`] = `
 
 exports[`TextInput handles next and previous without suggestion 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 chFqZQ"
+  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
 >
   <div
-    class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 OvUNf"
+    class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kJJhJg"
   >
     <input
       autocomplete="off"
-      class="StyledTextInput-sc-1x30a0s-0 NbgCz"
+      class="StyledTextInput-sc-1x30a0s-0 ddCwRo"
       data-testid="test-input"
       id="item"
       name="item"
@@ -2859,6 +2859,8 @@ exports[`TextInput read only copy 1`] = `
   margin: 0;
   border: 1px solid rgba(0, 0, 0, 0.33);
   border-radius: 4px;
+  flex: 1 1 auto;
+  min-width: 0;
   padding-right: 0px;
   border: none;
 }
@@ -2917,6 +2919,7 @@ exports[`TextInput read only copy 1`] = `
   box-sizing: border-box;
   flex-direction: row;
   display: flex;
+  align-items: stretch;
 }
 
 .c4 {
@@ -3103,6 +3106,8 @@ exports[`TextInput read only copy with width 1`] = `
   margin: 0;
   border: 1px solid rgba(0, 0, 0, 0.33);
   border-radius: 4px;
+  flex: 1 1 auto;
+  min-width: 0;
   padding-right: 0px;
   border: none;
 }
@@ -3162,6 +3167,7 @@ exports[`TextInput read only copy with width 1`] = `
   box-sizing: border-box;
   flex-direction: row;
   display: flex;
+  align-items: stretch;
 }
 
 .c4 {
@@ -4792,16 +4798,16 @@ exports[`TextInput select suggestion 3`] = `""`;
 
 exports[`TextInput select suggestion 4`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 chFqZQ"
+  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
 >
   <div
-    class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 OvUNf"
+    class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kJJhJg"
   >
     <input
       aria-autocomplete="list"
       aria-expanded="false"
       autocomplete="off"
-      class="StyledTextInput-sc-1x30a0s-0 bZddCO"
+      class="StyledTextInput-sc-1x30a0s-0 ejoMQd"
       data-testid="test-input"
       id="item"
       name="item"
@@ -5390,14 +5396,14 @@ exports[`TextInput should only show default placeholder when placeholder is a\\n
 
 exports[`TextInput should only show default placeholder when placeholder is a\\n  string 2`] = `
 <div
-  class="StyledGrommet-sc-19lkkz7-0 chFqZQ"
+  class="StyledGrommet-sc-19lkkz7-0 jhJvIT"
 >
   <div
-    class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 OvUNf"
+    class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 kJJhJg"
   >
     <input
       autocomplete="off"
-      class="StyledTextInput-sc-1x30a0s-0 NbgCz"
+      class="StyledTextInput-sc-1x30a0s-0 ddCwRo"
       data-testid="placeholder"
       id="placeholder"
       name="placeholder"

--- a/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.tsx.snap
+++ b/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.tsx.snap
@@ -1721,7 +1721,7 @@ exports[`TextInput icon 1`] = `
 `;
 
 exports[`TextInput icon reverse 1`] = `
-.c2 {
+.c3 {
   display: inline-block;
   flex: 0 0 auto;
   width: 24px;
@@ -1730,30 +1730,30 @@ exports[`TextInput icon reverse 1`] = `
   stroke: #666666;
 }
 
-.c2 g {
+.c3 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c2 *:not([stroke])[fill='none'] {
+.c3 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c2 *[stroke*='#'],
-.c2 *[STROKE*='#'] {
+.c3 *[stroke*='#'],
+.c3 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c2 *[fill-rule],
-.c2 *[FILL-RULE],
-.c2 *[fill*='#'],
-.c2 *[FILL*='#'] {
+.c3 *[fill-rule],
+.c3 *[FILL-RULE],
+.c3 *[fill*='#'],
+.c3 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
 
-.c3 {
+.c1 {
   box-sizing: border-box;
   font-size: inherit;
   font-family: inherit;
@@ -1770,49 +1770,49 @@ exports[`TextInput icon reverse 1`] = `
   padding-right: 48px;
 }
 
-.c3:focus {
+.c1:focus {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus >circle,
-.c3:focus >ellipse,
-.c3:focus >line,
-.c3:focus >path,
-.c3:focus >polygon,
-.c3:focus >polyline,
-.c3:focus >rect {
+.c1:focus >circle,
+.c1:focus >ellipse,
+.c1:focus >line,
+.c1:focus >path,
+.c1:focus >polygon,
+.c1:focus >polyline,
+.c1:focus >rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus ::-moz-focus-inner {
+.c1:focus ::-moz-focus-inner {
   border: 0;
 }
 
-.c3::-webkit-input-placeholder {
+.c1::-webkit-input-placeholder {
   color: #AAAAAA;
 }
 
-.c3::-moz-placeholder {
+.c1::-moz-placeholder {
   color: #AAAAAA;
 }
 
-.c3:-ms-input-placeholder {
+.c1:-ms-input-placeholder {
   color: #AAAAAA;
 }
 
-.c3 ::-webkit-search-decoration {
+.c1 ::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-.c3::-moz-focus-inner {
+.c1::-moz-focus-inner {
   border: none;
   outline: none;
 }
 
-.c3:-moz-placeholder,
-.c3::-moz-placeholder {
+.c1:-moz-placeholder,
+.c1::-moz-placeholder {
   opacity: 1;
 }
 
@@ -1821,7 +1821,7 @@ exports[`TextInput icon reverse 1`] = `
   width: 100%;
 }
 
-.c1 {
+.c2 {
   position: absolute;
   display: flex;
   justify: center;
@@ -1834,12 +1834,17 @@ exports[`TextInput icon reverse 1`] = `
 <div
   class="c0"
 >
-  <div
+  <input
+    autocomplete="off"
     class="c1"
+    name="item"
+  />
+  <div
+    class="c2"
   >
     <svg
       aria-label="Search"
-      class="c2"
+      class="c3"
       viewBox="0 0 24 24"
     >
       <path
@@ -1850,11 +1855,6 @@ exports[`TextInput icon reverse 1`] = `
       />
     </svg>
   </div>
-  <input
-    autocomplete="off"
-    class="c3"
-    name="item"
-  />
 </div>
 `;
 

--- a/src/js/components/TextInput/index.d.ts
+++ b/src/js/components/TextInput/index.d.ts
@@ -2,26 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import * as React from 'react';
 import { DropType } from '../Drop';
-
-type A11yTitleType = string;
-type TextAlignType = 'start' | 'center' | 'end' | 'justify';
-type WidthShirtSize =
-  | 'xsmall'
-  | 'small'
-  | 'medium'
-  | 'large'
-  | 'xlarge'
-  | string;
-type WidthType =
-  | 'xxsmall'
-  | 'xxlarge'
-  | WidthShirtSize
-  | '100%'
-  | {
-      width?: 'xxsmall' | 'xxlarge' | WidthShirtSize | '100%';
-      max?: 'xxsmall' | 'xxlarge' | WidthShirtSize | '100%';
-      min?: 'xxsmall' | 'xxlarge' | WidthShirtSize | '100%';
-    };
+import { A11yTitleType, TextAlignType, WidthType } from '../../utils';
 
 export interface TextInputProps
   extends Omit<
@@ -64,9 +45,9 @@ export interface TextInputProps
   }) => void;
   onSuggestionsOpen?: () => void;
   onSuggestionsClose?: () => void;
+  password?: boolean;
   placeholder?: string | React.ReactNode;
   plain?: boolean | 'full';
-  showPasswordToggle?: boolean;
   readOnlyCopy?: boolean;
   reverse?: boolean;
   size?: 'small' | 'medium' | 'large' | 'xlarge' | string;

--- a/src/js/components/TextInput/index.d.ts
+++ b/src/js/components/TextInput/index.d.ts
@@ -1,12 +1,27 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import * as React from 'react';
-import {
-  A11yTitleType,
-  Omit,
-  PlaceHolderType,
-  TextAlignType,
-  WidthType,
-} from '../../utils';
 import { DropType } from '../Drop';
+
+type A11yTitleType = string;
+type TextAlignType = 'start' | 'center' | 'end' | 'justify';
+type WidthShirtSize =
+  | 'xsmall'
+  | 'small'
+  | 'medium'
+  | 'large'
+  | 'xlarge'
+  | string;
+type WidthType =
+  | 'xxsmall'
+  | 'xxlarge'
+  | WidthShirtSize
+  | '100%'
+  | {
+      width?: 'xxsmall' | 'xxlarge' | WidthShirtSize | '100%';
+      max?: 'xxsmall' | 'xxlarge' | WidthShirtSize | '100%';
+      min?: 'xxsmall' | 'xxlarge' | WidthShirtSize | '100%';
+    };
 
 export interface TextInputProps
   extends Omit<
@@ -28,10 +43,12 @@ export interface TextInputProps
   dropProps?: DropType;
   focusIndicator?: boolean;
   defaultSuggestion?: number;
-  icon?: JSX.Element;
+  icon?: React.ReactNode;
   id?: string;
   messages?: {
     enterSelect?: string;
+    hidePassword?: string;
+    showPassword?: string;
     suggestionsCount?: string;
     suggestionsExist?: string;
     suggestionIsOpen?: string;
@@ -47,8 +64,9 @@ export interface TextInputProps
   }) => void;
   onSuggestionsOpen?: () => void;
   onSuggestionsClose?: () => void;
-  placeholder?: PlaceHolderType;
+  placeholder?: string | React.ReactNode;
   plain?: boolean | 'full';
+  showPasswordToggle?: boolean;
   readOnlyCopy?: boolean;
   reverse?: boolean;
   size?: 'small' | 'medium' | 'large' | 'xlarge' | string;

--- a/src/js/components/TextInput/propTypes.js
+++ b/src/js/components/TextInput/propTypes.js
@@ -37,9 +37,9 @@ if (process.env.NODE_ENV !== 'production') {
     onSuggestionSelect: PropTypes.func,
     onSuggestionsOpen: PropTypes.func,
     onSuggestionsClose: PropTypes.func,
+    password: PropTypes.bool,
     placeholder: PropTypes.node,
     plain: PropTypes.oneOfType([PropTypes.bool, PropTypes.oneOf(['full'])]),
-    showPasswordToggle: PropTypes.bool,
     readOnlyCopy: PropTypes.bool,
     reverse: PropTypes.bool,
     size: PropTypes.oneOfType([

--- a/src/js/components/TextInput/propTypes.js
+++ b/src/js/components/TextInput/propTypes.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import PropTypes from 'prop-types';
 import { widthPropType } from '../../utils/general-prop-types';
 
@@ -23,6 +25,8 @@ if (process.env.NODE_ENV !== 'production') {
     focusIndicator: PropTypes.bool,
     messages: PropTypes.shape({
       enterSelect: PropTypes.string,
+      hidePassword: PropTypes.string,
+      showPassword: PropTypes.string,
       suggestionsCount: PropTypes.string,
       suggestionsExist: PropTypes.string,
       suggestionIsOpen: PropTypes.string,
@@ -35,6 +39,7 @@ if (process.env.NODE_ENV !== 'production') {
     onSuggestionsClose: PropTypes.func,
     placeholder: PropTypes.node,
     plain: PropTypes.oneOfType([PropTypes.bool, PropTypes.oneOf(['full'])]),
+    showPasswordToggle: PropTypes.bool,
     readOnlyCopy: PropTypes.bool,
     reverse: PropTypes.bool,
     size: PropTypes.oneOfType([

--- a/src/js/components/TextInput/stories/Password.stories.js
+++ b/src/js/components/TextInput/stories/Password.stories.js
@@ -10,9 +10,8 @@ export const Password = () => {
   return (
     // Uncomment <Grommet> lines when using outside of storybook
     // <Grommet theme={...}>
-    <Box width="medium" margin="large">
+    <Box align="center" pad="large" width="medium">
       <TextInput
-        type="password"
         password
         value={value}
         onChange={(event) => setValue(event.target.value)}

--- a/src/js/components/TextInput/stories/Password.stories.js
+++ b/src/js/components/TextInput/stories/Password.stories.js
@@ -1,33 +1,20 @@
 import React from 'react';
 
-import { Hide, View } from 'grommet-icons';
-import { Box, Button, TextInput } from 'grommet';
+import { Box, TextInput } from 'grommet';
 
 export const Password = () => {
   const [value, setValue] = React.useState('');
-  const [reveal, setReveal] = React.useState(false);
 
   return (
     // Uncomment <Grommet> lines when using outside of storybook
     // <Grommet theme={...}>
-    <Box
-      width="medium"
-      direction="row"
-      margin="large"
-      align="center"
-      round="small"
-      border
-    >
+    <Box width="medium" margin="large">
       <TextInput
-        plain
-        type={reveal ? 'text' : 'password'}
+        type="password"
+        showPasswordToggle
         value={value}
         onChange={(event) => setValue(event.target.value)}
-        aria-label="Input Password"
-      />
-      <Button
-        icon={reveal ? <View size="medium" /> : <Hide size="medium" />}
-        onClick={() => setReveal(!reveal)}
+        aria-label="Password"
       />
     </Box>
     // </Grommet>

--- a/src/js/components/TextInput/stories/Password.stories.js
+++ b/src/js/components/TextInput/stories/Password.stories.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 
 import { Box, TextInput } from 'grommet';

--- a/src/js/components/TextInput/stories/Password.stories.js
+++ b/src/js/components/TextInput/stories/Password.stories.js
@@ -13,7 +13,7 @@ export const Password = () => {
     <Box width="medium" margin="large">
       <TextInput
         type="password"
-        showPasswordToggle
+        password
         value={value}
         onChange={(event) => setValue(event.target.value)}
         aria-label="Password"

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -1150,6 +1150,7 @@ exports[`Components loads 1`] = `
       "onSuggestionSelect": [Function],
       "onSuggestionsClose": [Function],
       "onSuggestionsOpen": [Function],
+      "password": [Function],
       "placeholder": [Function],
       "plain": [Function],
       "readOnlyCopy": [Function],

--- a/src/js/languages/default.json
+++ b/src/js/languages/default.json
@@ -214,6 +214,8 @@
   },
   "textInput": {
     "enterSelect": "(Press Enter to Select)",
+    "hidePassword": "Hide password",
+    "showPassword": "Show password",
     "suggestionsCount": "suggestions available",
     "suggestionsExist": "This input has suggestions use arrow keys to navigate",
     "suggestionIsOpen": "Suggestions drop is open, continue to use arrow keys to navigate"

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import {
   FlattenInterpolation,
   FlattenSimpleInterpolation,
@@ -2415,6 +2417,8 @@ export interface ThemeType {
     };
     icons?: {
       copy?: React.ReactNode | Icon;
+      hidePassword?: React.ReactNode | Icon;
+      showPassword?: React.ReactNode | Icon;
     };
     placeholder?: {
       extend?: ExtendType;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -16,11 +16,13 @@ import { Pause } from 'grommet-icons/icons/Pause';
 import { Play } from 'grommet-icons/icons/Play';
 import { FormPin } from 'grommet-icons/icons/FormPin';
 import { Previous } from 'grommet-icons/icons/Previous';
+import { Hide } from 'grommet-icons/icons/Hide';
 import { StatusCriticalSmall } from 'grommet-icons/icons/StatusCriticalSmall';
 import { StatusGoodSmall } from 'grommet-icons/icons/StatusGoodSmall';
 import { StatusWarningSmall } from 'grommet-icons/icons/StatusWarningSmall';
 import { StatusUnknownSmall } from 'grommet-icons/icons/StatusUnknownSmall';
 import { Subtract } from 'grommet-icons/icons/Subtract';
+import { View } from 'grommet-icons/icons/View';
 import { Volume } from 'grommet-icons/icons/Volume';
 import { VolumeLow } from 'grommet-icons/icons/VolumeLow';
 import { base as iconBase } from 'grommet-icons/themes/base';
@@ -2593,11 +2595,11 @@ export const generate = (baseSpacing = 24, scale = 6) => {
     textInput: {
       // extend: undefined,
       // disabled: { opacity: undefined },
-      // icons: {
-      //   copy: undefined,
-      //   hidePassword: undefined,
-      //   showPassword: undefined,
-      // },
+      icons: {
+        // copy: undefined,
+        hidePassword: Hide,
+        showPassword: View,
+      },
     },
     timeInput: {
       button: {

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { Actions } from 'grommet-icons/icons/Actions';
 import { AssistListening } from 'grommet-icons/icons/AssistListening';
 import { CircleInformation } from 'grommet-icons/icons/CircleInformation';
@@ -2593,6 +2595,8 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       // disabled: { opacity: undefined },
       // icons: {
       //   copy: undefined,
+      //   hidePassword: undefined,
+      //   showPassword: undefined,
       // },
     },
     timeInput: {

--- a/src/js/utils/styles.js
+++ b/src/js/utils/styles.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import { css } from 'styled-components';
 import isPropValid from '@emotion/is-prop-valid';
 import { backgroundStyle } from './background';
@@ -39,6 +41,19 @@ export const controlBorderStyle = css`
       )};
   border-radius: ${(props) => props.theme.global.control.border.radius};
 `;
+
+export const getInputIconPad = (props) => {
+  const matchedIconSize = props.theme?.icon?.size?.[props?.size || 'medium'];
+
+  if (props.theme?.icon?.matchSize && matchedIconSize) {
+    return `${
+      parseMetricToNum(matchedIconSize) +
+      parseMetricToNum(props.theme.global.edgeSize.medium)
+    }px`;
+  }
+
+  return props.theme.global.edgeSize.large;
+};
 
 export const edgeStyle = (
   kind,
@@ -584,12 +599,7 @@ export const inputStyle = css`
 // to ensure there is reasonable space between the icon and value or placeholder
 export const inputPadForIcon = css`
   ${(props) => {
-    const pad = props.theme?.icon?.matchSize
-      ? `${
-          parseMetricToNum(props.theme.icon?.size?.[props?.size || 'medium']) +
-          parseMetricToNum(props.theme.global.edgeSize.medium)
-        }px`
-      : props.theme.global.edgeSize.large;
+    const pad = getInputIconPad(props);
 
     return props.reverse ? `padding-right: ${pad};` : `padding-left: ${pad};`;
   }}


### PR DESCRIPTION
#### What does this PR do?

Adds a built-in password reveal/hide affordance to `TextInput` via `showPasswordToggle`.

This PR:
- adds password-toggle behavior and state handling in [TextInput.js](https://github.com/grommet/grommet/blob/6425-opsramp-textinput-password-affordance/src/js/components/TextInput/TextInput.js#L100-L179) and [TextInput.js](https://github.com/grommet/grommet/blob/6425-opsramp-textinput-password-affordance/src/js/components/TextInput/TextInput.js#L508-L647)
- places the toggle flush-right inside the field in [StyledTextInput.js](https://github.com/grommet/grommet/blob/6425-opsramp-textinput-password-affordance/src/js/components/TextInput/StyledTextInput.js#L16-L30) and [StyledTextInput.js](https://github.com/grommet/grommet/blob/6425-opsramp-textinput-password-affordance/src/js/components/TextInput/StyledTextInput.js#L113-L120)
- adds the public prop and message typings in [propTypes.js](https://github.com/grommet/grommet/blob/6425-opsramp-textinput-password-affordance/src/js/components/TextInput/propTypes.js#L24-L42) and [index.d.ts](https://github.com/grommet/grommet/blob/6425-opsramp-textinput-password-affordance/src/js/components/TextInput/index.d.ts#L42-L69)
- adds default i18n strings in [default.json](https://github.com/grommet/grommet/blob/6425-opsramp-textinput-password-affordance/src/js/languages/default.json#L215-L221)
- adds theme hooks for password icons in [base.js](https://github.com/grommet/grommet/blob/6425-opsramp-textinput-password-affordance/src/js/themes/base.js#L2594-L2600) and [base.d.ts](https://github.com/grommet/grommet/blob/6425-opsramp-textinput-password-affordance/src/js/themes/base.d.ts#L2415-L2422)
- updates the password story in [Password.stories.js](https://github.com/grommet/grommet/blob/6425-opsramp-textinput-password-affordance/src/js/components/TextInput/stories/Password.stories.js#L5-L18)
- adds Jest coverage in [TextInput-test.tsx](https://github.com/grommet/grommet/blob/6425-opsramp-textinput-password-affordance/src/js/components/TextInput/__tests__/TextInput-test.tsx#L68-L108)

Compare view:
https://github.com/grommet/grommet/compare/master...6425-opsramp-textinput-password-affordance

#### Where should the reviewer start?

Start in [TextInput.js](https://github.com/grommet/grommet/blob/6425-opsramp-textinput-password-affordance/src/js/components/TextInput/TextInput.js#L100-L179), especially:
- prop intake and password-toggle gating
- reveal/hide messages and reset behavior
- built-in toggle rendering and input type switching in [TextInput.js](https://github.com/grommet/grommet/blob/6425-opsramp-textinput-password-affordance/src/js/components/TextInput/TextInput.js#L508-L647)

Then review the layout work in [StyledTextInput.js](https://github.com/grommet/grommet/blob/6425-opsramp-textinput-password-affordance/src/js/components/TextInput/StyledTextInput.js#L16-L120), especially the inline button padding and flush-right wrapper.

#### What testing has been done on this PR?

- Ran `npx jest src/js/components/TextInput/__tests__/TextInput-test.tsx --runInBand --coverage=false`
- Ran `npm run build-storybook`
- Ran `npm run lint-fix`

#### How should this be manually tested?

- Open the password story in [Password.stories.js](https://github.com/grommet/grommet/blob/6425-opsramp-textinput-password-affordance/src/js/components/TextInput/stories/Password.stories.js#L5-L18).
- Verify the password toggle renders inside the field on the right.
- Verify the control is flush-right, matching the existing read-only copy affordance behavior.
- Verify when the password is hidden, the `Hide` icon is shown, as wired in [TextInput.js](https://github.com/grommet/grommet/blob/6425-opsramp-textinput-password-affordance/src/js/components/TextInput/TextInput.js#L527-L538).
- Verify when the password is revealed, the `View` icon is shown.
- Click the toggle and confirm the input switches between `type="password"` and `type="text"` in [TextInput.js](https://github.com/grommet/grommet/blob/6425-opsramp-textinput-password-affordance/src/js/components/TextInput/TextInput.js#L511-L514).
- Verify `readOnlyCopy` still behaves as before.
- Optionally verify theme overrides for `textInput.icons.showPassword` and `textInput.icons.hidePassword` from [base.d.ts](https://github.com/grommet/grommet/blob/6425-opsramp-textinput-password-affordance/src/js/themes/base.d.ts#L2418-L2421).

##### State Matrix

| Combination | Expected resolution |
| --- | --- |
| `password` vs `readOnlyCopy` | `readOnlyCopy` wins; no password toggle renders |
| `password` vs `icon` | Both are allowed when the icon stays on the leading side |
| `password` vs `icon` + `reverse` | Password toggle owns the trailing edge; reversed icon is suppressed |
| `password` vs `textAlign` | Text alignment is preserved; toggle remains flush-right |
| `password` vs theme icon override | Both icon component types and pre-created React elements are supported |
| `password` absent + `type="password"` | No built-in toggle; behaves like a normal password input |
| future `clear` vs `password` | Spec needed before implementation; likely another trailing-edge conflict to resolve |

As a checklist:

1. Verify `password` alone renders a flush-right toggle and switches between masked and revealed input.
2. Verify `password + readOnlyCopy` does not show the password toggle.
3. Verify `password + icon` keeps the icon when it is not reversed.
4. Verify `password + icon + reverse` suppresses the reversed icon so the trailing edge is not overloaded.
5. Verify `password + textAlign` preserves text alignment.
6. Verify theme overrides work for both icon components and icon elements.

#### Do Jest tests follow these best practices?

- [x] `screen` is used for querying.
- [x] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

This change comes from repeated consumer demand for a password reveal/hide pattern that had previously been implemented ad hoc. The built-in pattern is intentionally narrow: it adds a password-specific affordance instead of a generic trailing action API.

The layout also aligns the password toggle more closely with the existing in-field affordance treatment by making it flush-right inside the field.

#### What are the relevant issues?

- `grommet/hpe-design-system#6407`
- `grommet/hpe-design-system#6425`
- `grommet/hpe-design-system#5186`

#### Do the grommet docs need to be updated?

Yes.

`TextInput` docs should be updated to cover:
- `showPasswordToggle` in [index.d.ts](https://github.com/grommet/grommet/blob/6425-opsramp-textinput-password-affordance/src/js/components/TextInput/index.d.ts#L60-L69)
- default password messages in [default.json](https://github.com/grommet/grommet/blob/6425-opsramp-textinput-password-affordance/src/js/languages/default.json#L215-L221)
- theme hooks for `showPassword` / `hidePassword` icons in [base.d.ts](https://github.com/grommet/grommet/blob/6425-opsramp-textinput-password-affordance/src/js/themes/base.d.ts#L2418-L2421)

#### Should this PR be mentioned in the release notes?

Yes.

This adds a new supported `TextInput` capability and public prop.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.

This is an opt-in change via `showPasswordToggle` and does not affect existing `TextInput` behavior unless that prop is used.