### PR TITLE
fix(Form): treat required field value `0` as satisfied in buildValid

### DIFF
--- a/src/js/components/Form/Form.js
+++ b/src/js/components/Form/Form.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, {
   forwardRef,
   useCallback,
@@ -270,10 +272,15 @@ const Form = forwardRef(
         let valid = false;
         valid = requiredFields.current
           .filter((n) => Object.keys(validationRulesRef.current).includes(n))
-          .every(
-            (field) =>
-              value[field] && (value[field] !== '' || value[field] !== false),
-          );
+          .every((field) => {
+            const fieldValue = value[field];
+            return (
+              fieldValue !== undefined &&
+              fieldValue !== '' &&
+              fieldValue !== false &&
+              !(Array.isArray(fieldValue) && !fieldValue.length)
+            );
+          });
 
         if (Object.keys(nextErrors).length > 0) valid = false;
         return valid;

--- a/src/js/components/Form/__tests__/Form-test-uncontrolled.tsx
+++ b/src/js/components/Form/__tests__/Form-test-uncontrolled.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 
 import 'jest-styled-components';
@@ -214,6 +216,26 @@ describe('Form uncontrolled', () => {
       }),
     );
     expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test('onValidate treats 0 as a valid required value', () => {
+    const onValidate = jest.fn();
+    render(
+      <Grommet>
+        <Form onValidate={onValidate}>
+          <FormField name="test" required value={0} />
+          <Button type="submit" primary label="Submit" />
+        </Form>
+      </Grommet>,
+    );
+    fireEvent.click(screen.getByText('Submit'));
+    expect(onValidate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        errors: {},
+        infos: {},
+        valid: true,
+      }),
+    );
   });
 
   test('uncontrolled onValidate custom error', () => {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Fixes `Form`'s `buildValid` helper so that a required field whose value is the number `0` is correctly reported as valid. Previously `buildValid` used a plain truthiness check (`value[field] &&`), so `0` (a legitimate value, e.g. for a required numeric field) was treated as "missing" even though no validation error was ever added for that field. 
This is now aligned with `validateName`'s required check, which only treats `undefined`, `''`, `false`, or an empty array as missing.

#### Where should the reviewer start?

`src/js/components/Form/Form.js` — `buildValid`.

#### What testing has been done on this PR?

Added a regression test in `Form-test-uncontrolled.tsx` covering a required field with value `0`, asserting `onValidate` is called with `valid: true` and no errors. 
Ran the full `Form` and `FormField` Jest suites (107 tests) — all passing.

#### How should this be manually tested?

1. Render a `Form` containing a required `FormField`/`TextInput` bound to a numeric value.
2. Set the field's value to `0`.
3. Submit the form.
4. Before this fix: `onValidate`'s `valid` flag is `false` with no visible errors. After this fix: `valid` is `true`.

#### Do Jest tests follow these best practices?

- [x] `screen` is used for querying.
- [x] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

Found via a component-by-component bug review of `src/js/components`.

#### What are the relevant issues?

N/A

#### Screenshots (if appropriate)

N/A

#### Do the grommet docs need to be updated?

Nothing.

#### Should this PR be mentioned in the release notes?

Yes

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.
