### PR TITLE
fix(Select): prevent search input focus loss on option hover

### DIFF
--- a/src/js/components/Select/SelectContainer.js
+++ b/src/js/components/Select/SelectContainer.js
@@ -168,8 +168,14 @@ const SelectContainer = forwardRef(
 
     // for keyboard/screenreader, keep the active option in focus
     useEffect(() => {
-      if (activeIndex >= 0) activeRef.current?.focus();
-    }, [activeIndex]);
+      if (activeIndex >= 0) {
+        // When search is enabled and the user is using the mouse,
+        // don't let option hover steal focus from the search input.
+        // Only focus the active option when using keyboard navigation.
+        if (onSearch && !keyboardNavigation) return;
+        activeRef.current?.focus();
+      }
+    }, [activeIndex, keyboardNavigation, onSearch]);
 
     // set initial focus
     useEffect(() => {


### PR DESCRIPTION
**This PR fixes issue #7856.**

## Problem

When a `Select` has an `onSearch` prop, the search input correctly receives focus when the dropdown opens. However, as soon as the cursor moves over the options list, the search input loses focus. This makes it hard to keep typing a search query while visually targeting an option.

## Root cause

The `useEffect` that keeps the active option in focus (for keyboard/screenreader navigation) runs on **every** `activeIndex` change, regardless of the input method. When the user hovers over an option with the mouse:

1. `OptionsContainer.onMouseMove` sets `keyboardNavigation = false`
2. `onActiveOption` sets `activeIndex` to the hovered option
3. The effect calls `activeRef.current.focus()`, stealing focus from the search input

## Fix

Only focus the active option when using keyboard navigation, or when search is not enabled. When `onSearch` is active and the user is using the mouse, the search input keeps focus:

```js
useEffect(() => {
  if (activeIndex >= 0) {
    if (onSearch && !keyboardNavigation) return;
    activeRef.current?.focus();
  }
}, [activeIndex, keyboardNavigation, onSearch]);
```

This preserves all existing behavior:
- **Keyboard navigation** (up/down arrows): active option still receives focus
- **Mouse without search**: active option still receives focus (unchanged)
- **Mouse with search**: search input keeps focus; the hovered option is still visually highlighted via `activeIndex`

Applies to both `Select` and `SelectMultiple` (both share `SelectContainer`).