### PR TITLE
fix(Data): handle both array and number selected count when announcing

### DIFF
--- a/src/js/components/Data/Data.js
+++ b/src/js/components/Data/Data.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext, useEffect, useMemo, useState } from 'react';
 import { AnnounceContext } from '../../contexts';
 import { Box } from '../Box';
@@ -87,7 +89,7 @@ export const Data = ({
           items,
         },
       })}${
-        selected > 0
+        (Array.isArray(selected) ? selected.length : selected) > 0
           ? `, ${format({
               id: 'dataSummary.selected',
               messages: messages?.dataSummary,

--- a/src/js/components/Data/__tests__/Data-announce-test.tsx
+++ b/src/js/components/Data/__tests__/Data-announce-test.tsx
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { AnnounceContext } from '../../../contexts/AnnounceContext';
+import { Grommet } from '../../Grommet';
+import { DataTable } from '../../DataTable';
+import { Data } from '..';
+
+const DATA = [
+  { name: 'aa', enabled: true },
+  { name: 'bb', enabled: false },
+  { name: 'cc', enabled: true },
+];
+
+// Regression test for a bug where the "selected" announcement never fired.
+// DataTable reports selection to Data's context as a number
+// (select.length), while Data's own local `selected` state starts out as
+// an array ([]). The announce effect must handle both shapes.
+test('announces the selected count once rows are selected via DataTable', () => {
+  const announce = jest.fn();
+
+  const App = () => {
+    const [select, setSelect] = useState<(string | number)[]>([]);
+    return (
+      <AnnounceContext.Provider value={announce}>
+        <Grommet>
+          <Data data={DATA}>
+            <DataTable select={select} onSelect={setSelect} />
+          </Data>
+        </Grommet>
+      </AnnounceContext.Provider>
+    );
+  };
+  render(<App />);
+
+  fireEvent.click(screen.getByLabelText('select all'));
+
+  expect(
+    announce.mock.calls.some(([message]) => /3 selected/i.test(String(message))),
+  ).toBe(true);
+});


### PR DESCRIPTION
#### What does this PR do?
Fixes `Data`'s screen-reader announcement of the selected-row count.

`Data.js` keeps `selected` in local state, initialized as an array (`useState([])`). But `DataTable` actually reports selection back into `Data`'s context as a number (`select.length`), not an array. 
The code compared this value directly with `selected > 0`, which happened to work only for the empty-array case — once a real selection came in, the comparison was always `false`, so the "N selected" part of the announcement never fired.

**before fixed**
```js
selected > 0
```

**after fixed**
```js
(Array.isArray(selected) ? selected.length : selected) > 0
```

#### Where should the reviewer start?
- `src/js/components/Data/Data.js`
- `src/js/components/Data/__tests__/Data-announce-test.tsx`

#### What testing has been done on this PR?

Ran the Data, DataTable, and DataSummary test suites locally; all pass.

```bash
$ node ./node_modules/.bin/jest src/js/components/Data src/js/components/DataTable src/js/components/DataSummary --silent
Jest: Coverage for statements (44.65%) does not meet "global" threshold (86.6%)
Jest: Coverage for branches (39.14%) does not meet "global" threshold (76.3%)
Jest: Coverage for lines (45.34%) does not meet "global" threshold (87.5%)
Jest: Coverage for functions (45.74%) does not meet "global" threshold (88%)
Test Suites: 13 passed, 13 total
Tests:       212 passed, 212 total
Snapshots:   236 passed, 236 total
Time:        57.236 s
(Coverage-threshold warnings are expected since only a subset of the repo was targeted.)
```

#### How should this be manually tested?
Render a Data + DataTable pair with toolbar enabled, select some rows, and confirm the live-region announcement text (visible via a screen reader, or by inspecting #grommet-announcer in the DOM) includes the "N selected" portion after selecting rows.

#### Do Jest tests follow these best practices?
 - [x] screen is used for querying.
 - [x]  The correct query is used.
 - [ ] `asFragment()`  is used for snapshot testing.
→ The added test asserts on announce mock call arguments rather than rendered DOM, so snapshot testing isn't applicable here.

#### Any background context you want to provide?
Found as part of an internal bug audit of src/js/components. 
A related latent issue in `DataSummary.js` (same selected > 0 pattern) is addressed separately in a follow-up PR.

#### What are the relevant issues?
~~None.~~

- https://github.com/grommet/grommet/pull/8022

#### Screenshots (if appropriate)
N/A

#### Do the grommet docs need to be updated?
No.

#### Should this PR be mentioned in the release notes?
Optional. A short accessibility bug-fix note would be reasonable, e.g. 
"Fixed Data not announcing the selected-row count to screen readers."

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.
