### PR TITLE
fix(Calendar): show today indicator when no date is selected

### DIFF
--- a/src/js/components/Calendar/Calendar.js
+++ b/src/js/components/Calendar/Calendar.js
@@ -227,6 +227,7 @@ const CalendarDay = forwardRef(
       size,
       isInRange,
       isSelected,
+      isToday,
       otherMonth,
       rangePosition,
       buttonProps = {},
@@ -241,6 +242,7 @@ const CalendarDay = forwardRef(
         aria-selected={isSelected}
         inRange={isInRange}
         isSelected={isSelected}
+        isToday={isToday}
         rangePosition={rangePosition}
         sizeProp={size}
         fillContainer={fill}
@@ -262,6 +264,7 @@ const CalendarDay = forwardRef(
               hover={hover}
               inRange={isInRange}
               isSelected={isSelected}
+              isToday={isToday}
               otherMonth={otherMonth}
               sizeProp={size}
               fillContainer={fill}
@@ -792,6 +795,9 @@ const Calendar = forwardRef(
     let firstDayInMonth;
     let blankWeek = false;
 
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
     while (day.getTime() < displayBounds[1].getTime()) {
       if (day.getDay() === firstDayOfWeek) {
         if (days) {
@@ -857,6 +863,7 @@ const Calendar = forwardRef(
       } else {
         const dateObject = day;
         // this.dayRefs[dateObject] = React.createRef();
+        const isToday = day.getTime() === today.getTime();
         let selected = false;
         let inRange = false;
         let rangePosition;
@@ -902,6 +909,7 @@ const Calendar = forwardRef(
               }}
               isInRange={inRange}
               isSelected={selected}
+              isToday={isToday}
               otherMonth={day.getMonth() !== reference.getMonth()}
               rangePosition={rangePosition}
               size={size}

--- a/src/js/components/Calendar/StyledCalendar.js
+++ b/src/js/components/Calendar/StyledCalendar.js
@@ -283,6 +283,7 @@ const StyledDay = styled.div.withConfig(styledComponentsConfig)`
   ${(props) => props.responsive && responsiveDaySizeStyle(props)}
   ${(props) => dayStyle(props)}
   ${(props) => dayFontStyle(props)}
+  ${(props) => props.isToday && 'border-bottom: 2px solid;'}
    ${(props) => {
     // fallback to medium if no size-specific styles
     const round =

--- a/src/js/components/Calendar/index.d.ts
+++ b/src/js/components/Calendar/index.d.ts
@@ -12,6 +12,7 @@ export interface RenderProps {
   day: number;
   isInRange: boolean;
   isSelected: boolean;
+  isToday: boolean;
 }
 
 export interface CalendarHeaderProps {

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -692,6 +692,14 @@ export const generate = (baseSpacing = 24, scale = 6) => {
           //   color: undefined,
           // },
         },
+        today: {
+          color: 'text',
+          // border: {
+          //   color: undefined,
+          //   side: 'bottom',
+          //   size: 'xsmall',
+          // },
+        },
         inRange: {
           // color: undefined,
           font: {


### PR DESCRIPTION
Fixes #8009

### Changes

When the Calendar opens without a selected date, today's date now receives a visual indicator (bottom border) so users have a point of orientation. The indicator also shows alongside the selected date.

### Implementation

- Added `isToday` prop to `CalendarDay`, `StyledDay`, and `StyledDayContainer` components
- Computed `isToday` by comparing each day with the current date (both zeroed to midnight)
- Added a bottom-border style to `StyledDay` when `isToday` is true
- Added `today` theme entry to `base.js` for future theming
- Exposed `isToday` in the TypeScript `RenderProps` interface

### Testing

- The today indicator appears when the current month is displayed
- The indicator does not interfere with the selected/in-range state
- Existing snapshots are unaffected (the test uses January 2020, not the current month)
