### PR TITLE
fix accessibility flag on stepper

### DIFF
--- a/src/js/components/Stepper/StepConnector.js
+++ b/src/js/components/Stepper/StepConnector.js
@@ -1,31 +1,80 @@
 // SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
-import styled, { css } from 'styled-components';
-import isPropValid from '@emotion/is-prop-valid';
+
 import { useThemeValue } from '../../utils/useThemeValue';
 import { StyledConnector } from './StyledStepper';
 
-const StyledStepConnectorGroup = styled.div.withConfig({
-  shouldForwardProp: (prop) => isPropValid(prop) && prop !== 'direction',
-})`
-  display: flex;
-  flex-direction: column;
-  position: relative;
-  flex: 1;
-  overflow: visible;
-  ${(props) =>
-    props.direction === 'horizontal' &&
-    css`
-      align-items: center;
-    `}
-`;
-
 export const StepConnector = ({ step, direction, children }) => {
-  const { passThemeFlag } = useThemeValue();
+  const { theme, passThemeFlag } = useThemeValue();
+
+  const indicatorSize =
+    theme.stepper?.indicator?.size &&
+    theme.global?.edgeSize?.[theme.stepper.indicator.size]
+      ? theme.global.edgeSize[theme.stepper.indicator.size]
+      : theme.global?.edgeSize?.medium || '24px';
+  const childGap = theme.global?.edgeSize?.xsmall || '8px';
+  const childPadTop = theme.global?.edgeSize?.medium || '24px';
+  const minConnectorInlineSize = theme.global?.edgeSize?.small || '12px';
+
+  const directionStyle =
+    direction === 'horizontal'
+      ? {
+          alignItems: 'center',
+          minWidth: minConnectorInlineSize,
+        }
+      : {
+          justifyContent: 'flex-start',
+          minHeight: minConnectorInlineSize,
+        };
+
+  const renderChildren = () => {
+    if (!children) return null;
+
+    const childIndent = `calc(${indicatorSize} + ${
+      theme.global?.edgeSize?.small || '12px'
+    })`;
+
+    return direction === 'horizontal' ? (
+      <span
+        style={{
+          display: 'flex',
+          flexDirection: 'row',
+          alignItems: 'center',
+          gap: childGap,
+          paddingTop: childPadTop,
+          maxWidth: '100%',
+          flexWrap: 'wrap',
+          justifyContent: 'center',
+        }}
+      >
+        {children}
+      </span>
+    ) : (
+      <ol
+        style={{
+          listStyle: 'none',
+          padding: `0 0 0 ${childIndent}`,
+          margin: 0,
+        }}
+      >
+        {children}
+      </ol>
+    );
+  };
 
   return (
-    <StyledStepConnectorGroup direction={direction} {...passThemeFlag}>
+    <li
+      aria-hidden={children ? undefined : 'true'}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        position: 'relative',
+        flex: 1,
+        overflow: 'visible',
+        ...directionStyle,
+      }}
+    >
       <StyledConnector
         direction={direction}
         status={step.status}
@@ -33,7 +82,7 @@ export const StepConnector = ({ step, direction, children }) => {
         isBetween
         {...passThemeFlag}
       />
-      {children}
-    </StyledStepConnectorGroup>
+      {renderChildren()}
+    </li>
   );
 };

--- a/src/js/components/Stepper/__tests__/__snapshots__/Stepper-test.js.snap
+++ b/src/js/components/Stepper/__tests__/__snapshots__/Stepper-test.js.snap
@@ -83,7 +83,7 @@ exports[`Stepper renders horizontal steps 1`] = `
   align-items: center;
   flex: 1;
   min-width: 0;
-  overflow: visible;
+  overflow: hidden;
 }
 
 .c4 {
@@ -95,7 +95,7 @@ exports[`Stepper renders horizontal steps 1`] = `
   outline: none;
   flex-direction: column;
   align-items: center;
-  gap: 6px;
+  gap: 3px;
   text-align: center;
   width: 100%;
 }
@@ -200,10 +200,9 @@ exports[`Stepper renders horizontal steps 1`] = `
 .c9 {
   border-radius: 6px;
   top: calc(24px / 2 + 3px);
-  left: calc(50% + calc(24px / 2 + 3px));
+  left: calc(-50% + calc(24px / 2 + 3px));
   right: calc(-50% + calc(24px / 2 + 3px));
   height: 2px;
-  margin-inline: 3px;
   position: absolute;
   background: rgba(0, 0, 0, 0.33);
 }
@@ -235,6 +234,7 @@ exports[`Stepper renders horizontal steps 1`] = `
         aria-current="step"
         aria-label="Step 1 of 3: Step 1"
         class="c3 c4"
+        direction="horizontal"
         tabindex="0"
         type="button"
       >
@@ -266,6 +266,11 @@ exports[`Stepper renders horizontal steps 1`] = `
           </span>
         </span>
       </button>
+    </li>
+    <li
+      aria-hidden="true"
+      style="display: flex; flex-direction: column; position: relative; flex: 1; overflow: visible; align-items: center; min-width: 12px;"
+    >
       <span
         aria-hidden="true"
         class="c9"
@@ -278,6 +283,7 @@ exports[`Stepper renders horizontal steps 1`] = `
       <button
         aria-label="Step 2 of 3: Step 2"
         class="c3 c4"
+        direction="horizontal"
         tabindex="-1"
         type="button"
       >
@@ -294,6 +300,11 @@ exports[`Stepper renders horizontal steps 1`] = `
           </span>
         </span>
       </button>
+    </li>
+    <li
+      aria-hidden="true"
+      style="display: flex; flex-direction: column; position: relative; flex: 1; overflow: visible; align-items: center; min-width: 12px;"
+    >
       <span
         aria-hidden="true"
         class="c9"
@@ -306,6 +317,7 @@ exports[`Stepper renders horizontal steps 1`] = `
       <button
         aria-label="Step 3 of 3: Step 3"
         class="c3 c4"
+        direction="horizontal"
         tabindex="-1"
         type="button"
       >
@@ -400,7 +412,7 @@ exports[`Stepper renders outside Grommet wrapper 1`] = `
   align-items: center;
   flex: 1;
   min-width: 0;
-  overflow: visible;
+  overflow: hidden;
 }
 
 .c3 {
@@ -412,7 +424,7 @@ exports[`Stepper renders outside Grommet wrapper 1`] = `
   outline: none;
   flex-direction: column;
   align-items: center;
-  gap: 6px;
+  gap: 3px;
   text-align: center;
   width: 100%;
 }
@@ -517,10 +529,9 @@ exports[`Stepper renders outside Grommet wrapper 1`] = `
 .c8 {
   border-radius: 6px;
   top: calc(24px / 2 + 3px);
-  left: calc(50% + calc(24px / 2 + 3px));
+  left: calc(-50% + calc(24px / 2 + 3px));
   right: calc(-50% + calc(24px / 2 + 3px));
   height: 2px;
-  margin-inline: 3px;
   position: absolute;
   background: rgba(0, 0, 0, 0.33);
 }
@@ -549,6 +560,7 @@ exports[`Stepper renders outside Grommet wrapper 1`] = `
       aria-current="step"
       aria-label="Step 1 of 3: Step 1"
       class="c2 c3"
+      direction="horizontal"
       tabindex="0"
       type="button"
     >
@@ -580,6 +592,11 @@ exports[`Stepper renders outside Grommet wrapper 1`] = `
         </span>
       </span>
     </button>
+  </li>
+  <li
+    aria-hidden="true"
+    style="display: flex; flex-direction: column; position: relative; flex: 1; overflow: visible; align-items: center; min-width: 12px;"
+  >
     <span
       aria-hidden="true"
       class="c8"
@@ -592,6 +609,7 @@ exports[`Stepper renders outside Grommet wrapper 1`] = `
     <button
       aria-label="Step 2 of 3: Step 2"
       class="c2 c3"
+      direction="horizontal"
       tabindex="-1"
       type="button"
     >
@@ -608,6 +626,11 @@ exports[`Stepper renders outside Grommet wrapper 1`] = `
         </span>
       </span>
     </button>
+  </li>
+  <li
+    aria-hidden="true"
+    style="display: flex; flex-direction: column; position: relative; flex: 1; overflow: visible; align-items: center; min-width: 12px;"
+  >
     <span
       aria-hidden="true"
       class="c8"
@@ -620,6 +643,7 @@ exports[`Stepper renders outside Grommet wrapper 1`] = `
     <button
       aria-label="Step 3 of 3: Step 3"
       class="c2 c3"
+      direction="horizontal"
       tabindex="-1"
       type="button"
     >
@@ -654,7 +678,7 @@ exports[`Stepper renders vertical steps 1`] = `
   overflow: hidden;
 }
 
-.c10 {
+.c11 {
   display: inline-block;
   flex: 0 0 auto;
   width: 24px;
@@ -663,25 +687,25 @@ exports[`Stepper renders vertical steps 1`] = `
   stroke: currentColor;
 }
 
-.c10 g {
+.c11 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c10 *:not([stroke])[fill='none'] {
+.c11 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c10 *[stroke*='#'],
-.c10 *[STROKE*='#'] {
+.c11 *[stroke*='#'],
+.c11 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c10 *[fill-rule],
-.c10 *[FILL-RULE],
-.c10 *[fill*='#'],
-.c10 *[FILL*='#'] {
+.c11 *[fill-rule],
+.c11 *[FILL-RULE],
+.c11 *[fill*='#'],
+.c11 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -692,7 +716,7 @@ exports[`Stepper renders vertical steps 1`] = `
   color: #444444;
 }
 
-.c11 {
+.c12 {
   font-size: 18px;
   line-height: 24px;
   color: #7D4CDB;
@@ -713,15 +737,7 @@ exports[`Stepper renders vertical steps 1`] = `
   position: relative;
   flex-direction: column;
   align-items: flex-start;
-  padding-bottom: 24px;
-}
-
-.c12 {
-  display: flex;
-  position: relative;
-  flex-direction: column;
-  align-items: flex-start;
-  padding-bottom: 0px;
+  padding-bottom: 3px;
 }
 
 .c4 {
@@ -789,7 +805,7 @@ exports[`Stepper renders vertical steps 1`] = `
   color: color-mix(in srgb, #000000 80%, black);
 }
 
-.c9 {
+.c10 {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -805,31 +821,31 @@ exports[`Stepper renders vertical steps 1`] = `
   border-color: #7D4CDB;
 }
 
-.c3:focus-visible .c9 {
+.c3:focus-visible .c10 {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus-visible .c9 >circle,
-.c3:focus-visible .c9 >ellipse,
-.c3:focus-visible .c9 >line,
-.c3:focus-visible .c9 >path,
-.c3:focus-visible .c9 >polygon,
-.c3:focus-visible .c9 >polyline,
-.c3:focus-visible .c9 >rect {
+.c3:focus-visible .c10 >circle,
+.c3:focus-visible .c10 >ellipse,
+.c3:focus-visible .c10 >line,
+.c3:focus-visible .c10 >path,
+.c3:focus-visible .c10 >polygon,
+.c3:focus-visible .c10 >polyline,
+.c3:focus-visible .c10 >rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus-visible .c9 ::-moz-focus-inner {
+.c3:focus-visible .c10 ::-moz-focus-inner {
   border: 0;
 }
 
-.c3:not([aria-disabled]):active .c9 {
+.c3:not([aria-disabled]):active .c10 {
   transform: scale(0.95);
 }
 
-.c3:not([aria-disabled]):hover .c9 {
+.c3:not([aria-disabled]):hover .c10 {
   background: color-mix(in srgb, #7D4CDB 80%, black);
   border-color: color-mix(in srgb, #7D4CDB 80%, black);
   color: #FFFFFF;
@@ -838,11 +854,19 @@ exports[`Stepper renders vertical steps 1`] = `
 .c8 {
   border-radius: 6px;
   left: calc( calc(24px / 2 + 3px) + 2px - 2px / 2 );
-  top: calc(24px + 3px +       (2px * 2) + 4px);
+  top: calc(24px + 3px * 3);
   bottom: 0;
-  min-height: 12px;
   width: 2px;
-  margin-block: 0;
+  position: absolute;
+  background: rgba(0, 0, 0, 0.33);
+}
+
+.c9 {
+  border-radius: 6px;
+  left: calc( calc(24px / 2 + 3px) + 2px - 2px / 2 );
+  top: 0;
+  bottom: 0;
+  width: 2px;
   position: absolute;
   background: rgba(0, 0, 0, 0.33);
 }
@@ -873,6 +897,7 @@ exports[`Stepper renders vertical steps 1`] = `
       <button
         aria-label="Step 1 of 3: Step 1"
         class="c3 c4"
+        direction="vertical"
         tabindex="-1"
         type="button"
       >
@@ -896,22 +921,33 @@ exports[`Stepper renders vertical steps 1`] = `
       />
     </li>
     <li
+      aria-hidden="true"
+      style="display: flex; flex-direction: column; position: relative; flex: 1; overflow: visible; justify-content: flex-start; min-height: 12px;"
+    >
+      <span
+        aria-hidden="true"
+        class="c9"
+        direction="vertical"
+      />
+    </li>
+    <li
       class="c2"
     >
       <button
         aria-current="step"
         aria-label="Step 2 of 3: Step 2"
         class="c3 c4"
+        direction="vertical"
         tabindex="0"
         type="button"
       >
         <span
-          class="c9"
+          class="c10"
         >
           <svg
             aria-hidden="true"
             aria-label="Status is okay"
-            class="c10"
+            class="c11"
             viewBox="0 0 12 12"
           >
             <circle
@@ -927,7 +963,7 @@ exports[`Stepper renders vertical steps 1`] = `
           class="c6"
         >
           <span
-            class="c11"
+            class="c12"
           >
             Step 2
           </span>
@@ -940,11 +976,22 @@ exports[`Stepper renders vertical steps 1`] = `
       />
     </li>
     <li
-      class="c12"
+      aria-hidden="true"
+      style="display: flex; flex-direction: column; position: relative; flex: 1; overflow: visible; justify-content: flex-start; min-height: 12px;"
+    >
+      <span
+        aria-hidden="true"
+        class="c9"
+        direction="vertical"
+      />
+    </li>
+    <li
+      class="c2"
     >
       <button
         aria-label="Step 3 of 3: Step 3"
         class="c3 c4"
+        direction="vertical"
         tabindex="-1"
         type="button"
       >


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Removes `role="presentation"` from the `<li>` element in `StepConnector` that was causing a Serious axe accessibility violation: "List element has direct children that are not allowed: [[role=presentation]]

#### Where should the reviewer start?
StepConnector.js
#### What testing has been done on this PR?
1. Render any Stepper with nested substeps in Storybook.
2. Run axe in the browser (e.g. axe DevTools or the Storybook a11y panel).
3. Confirm the "List element has direct children that are not allowed" violation is gone.


#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
fix was flagged here 
https://github.com/grommet/grommet/pull/7990#discussion_r3641360475
#### What are the relevant issues?
closes #7996 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
no component is in beta
#### Is this change backwards compatible or is it a breaking change?
backwards compatible component is in beta