### PR TITLE
fix: add defaultMode to ThemeType TypeScript definitions (Closes #4607)

### DIFF
--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -337,6 +337,7 @@ interface StepperStatusWithHelperTextStateType extends StepperStatusStateType {
 }
 
 export interface ThemeType {
+  defaultMode?: 'dark' | 'light' | 'auto';
   global?: {
     active?: {
       background?:


### PR DESCRIPTION
Fixes #4607

Adds `defaultMode` to the `ThemeType` interface in `themes/base.d.ts`.

`defaultMode` is a top-level theme property that allows the theme to specify a default mode (`dark` | `light` | `auto`) used when `themeMode` is not specified on the `<Grommet>` component.