### PR TITLE
fix(DataTableColumns): prevent empty column selection from auto-resetting to all (Closes #7984)

### DIFF
--- a/src/js/components/Data/DataForm.js
+++ b/src/js/components/Data/DataForm.js
@@ -136,10 +136,14 @@ const formValueToView = (value, views) => {
   const valueCopy = { ...value };
 
   Object.keys(viewFormKeyMap).forEach((key) => {
-    if (valueCopy[viewFormKeyMap[key]]) {
-      result[key] = valueCopy[viewFormKeyMap[key]];
+    const formKey = viewFormKeyMap[key];
+    if (valueCopy[formKey]) {
+      result[key] = valueCopy[formKey];
+    } else if (formKey === formColumnsKey && valueCopy[formKey] !== undefined) {
+      // _columns can be an empty array (no columns selected)
+      result[key] = valueCopy[formKey];
     }
-    delete valueCopy[viewFormKeyMap[key]];
+    delete valueCopy[formKey];
   });
 
   // flatten any nested objects
@@ -165,7 +169,14 @@ const formValueToView = (value, views) => {
 const clearEmpty = (formValue, pendingReset) => {
   const value = formValue;
   Object.keys(value).forEach((k) => {
-    if (Array.isArray(value[k]) && value[k].length === 0) delete value[k];
+    // _columns (formColumnsKey) can be an empty array to indicate
+    // no columns selected; don't delete it.
+    if (
+      Array.isArray(value[k]) &&
+      value[k].length === 0 &&
+      k !== formColumnsKey
+    )
+      delete value[k];
     // special case for when range selector returns to its min/max
     // flat format with full: true needed to match filter name structure
     // { a: b: { _range: [0, 100] } } ==> a.b._range: [0, 100]

--- a/src/js/components/DataTable/DataTable.js
+++ b/src/js/components/DataTable/DataTable.js
@@ -558,6 +558,23 @@ const DataTable = ({
     />
   );
 
+  // When no columns are visible (e.g. user deselected all in DataTableColumns),
+  // show a message instead of an empty table.
+  if (columns.length === 0 && view?.columns !== undefined) {
+    return (
+      <Container {...containterProps}>
+        <Box align="center" pad="medium">
+          <Text>
+            {format({
+              id: 'dataTableColumns.noColumnsSelected',
+              messages: messages?.dataTableColumns,
+            })}
+          </Text>
+        </Box>
+      </Container>
+    );
+  }
+
   return (
     <Container {...containterProps}>
       <OverflowContainer {...overflowContainerProps}>

--- a/src/js/components/DataTableColumns/DataTableColumns.js
+++ b/src/js/components/DataTableColumns/DataTableColumns.js
@@ -134,7 +134,7 @@ const Content = ({ drop, options = [], activePanel, ...rest }) => {
     </Box>
   );
 
-  const orderColumnsContent = (
+  const orderColumnsContent = value.length > 0 ? (
     <Box pad={theme.dataTableColumns.orderColumns.pad}>
       <List
         id={`${dataId}--order-columns`}
@@ -154,6 +154,15 @@ const Content = ({ drop, options = [], activePanel, ...rest }) => {
         primaryKey={(objectOptions && 'label') || undefined}
         pinned={pinned}
       />
+    </Box>
+  ) : (
+    <Box pad={theme.dataTableColumns.orderColumns.pad}>
+      <Text>
+        {format({
+          id: 'dataTableColumns.noColumnsSelected',
+          messages: messages?.dataTableColumns,
+        })}
+      </Text>
     </Box>
   );
 

--- a/src/js/languages/default.json
+++ b/src/js/languages/default.json
@@ -85,7 +85,8 @@
     "select": "Select columns",
     "tip": "Manage columns",
     "selectAria": "Select which columns to show in the data table",
-    "orderAria": "Reorder the visible columns in the data table"
+    "orderAria": "Reorder the visible columns in the data table",
+    "noColumnsSelected": "No columns selected"
   },
   "dataTableGroupBy": {
     "clear": "Clear group",


### PR DESCRIPTION
Deselecting all columns in `DataTableColumns` immediately re-selected all columns, and no empty state was shown.

## Root cause

Two bugs in `DataForm.js`:

1. **`clearEmpty()`** deleted the `_columns` key whenever its value was an empty array. Since `[]` means "no columns selected" (a valid state), the form lost the user's empty selection and fell back to the initial value (all columns).
2. **`formValueToView()`** skipped `_columns` when it was an empty array (falsy check with `if (valueCopy[key])`), so the chosen empty state never round-tripped to the view.

## Fix

- Skip `_columns` in `clearEmpty()` when it is an empty array.
- Pass `_columns` through `formValueToView()` even when it is an empty array.
- Show a **"No columns selected"** message in the order-columns tab of `DataTableColumns` when `value` is empty.
- Surface the same message in `DataTable` when no columns are visible (instead of silently rendering a column-less table).

Closes #7984
