### PR TITLE
fix(Box): guard navigator access in responsive container SSR fallback

### DIFF
--- a/src/js/components/Box/ResponsiveContainerProvider.js
+++ b/src/js/components/Box/ResponsiveContainerProvider.js
@@ -11,8 +11,10 @@ const responsiveContainerValue = true;
 export const ResponsiveContainerProvider = ({ container, theme, children }) => {
   const [value, setValue] = useState(
     () =>
-      deviceResponsive(navigator.userAgent, theme) ||
-      theme?.global?.deviceBreakpoints.tablet,
+      deviceResponsive(
+        typeof navigator !== 'undefined' ? navigator.userAgent : undefined,
+        theme,
+      ) || theme?.global?.deviceBreakpoints.tablet,
   );
 
   useEffect(() => {

--- a/src/js/components/Box/__tests__/Box-layout-test.tsx
+++ b/src/js/components/Box/__tests__/Box-layout-test.tsx
@@ -64,6 +64,30 @@ describe('Box', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  test('responsive container does not crash when navigator is unavailable (SSR)', () => {
+    const originalNavigator = global.navigator;
+    // simulate a server-side rendering environment, where `navigator`
+    // is not defined on the global object
+    // @ts-expect-error simulating an environment without navigator
+    delete global.navigator;
+
+    try {
+      expect(() =>
+        render(
+          <Grommet>
+            <Box responsive="container" width="1280px">
+              <ResponsiveContext.Consumer>
+                {(size2) => size2}
+              </ResponsiveContext.Consumer>
+            </Box>
+          </Grommet>,
+        ),
+      ).not.toThrow();
+    } finally {
+      global.navigator = originalNavigator;
+    }
+  });
+
   test('responsive container small', () => {
     jest.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
       width: 300,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Fixes `Box` so that `<Box responsive="container">` no longer crashes during server-side rendering.
`ResponsiveContainerProvider` read `navigator.userAgent` directly inside its `useState` initializer, which runs on the very first render. 
Since `navigator` is not defined in Node.js, any SSR pass through `<Box responsive="container">` threw a `ReferenceError` and crashed the render.

This guards the access with `typeof navigator !== 'undefined'` so it falls back to `undefined` during SSR. `deviceResponsive()` already handles a missing `userAgent` by falling back to `theme.global.deviceBreakpoints`.

#### Where should the reviewer start?

`src/js/components/Box/ResponsiveContainerProvider.js` — the `useState` initializer -> (`ResponsiveContainerProvider.js:12-16`).

#### What testing has been done on this PR?

Added a regression test in `Box-layout-test.tsx` that deletes `navigator` from the global object to simulate an SSR environment, then renders `<Box responsive="container">` and asserts it does not throw.
Verified the test fails with a `ReferenceError` against the pre-fix code and passes with the fix.

#### How should this be manually tested?

1. Render `<Box responsive="container">...</Box>` in a server-side rendering context (ex. Next.js `getServerSideProps`/App Router SSR, or `react-dom/server`'s `renderToString`) where `navigator` is not defined.
2. Before this fix: the render throws `ReferenceError: navigator is not defined` and crashes the page.
3. After this fix: the render completes successfully, falling back to the theme's default device breakpoint until the client hydrates and the actual container size is measured.

#### Do Jest tests follow these best practices?

- [x] `screen` is used for querying.
- [x] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

Found via a component-by-component bug review of `src/js/components`.

#### What are the relevant issues?

N/A

#### Screenshots (if appropriate)

N/A

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

Yes.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.
