### PR TITLE
fix(DataTable): add default background to pinned columns to prevent scroll overlap

### DIFF
--- a/src/js/components/DataTable/StyledDataTable.js
+++ b/src/js/components/DataTable/StyledDataTable.js
@@ -147,6 +147,7 @@ const StyledDataTableCell = styled(TableCell)`
     props.pin &&
     props.pin.length > 0 &&
     `position: sticky;
+    background: ${normalizeColor('background', props.theme)};
     ${props.pin
       .map(
         (p) =>


### PR DESCRIPTION
## What does this PR do?

Fixes #7941

Pinned columns use `position: sticky` but were missing a default background color. When the table is horizontally scrolled, the left-scrolling content was bleeding through underneath the pinned column, causing the pinned content to overlap with other column content.

## How does this fix it?

Added a default background (`normalizeColor('background', props.theme)`) to the pinned cell styles in `StyledDataTableCell`, so pinned columns always have an opaque background that hides the scrolled content beneath them. Users can still override this via the existing `background` prop or `theme.dataTable.pinned.extend`.

## Screenshots

N/A

## Checklist

- [x] I'm able to reproduce the issue
- [x] I've tested the fix
- [x] I've provided a CodeSandbox reproduction where possible