### PR TITLE
add workflow to thank contributors on new PRs and flag failing Jest c…

### DIFF
--- a/.github/workflows/thank-you-new-prs.yml
+++ b/.github/workflows/thank-you-new-prs.yml
@@ -92,9 +92,9 @@ jobs:
               fi
 
               if [ "$IS_FIRST_TIMER" = "true" ]; then
-                MESSAGE="${MARKER}"$'\n'"Thanks so much for your first contribution to Grommet, and welcome! 🎉 A maintainer will review it as soon as they can. In the meantime, feel free to check out our [contributing guide](https://github.com/${REPO}/blob/master/CONTRIBUTING.md) if you have any questions."
+                MESSAGE="${MARKER}"$'\n'"Thanks so much for your first contribution to Grommet, and welcome! 🎉"$'\n\n'"A maintainer will review it as soon as they can. The Grommet team is committed to maintaining quality across utility, usability, accessibility, and developer experience — honoring those standards takes time, but it's what makes Grommet a library the whole community can trust."$'\n\n'"In the meantime, feel free to check out our [contributing guide](https://github.com/${REPO}/blob/master/CONTRIBUTING.md) if you have any questions."$'\n\n'"_(This message was posted automatically by the Grommet bot.)_"
               else
-                MESSAGE="${MARKER}"$'\n'"Thank you for the contribution! The Grommet team will take a look at this as soon as we can. 🙏"
+                MESSAGE="${MARKER}"$'\n'"Thank you for the contribution! 🙏"$'\n\n'"A maintainer will review it as soon as they can. The Grommet team is committed to maintaining quality across utility, usability, accessibility, and developer experience — honoring those standards takes time, but it's what makes Grommet a library the whole community can trust."$'\n\n'"_(This message was posted automatically by the Grommet bot.)_"
               fi
 
               # Look for failing Jest/test checks on the PR so the

--- a/.github/workflows/thank-you-new-prs.yml
+++ b/.github/workflows/thank-you-new-prs.yml
@@ -29,9 +29,9 @@ jobs:
           DRY_RUN: ${{ inputs.dry_run == true }}
         run: |
           MARKER="<!-- grommet-thank-you-bot -->"
-          # GitHub logins of the Grommet team - PRs already commented on by
-          # one of these are left alone since a maintainer has responded.
-          TEAM_MEMBERS="seanhillweb jcfilben MikeKingdom halocline Sulaymon333"
+          # Fetch current members of the grommet/devs team dynamically.
+          # Requires a token with read:org scope (set ORG_READ_TOKEN secret).
+          TEAM_MEMBERS=$(gh api orgs/grommet/teams/devs/members --jq '.[].login')
           echo "Dry run: $DRY_RUN"
 
           PR_NUMBERS=$(gh pr list --repo "$REPO" --state open --json number -q '.[].number')

--- a/.github/workflows/thank-you-new-prs.yml
+++ b/.github/workflows/thank-you-new-prs.yml
@@ -36,7 +36,8 @@ jobs:
           for PR in $PR_NUMBERS; do
             EXISTING=$(gh pr view "$PR" --repo "$REPO" --json comments -q '.comments[].body' | grep -F "$MARKER" || true)
             if [ -z "$EXISTING" ]; then
-              ASSOCIATION=$(gh pr view "$PR" --repo "$REPO" --json authorAssociation -q '.authorAssociation')
+              # gh pr view has no authorAssociation field; use the REST API directly.
+              ASSOCIATION=$(gh api "repos/${REPO}/pulls/${PR}" --jq '.author_association')
               if [ "$ASSOCIATION" = "FIRST_TIME_CONTRIBUTOR" ] || [ "$ASSOCIATION" = "FIRST_TIMER" ]; then
                 MESSAGE="${MARKER}
           Thanks so much for your first contribution to Grommet, and welcome! 🎉 A maintainer will review it as soon as they can. In the meantime, feel free to check out our [contributing guide](https://github.com/${REPO}/blob/master/CONTRIBUTING.md) if you have any questions."

--- a/.github/workflows/thank-you-new-prs.yml
+++ b/.github/workflows/thank-you-new-prs.yml
@@ -28,13 +28,14 @@ jobs:
           REPO: ${{ github.repository }}
           DRY_RUN: ${{ inputs.dry_run == true }}
         run: |
+          set -e
           MARKER="<!-- grommet-thank-you-bot -->"
           # Fetch current members of the grommet/devs team dynamically.
           # Requires a token with read:org scope (set ORG_READ_TOKEN secret).
           TEAM_MEMBERS=$(gh api orgs/grommet/teams/devs/members --jq '.[].login')
           echo "Dry run: $DRY_RUN"
 
-          PR_NUMBERS=$(gh pr list --repo "$REPO" --state open --json number -q '.[].number')
+          PR_NUMBERS=$(gh pr list --repo "$REPO" --state open --limit 100 --json number -q '.[].number')
 
           for PR in $PR_NUMBERS; do
             PR_AUTHOR=$(gh pr view "$PR" --repo "$REPO" --json author -q '.author.login')
@@ -69,7 +70,9 @@ jobs:
               fi
 
               # gh pr view has no authorAssociation field; use the REST API directly.
-              ASSOCIATION=$(gh api "repos/${REPO}/pulls/${PR}" --jq '.author_association')
+              PR_DATA=$(gh api "repos/${REPO}/pulls/${PR}" --jq '{association: .author_association, author: .user.login}')
+              ASSOCIATION=$(echo "$PR_DATA" | jq -r '.association')
+              AUTHOR=$(echo "$PR_DATA" | jq -r '.author')
 
               IS_FIRST_TIMER=""
               if [ "$ASSOCIATION" = "FIRST_TIME_CONTRIBUTOR" ] || [ "$ASSOCIATION" = "FIRST_TIMER" ]; then
@@ -81,7 +84,6 @@ jobs:
                 # author until one of their PRs actually merges, so the same
                 # person can show up as "first time" across several open PRs.
                 # Only send the welcome message once per author.
-                AUTHOR=$(gh api "repos/${REPO}/pulls/${PR}" --jq '.user.login')
                 OTHER_PRS=$(gh api "search/issues?q=repo:${REPO}+type:pr+author:${AUTHOR}" --jq '.items[].number' | grep -vx "$PR" || true)
                 for OTHER_PR in $OTHER_PRS; do
                   if gh pr view "$OTHER_PR" --repo "$REPO" --json comments -q '.comments[].body' | grep -qF "$MARKER"; then

--- a/.github/workflows/thank-you-new-prs.yml
+++ b/.github/workflows/thank-you-new-prs.yml
@@ -1,0 +1,77 @@
+name: Thank New Contributors
+
+# Runs every morning and leaves a welcome comment on any open PR
+# that doesn't already have one, thanking the contributor.
+on:
+  schedule:
+    - cron: '0 13 * * *' # 9am ET / 13:00 UTC daily
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Log what would be posted without actually commenting'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  pull-requests: write
+
+jobs:
+  thank-new-prs:
+    name: Comment on new PRs
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Comment on PRs missing a welcome message
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          DRY_RUN: ${{ inputs.dry_run == true }}
+        run: |
+          MARKER="<!-- grommet-thank-you-bot -->"
+          echo "Dry run: $DRY_RUN"
+
+          PR_NUMBERS=$(gh pr list --repo "$REPO" --state open --json number -q '.[].number')
+
+          for PR in $PR_NUMBERS; do
+            EXISTING=$(gh pr view "$PR" --repo "$REPO" --json comments -q '.comments[].body' | grep -F "$MARKER" || true)
+            if [ -z "$EXISTING" ]; then
+              ASSOCIATION=$(gh pr view "$PR" --repo "$REPO" --json authorAssociation -q '.authorAssociation')
+              if [ "$ASSOCIATION" = "FIRST_TIME_CONTRIBUTOR" ] || [ "$ASSOCIATION" = "FIRST_TIMER" ]; then
+                MESSAGE="${MARKER}
+          Thanks so much for your first contribution to Grommet, and welcome! 🎉 A maintainer will review it as soon as they can. In the meantime, feel free to check out our [contributing guide](https://github.com/${REPO}/blob/master/CONTRIBUTING.md) if you have any questions."
+              else
+                MESSAGE="${MARKER}
+          Thank you for the contribution! The Grommet team will take a look at this as soon as we can. 🙏"
+              fi
+
+              # Look for failing Jest/test checks on the PR so the
+              # contributor has somewhere concrete to start.
+              FAILING_TESTS=$(gh pr checks "$PR" --repo "$REPO" --json name,bucket,link 2>/dev/null \
+                | jq -r '.[] | select(.bucket == "fail") | select(.name | test("jest|test"; "i")) | "- [\(.name)](\(.link))"' \
+                || true)
+
+              if [ -n "$FAILING_TESTS" ]; then
+                MESSAGE="${MESSAGE}
+
+          It also looks like the following check(s) are currently failing:
+          ${FAILING_TESTS}
+
+          Taking a look at the failing Jest test(s) above would be a great place to start while you wait for a full review."
+              fi
+
+              if [ "$DRY_RUN" = "true" ]; then
+                echo "[dry run] Would comment on PR #$PR:"
+                echo "$MESSAGE"
+                echo '---'
+              else
+                echo "Commenting on PR #$PR"
+                gh pr comment "$PR" --repo "$REPO" --body "$MESSAGE"
+              fi
+            else
+              echo "Commenting on PR #$PR (authorAssociation: $ASSOCIATION)"
+              gh pr comment "$PR" --repo "$REPO" --body "$MESSAGE"
+            else
+              echo "PR #$PR already has a welcome comment, skipping."
+            fi
+          done

--- a/.github/workflows/thank-you-new-prs.yml
+++ b/.github/workflows/thank-you-new-prs.yml
@@ -60,11 +60,9 @@ jobs:
               fi
 
               if [ "$IS_FIRST_TIMER" = "true" ]; then
-                MESSAGE="${MARKER}
-          Thanks so much for your first contribution to Grommet, and welcome! 🎉 A maintainer will review it as soon as they can. In the meantime, feel free to check out our [contributing guide](https://github.com/${REPO}/blob/master/CONTRIBUTING.md) if you have any questions."
+                MESSAGE="${MARKER}"$'\n'"Thanks so much for your first contribution to Grommet, and welcome! 🎉 A maintainer will review it as soon as they can. In the meantime, feel free to check out our [contributing guide](https://github.com/${REPO}/blob/master/CONTRIBUTING.md) if you have any questions."
               else
-                MESSAGE="${MARKER}
-          Thank you for the contribution! The Grommet team will take a look at this as soon as we can. 🙏"
+                MESSAGE="${MARKER}"$'\n'"Thank you for the contribution! The Grommet team will take a look at this as soon as we can. 🙏"
               fi
 
               # Look for failing Jest/test checks on the PR so the
@@ -74,12 +72,7 @@ jobs:
                 || true)
 
               if [ -n "$FAILING_TESTS" ]; then
-                MESSAGE="${MESSAGE}
-
-          It also looks like the following check(s) are currently failing:
-          ${FAILING_TESTS}
-
-          Taking a look at the failing Jest test(s) above would be a great place to start while you wait for a full review."
+                MESSAGE="${MESSAGE}"$'\n\n'"It also looks like the following check(s) are currently failing:"$'\n'"${FAILING_TESTS}"$'\n\n'"Taking a look at the failing Jest test(s) above would be a great place to start while you wait for a full review."
               fi
 
               if [ "$DRY_RUN" = "true" ]; then

--- a/.github/workflows/thank-you-new-prs.yml
+++ b/.github/workflows/thank-you-new-prs.yml
@@ -91,9 +91,6 @@ jobs:
                 gh pr comment "$PR" --repo "$REPO" --body "$MESSAGE"
               fi
             else
-              echo "Commenting on PR #$PR (authorAssociation: $ASSOCIATION)"
-              gh pr comment "$PR" --repo "$REPO" --body "$MESSAGE"
-            else
               echo "PR #$PR already has a welcome comment, skipping."
             fi
           done

--- a/.github/workflows/thank-you-new-prs.yml
+++ b/.github/workflows/thank-you-new-prs.yml
@@ -37,6 +37,19 @@ jobs:
           PR_NUMBERS=$(gh pr list --repo "$REPO" --state open --json number -q '.[].number')
 
           for PR in $PR_NUMBERS; do
+            PR_AUTHOR=$(gh pr view "$PR" --repo "$REPO" --json author -q '.author.login')
+            IS_TEAM_AUTHOR=""
+            for TEAM_MEMBER in $TEAM_MEMBERS; do
+              if [ "$PR_AUTHOR" = "$TEAM_MEMBER" ]; then
+                IS_TEAM_AUTHOR="true"
+                break
+              fi
+            done
+            if [ "$IS_TEAM_AUTHOR" = "true" ]; then
+              echo "PR #$PR opened by team member $PR_AUTHOR, skipping."
+              continue
+            fi
+
             EXISTING=$(gh pr view "$PR" --repo "$REPO" --json comments -q '.comments[].body' | grep -F "$MARKER" || true)
             if [ -z "$EXISTING" ]; then
               TEAM_RESPONDED=""

--- a/.github/workflows/thank-you-new-prs.yml
+++ b/.github/workflows/thank-you-new-prs.yml
@@ -38,7 +38,28 @@ jobs:
             if [ -z "$EXISTING" ]; then
               # gh pr view has no authorAssociation field; use the REST API directly.
               ASSOCIATION=$(gh api "repos/${REPO}/pulls/${PR}" --jq '.author_association')
+
+              IS_FIRST_TIMER=""
               if [ "$ASSOCIATION" = "FIRST_TIME_CONTRIBUTOR" ] || [ "$ASSOCIATION" = "FIRST_TIMER" ]; then
+                IS_FIRST_TIMER="true"
+              fi
+
+              if [ "$IS_FIRST_TIMER" = "true" ]; then
+                # GitHub reports FIRST_TIME_CONTRIBUTOR on every PR from an
+                # author until one of their PRs actually merges, so the same
+                # person can show up as "first time" across several open PRs.
+                # Only send the welcome message once per author.
+                AUTHOR=$(gh api "repos/${REPO}/pulls/${PR}" --jq '.user.login')
+                OTHER_PRS=$(gh api "search/issues?q=repo:${REPO}+type:pr+author:${AUTHOR}" --jq '.items[].number' | grep -vx "$PR" || true)
+                for OTHER_PR in $OTHER_PRS; do
+                  if gh pr view "$OTHER_PR" --repo "$REPO" --json comments -q '.comments[].body' | grep -qF "$MARKER"; then
+                    IS_FIRST_TIMER=""
+                    break
+                  fi
+                done
+              fi
+
+              if [ "$IS_FIRST_TIMER" = "true" ]; then
                 MESSAGE="${MARKER}
           Thanks so much for your first contribution to Grommet, and welcome! 🎉 A maintainer will review it as soon as they can. In the meantime, feel free to check out our [contributing guide](https://github.com/${REPO}/blob/master/CONTRIBUTING.md) if you have any questions."
               else

--- a/.github/workflows/thank-you-new-prs.yml
+++ b/.github/workflows/thank-you-new-prs.yml
@@ -30,24 +30,19 @@ jobs:
         run: |
           set -e
           MARKER="<!-- grommet-thank-you-bot -->"
-          # GitHub logins of the Grommet team - PRs already commented on by
-          # one of these are left alone since a maintainer has responded.
-          TEAM_MEMBERS="seanhillweb jcfilben MikeKingdom halocline Sulaymon333 britt6612"
           echo "Dry run: $DRY_RUN"
 
-          PR_NUMBERS=$(gh pr list --repo "$REPO" --state open --limit 100 --json number -q '.[].number')
+          PR_NUMBERS=$(gh pr list --repo "$REPO" --state open --limit 100 --json number,createdAt \
+            -q '.[] | select(.createdAt >= "2026-01-01") | .number')
 
           for PR in $PR_NUMBERS; do
-            PR_AUTHOR=$(gh pr view "$PR" --repo "$REPO" --json author -q '.author.login')
-            IS_TEAM_AUTHOR=""
-            for TEAM_MEMBER in $TEAM_MEMBERS; do
-              if [ "$PR_AUTHOR" = "$TEAM_MEMBER" ]; then
-                IS_TEAM_AUTHOR="true"
-                break
-              fi
-            done
-            if [ "$IS_TEAM_AUTHOR" = "true" ]; then
-              echo "PR #$PR opened by team member $PR_AUTHOR, skipping."
+            # Use the REST API for author_association since gh pr view doesn't expose it.
+            PR_DATA=$(gh api "repos/${REPO}/pulls/${PR}" --jq '{association: .author_association, author: .user.login}')
+            ASSOCIATION=$(echo "$PR_DATA" | jq -r '.association')
+            AUTHOR=$(echo "$PR_DATA" | jq -r '.author')
+
+            if [ "$ASSOCIATION" = "MEMBER" ] || [ "$ASSOCIATION" = "OWNER" ] || [ "$ASSOCIATION" = "COLLABORATOR" ]; then
+              echo "PR #$PR opened by org member/collaborator $AUTHOR, skipping."
               continue
             fi
           if [ "$ASSOCIATION" = "BOT" ] || [[ "$PR_AUTHOR" == *"[bot]" ]]; then
@@ -57,26 +52,13 @@ jobs:
 
             EXISTING=$(gh pr view "$PR" --repo "$REPO" --json comments -q '.comments[].body' | grep -F "$MARKER" || true)
             if [ -z "$EXISTING" ]; then
-              TEAM_RESPONDED=""
-              COMMENT_AUTHORS=$(gh pr view "$PR" --repo "$REPO" --json comments -q '.comments[].author.login')
-              for COMMENT_AUTHOR in $COMMENT_AUTHORS; do
-                for TEAM_MEMBER in $TEAM_MEMBERS; do
-                  if [ "$COMMENT_AUTHOR" = "$TEAM_MEMBER" ]; then
-                    TEAM_RESPONDED="true"
-                    break 2
-                  fi
-                done
-              done
-
-              if [ "$TEAM_RESPONDED" = "true" ]; then
+              # Skip if any org member or collaborator has already commented.
+              TEAM_RESPONDED=$(gh pr view "$PR" --repo "$REPO" --json comments \
+                -q '.comments[].authorAssociation' | grep -E "^(MEMBER|OWNER|COLLABORATOR)$" || true)
+              if [ -n "$TEAM_RESPONDED" ]; then
                 echo "PR #$PR already has a team response, skipping."
                 continue
               fi
-
-              # gh pr view has no authorAssociation field; use the REST API directly.
-              PR_DATA=$(gh api "repos/${REPO}/pulls/${PR}" --jq '{association: .author_association, author: .user.login}')
-              ASSOCIATION=$(echo "$PR_DATA" | jq -r '.association')
-              AUTHOR=$(echo "$PR_DATA" | jq -r '.author')
 
               IS_FIRST_TIMER=""
               if [ "$ASSOCIATION" = "FIRST_TIME_CONTRIBUTOR" ] || [ "$ASSOCIATION" = "FIRST_TIMER" ]; then

--- a/.github/workflows/thank-you-new-prs.yml
+++ b/.github/workflows/thank-you-new-prs.yml
@@ -30,9 +30,9 @@ jobs:
         run: |
           set -e
           MARKER="<!-- grommet-thank-you-bot -->"
-          # Fetch current members of the grommet/devs team dynamically.
-          # Requires a token with read:org scope (set ORG_READ_TOKEN secret).
-          TEAM_MEMBERS=$(gh api orgs/grommet/teams/devs/members --jq '.[].login')
+          # GitHub logins of the Grommet team - PRs already commented on by
+          # one of these are left alone since a maintainer has responded.
+          TEAM_MEMBERS="seanhillweb jcfilben MikeKingdom halocline Sulaymon333 britt6612"
           echo "Dry run: $DRY_RUN"
 
           PR_NUMBERS=$(gh pr list --repo "$REPO" --state open --limit 100 --json number -q '.[].number')

--- a/.github/workflows/thank-you-new-prs.yml
+++ b/.github/workflows/thank-you-new-prs.yml
@@ -50,6 +50,10 @@ jobs:
               echo "PR #$PR opened by team member $PR_AUTHOR, skipping."
               continue
             fi
+          if [ "$ASSOCIATION" = "BOT" ] || [[ "$PR_AUTHOR" == *"[bot]" ]]; then
+            echo "PR #$PR opened by bot $PR_AUTHOR, skipping."
+            continue
+          fi
 
             EXISTING=$(gh pr view "$PR" --repo "$REPO" --json comments -q '.comments[].body' | grep -F "$MARKER" || true)
             if [ -z "$EXISTING" ]; then

--- a/.github/workflows/thank-you-new-prs.yml
+++ b/.github/workflows/thank-you-new-prs.yml
@@ -104,7 +104,7 @@ jobs:
                 || true)
 
               if [ -n "$FAILING_TESTS" ]; then
-                MESSAGE="${MESSAGE}"$'\n\n'"It also looks like the following check(s) are currently failing:"$'\n'"${FAILING_TESTS}"$'\n\n'"Taking a look at the failing Jest test(s) above would be a great place to start while you wait for a full review."
+                MESSAGE="${MESSAGE}"$'\n\n'"It looks like the following check(s) are currently failing:"$'\n'"${FAILING_TESTS}"$'\n\n'"Taking a look at the failing Jest test(s) above would be a great place to start while you wait for a full review."
               fi
 
               if [ "$DRY_RUN" = "true" ]; then

--- a/.github/workflows/thank-you-new-prs.yml
+++ b/.github/workflows/thank-you-new-prs.yml
@@ -29,6 +29,9 @@ jobs:
           DRY_RUN: ${{ inputs.dry_run == true }}
         run: |
           MARKER="<!-- grommet-thank-you-bot -->"
+          # GitHub logins of the Grommet team - PRs already commented on by
+          # one of these are left alone since a maintainer has responded.
+          TEAM_MEMBERS="seanhillweb jcfilben MikeKingdom halocline Sulaymon333"
           echo "Dry run: $DRY_RUN"
 
           PR_NUMBERS=$(gh pr list --repo "$REPO" --state open --json number -q '.[].number')
@@ -36,6 +39,22 @@ jobs:
           for PR in $PR_NUMBERS; do
             EXISTING=$(gh pr view "$PR" --repo "$REPO" --json comments -q '.comments[].body' | grep -F "$MARKER" || true)
             if [ -z "$EXISTING" ]; then
+              TEAM_RESPONDED=""
+              COMMENT_AUTHORS=$(gh pr view "$PR" --repo "$REPO" --json comments -q '.comments[].author.login')
+              for COMMENT_AUTHOR in $COMMENT_AUTHORS; do
+                for TEAM_MEMBER in $TEAM_MEMBERS; do
+                  if [ "$COMMENT_AUTHOR" = "$TEAM_MEMBER" ]; then
+                    TEAM_RESPONDED="true"
+                    break 2
+                  fi
+                done
+              done
+
+              if [ "$TEAM_RESPONDED" = "true" ]; then
+                echo "PR #$PR already has a team response, skipping."
+                continue
+              fi
+
               # gh pr view has no authorAssociation field; use the REST API directly.
               ASSOCIATION=$(gh api "repos/${REPO}/pulls/${PR}" --jq '.author_association')
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->
Add workflow to thank new PR contributors and surface failing Jest checks

#### What does this PR do?
Adds `.github/workflows/thank-you-new-prs.yml`, a scheduled GitHub Action that runs every morning and leaves a welcome comment on any open PR that doesn't already have one from this bot.

- Uses a hidden `<!-- grommet-thank-you-bot -->` marker in the comment body so each PR only ever gets commented on once.
- Looks up the PR author's `authorAssociation` and tailors the message: first-time contributors (`FIRST_TIME_CONTRIBUTOR`/`FIRST_TIMER`) get a warmer welcome with a link to the contributing guide; everyone else gets a shorter generic thank-you.
- Checks the PR's CI status via `gh pr checks` and, if any check with "jest"/"test" in its name is failing, appends a list of the failing check(s) to the comment so the contributor has something concrete to start on while waiting for review.
- Supports a `dry_run` input (`workflow_dispatch`, defaults to `true`) that logs what would be posted without actually commenting, so it can be safely tested before running for real.

#### Where should the reviewer start?
`.github/workflows/thank-you-new-prs.yml` — it's a single shell step; read top to bottom (marker check → author-association branch → failing-checks lookup → dry-run/post).

#### What testing has been done on this PR?
Ran the workflow via `workflow_dispatch` with `dry_run: true` against this repo and confirmed the job log printed the correct message per open PR (first-timer vs. returning contributor wording, and failing-check callouts where applicable) without posting any comments.

#### How should this be manually tested?
1. Go to the Actions tab → **Thank New Contributors** → **Run workflow**, select this branch, leave `dry_run: true`, and run it.
2. Review the job log for the `[dry run] Would comment on PR #N:` output for each open PR and confirm the wording/failing-checks look correct.
3. Once satisfied, re-run with `dry_run: false` to verify it posts a real comment on a PR, and re-run again to confirm it skips PRs that already have the marker comment.

#### Do Jest tests follow these best practices?
- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

N/A — this PR only adds a CI workflow; no component/Jest changes.

#### Any background context you want to provide?
Goal is to make sure every new contributor gets an immediate, friendly acknowledgment instead of waiting in silence for a maintainer, and to nudge them toward fixing obvious failing tests in the meantime.

#### What are the relevant issues?


#### Screenshots (if appropriate)
N/A

#### Do the grommet docs need to be updated?
No — this is an internal maintainer/community-ops workflow, not part of the public component API.

#### Should this PR be mentioned in the release notes?
No.

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible