### PR TITLE
fix(DataTable): correctly detect numeric array indices in buildState `set()`

### DIFF
--- a/src/js/components/DataTable/__tests__/buildState-test.js
+++ b/src/js/components/DataTable/__tests__/buildState-test.js
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
+import { set } from '../buildState';
+
+describe('buildState', () => {
+  test('set() creates an array for a numeric path segment', () => {
+    expect(set({}, 'a.0', 'x')).toEqual({ a: ['x'] });
+    expect(set({}, 'a.0.b', 'x')).toEqual({ a: [{ b: 'x' }] });
+  });
+
+  test('set() creates an object for a non-numeric path segment', () => {
+    expect(set({}, 'a.b', 'x')).toEqual({ a: { b: 'x' } });
+  });
+});

--- a/src/js/components/DataTable/buildState.js
+++ b/src/js/components/DataTable/buildState.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 // This file contains helper functions for DataTable, to keep the component
 // files simpler.
 
@@ -10,7 +12,7 @@ export const set = (obj, path, value) => {
     if (Object(acc[item]) === acc[item]) {
       return acc[item];
     }
-    acc[item] = Math.abs(parts[index + 1]) > 0 === +parts[index + 1] ? [] : {};
+    acc[item] = /^\d+$/.test(parts[index + 1]) ? [] : {};
     return acc[item];
   }, obj)[parts[parts.length - 1]] = value;
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Fixes a bug in the `set()` helper in `buildState.js` (used by `DataTable`, and internally by `DataTableGroupBy`, etc.) where the check for whether a path segment is a numeric array index was always `false`.

**before fixed**
```js
acc[item] = Math.abs(parts[index + 1]) > 0 === +parts[index + 1] ? [] : {};
```

**after fixed**
```js
acc[item] = /^\d+$/.test(parts[index + 1]) ? [] : {};
```

Before check compared a boolean to a number, which is always false under ===. 
So set() always built a plain object, even for numeric path segments that should have produced an array — e.g. a column.property or footer path with a numeric index would silently end up as an object instead of an array.


#### Where should the reviewer start?

`src/js/components/DataTable/buildState.js`
`src/js/components/DataTable/__tests__/buildState-test.js`

#### What testing has been done on this PR?

```bash
$ node ./node_modules/.bin/jest src/js/components/DataTable --silent
Jest: Coverage for statements (33.69%) does not meet "global" threshold (86.6%)
Jest: Coverage for branches (28.31%) does not meet "global" threshold (76.3%)
Jest: Coverage for lines (34.52%) does not meet "global" threshold (87.5%)
Jest: Coverage for functions (33.85%) does not meet "global" threshold (88%)
Test Suites: 4 passed, 4 total
Tests:       97 passed, 97 total
Snapshots:   118 passed, 118 total
Time:        17.324 s
```

#### How should this be manually tested?

`set()` is an internal utility function with no UI, so no manual UI testing is needed. 
To verify the behavior directly:
```js
import { set } from './buildState';

set({}, 'a.0', 'x'); // before: { a: { '0': 'x' } } → after: { a: ['x'] }
```

import { set } from './buildState';
set({}, 'a.0', 'x'); // before: { a: { '0': 'x' } } → after: { a: ['x'] }

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

Found as part of an internal bug audit of `src/js/components`

#### What are the relevant issues?

None

#### Screenshots (if appropriate)

N/A

#### Do the grommet docs need to be updated?

No

#### Should this PR be mentioned in the release notes?

Optional. 
A short bug-fix note would be reasonable, e.g. "Fixed DataTable buildState incorrectly building objects instead of arrays for numeric path segments."

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible — no breaking change.