### PR TITLE
fix(FileInput): keep native FileList in sync across multiple browses

### DIFF
--- a/src/js/components/FileInput/FileInput.js
+++ b/src/js/components/FileInput/FileInput.js
@@ -194,6 +194,26 @@ const FileInput = forwardRef(
       });
     } else message = `${files.length} items`;
 
+    // Keep the native <input>'s FileList in sync with the `files` state.
+    // The native input only ever holds whatever was picked in the most
+    // recent browse/drop, so once `files` accumulates selections across
+    // multiple browses (multiple mode), the native FileList needs to be
+    // rebuilt from the full `files` array, not just patched, otherwise
+    // it silently diverges from what's shown in the UI (e.g. a native
+    // form submission would miss files from earlier browses).
+    // https://stackoverflow.com/a/64019766
+    const syncNativeFiles = (nextFiles) => {
+      /* eslint-disable no-undef */
+      const dt = new DataTransfer();
+      nextFiles.forEach((file) => dt.items.add(file));
+      const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        'files',
+      ).set;
+      /* eslint-enable no-undef */
+      nativeInputValueSetter.call(inputRef.current, dt.files);
+    };
+
     const removeFile = (index) => {
       let nextFiles;
       if (index === 'all') {
@@ -204,24 +224,12 @@ const FileInput = forwardRef(
       }
       setFiles(nextFiles);
 
-      // Need to have a way to track the files other than an array
-      // since inputRef.current.files is a read-only FileList
-      // https://stackoverflow.com/a/64019766
-      /* eslint-disable no-undef */
-      const dt = new DataTransfer();
-      const curFiles = inputRef.current.files;
-      if (index === 'all' || nextFiles.length === 0)
+      if (nextFiles.length === 0) {
         inputRef.current.value = '';
-      for (let i = 0; i < curFiles.length; i += 1) {
-        const curfile = curFiles[i];
-        if (index !== i) dt.items.add(curfile);
+      } else {
+        syncNativeFiles(nextFiles);
       }
 
-      const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
-        window.HTMLInputElement.prototype,
-        'files',
-      ).set;
-      nativeInputValueSetter.call(inputRef.current, dt.files);
       const event = new Event('input', { bubbles: true });
       inputRef.current.dispatchEvent(event);
 
@@ -347,6 +355,10 @@ const FileInput = forwardRef(
                 }
               }
               setFiles(nextFiles);
+              // In multiple mode, the native input only reflects this
+              // browse's selection, so it needs to be resynced with the
+              // full accumulated list.
+              if (multiple) syncNativeFiles(nextFiles);
               setDragOver(false);
               if (onChange) onChange(event, { files: nextFiles });
             }}

--- a/src/js/components/FileInput/__tests__/FileInput-test.tsx
+++ b/src/js/components/FileInput/__tests__/FileInput-test.tsx
@@ -269,4 +269,111 @@ describe('FileInput', () => {
     expect(screen.getByText('hello.txt')).toBeInTheDocument();
     expect(onChange).toHaveBeenCalledTimes(1);
   });
+
+  describe('native FileList sync across multiple browses', () => {
+    // jsdom doesn't implement DataTransfer, and its native
+    // HTMLInputElement#files setter only accepts a real (unconstructable
+    // in jsdom) FileList. Stand in for both so the component's actual
+    // DataTransfer-based sync codepath can run in tests, the same way it
+    // does in real browsers.
+    class FakeDataTransfer {
+      fileArr: File[] = [];
+
+      items = {
+        add: (file: File) => {
+          this.fileArr.push(file);
+        },
+      };
+
+      get files() {
+        return this.fileArr;
+      }
+    }
+
+    let originalFilesDescriptor: PropertyDescriptor;
+
+    beforeEach(() => {
+      originalFilesDescriptor = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        'files',
+      ) as PropertyDescriptor;
+      (global as { DataTransfer?: unknown }).DataTransfer = FakeDataTransfer;
+      Object.defineProperty(window.HTMLInputElement.prototype, 'files', {
+        configurable: true,
+        get(this: HTMLInputElement & { __fakeFiles?: File[] }) {
+          return this.__fakeFiles ?? originalFilesDescriptor.get?.call(this);
+        },
+        set(this: HTMLInputElement & { __fakeFiles?: File[] }, value: File[]) {
+          this.__fakeFiles = value;
+        },
+      });
+    });
+
+    afterEach(() => {
+      Object.defineProperty(
+        window.HTMLInputElement.prototype,
+        'files',
+        originalFilesDescriptor,
+      );
+      delete (global as { DataTransfer?: unknown }).DataTransfer;
+    });
+
+    test('native input keeps files selected across separate browses', () => {
+      render(
+        <Grommet>
+          <FileInput name="file" multiple />
+        </Grommet>,
+      );
+
+      const input = document.querySelector(
+        'input[type="file"]',
+      ) as HTMLInputElement;
+
+      const fileA = new File(['a'], 'a.txt', { type: 'text/plain' });
+      const fileB = new File(['b'], 'b.txt', { type: 'text/plain' });
+
+      fireEvent.change(input, { target: { files: [fileA] } });
+      fireEvent.change(input, { target: { files: [fileB] } });
+
+      expect(screen.getByText('a.txt')).toBeInTheDocument();
+      expect(screen.getByText('b.txt')).toBeInTheDocument();
+
+      // the native input's own FileList should reflect both selections,
+      // not just the most recent browse, so a real <form> submission
+      // would include every file shown in the UI.
+      // fireEvent.change shadows the prototype accessor with its own
+      // instance property, so remove that to read back what the
+      // component actually synced onto the native input.
+      delete (input as unknown as { files?: unknown }).files;
+      const nativeFiles = Array.from(input.files || []);
+      expect(nativeFiles.map((f) => f.name).sort()).toEqual(['a.txt', 'b.txt']);
+    });
+
+    test('native input reflects remaining files after removeFile', () => {
+      render(
+        <Grommet>
+          <FileInput name="file" multiple />
+        </Grommet>,
+      );
+
+      const input = document.querySelector(
+        'input[type="file"]',
+      ) as HTMLInputElement;
+
+      const fileA = new File(['a'], 'a.txt', { type: 'text/plain' });
+      const fileB = new File(['b'], 'b.txt', { type: 'text/plain' });
+
+      fireEvent.change(input, { target: { files: [fileA] } });
+      fireEvent.change(input, { target: { files: [fileB] } });
+
+      fireEvent.click(screen.getByLabelText(/a\.txt/i));
+
+      expect(screen.queryByText('a.txt')).not.toBeInTheDocument();
+      expect(screen.getByText('b.txt')).toBeInTheDocument();
+
+      delete (input as unknown as { files?: unknown }).files;
+      const nativeFiles = Array.from(input.files || []);
+      expect(nativeFiles.map((f) => f.name)).toEqual(['b.txt']);
+    });
+  });
 });


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Fixed `FileInput` so files selected across multiple browses (`multiple` mode) no longer silently disappear from a native `<input>`'s FileList.
Previously, the `files` React state correctly accumulated selections across multiple browse actions, but the native `<input>`'s own `.files` FileList was never resynced — it only ever reflected whatever was picked in the most recent browse, since the browser replaces it on every browse. 
`removeFile` compounded this by rebuilding its `DataTransfer` from that stale native FileList instead of the full `files` array. 

As a result, files selected in an earlier browse would silently vanish from a native form submission (e.g. `enctype="multipart/form-data"`) after any later browse or file removal, even though the UI still showed them as selected.

So Adding a shared `syncNativeFiles` helper that always rebuilds the native input's FileList from the complete `files` array, and used it after merging in `onChange` (multiple mode) and in `removeFile`.

#### Where should the reviewer start?

`src/js/components/FileInput/FileInput.js` — the new `syncNativeFiles` helper (`FileInput.js:205`) and its two call sites:
- inside `removeFile` (`FileInput.js:230`)
- inside the native input's `onChange` handler for multiple mode (`FileInput.js:361`)


#### What testing has been done on this PR?

Added two regression tests in `FileInput-test.tsx`:
- the native input's FileList contains files from both of two separate browses, not just the most recent one
- the native input's FileList correctly reflects the remaining file after `removeFile`

Since jsdom implements neither `DataTransfer` nor a constructable `FileList`, both tests polyfill them locally (scoped, restored after) to exercise the real sync path. 
Fail on pre-fix code, pass with the fix. Full `FileInput` suite: 20/20 passed.

#### How should this be manually tested?

1. Render `<FileInput multiple name="file" />` inside a native `<form>`.
2. Browse and select a file, then browse again and select a different file.
3. Before this fix: submitting the form natively (or reading `inputRef.current.files` directly) only includes the file from the second browse, even though the UI shows both.
4. After this fix: the native form submission includes both files, matching what's shown in the UI. Removing a file via the remove button also correctly updates the native FileList to the remaining files.


#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

Found via a component-by-component bug review of `src/js/components`.

#### What are the relevant issues?

N/A

#### Screenshots (if appropriate)

N/A

#### Do the grommet docs need to be updated?

No

#### Should this PR be mentioned in the release notes?

Yes

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.
