### PR TITLE
Remove override for notification icon in wizard

### DIFF
--- a/src/js/components/Wizard/WizardContent.js
+++ b/src/js/components/Wizard/WizardContent.js
@@ -14,8 +14,6 @@ export const WizardContent = ({ ...rest }) => {
   const { currentStepObj, renderStep, validationError } = wizard;
 
   const contentTheme = theme.wizard?.content;
-  const errorTheme = theme.wizard?.error;
-  const Icon = errorTheme?.icon || (() => null);
 
   if (!currentStepObj) return null;
 
@@ -26,11 +24,7 @@ export const WizardContent = ({ ...rest }) => {
     <Box {...contentTheme} flex="grow" {...rest}>
       {body}
       {validationError && (
-        <Notification
-          status="critical"
-          message={validationError}
-          icon={<Icon />}
-        />
+        <Notification status="critical" message={validationError} />
       )}
     </Box>
   );

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -2520,9 +2520,6 @@ export interface ThemeType {
         skip?: { icon?: React.ReactNode | Icon };
       };
     };
-    error?: {
-      icon?: React.ReactNode | Icon;
-    };
   };
   worldMap?: {
     color?: ColorType;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
 // SPDX-License-Identifier: Apache-2.0
 import { Actions } from 'grommet-icons/icons/Actions';
-import { Alert } from 'grommet-icons/icons/Alert';
 import { AssistListening } from 'grommet-icons/icons/AssistListening';
 import { CircleInformation } from 'grommet-icons/icons/CircleInformation';
 import { ClosedCaption } from 'grommet-icons/icons/ClosedCaption';
@@ -2788,9 +2787,6 @@ export const generate = (baseSpacing = 24, scale = 6) => {
           cancel: { icon: undefined },
           skip: { icon: FormNext },
         },
-      },
-      error: {
-        icon: Alert,
       },
     },
     worldMap: {


### PR DESCRIPTION
#### What does this PR do?
Removes `theme.wizard.error.icon` and instead just uses the icon defined for critical notifications in the theme so we maintain visual consistency across applications by using the same icons for the same things.

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no

#### Should this PR be mentioned in the release notes?
no, Wizard hasn't been released yet

#### Is this change backwards compatible or is it a breaking change?
backwards compatible