### PR TITLE
fix: DateTimeInput focus goes to hours picker instead of calendar on open (#8060)

### DIFF
--- a/src/js/components/DateTimeInput/DateTimeInput.js
+++ b/src/js/components/DateTimeInput/DateTimeInput.js
@@ -1363,6 +1363,7 @@ const DateTimeInput = forwardRef(
                 />
                 <TimeInput
                   inline
+                  focusOnMount={false}
                   format={resolvedFormat}
                   value={timeValue}
                   showSeconds={showSeconds}

--- a/src/js/components/TimeInput/TimeInput.js
+++ b/src/js/components/TimeInput/TimeInput.js
@@ -107,6 +107,7 @@ const TimeInput = forwardRef(
       defaultValue,
       disabled,
       format = DEFAULT_FORMAT,
+      focusOnMount = true,
       id,
       inline = false,
       messages,
@@ -673,6 +674,7 @@ const TimeInput = forwardRef(
       return (
         <TimeInputPopup
           inline
+          focusOnMount={focusOnMount}
           activeSection={activeSection}
           format={format}
           formatMessage={formatMessage}

--- a/src/js/components/TimeInput/TimeInputPopup.js
+++ b/src/js/components/TimeInput/TimeInputPopup.js
@@ -202,6 +202,7 @@ const TimeInputPopup = ({
   align,
   format,
   formatMessage,
+  focusOnMount = true,
   hoursOptions,
   id,
   incrementSection,
@@ -528,33 +529,42 @@ const TimeInputPopup = ({
   ]);
 
   useLayoutEffect(() => {
-    // Avoid stealing pointer interactions: while the user is actively
-    // clicking inside the popup, let that click settle before refocusing.
-    if (pointerDownInsideRef.current) return undefined;
+    // Scroll selected options into view regardless. But avoid stealing
+    // focus when the popup mounts inside another component (e.g. Calendar
+    // in DateTimeInput) that manages its own initial focus.
+    if (focusOnMount && !pointerDownInsideRef.current) {
+      const scrollRaf = requestAnimationFrame(() => {
+        scrollSelectedOptionsIntoView();
+      });
+
+      let rafB;
+      const rafA = requestAnimationFrame(() => {
+        scrollSelectedOptionsIntoView();
+        const focused = focusCurrentPopupOption();
+        // Retry one more frame to handle occasional mount timing races.
+        if (!focused) {
+          rafB = requestAnimationFrame(() => {
+            scrollSelectedOptionsIntoView();
+            focusCurrentPopupOption();
+          });
+        }
+      });
+
+      return () => {
+        window.cancelAnimationFrame(scrollRaf);
+        window.cancelAnimationFrame(rafA);
+        if (rafB) window.cancelAnimationFrame(rafB);
+      };
+    }
 
     const scrollRaf = requestAnimationFrame(() => {
       scrollSelectedOptionsIntoView();
     });
 
-    let rafB;
-    const rafA = requestAnimationFrame(() => {
-      scrollSelectedOptionsIntoView();
-      const focused = focusCurrentPopupOption();
-      // Retry one more frame to handle occasional mount timing races.
-      if (!focused) {
-        rafB = requestAnimationFrame(() => {
-          scrollSelectedOptionsIntoView();
-          focusCurrentPopupOption();
-        });
-      }
-    });
-
     return () => {
       window.cancelAnimationFrame(scrollRaf);
-      window.cancelAnimationFrame(rafA);
-      if (rafB) window.cancelAnimationFrame(rafB);
     };
-  }, [focusCurrentPopupOption, scrollSelectedOptionsIntoView]);
+  }, [focusCurrentPopupOption, focusOnMount, scrollSelectedOptionsIntoView]);
 
   const popupContent = (
     <Box

--- a/src/js/components/TimeInput/index.d.ts
+++ b/src/js/components/TimeInput/index.d.ts
@@ -6,6 +6,7 @@ export interface TimeInputProps {
   defaultValue?: string;
   disabled?: boolean;
   format?: '12' | '24';
+  focusOnMount?: boolean;
   id?: string;
   messages?: {
     activePeriodValue?: string;

--- a/src/js/components/TimeInput/propTypes.js
+++ b/src/js/components/TimeInput/propTypes.js
@@ -8,6 +8,7 @@ if (process.env.NODE_ENV !== 'production') {
     defaultValue: PropTypes.string,
     disabled: PropTypes.bool,
     format: PropTypes.oneOf(['12', '24']),
+    focusOnMount: PropTypes.bool,
     id: PropTypes.string,
     messages: PropTypes.shape({
       activePeriodValue: PropTypes.string,


### PR DESCRIPTION
## Description

When opening the DateTimeInput drop (focus on input + press space), the focus is placed on the hours picker instead of the Calendar first.

## Root Cause

The `Calendar` component mounts with `initialFocus="days"` and correctly focuses the first day. However, the inline `TimeInput` popup runs a `useLayoutEffect` with `requestAnimationFrame` that calls `focusCurrentPopupOption()`, which steals focus from the Calendar and moves it to the hours column.

## Fix

Added a `focusOnMount` prop to `TimeInput` (default `true`), propagated to `TimeInputPopup`. When `false`, the popup still scrolls the selected options into view but skips the auto-focus of the current popup option.

`DateTimeInput` now passes `focusOnMount={false}` to its inline `TimeInput`, so the Calendar keeps initial focus as expected.

## Files Changed

- `src/js/components/TimeInput/TimeInput.js` — accept and forward `focusOnMount`
- `src/js/components/TimeInput/TimeInputPopup.js` — skip auto-focus when `focusOnMount` is false
- `src/js/components/TimeInput/propTypes.js` — add prop type
- `src/js/components/TimeInput/index.d.ts` — add TS type
- `src/js/components/DateTimeInput/DateTimeInput.js` — pass `focusOnMount={false}`

## Related Issue

Closes #8060