### PR TITLE
fix(DataSort): stop the options prop from being overridden

### DIFF
--- a/src/js/components/DataSort/DataSort.js
+++ b/src/js/components/DataSort/DataSort.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, { useContext, useMemo, useState } from 'react';
 import { Descend } from 'grommet-icons/icons/Descend';
 import { DataContext } from '../../contexts/DataContext';
@@ -26,8 +28,7 @@ const Content = ({ options: optionsArg }) => {
 
     if (optionsArg) {
       props = { options: optionsArg };
-    }
-    if (properties && Array.isArray(properties)) {
+    } else if (properties && Array.isArray(properties)) {
       props = { options: properties };
     } else if (properties && typeof properties === 'object') {
       props = {

--- a/src/js/components/DataSort/__tests__/DataSort-test.tsx
+++ b/src/js/components/DataSort/__tests__/DataSort-test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import {
   act,
@@ -5,6 +7,7 @@ import {
   render,
   screen,
   waitFor,
+  within,
 } from '@testing-library/react';
 import 'jest-styled-components';
 import '@testing-library/jest-dom';
@@ -127,5 +130,37 @@ describe('DataSort', () => {
 
     expect(drop).toBeTruthy();
     expect(drop).toMatchSnapshot();
+  });
+
+  test('options prop takes priority over derived properties', async () => {
+    const items = [
+      { name: 'a', loc: 'Home' },
+      { name: 'b', loc: 'School' },
+    ];
+    const properties = {
+      name: { label: 'My Name' },
+      loc: { label: 'Location' },
+    };
+
+    render(
+      <Grommet>
+        <Data data={items} properties={properties}>
+          <DataFilters>
+            <DataSort options={['custom-a', 'custom-b']} />
+          </DataFilters>
+        </Data>
+      </Grommet>,
+    );
+
+    const propButton = screen.getByRole('button', {
+      name: 'Sort by Open Drop',
+    });
+    fireEvent.click(propButton);
+    const drop = await waitFor(() => screen.getByRole('listbox'));
+
+    expect(within(drop).getByText('custom-a')).toBeInTheDocument();
+    expect(within(drop).getByText('custom-b')).toBeInTheDocument();
+    expect(within(drop).queryByText('My Name')).not.toBeInTheDocument();
+    expect(within(drop).queryByText('Location')).not.toBeInTheDocument();
   });
 });

--- a/src/js/components/DataSort/index.d.ts
+++ b/src/js/components/DataSort/index.d.ts
@@ -1,7 +1,10 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import * as React from 'react';
 
 export interface DataSortProps {
   drop?: boolean;
+  options?: any[];
 }
 
 export interface DataSortExtendedProps extends DataSortProps {}

--- a/src/js/components/DataSort/propTypes.js
+++ b/src/js/components/DataSort/propTypes.js
@@ -1,9 +1,12 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import PropTypes from 'prop-types';
 
 let PropType = {};
 if (process.env.NODE_ENV !== 'production') {
   PropType = {
     drop: PropTypes.bool,
+    options: PropTypes.array,
   };
 }
 export const DataSortPropTypes = PropType;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Fixes `DataSort` so an explicit `options` prop is no longer silently overridden by properties- or data-derived options.
Previously the `options` branch was a standalone `if`, not part of the `if/else if` chain with the properties-derived branches:
```js
if (optionsArg) {
  props = { options: optionsArg };
}
if (properties && Array.isArray(properties)) {
  props = { options: properties };
} else if (properties && typeof properties === 'object') {
  props = { ... };
}
```
So whatever was assigned from a caller-supplied `options` prop was immediately overwritten whenever `properties` was also present. Changed it to an `if/else if/else` chain so an explicit `options` prop takes priority.
Also added `options` to the component's propTypes and TS types, since it was previously usable at runtime but undeclared.

#### Where should the reviewer start?

`src/js/components/DataSort/DataSort.js` — the `props` assignment inside the `useMemo` in the `Content` component (around `DataSort.js:29`).

#### What testing has been done on this PR?

Added a regression test in `DataSort-test.tsx` covering an explicit `options` prop passed alongside `properties`.
It verifies the drop shows the caller-supplied option values and not the properties-derived labels.
Full `DataSort` Jest suite was run and all 7 tests passed.

#### How should this be manually tested?

1. Render a `Data` with `properties` defined (e.g. `{ name: { label: 'My Name' } }`) wrapping a `DataFilters` containing `<DataSort options={['custom-a', 'custom-b']} />`.
2. Before this fix: opening the sort drop shows the properties-derived labels (`My Name`, ...), not the `options` values — the explicit `options` prop is silently discarded.
3. After this fix: opening the sort drop shows `custom-a` / `custom-b` as passed via `options`.

#### Do Jest tests follow these best practices?

- [x] `screen` is used for querying.
- [x] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing. (N/A — no snapshot assertions in the new test)

#### Any background context you want to provide?

Found via a component-by-component bug review of `src/js/components`.

#### What are the relevant issues?

N/A

#### Screenshots (if appropriate)

N/A

#### Do the grommet docs need to be updated?

No

#### Should this PR be mentioned in the release notes?

Yes

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.