### PR TITLE
[Minor update] for SPDX license header tooling for OSRB compliance

### DIFF
--- a/tools/license-header.js
+++ b/tools/license-header.js
@@ -14,8 +14,8 @@
  *   node tools/license-header.js --staged   Fix only files staged for commit
  *                                            (progressive migration) and
  *                                            re-stage anything it corrects.
- *   node tools/license-header.js [paths...] Limit to the given files/dirs.
- *                                            usable with --check or --staged.
+ *                                           usable with --check (ignored when
+ *                                           --staged is set).
  */
 
 const fs = require('fs');
@@ -50,7 +50,7 @@ function isIncluded(filePath) {
 function collectStagedFiles() {
   const output = execFileSync(
     'git',
-    ['diff', '--cached', '--name-only', '--diff-filter=ACM'],
+    ['diff', '--cached', '--name-only', '--diff-filter=ACMR'],
     { encoding: 'utf8' },
   );
   return output

--- a/tools/license-header.js
+++ b/tools/license-header.js
@@ -14,6 +14,7 @@
  *   node tools/license-header.js --staged   Fix only files staged for commit
  *                                            (progressive migration) and
  *                                            re-stage anything it corrects.
+ *   node tools/license-header.js [paths...] Limit to the given files/dirs.
  *                                           usable with --check (ignored when
  *                                           --staged is set).
  */


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
- improves how license-script captures licencse tracking for renamed file and improve comment

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?
 see `license-header.js`

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?
- relates to https://github.com/grommet/hpe-design-system/issues/6360

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
