### PR TITLE
Fix: datasummary selected count comparison

### DIFF
--- a/src/js/components/DataSummary/DataSummary.js
+++ b/src/js/components/DataSummary/DataSummary.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext } from 'react';
 import { Text } from '../Text';
 import { DataContext } from '../../contexts/DataContext';
@@ -28,6 +30,10 @@ export const DataSummary = ({ messages, ...rest }) => {
     messages: messages || dataMessages?.dataSummary,
   });
 
+  // `selected` is a count when reported by DataTable, but may also be
+  // supplied as an array of ids when DataContext is provided directly
+  const selectedCount = Array.isArray(selected) ? selected.length : selected;
+
   return (
     <Text margin={theme.dataSummary?.margin} {...rest}>
       {format({
@@ -39,9 +45,9 @@ export const DataSummary = ({ messages, ...rest }) => {
           items,
         },
       })}
-      {selected > 0 ? (
+      {selectedCount > 0 ? (
         <>
-          {/* separator with margin to ensure | is not confused 
+          {/* separator with margin to ensure | is not confused
           as a 1 in the selected count */}
           <Text margin={theme.dataSummary?.separator?.margin}>|</Text>
           <Text>
@@ -49,7 +55,7 @@ export const DataSummary = ({ messages, ...rest }) => {
               id: 'dataSummary.selected',
               messages: messages || dataMessages?.dataSummary,
               values: {
-                selected,
+                selected: selectedCount,
               },
             })}
           </Text>

--- a/src/js/components/DataSummary/__tests__/DataSummary-test.tsx
+++ b/src/js/components/DataSummary/__tests__/DataSummary-test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import 'jest-styled-components';
@@ -6,6 +8,8 @@ import { Data } from '../../Data';
 import { DataFilters } from '../../DataFilters';
 import { DataTable } from '../../DataTable';
 import { Grommet } from '../../Grommet';
+// @ts-expect-error DataContext.js has no type declarations
+import { DataContext } from '../../../contexts/DataContext';
 import { DataSummary } from '..';
 
 // asserts that DataSummary has text. Previously this was set to 2 to include AnnounceContext
@@ -92,6 +96,28 @@ describe('DataSummary', () => {
     expect(screen.getByText('1 selected')).toBeTruthy();
     const rowCheckbox = screen.getByRole('checkbox', { name: 'select b' });
     fireEvent.click(rowCheckbox);
+    expect(screen.getByText('2 selected')).toBeTruthy();
+  });
+
+  // regression test: DataTable always reports `selected` to DataContext as
+  // a number (select.length), but DataContext can also be supplied
+  // directly (bypassing DataTable) with `selected` as an array of ids.
+  test('renders selected count when selected is provided as an array', () => {
+    render(
+      <Grommet>
+        <DataContext.Provider
+          value={{
+            data,
+            total: data.length,
+            filteredTotal: data.length,
+            selected: ['a', 'b'],
+          }}
+        >
+          <DataSummary />
+        </DataContext.Provider>
+      </Grommet>,
+    );
+
     expect(screen.getByText('2 selected')).toBeTruthy();
   });
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fixes a bug in `DataSummary` where the selected count was not displayed correctly when `selected` is provided as an array of ids rather than a number.
`DataTable` reports `selected` to `DataContext` as a number (`select.length`), but `DataContext` can also be supplied directly with `selected` as an array. In that case, `selected > 0` failed silently, and even once gated correctly, the raw array was passed into the message template instead of a count. 
Both cases are now normalized to a count before being used for the check and the message.

#### Where should the reviewer start?
Start with the diff around `selectedCount` in `src/js/components/DataSummary/DataSummary.js`.

#### What testing has been done on this PR?
Added a regression test covering the case where `selected` is provided as an array, and verified all existing tests still pass with `jest src/js/components/DataSummary`.

#### How should this be manually tested?
Render `DataSummary` with `DataContext.Provider` supplying `selected` as both a number (simulating the `DataTable` path) and an array of ids (direct usage), and confirm the correct count (e.g. "2 selected") is displayed in both cases.

#### Do Jest tests follow these best practices?
- [x] `screen` is used for querying.
- [x] The correct query is used.
- [ ] `asFragment()` is used for snapshot testing. (not applicable here — the test only asserts on visible text)

#### Any background context you want to provide?
`selected` was expected to always be a number from `DataTable`, but when `DataContext` is used directly (bypassing `DataTable`), it can be an array, which broke the rendering.

#### What are the relevant issues?

- https://github.com/grommet/grommet/pull/8022

#### Screenshots (if appropriate)
No - no visual change beyond the fixed count display, so likely not needed.

#### Do the grommet docs need to be updated?
No - this is an internal logic fix with no change to public API or documented behavior.

#### Should this PR be mentioned in the release notes?
Yes - worth noting as a bug fix in the release notes.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible — no breaking changes.

