### PR TITLE
fix(Carousel): sync activeChildState on internal navigation to fix controlled mode (Fixes #7542)

### DIFF
--- a/src/js/components/Carousel/Carousel.js
+++ b/src/js/components/Carousel/Carousel.js
@@ -76,6 +76,7 @@ const Carousel = ({
     });
     setInTransition(true);
     setDirection('left');
+    setActiveChildState(nextActiveIndex);
     onChildChange(nextActiveIndex);
   }, [activeIndex, inTransition, lastIndex, onChildChange]);
 
@@ -89,6 +90,7 @@ const Carousel = ({
     });
     setInTransition(true);
     setDirection('right');
+    setActiveChildState(nextActiveIndex);
     onChildChange(nextActiveIndex);
   }, [activeIndex, inTransition, lastIndex, onChildChange]);
 
@@ -99,6 +101,7 @@ const Carousel = ({
         setIndexes({ activeIndex: index, priorActiveIndex: activeIndex });
         setInTransition(true);
         setDirection(index > activeIndex ? 'left' : 'right');
+        setActiveChildState(index);
         onChildChange(index);
       }
     },


### PR DESCRIPTION
### Fixes #7542

**Bug**: In controlled mode (using `activeChild` prop), navigating with the carousel's internal next/previous buttons then changing `activeChild` from an external controller doesn't navigate back as expected.

**Root cause**: Internal navigation handlers (`onRight`, `onLeft`, `onSelect`) updated `activeIndex` but never updated `activeChildState`. The `onControlledNavigation` guard `activeChild === activeChildState` then wrongly returned early when an external controller set the prop back to a previously-seen value — e.g. after going 0 → 1 via the next button, setting `activeChild` back to 0 was ignored because `activeChildState` was still `0`.

**Fix**: Call `setActiveChildState(nextActiveIndex)` (respectively `setActiveChildState(index)` for `onSelect`) in all internal navigation handlers, so `activeChildState` always tracks the current prop-equivalent value.

**Reproduction**: [Carousel controlled story](https://storybook.grommet.io/?path=/story/media-carousel-controlled--controlled) — navigate to slide 1 with the next arrow, then use an external button to return to slide 0. With the fix, the Carousel correctly returns to slide 0. Without it, it stays on slide 1.