### PR TITLE
fix(Layer): only run unmount cleanup on unmount, not on prop change

### DIFF
--- a/src/js/components/Layer/Layer.js
+++ b/src/js/components/Layer/Layer.js
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React, {
   forwardRef,
   useContext,
@@ -55,16 +57,40 @@ const Layer = forwardRef((props, ref) => {
       setLayerContainer(getNewContainer(containerTarget, targetChildPosition)),
     [containerTarget, targetChildPosition],
   );
-  // just a few things to clean up when the Layer is unmounted
+
+  // Keep the latest prop/state values available to the unmount-only
+  // cleanup effect below without making it re-fire on every change to
+  // them (see cleanupPropsRef usage).
+  const cleanupPropsRef = useRef();
+  cleanupPropsRef.current = {
+    animate,
+    animation,
+    containerTarget,
+    layerContainer,
+    modal,
+  };
+
+  // just a few things to clean up when the Layer is unmounted.
+  // Deps are intentionally empty so this only runs on unmount rather
+  // than on every change to the values it reads, which would otherwise
+  // tear down an open Layer whenever modal/animate/animation/
+  // containerTarget changed.
   useLayoutEffect(
     () => () => {
+      const {
+        animate: cleanupAnimate,
+        animation: cleanupAnimation,
+        containerTarget: cleanupContainerTarget,
+        layerContainer: cleanupLayerContainer,
+        modal: cleanupModal,
+      } = cleanupPropsRef.current;
       const originalFocusedElement = originalFocusedElementRef.current;
       if (originalFocusedElement) {
         // Restore focus if:
         // - modal layer (always restore), or
         // - non-modal layer that had focus when it closed
         const shouldRestoreFocus =
-          modal || (!modal && focusWithinLayerRef.current);
+          cleanupModal || (!cleanupModal && focusWithinLayerRef.current);
         if (shouldRestoreFocus && originalFocusedElement.focus) {
           // wait for the fixed positioning to come back to normal
           // see layer styling for reference
@@ -77,14 +103,15 @@ const Layer = forwardRef((props, ref) => {
           originalFocusedElement.parentNode.focus();
         }
       }
-      if (layerContainer) {
-        const activeAnimation = animation !== undefined ? animation : animate;
+      if (cleanupLayerContainer) {
+        const activeAnimation =
+          cleanupAnimation !== undefined ? cleanupAnimation : cleanupAnimate;
         if (activeAnimation !== false) {
           // undefined uses 'slide' as the default
           // animate out and remove later
-          const layerClone = layerContainer.cloneNode(true);
+          const layerClone = cleanupLayerContainer.cloneNode(true);
           layerClone.id = 'layerClone';
-          containerTarget.appendChild(layerClone);
+          cleanupContainerTarget.appendChild(layerClone);
           const clonedContainer = layerClone.querySelector(
             '[class*="StyledLayer__StyledContainer"]',
           );
@@ -93,25 +120,25 @@ const Layer = forwardRef((props, ref) => {
           }
           setTimeout(() => {
             // we add the id and query here so the unit tests work
-            const rootNode = containerTarget.getRootNode();
+            const rootNode = cleanupContainerTarget.getRootNode();
             // Not all root nodes (ShadowRoot, DocumentFragment)
             //  have getElementById.
             if (rootNode && typeof rootNode.getElementById === 'function') {
               const clone = rootNode.getElementById('layerClone');
               if (clone) {
-                if (containerTarget.contains(clone)) {
-                  containerTarget.removeChild(clone);
+                if (cleanupContainerTarget.contains(clone)) {
+                  cleanupContainerTarget.removeChild(clone);
                 }
-                layerContainer.remove();
+                cleanupLayerContainer.remove();
               }
             }
           }, animationDuration);
-        } else if (containerTarget.contains(layerContainer)) {
-          containerTarget.removeChild(layerContainer);
+        } else if (cleanupContainerTarget.contains(cleanupLayerContainer)) {
+          cleanupContainerTarget.removeChild(cleanupLayerContainer);
         }
       }
     },
-    [animate, animation, containerTarget, layerContainer, modal],
+    [],
   );
 
   return layerContainer

--- a/src/js/components/Layer/__tests__/Layer-test.tsx
+++ b/src/js/components/Layer/__tests__/Layer-test.tsx
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import 'jest-styled-components';
 import { render, fireEvent, screen, act } from '@testing-library/react';
@@ -15,6 +17,9 @@ import {
   LayerPositionType,
 } from '../..';
 import { LayerContainer } from '../LayerContainer';
+
+// matches StyledLayer's animationDuration (200ms)
+const LAYER_ANIMATION_DURATION = 200;
 
 const SimpleLayer = () => {
   const [showLayer, setShowLayer] = React.useState(true);
@@ -620,6 +625,38 @@ describe('Layer', () => {
       jest.runOnlyPendingTimers();
     });
     expect(document.activeElement).toBe(triggerButton);
+    jest.useRealTimers();
+  });
+
+  test('does not tear down an open Layer when modal prop changes', () => {
+    jest.useFakeTimers();
+
+    const { rerender } = render(
+      <Grommet>
+        <Layer data-testid="layer-content" modal={false}>
+          This is a layer
+        </Layer>
+      </Grommet>,
+    );
+
+    expect(getByTestId(document.body, 'layer-content')).toBeTruthy();
+
+    // changing modal (or animate/animation/containerTarget) on an
+    // already-open Layer should not run the unmount cleanup logic
+    rerender(
+      <Grommet>
+        <Layer data-testid="layer-content" modal>
+          This is a layer
+        </Layer>
+      </Grommet>,
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(LAYER_ANIMATION_DURATION);
+    });
+
+    expect(getByTestId(document.body, 'layer-content')).toBeTruthy();
+
     jest.useRealTimers();
   });
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

- When `modal`, `animate`, `animation`, or `containerTarget` change while it's open.
- `useLayoutEffect` method  in `Layer.js` had those values in its dependency array. Since the effect body itself does nothing but return a cleanup function, because React was running that cleanup (focus restore + animate-out + DOM removal) every time one of those values changed, not just on unmount — so changing e.g. `modal` on an already-open Layer would visually remove it from the DOM after the animate-out timeout.
- Therefore, this fix stores the latest values in a ref and runs the cleanup effect with an empty dependency array so it only fires on actual unmount.

#### Where should the reviewer start?

- `src/js/components/Layer/Layer.js` — the cleanup `useLayoutEffect` (previously `Layer.js:59-115`, now uses `cleanupPropsRef` with an empty dependency array).

#### What testing has been done on this PR?

- Added a regression test in `Layer-test.tsx` that opens a `Layer` with `modal={false}`, rerenders it with `modal` changed to `true`, advances fake timers past the animate-out duration (200ms), and asserts the layer content is still present in the DOM.
- Verified the test fails against the pre-fix code (element removed from the DOM) and passes with the fix. And full `Layer` Jest suite was run and all 123 tests passed.

#### How should this be manually tested?

1. Render an open `Layer` with `modal={false}`.
2. Trigger a rerender that changes `modal` to `true` (or toggles `animate`/`animation`/`containerTarget`) while the Layer stays mounted.
3. Before this fix: after ~200ms the Layer disappears from the DOM, even though it was never closed.
4. After this fix: the Layer remains visible and only tears down when it's actually unmounted (e.g. closed via `onEsc`/`onClickOutside`).

#### Do Jest tests follow these best practices?

- [x] `screen` is used for querying.
- [x] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing. (N/A — no snapshot assertions in the new test)

#### Any background context you want to provide?

Found via a component-by-component bug review of `src/js/components`.

#### What are the relevant issues?

N/A

#### Screenshots (if appropriate)

N/A

#### Do the grommet docs need to be updated?

No

#### Should this PR be mentioned in the release notes?

Yes

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.