### PR TITLE
fix(Wizard): use gap instead of margin for content spacing

### DIFF
--- a/src/js/components/Wizard/Wizard.js
+++ b/src/js/components/Wizard/Wizard.js
@@ -671,7 +671,7 @@ const Wizard = forwardRef(
                 {effectiveShowProgress &&
                   responsiveSize !== 'small' &&
                   responsiveSize !== 'xsmall' && <WizardProgress />}
-                <Box flex="grow">
+                <Box flex="grow" gap={theme.wizard?.content?.gap}>
                   <WizardStepHeader />
                   <WizardContent />
                 </Box>

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -2773,7 +2773,6 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         gap: 'medium',
         background: 'background-front',
         round: 'small',
-        margin: { top: 'medium' },
       },
       footer: {
         pad: { horizontal: 'large', vertical: 'small' },


### PR DESCRIPTION
## Description

`theme.wizard.content.margin` was used to create space between the step header and step content in the Wizard. This changes the spacing to use the `gap` property on the parent Box instead, aligning with flexbox layout practices.

## Changes

- **src/js/themes/base.js**: Removed `margin: { top: 'medium' }` from `wizard.content` theme
- **src/js/components/Wizard/Wizard.js**: Added `gap={theme.wizard?.content?.gap}` to the Box wrapping `WizardStepHeader` and `WizardContent` in the default layout

Closes #8034