### PR TITLE
fix: Calendar selected day uses inconsistent color in dark mode (#8063)

### DIFF
--- a/src/js/components/Calendar/StyledCalendar.js
+++ b/src/js/components/Calendar/StyledCalendar.js
@@ -217,7 +217,7 @@ const dayStyle = (props) => {
   let backgroundObj;
   let colorObj;
   if (props.isSelected) {
-    backgroundObj = props.theme.calendar.day?.selected?.background || 'control';
+    backgroundObj = props.theme.calendar.day?.selected?.background || 'selected';
     colorObj = props.theme.calendar.day?.selected?.color;
   } else if (props.inRange) {
     // for backwards compatability, only apply this if caller hasn't specified


### PR DESCRIPTION
## Description

In dark mode, the Calendar's selected day uses `control` color which resolves to `accent-1` (green `#6FFFB0`), while the TimeInput (used together in DateTimeInput) uses `selected` which resolves to `brand` (purple `#7D4CDB`). This creates an inconsistent look where calendar selection is green and time selection is purple.

## Root Cause

In `StyledCalendar.js`, the `dayStyle` function has a fallback background of `'control'` for selected days. In the base theme, `control` resolves differently in dark vs light mode:
- light: `control` → `brand` (purple)
- dark: `control` → `accent-1` (green)

But `selected` always resolves to `brand` in both modes. The correct semantic token for a selected state is `selected`, not `control`.

## Fix

Changed the fallback from `'control'` to `'selected'` for selected days. This:
- Keeps light mode identical (both tokens resolve to `brand`)
- Makes dark mode consistent with the `selected` token used by TimeInput and other components
- Is semantically correct — a selected day should use the selected color

## Related Issue

Closes #8063