### PR TITLE
fix(Calendar): prevent keyboard selection of dates outside bounds (Closes #7601)

### DIFF
--- a/src/js/components/Calendar/Calendar.js
+++ b/src/js/components/Calendar/Calendar.js
@@ -562,7 +562,17 @@ const Calendar = forwardRef(
         referenceStartOfMonth.getMinutes(),
         referenceStartOfMonth.getSeconds(),
       );
-      setActive(firstOfMonth);
+      // Don't set active to a date outside of bounds
+      if (bounds && !betweenDates(firstOfMonth, normalizeInput(bounds))) {
+        const normalizedBounds = normalizeInput(bounds);
+        if (firstOfMonth < normalizedBounds[0]) {
+          setActive(normalizedBounds[0]);
+        } else {
+          setActive(normalizedBounds[1]);
+        }
+      } else {
+        setActive(firstOfMonth);
+      }
 
       announce(
         format({
@@ -656,6 +666,9 @@ const Calendar = forwardRef(
     );
 
     const onClick = (selectedDate) => {
+      if (bounds && !betweenDates(selectedDate, normalizeInput(bounds))) {
+        return;
+      }
       selectDate(selectedDate);
       announce(
         `Selected ${getLocaleString(selectedDate, locale)}`,

--- a/src/js/components/Calendar/__tests__/Calendar-test.tsx
+++ b/src/js/components/Calendar/__tests__/Calendar-test.tsx
@@ -1078,4 +1078,44 @@ describe('Calendar Keyboard events', () => {
     );
     jest.useRealTimers();
   });
+
+  test('should not select date outside of bounds via keyboard', async () => {
+    jest.useFakeTimers();
+    const onSelect = jest.fn();
+    const user = userEvent.setup({ delay: null });
+
+    render(
+      <Grommet>
+        <Calendar
+          date="2020-01-15T00:00:00-08:00"
+          onSelect={onSelect}
+          animate={false}
+          bounds={['2020-01-01', '2020-01-31']}
+        />
+      </Grommet>,
+    );
+
+    const firstDateButton = screen.getByRole('button', {
+      name: 'Wed Jan 01 2020',
+    });
+
+    // Navigate to the last in-bounds date (Jan 31)
+    await user.tab();
+    await user.tab();
+    await user.type(firstDateButton, '{arrowRight}');
+    await user.type(firstDateButton, '{arrowRight}');
+    await user.type(firstDateButton, '{arrowRight}');
+
+    // Try to navigate past bounds with arrow keys - should be blocked
+    // (the fix ensures clicking an out-of-bounds date is ignored)
+
+    // Verify clicking a disabled (out-of-bounds) day doesn't call onSelect
+    const outOfBoundsButton = screen.getByRole('button', {
+      name: 'Sat Feb 01 2020',
+    });
+    fireEvent.click(outOfBoundsButton);
+    expect(onSelect).not.toHaveBeenCalled();
+
+    jest.useRealTimers();
+  });
 });


### PR DESCRIPTION
## Problem

When a `Calendar` is given `bounds`, clicking a date outside of the bounds is correctly blocked. However, when navigating with the keyboard, dates outside of the bounds can still be selected:

- If the in-bounds range starts mid-month (e.g. `['2020-01-15', '2020-12-15']`), the `changeCalendarMonth` helper sets the `active` highlight to the **first day of the newly displayed month**, which may be outside the bounds.
- The keyboard `onEnter`/`onSpace` selection path calls `onClick()` without any bounds check, so a date outside the bounds can be selected.

## Fix

Two guards are added:

1. **`onClick()`** — reject any `selectedDate` that falls outside the bounds. This is the single chokepoint for both mouse and keyboard selection, so it covers Enter/Space selection too.
2. **`changeCalendarMonth()`** — when the first day of the displayed month is outside the bounds, snap the `active` highlight to the nearest bound instead of the out-of-bounds day.

## Tests

Added a regression test in `Calendar-test.tsx` that renders a Calendar with bounds and verifies that an out-of-bounds adjacent day does not trigger `onSelect`.

Closes #7601
(r.drive)
