### PR TITLE
Add Form to WizardContent with validation/submit

### DIFF
--- a/src/js/components/Form/Form.js
+++ b/src/js/components/Form/Form.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, {
   forwardRef,
   useCallback,
@@ -751,7 +753,8 @@ const Form = forwardRef(
                 // Show form's validity when clicking on Submit
                 valid: buildValid(nextErrors),
               };
-              if (onValidate) onValidate(nextValidationResults);
+              if (onValidate)
+                onValidate({ submitting: true, ...nextValidationResults });
               validationResultsRef.current = nextValidationResults;
               updateAnalytics();
               return nextValidationResults;

--- a/src/js/components/Form/Form.js
+++ b/src/js/components/Form/Form.js
@@ -547,8 +547,9 @@ const Form = forwardRef(
           // form drives, pattern #1
           useValue = formValue;
         else if (formValue === undefined && name)
-          // form has reset, so reset input value as well
-          useValue = initialValue;
+          // controlled form: keep input controlled; uncontrolled: reset
+          useValue =
+            valueProp !== undefined ? initialValue ?? '' : initialValue;
         else useValue = inputValue;
 
         return [

--- a/src/js/components/Form/index.d.ts
+++ b/src/js/components/Form/index.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import * as React from 'react';
 
 export interface FormExtendedEvent<R = Record<string, unknown>, T = Element>
@@ -18,6 +20,7 @@ export interface FormProps<T> {
     errors: Record<string, any>;
     infos: Record<string, any>;
     valid: boolean;
+    submitting?: boolean;
   }) => void;
   validate?: 'blur' | 'submit' | 'change';
   value?: T;

--- a/src/js/components/Wizard/Wizard.js
+++ b/src/js/components/Wizard/Wizard.js
@@ -288,6 +288,16 @@ const Wizard = forwardRef(
 
     // Run step.validate (sync or async). Returns { ok, error }.
     const runValidation = useCallback(async () => {
+      const formElement = document.getElementById(`${currentStep}-form`);
+      const formIsValid =
+        formElement?.getAttribute('data-form-valid') === 'true';
+
+      if (!formIsValid) {
+        return {
+          ok: false,
+          error: format({ id: 'wizard.validationError', messages }),
+        };
+      }
       if (typeof currentStepObj?.validate !== 'function') {
         return { ok: true };
       }
@@ -314,7 +324,7 @@ const Wizard = forwardRef(
             err?.message || format({ id: 'wizard.validationError', messages }),
         };
       }
-    }, [currentStepObj, formValue, format, messages]);
+    }, [currentStep, currentStepObj, formValue, format, messages]);
 
     const next = useCallback(async () => {
       if (isValidating) return;
@@ -520,7 +530,9 @@ const Wizard = forwardRef(
       if (onComplete) {
         // setCompletedSteps above is async; include currentStep here so the
         // payload reflects the just-completed final step.
-        const completedStepsList = [...completedSteps, currentStep];
+        const nextCompleted = new Set(completedSteps);
+        nextCompleted.add(currentStep);
+        const completedStepsList = Array.from(nextCompleted);
         onComplete({ value: formValue, completedSteps: completedStepsList });
       }
       if (sendAnalytics)

--- a/src/js/components/Wizard/Wizard.js
+++ b/src/js/components/Wizard/Wizard.js
@@ -290,12 +290,12 @@ const Wizard = forwardRef(
     const runValidation = useCallback(async () => {
       const formElement = document.getElementById(`${currentStep}-form`);
       const formIsValid =
-        formElement?.getAttribute('data-form-valid') === 'true';
+        formElement?.getAttribute('data-form-valid') !== 'false';
 
       if (!formIsValid) {
         return {
           ok: false,
-          error: format({ id: 'wizard.validationError', messages }),
+          error: undefined,
         };
       }
       if (typeof currentStepObj?.validate !== 'function') {

--- a/src/js/components/Wizard/WizardContent.js
+++ b/src/js/components/Wizard/WizardContent.js
@@ -23,8 +23,6 @@ export const WizardContent = ({ ...rest }) => {
   } = wizard;
 
   const contentTheme = theme.wizard?.content;
-  const errorTheme = theme.wizard?.error;
-  const Icon = errorTheme?.icon || (() => null);
 
   const onValidate = useCallback(
     ({ valid, errors, submitting }) => {

--- a/src/js/components/Wizard/WizardContent.js
+++ b/src/js/components/Wizard/WizardContent.js
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
 // SPDX-License-Identifier: Apache-2.0
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Form } from '../Form';
 import { Box } from '../Box';
 import { Notification } from '../Notification';
@@ -26,35 +26,44 @@ export const WizardContent = ({ ...rest }) => {
   const errorTheme = theme.wizard?.error;
   const Icon = errorTheme?.icon || (() => null);
 
+  const onValidate = useCallback(
+    ({ valid, errors, submitting }) => {
+      const formElement = document.getElementById(`${currentStep}-form`);
+      if (formElement) {
+        formElement.setAttribute('data-form-valid', String(valid));
+      }
+
+      if (submitting) {
+        // focus the first error field that exists in the DOM
+        const names = Object.keys(errors || {});
+        const firstInvalid = names.reduce((found, name) => {
+          if (found) return found;
+          const matches = document.getElementsByName(name);
+          return matches.length > 0 ? matches[0] : null;
+        }, null);
+        if (firstInvalid) {
+          setTimeout(() => firstInvalid.focus(), 0);
+        }
+        if (!valid) {
+          // Since onSubmit won't get called in this case, go ahead and
+          // call next() to trigger wizard-level state changes. By calling
+          // next() here, it will get to the runValidation step, see that
+          // the form is invalid from the data-form-valid attribute and set
+          // the appropriate blocked state.
+          // TODO: consider a method on the wizard context to set the
+          //       blocked state directly instead of calling next()
+          next();
+        }
+      }
+    },
+    [currentStep, next],
+  );
+
   if (!currentStepObj) return null;
 
   const stepRender = currentStepObj.render || renderStep;
   const body = stepRender ? stepRender(currentStepObj, wizard) : null;
 
-  const onValidate = (validationResults) => {
-    // focus first error field if any
-    const names = [
-      ...Object.keys(validationResults.errors),
-      ...Object.keys(validationResults.infos),
-    ];
-    if (names.length > 0) {
-      const selector = names.map((name) => `[name=${name}]`).join(',');
-      const firstInvalid = document.querySelectorAll(selector)[0];
-      if (firstInvalid) {
-        setTimeout(() => firstInvalid.focus(), 0);
-      }
-    }
-    const valid = names.length === 0;
-    const formElement = document.getElementById(`${currentStep}-form`);
-    if (formElement) {
-      formElement.setAttribute('data-form-valid', String(valid));
-    }
-    if (!valid) {
-      // Go ahead and call next() to trigger
-      // wizard-level validation error message.
-      next();
-    }
-  };
   return (
     <Form
       id={`${currentStep}-form`}

--- a/src/js/components/Wizard/WizardContent.js
+++ b/src/js/components/Wizard/WizardContent.js
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
+import { Form } from '../Form';
 import { Box } from '../Box';
 import { Notification } from '../Notification';
 import { useThemeValue } from '../../utils/useThemeValue';
@@ -11,7 +12,15 @@ import { useWizard } from './WizardContext';
 export const WizardContent = ({ ...rest }) => {
   const { theme } = useThemeValue();
   const wizard = useWizard();
-  const { currentStepObj, renderStep, validationError } = wizard;
+  const {
+    currentStep,
+    currentStepObj,
+    formValue,
+    next,
+    renderStep,
+    setFormValue,
+    validationError,
+  } = wizard;
 
   const contentTheme = theme.wizard?.content;
   const errorTheme = theme.wizard?.error;
@@ -22,17 +31,56 @@ export const WizardContent = ({ ...rest }) => {
   const stepRender = currentStepObj.render || renderStep;
   const body = stepRender ? stepRender(currentStepObj, wizard) : null;
 
+  const onValidate = (validationResults) => {
+    // focus first error field if any
+    const names = [
+      ...Object.keys(validationResults.errors),
+      ...Object.keys(validationResults.infos),
+    ];
+    if (names.length > 0) {
+      const selector = names.map((name) => `[name=${name}]`).join(',');
+      const firstInvalid = document.querySelectorAll(selector)[0];
+      if (firstInvalid) {
+        setTimeout(() => firstInvalid.focus(), 0);
+      }
+    }
+    const valid = names.length === 0;
+    const formElement = document.getElementById(`${currentStep}-form`);
+    if (formElement) {
+      formElement.setAttribute('data-form-valid', String(valid));
+    }
+    if (!valid) {
+      // Go ahead and call next() to trigger
+      // wizard-level validation error message.
+      next();
+    }
+  };
   return (
-    <Box {...contentTheme} flex="grow" {...rest}>
-      {body}
-      {validationError && (
-        <Notification
-          status="critical"
-          message={validationError}
-          icon={<Icon />}
-        />
-      )}
-    </Box>
+    <Form
+      id={`${currentStep}-form`}
+      value={formValue}
+      onChange={setFormValue}
+      onSubmit={next}
+      onValidate={onValidate}
+      method="post"
+      data-form-valid="true"
+      style={{ display: 'flex', flex: '1 1 auto' }}
+    >
+      <Box {...contentTheme} flex="grow" {...rest}>
+        {body}
+        {validationError && (
+          <Notification
+            status="critical"
+            message={validationError}
+            icon={
+              <Box margin={{ top: '4px' }}>
+                <Icon />
+              </Box>
+            }
+          />
+        )}
+      </Box>
+    </Form>
   );
 };
 

--- a/src/js/components/Wizard/WizardFooter.js
+++ b/src/js/components/Wizard/WizardFooter.js
@@ -14,11 +14,11 @@ export const WizardFooter = ({ children, ...rest }) => {
   const { theme } = useThemeValue();
   const { format } = React.useContext(MessageContext);
   const {
+    currentStep,
     currentStepObj,
     currentStepIndex,
     totalSteps,
     canGoNext,
-    next,
     previous,
     skip,
     complete,
@@ -93,7 +93,8 @@ export const WizardFooter = ({ children, ...rest }) => {
           icon={NextIcon ? <NextIcon aria-hidden="true" /> : undefined}
           reverse
           disabled={!canGoNext}
-          onClick={next}
+          type="submit"
+          form={`${currentStep}-form`}
         />
       ),
     ];

--- a/src/js/components/Wizard/__tests__/Wizard-test.js
+++ b/src/js/components/Wizard/__tests__/Wizard-test.js
@@ -193,7 +193,9 @@ describe('Wizard', () => {
     );
   });
 
-  test('blocks next when required form field is invalid, then advances once valid', async () => {
+  test(
+    'blocks next when required form field is invalid, then advances once valid',
+    async () => {
     const user = userEvent.setup();
     const onStepChange = jest.fn();
     const steps = [

--- a/src/js/components/Wizard/__tests__/Wizard-test.js
+++ b/src/js/components/Wizard/__tests__/Wizard-test.js
@@ -9,7 +9,7 @@ import { axe } from 'jest-axe';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { Grommet, Wizard } from '../..';
+import { FormField, Grommet, TextInput, Wizard } from '../..';
 
 const basicSteps = [
   { id: 'step1', title: 'Step 1', description: 'First step' },
@@ -191,6 +191,48 @@ describe('Wizard', () => {
     await waitFor(() =>
       expect(screen.getByRole('heading', { name: 'Step 2' })).toBeTruthy(),
     );
+  });
+
+  test('blocks next when required form field is invalid, then advances once valid', async () => {
+    const user = userEvent.setup();
+    const onStepChange = jest.fn();
+    const steps = [
+      {
+        id: 's1',
+        title: 'Step 1',
+        render: () => (
+          <FormField htmlFor="wizard-email" label="Email" name="email" required>
+            <TextInput
+              id="wizard-email"
+              name="email"
+              placeholder="you@example.com"
+            />
+          </FormField>
+        ),
+      },
+      { id: 's2', title: 'Step 2' },
+    ];
+    render(
+      <Grommet>
+        <Wizard
+          steps={steps}
+          renderStep={renderStep}
+          onStepChange={onStepChange}
+          aria-label="Test wizard"
+        />
+      </Grommet>,
+    );
+    await user.click(screen.getByRole('button', { name: /next/i }));
+    // We should still be on step 1 and a blocked event should fire.
+    expect(screen.getByRole('heading', { name: 'Step 1' })).toBeTruthy();
+    const blockedEvent = onStepChange.mock.calls
+      .map((call) => call[0])
+      .find((event) => event.trigger === 'next' && event.phase === 'blocked');
+    expect(blockedEvent).toBeTruthy();
+
+    await user.type(screen.getByRole('textbox', { name: 'Email' }), 'a@b.com');
+    await user.click(screen.getByRole('button', { name: /next/i }));
+    expect(screen.getByRole('heading', { name: 'Step 2' })).toBeTruthy();
   });
 
   test('branching via nextStep(formValue) routes to declared id', async () => {

--- a/src/js/components/Wizard/stories/Validation.stories.js
+++ b/src/js/components/Wizard/stories/Validation.stories.js
@@ -2,14 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 
-import {
-  Box,
-  Notification,
-  Paragraph,
-  TextInput,
-  Form,
-  FormField,
-} from 'grommet';
+import { Box, Notification, Paragraph, TextInput, FormField } from 'grommet';
 import { Wizard } from '../Wizard';
 
 const validateEmail = (email) => {
@@ -34,69 +27,42 @@ const Validation = () => {
       title: 'Email',
       description: 'Enter a valid email address.',
       skippable: true,
-      validate: (value) =>
-        validateEmail(value.email) ? 'Fix the issues to continue' : true,
-      render: (step, api) => {
-        const emailError =
-          api.validationError && validateEmail(api.formValue.email);
-        return (
-          <Form
-            value={api.formValue}
-            onChange={(nextValue) => api.setFormValue(nextValue)}
-            validate="submit"
-          >
-            <FormField
-              htmlFor="wizard-email"
-              label="Email"
-              name="email"
-              required
-              validate={validateEmail}
-              error={emailError}
-            >
-              <TextInput
-                id="wizard-email"
-                name="email"
-                placeholder="you@example.com"
-              />
-            </FormField>
-          </Form>
-        );
-      },
+      render: (/* step, api */) => (
+        <FormField
+          htmlFor="wizard-email"
+          label="Email"
+          name="email"
+          required
+          validate={validateEmail}
+        >
+          <TextInput
+            id="wizard-email"
+            name="email"
+            placeholder="you@example.com"
+          />
+        </FormField>
+      ),
     },
     {
       id: 'password',
       title: 'Password',
       description: 'Choose a password.',
-      validate: (value) =>
-        validatePassword(value.password) ? 'Fix the issues to continue' : true,
-      render: (step, api) => {
-        const passwordError =
-          api.validationError && validatePassword(api.formValue.password);
-
-        return (
-          <Form
-            value={api.formValue}
-            onChange={(nextValue) => api.setFormValue(nextValue)}
-            validate="change"
-          >
-            <FormField
-              htmlFor="wizard-password"
-              label="Password"
-              name="password"
-              required
-              validate={validatePassword}
-              error={passwordError}
-            >
-              <TextInput
-                id="wizard-password"
-                name="password"
-                type="password"
-                placeholder="password"
-              />
-            </FormField>
-          </Form>
-        );
-      },
+      render: (/* step, api */) => (
+        <FormField
+          htmlFor="wizard-password"
+          label="Password"
+          name="password"
+          required
+          validate={validatePassword}
+        >
+          <TextInput
+            id="wizard-password"
+            name="password"
+            type="password"
+            placeholder="password"
+          />
+        </FormField>
+      ),
     },
     {
       id: 'confirm',

--- a/src/js/components/Wizard/stories/Validation.stories.js
+++ b/src/js/components/Wizard/stories/Validation.stories.js
@@ -27,6 +27,12 @@ const Validation = () => {
       title: 'Email',
       description: 'Enter a valid email address.',
       skippable: true,
+      validate: (value) => {
+        if (value.extra !== 'please') {
+          return 'You must enter "please" in the Extra field to proceed.';
+        }
+        return undefined;
+      },
       render: (/* step, api */) => (
         <>
           <FormField

--- a/src/js/components/Wizard/stories/Validation.stories.js
+++ b/src/js/components/Wizard/stories/Validation.stories.js
@@ -28,19 +28,28 @@ const Validation = () => {
       description: 'Enter a valid email address.',
       skippable: true,
       render: (/* step, api */) => (
-        <FormField
-          htmlFor="wizard-email"
-          label="Email"
-          name="email"
-          required
-          validate={validateEmail}
-        >
-          <TextInput
-            id="wizard-email"
+        <>
+          <FormField
+            htmlFor="wizard-email"
+            label="Email"
             name="email"
-            placeholder="you@example.com"
-          />
-        </FormField>
+            required
+            validate={validateEmail}
+          >
+            <TextInput
+              id="wizard-email"
+              name="email"
+              placeholder="you@example.com"
+            />
+          </FormField>
+          <FormField htmlFor="wizard-extra" label="Extra" name="extra" required>
+            <TextInput
+              id="wizard-extra"
+              name="extra"
+              placeholder="Extra information"
+            />
+          </FormField>
+        </>
       ),
     },
     {


### PR DESCRIPTION

#### What does this PR do?

This wraps step content in WizardContent with a Form. The Next button changes to a `type="submit"` and is linked to the Form by the form's id. When the form is submitted by the Next button it does validation. The onValidation callback on the form will mark the form element as valid or invalid (via a `data` attribute.) If valid, the form onSubmit gets called and does the normal `next()` processing for the step. The step validation will check this attribute and set the step to blocked if form validation failed. If form validation passed, it will next do the step validation callback as before and block if necessary.

The way it links up the Form validation per step is basically the same as how it was done in our original Wizard example pattern.

I also fixed an issue in the `onComplete` handling where it was not correctly listing the completed steps. It would include an empty Set as the first entry and would also add a duplicate of the currentStep if you happened to use Previous to go back and then come forward again.

Fixed an issue in Form where it causes the input to change from uncontrolled to controlled.

#### Where should the reviewer start?
WizardContent.js

#### What testing has been done on this PR?
Manual plus storybook.

#### How should this be manually tested?
Try the newly modified Validation story.

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
