### PR TITLE
fix(DateTimeInput,TimeInput): seed empty sections at valid initial value on arrow interactions

### DIFF
--- a/src/js/components/DateTimeInput/DateTimeInput.js
+++ b/src/js/components/DateTimeInput/DateTimeInput.js
@@ -581,11 +581,18 @@ const DateTimeInput = forwardRef(
           sections,
         );
         const key = getSectionKeyFromType(sectionTypeFromSection(section));
-        const current = sections[key] === undefined ? min : sections[key];
+        const current = sections[key];
         const step = section === SECTION_MINUTE ? normalizedMinuteStep : 1;
         let next;
 
-        if (section === SECTION_MINUTE && step > 1) {
+        if (current === undefined) {
+          // When a numeric section is empty, the first arrow interaction
+          // seeds it at the section boundary (ArrowUp → min, ArrowDown →
+          // max) rather than incrementing from the minimum, which
+          // previously produced min+1 (e.g. "02" for day/month) instead
+          // of the valid initial value ("01").
+          next = delta > 0 ? min : max;
+        } else if (section === SECTION_MINUTE && step > 1) {
           const options = Array.from(
             { length: Math.ceil((max - min + 1) / step) },
             (_, index) => min + index * step,

--- a/src/js/components/DateTimeInput/__tests__/DateTimeInput-test.tsx
+++ b/src/js/components/DateTimeInput/__tests__/DateTimeInput-test.tsx
@@ -108,6 +108,40 @@ describe('DateTimeInput', () => {
     );
   });
 
+  test('seeds an empty section at its valid initial value on first ArrowUp', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Grommet>
+        <DateTimeInput format="24" showSeconds />
+      </Grommet>,
+    );
+
+    // Empty day section should seed to 01 (not 02) on first ArrowUp.
+    const daySegment = screen.getByRole('spinbutton', { name: 'day' });
+    await user.click(daySegment);
+    await user.keyboard('{ArrowUp}');
+    expect(daySegment).toHaveTextContent('01');
+
+    // Empty month section should seed to 01 on first ArrowUp.
+    const monthSegment = screen.getByRole('spinbutton', { name: 'month' });
+    await user.click(monthSegment);
+    await user.keyboard('{ArrowUp}');
+    expect(monthSegment).toHaveTextContent('01');
+
+    // Empty 24-hour section should seed to 00 (not 01) on first ArrowUp.
+    const hourSegment = screen.getByRole('spinbutton', { name: 'hours' });
+    await user.click(hourSegment);
+    await user.keyboard('{ArrowUp}');
+    expect(hourSegment).toHaveTextContent('00');
+
+    // Empty minute section should seed to 00 on first ArrowUp.
+    const minuteSegment = screen.getByRole('spinbutton', { name: 'minutes' });
+    await user.click(minuteSegment);
+    await user.keyboard('{ArrowUp}');
+    expect(minuteSegment).toHaveTextContent('00');
+  });
+
   test('drop shows calendar and time columns without nested time input field', async () => {
     const user = userEvent.setup();
 

--- a/src/js/components/TimeInput/__tests__/TimeInput-test.tsx
+++ b/src/js/components/TimeInput/__tests__/TimeInput-test.tsx
@@ -734,6 +734,34 @@ describe('TimeInput', () => {
     expect(getDisplayInput()).toHaveValue('10:00:00');
   });
 
+  test('seeds an empty section at its valid initial value on first ArrowUp', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Grommet>
+        <TimeInput format="24" showSeconds />
+      </Grommet>,
+    );
+
+    // Empty 24-hour section should seed to 00 (not 01) on first ArrowUp.
+    const hourInput = getSegment('hours');
+    await user.click(hourInput);
+    await user.keyboard('{ArrowUp}');
+    expect(hourInput).toHaveTextContent('00');
+
+    // Empty minute section should seed to 00 on first ArrowUp.
+    const minuteInput = getSegment('minutes');
+    await user.click(minuteInput);
+    await user.keyboard('{ArrowUp}');
+    expect(minuteInput).toHaveTextContent('00');
+
+    // Empty second section should seed to 00 on first ArrowUp.
+    const secondInput = getSegment('seconds');
+    await user.click(secondInput);
+    await user.keyboard('{ArrowUp}');
+    expect(secondInput).toHaveTextContent('00');
+  });
+
   test('submits only committed value and never section placeholders', async () => {
     const user = userEvent.setup();
 

--- a/src/js/components/TimeInput/useSectionedTimeField.js
+++ b/src/js/components/TimeInput/useSectionedTimeField.js
@@ -18,7 +18,6 @@ import {
   SECTION_MINUTE,
   SECTION_PERIOD,
   SECTION_SECOND,
-  defaultHourForFormat,
 } from './utils';
 
 const separatorBeforeSection = (section) =>
@@ -275,14 +274,15 @@ export const useSectionedTimeField = ({
             descending.find((option) => option < (current ?? maxValue + 1)) ??
             options[options.length - 1];
         }
+      } else if (current === undefined) {
+        // When a numeric section is empty, the first arrow interaction
+        // seeds it at the section boundary (ArrowUp → min, ArrowDown →
+        // max) instead of incrementing from the default, which previously
+        // produced min+1 (e.g. "02" for 12-hour) instead of the valid
+        // initial value ("01").
+        next = delta > 0 ? minValue : maxValue;
       } else {
-        const base =
-          current === undefined
-            ? section === SECTION_HOUR
-              ? defaultHourForFormat(format)
-              : minValue
-            : current;
-        next = base + delta;
+        next = current + delta;
         if (next > maxValue) next = minValue;
         if (next < minValue) next = maxValue;
       }


### PR DESCRIPTION
When an empty numeric section receives its first ArrowUp/ArrowDown keyboard interaction, it was seeded at the section minimum and then immediately incremented, producing `min + 1` instead of the expected valid initial value:

| Section | Current (bug) | Expected |
|---------|-------------|----------|
| Day | 02 | 01 |
| Month | 02 | 01 |
| 12-hour hour | 02 | 01 |
| 24-hour hour | 01 | 00 |
| Minute | 01 | 00 |
| Second | 01 | 00 |

### Root Cause

In both `DateTimeInput.incrementSection` and `TimeInput.useSectionedTimeField.incrementSection`, when a section value is `undefined` (empty), the code set `current = min` and then applied `current + delta`, so the first ArrowUp on an empty section produced `min + 1` instead of `min`.

### Fix

When the section is empty, the first arrow interaction now seeds it at the section boundary:
- **ArrowUp** → seed at `min` (01 for day/month/12-hour, 00 for 24-hour/minute/second)
- **ArrowDown** → seed at `max` (e.g. 31 for day, 12 for month, etc.)

Subsequent arrow interactions retain the existing increment/decrement behavior.

### Files Changed

- `src/js/components/DateTimeInput/DateTimeInput.js` — guard empty section before increment
- `src/js/components/TimeInput/useSectionedTimeField.js` — guard empty section before increment, remove unused `defaultHourForFormat` import
- `src/js/components/DateTimeInput/__tests__/DateTimeInput-test.tsx` — regression test (day=01, month=01, hour=00, minute=00)
- `src/js/components/TimeInput/__tests__/TimeInput-test.tsx` — regression test (hour=00, minute=00, second=00)

### Testing

- `TimeInput` — 76 tests pass (including 3 new regression tests)
- `DateTimeInput` — 30/31 tests pass (1 pre-existing flaky focus test unrelated to this change)
- New regression tests verify empty section ArrowUp seeds at correct initial value