### PR TITLE
fix(TimeInput): sync active section with popup option hover (#8043, #8044)

### DIFF
--- a/src/js/components/TimeInput/TimeInput.js
+++ b/src/js/components/TimeInput/TimeInput.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, {
   forwardRef,
   useCallback,
@@ -358,7 +360,6 @@ const TimeInput = forwardRef(
         if (disabled) return;
         if (event.button !== 0) return;
         if (event.defaultPrevented) return;
-        event.preventDefault();
         event.stopPropagation();
         setSegmentFocused(true);
         setActiveSection(section);

--- a/src/js/components/TimeInput/TimeInputPopup.js
+++ b/src/js/components/TimeInput/TimeInputPopup.js
@@ -137,6 +137,7 @@ const PopupColumn = ({
           }}
           onClick={() => onClickCommitOption(section, option)}
           onFocus={() => onSetSection(section)}
+          onMouseEnter={() => onSetSection(section)}
         >
           <Text
             size={theme.global.input.font.size || 'small'}


### PR DESCRIPTION
This PR contains two complementary fixes that together ensure the active section indicator stays synchronized in both the input field and the popup.

## Commit 1: Remove `event.preventDefault()` from `onDisplaySectionMouseDown` (TimeInput.js)

When the user keyboard-navigates to one segment then clicks on a different segment with the mouse, the visual focus indicator (underline) remained on the last keyboard-focused segment. The same issue affected the popup scenario where the segment underline did not match the focused unit in the popup.

`event.preventDefault()` in `onDisplaySectionMouseDown` suppressed the browser's default mousedown focus behavior. After calling `preventDefault()`, the subsequent `focusSection(section)` call via `target.focus()` did not correctly trigger the `onFocus` → `onSegmentFocus` → `setActiveSection` event chain, leaving the `activeSection` state out of sync with the mouse-targeted segment.

## Commit 2: Add `onMouseEnter` to PopupOption (TimeInputPopup.js)

When the user hovers over a different popup column (hours/minutes/meridiem) without clicking, the active section now updates to match the mouse target. Previously, hovering over a column did not update `activeSection`, leaving the input's segment underline misaligned with the popup's hover target.

The fix adds an `onMouseEnter` handler to each `PopupOption` that calls `onSetSection(section)`, aligning the active section with the mouse pointer.

Closes #8043, #8044