### PR TITLE
fix(DateTimeInput): sync segment underline with popup TimeInput focus

### DIFF
--- a/src/js/components/DateTimeInput/DateTimeInput.js
+++ b/src/js/components/DateTimeInput/DateTimeInput.js
@@ -792,6 +792,15 @@ const DateTimeInput = forwardRef(
       setActiveSection,
     ]);
 
+    
+    const handleTimeActiveSectionChange = useCallback(
+      (timeSection) => {
+        const dtSection = TIME_TO_DT_SECTION[timeSection];
+        if (dtSection !== undefined) setActiveSection(dtSection);
+      },
+      [setActiveSection],
+    );
+
     const closePicker = useCallback(() => {
       setSegmentFocused(false);
       suppressSegmentFocusRef.current = true;
@@ -1362,6 +1371,7 @@ const DateTimeInput = forwardRef(
                   disabled={disabled}
                   readOnly={readOnly}
                   onChange={handleTimeSelect}
+                  onActiveSectionChange={handleTimeActiveSectionChange}
                   onPartialChange={handleTimePartialChange}
                 />
               </Box>

--- a/src/js/components/TimeInput/TimeInput.js
+++ b/src/js/components/TimeInput/TimeInput.js
@@ -114,6 +114,7 @@ const TimeInput = forwardRef(
       name,
       onChange,
       onPartialChange,
+      onActiveSectionChange,
       readOnly = false,
       showSeconds,
       value: valueArg,
@@ -465,6 +466,7 @@ const TimeInput = forwardRef(
         setSegmentFocused(true);
         if (readOnly || disabled) return;
         setActiveSection(section);
+        onActiveSectionChange?.(section);
       },
       [
         announce,
@@ -474,6 +476,7 @@ const TimeInput = forwardRef(
         open,
         readOnly,
         segmentFocused,
+        onActiveSectionChange,
         setActiveSection,
       ],
     );

--- a/src/js/components/TimeInput/propTypes.js
+++ b/src/js/components/TimeInput/propTypes.js
@@ -26,6 +26,7 @@ if (process.env.NODE_ENV !== 'production') {
     minuteStep: PropTypes.number,
     name: PropTypes.string,
     onChange: PropTypes.func,
+    onActiveSectionChange: PropTypes.func,
     readOnly: PropTypes.bool,
     showSeconds: PropTypes.bool,
     value: PropTypes.string,


### PR DESCRIPTION
## Description

Fixes #8044

When the Drop popup is open and the user focuses a different segment in the TimeInput (hours, minutes, seconds, or meridiem), the segment underline in the DateTimeInput main field should sync to match the focused segment.

## Changes

- **TimeInput/propTypes.js**: Added `onActiveSectionChange` prop type
- **TimeInput/TimeInput.js**: Added `onActiveSectionChange` callback prop, called in `onSegmentFocus` when the active section changes
- **DateTimeInput/DateTimeInput.js**: Added `handleTimeActiveSectionChange` handler that maps TimeInput section indices to DateTimeInput section constants via `TIME_TO_DT_SECTION`, and passes it to the popup TimeInput via `onActiveSectionChange`

## How it works

1. When the user focuses a segment in the popup TimeInput (click, tab, arrow keys), `onSegmentFocus` fires
2. TimeInput calls `onActiveSectionChange?.(section)` with the focused section index
3. DateTimeInput receives the section index and maps it to its own section constant (SECTION_HOUR, SECTION_MINUTE, etc.)
4. The mapped section is used to highlight the matching segment underline in the main input field

## Verification

- Open DateTimeInput with a time format
- Open the dropdown popup
- Click between hours, minutes, and meridiem segments in the TimeInput
- The underline in the main input should follow the focused segment
- Keyboard navigation (arrow keys, tab) should also sync correctly