### PR TITLE
ITOM-125490: DateTimeInput: First ArrowUp press skips 01 and sets value to 02

### DIFF
--- a/src/js/components/DateTimeInput/DateTimeInput.js
+++ b/src/js/components/DateTimeInput/DateTimeInput.js
@@ -581,7 +581,12 @@ const DateTimeInput = forwardRef(
           sections,
         );
         const key = getSectionKeyFromType(sectionTypeFromSection(section));
-        const current = sections[key] === undefined ? min : sections[key];
+        if (sections[key] === undefined) {
+          setSectionValue(section, min);
+          return;
+        }
+
+        const current = sections[key];
         const step = section === SECTION_MINUTE ? normalizedMinuteStep : 1;
         let next;
 

--- a/src/js/components/DateTimeInput/__tests__/DateTimeInput-test.tsx
+++ b/src/js/components/DateTimeInput/__tests__/DateTimeInput-test.tsx
@@ -521,6 +521,31 @@ describe('DateTimeInput', () => {
     expect(minuteSegment).toHaveTextContent('45');
   });
 
+  test('seeds empty day, month, and hour sections on first arrow interaction', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Grommet>
+        <DateTimeInput format="12" />
+      </Grommet>,
+    );
+
+    const daySegment = screen.getByRole('spinbutton', { name: 'day' });
+    await user.click(daySegment);
+    await user.keyboard('{ArrowUp}');
+    expect(daySegment).toHaveTextContent('01');
+
+    const monthSegment = screen.getByRole('spinbutton', { name: 'month' });
+    await user.click(monthSegment);
+    await user.keyboard('{ArrowUp}');
+    expect(monthSegment).toHaveTextContent('01');
+
+    const hourSegment = screen.getByRole('spinbutton', { name: 'hours' });
+    await user.click(hourSegment);
+    await user.keyboard('{ArrowUp}');
+    expect(hourSegment).toHaveTextContent('01');
+  });
+
   test('seeds empty year to current year on first arrow interaction', async () => {
     const user = userEvent.setup();
 
@@ -537,6 +562,26 @@ describe('DateTimeInput', () => {
     expect(yearSegment).toHaveTextContent(
       String(new Date().getFullYear()).padStart(4, '0'),
     );
+  });
+
+  test('seeds empty 24-hour and minute sections at zero', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Grommet>
+        <DateTimeInput format="24" />
+      </Grommet>,
+    );
+
+    const hourSegment = screen.getByRole('spinbutton', { name: 'hours' });
+    await user.click(hourSegment);
+    await user.keyboard('{ArrowUp}');
+    expect(hourSegment).toHaveTextContent('00');
+
+    const minuteSegment = screen.getByRole('spinbutton', { name: 'minutes' });
+    await user.click(minuteSegment);
+    await user.keyboard('{ArrowDown}');
+    expect(minuteSegment).toHaveTextContent('00');
   });
 
   test('uses locale-driven DMY ordering for date sections', () => {


### PR DESCRIPTION
#### What does this PR do?

Fixes `DateTimeInput` keyboard behavior when a numeric section is empty.

The first ArrowUp or ArrowDown now seeds the section to its valid initial value instead of incrementing from it. For example, an empty day, month, or 12-hour value now becomes `01` instead of `02`.

#### Where should the reviewer start?

- `src/js/components/DateTimeInput/DateTimeInput.js`
- `src/js/components/DateTimeInput/__tests__/DateTimeInput-test.tsx`

#### What testing has been done on this PR?

- `npx jest src/js/components/DateTimeInput/__tests__/DateTimeInput-test.tsx --runInBand --coverage=false`
  - 32 tests passed.
- ESLint passed.
- Prettier check passed.
- Editor diagnostics passed.
- `git diff --check` passed.

#### How should this be manually tested?

1. Render an empty `DateTimeInput` with `format="12"`.
2. Focus the day, month, or hour section.
3. Press ArrowUp or ArrowDown.
4. Verify the section displays `01`, not `02`.
5. Render an empty `DateTimeInput` with `format="24"`.
6. Focus hour or minute and press either arrow key.
7. Verify the section displays `00`.
8. Press an arrow key again and verify normal increment/decrement behavior continues.

#### Do Jest tests follow these best practices?

- [x] `screen` is used for querying.
- [x] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [x] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

The previous implementation treated an empty numeric section as its minimum value and immediately applied the arrow delta. For a day, month, or 12-hour section, this calculated $1 + 1 = 2$, resulting in `02`.

#### What are the relevant issues?

- ITOM-125490

#### Screenshots (if appropriate)

Not applicable.

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

No.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible. This corrects keyboard behavior for empty sections without changing the public API.