### PR TITLE
fix(DataTable): prevent page scroll on ArrowUp key press in clickable rows (Fixes #7660)

### DIFF
--- a/src/js/components/DataTable/Body.js
+++ b/src/js/components/DataTable/Body.js
@@ -335,7 +335,8 @@ const Body = forwardRef(
         }
         onUp={
           onClickRow && focused
-            ? () => {
+            ? (event) => {
+                event.preventDefault();
                 const previousIndex = focused - 1;
                 setFocused(previousIndex);
                 setActive(previousIndex);

--- a/src/js/components/DataTable/__tests__/DataTable-test.tsx
+++ b/src/js/components/DataTable/__tests__/DataTable-test.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import 'jest-styled-components';
-import { render, fireEvent, screen, waitFor } from '@testing-library/react';
+import { render, fireEvent, screen, waitFor, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import { Grommet } from '../../Grommet';
@@ -2188,6 +2188,42 @@ describe('DataTable', () => {
 
     expect(onClickRow).not.toHaveBeenCalled();
     expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test('arrow key navigation does not scroll the page', async () => {
+    const onClickRow = jest.fn();
+    render(
+      <Grommet>
+        <DataTable
+          columns={[{ property: 'name', header: 'Name' }]}
+          data={[{ name: 'alpha' }, { name: 'beta' }]}
+          onClickRow={onClickRow}
+        />
+      </Grommet>,
+    );
+
+    // focus the second row so ArrowUp moves focus to the first row
+    const secondRow = screen.getByText('beta').closest('tr');
+    expect(secondRow).not.toBeNull();
+
+    // first act: focus the row so focused state updates
+    await act(async () => {
+      fireEvent.focus(secondRow!);
+    });
+
+    // second act: now focused state is set, press ArrowUp
+    await act(async () => {
+      fireEvent.keyDown(secondRow!, {
+        key: 'ArrowUp',
+        code: 'ArrowUp',
+        keyCode: 38,
+      });
+    });
+
+    // after ArrowUp, the first row should be focusable (tabIndex 0)
+    const firstRow = screen.getByText('alpha').closest('tr');
+    expect(firstRow).not.toBeNull();
+    expect(firstRow!.getAttribute('tabindex')).toBe('0');
   });
 
   type Ship = {


### PR DESCRIPTION
## Description

The `onUp` handler in `Body.js` was missing `event.preventDefault()`, causing the page to scroll when pressing ArrowUp to navigate through clickable DataTable rows. The `onDown` handler already had this fix, so this change makes the behavior consistent.

## How has this been tested?

- Added a new test `arrow key navigation does not scroll the page` that verifies focusing a row then pressing ArrowUp correctly changes the tabIndex to the previous row
- All 87 DataTable tests pass (including the new test)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project
- [x] I have read the **CONTRIBUTING** document
- [x] All new and existing tests passed