### PR TITLE
enhance inline prop to datetimeinput to enable items below outside of drop

### DIFF
--- a/src/js/components/DateTimeInput/DateTimeInput.js
+++ b/src/js/components/DateTimeInput/DateTimeInput.js
@@ -1196,7 +1196,7 @@ const DateTimeInput = forwardRef(
         <Calendar
           size={inline === 'all' ? 'small' : undefined}
           date={getCalendarDate(sections)}
-          initialFocus="days"
+          initialFocus={inline !== 'all' ? 'days' : undefined}
           onSelect={disabled || readOnly ? undefined : handleCalendarSelect}
         />
         <Box

--- a/src/js/components/DateTimeInput/DateTimeInput.js
+++ b/src/js/components/DateTimeInput/DateTimeInput.js
@@ -1187,6 +1187,45 @@ const DateTimeInput = forwardRef(
     const generatedId = useId();
     const dropId = `${id || generatedId}__drop`;
 
+    const pickerContent = (
+      <Box
+        direction="row"
+        pad={theme.dateTimeInput?.drop?.pad}
+        gap={theme.dateTimeInput?.drop?.gap}
+      >
+        <Calendar
+          size={inline === 'all' ? 'small' : undefined}
+          date={getCalendarDate(sections)}
+          initialFocus="days"
+          onSelect={disabled || readOnly ? undefined : handleCalendarSelect}
+        />
+        <Box
+          alignSelf="stretch"
+          flex={false}
+          border={{
+            side: 'start',
+            color: theme.dateTimeInput?.drop?.border?.color,
+            size: theme.dateTimeInput?.drop?.border?.size,
+          }}
+        />
+        <TimeInput
+          inline
+          columnMaxHeight={inline === 'all' ? 'small' : undefined}
+          format={resolvedFormat}
+          value={timeValue}
+          showSeconds={showSeconds}
+          messages={messages}
+          minuteStep={normalizedMinuteStep}
+          disabled={disabled}
+          readOnly={readOnly}
+          onChange={disabled || readOnly ? undefined : handleTimeSelect}
+          onPartialChange={
+            disabled || readOnly ? undefined : handleTimePartialChange
+          }
+        />
+      </Box>
+    );
+
     return (
       <Keyboard onEsc={open ? closePicker : undefined}>
         <Box>
@@ -1335,89 +1374,19 @@ const DateTimeInput = forwardRef(
               value={value || ''}
             />
           )}
-          {inline === 'all' ? (
-            <Box
-              direction="row"
-              pad={theme.dateTimeInput?.drop?.pad}
-              gap={theme.dateTimeInput?.drop?.gap}
-            >
-              <Calendar
-                size="small"
-                date={getCalendarDate(sections)}
-                initialFocus="days"
-                onSelect={
-                  disabled || readOnly ? undefined : handleCalendarSelect
-                }
-              />
-              <Box
-                alignSelf="stretch"
-                flex={false}
-                border={{
-                  side: 'start',
-                  color: theme.dateTimeInput?.drop?.border?.color,
-                  size: theme.dateTimeInput?.drop?.border?.size,
-                }}
-              />
-              <TimeInput
-                inline
-                columnMaxHeight="small"
-                format={resolvedFormat}
-                value={timeValue}
-                showSeconds={showSeconds}
-                messages={messages}
-                minuteStep={normalizedMinuteStep}
-                disabled={disabled}
-                readOnly={readOnly}
-                onChange={disabled || readOnly ? undefined : handleTimeSelect}
-                onPartialChange={
-                  disabled || readOnly ? undefined : handleTimePartialChange
-                }
-              />
-            </Box>
-          ) : (
-            open && (
-              <Drop
-                id={dropId}
-                target={dropTarget}
-                align={{ top: 'bottom', left: 'left' }}
-                onEsc={closePicker}
-                onClickOutside={closePicker}
-              >
-                <Box
-                  direction="row"
-                  pad={theme.dateTimeInput?.drop?.pad}
-                  gap={theme.dateTimeInput?.drop?.gap}
+          {inline === 'all'
+            ? pickerContent
+            : open && (
+                <Drop
+                  id={dropId}
+                  target={dropTarget}
+                  align={{ top: 'bottom', left: 'left' }}
+                  onEsc={closePicker}
+                  onClickOutside={closePicker}
                 >
-                  <Calendar
-                    date={getCalendarDate(sections)}
-                    initialFocus="days"
-                    onSelect={handleCalendarSelect}
-                  />
-                  <Box
-                    alignSelf="stretch"
-                    flex={false}
-                    border={{
-                      side: 'start',
-                      color: theme.dateTimeInput?.drop?.border?.color,
-                      size: theme.dateTimeInput?.drop?.border?.size,
-                    }}
-                  />
-                  <TimeInput
-                    inline
-                    format={resolvedFormat}
-                    value={timeValue}
-                    showSeconds={showSeconds}
-                    messages={messages}
-                    minuteStep={normalizedMinuteStep}
-                    disabled={disabled}
-                    readOnly={readOnly}
-                    onChange={handleTimeSelect}
-                    onPartialChange={handleTimePartialChange}
-                  />
-                </Box>
-              </Drop>
-            )
-          )}
+                  {pickerContent}
+                </Drop>
+              )}
         </Box>
       </Keyboard>
     );

--- a/src/js/components/DateTimeInput/DateTimeInput.js
+++ b/src/js/components/DateTimeInput/DateTimeInput.js
@@ -391,6 +391,7 @@ const DateTimeInput = forwardRef(
       minuteStep = 1,
       name,
       onChange,
+      pickerInline = false,
       plain: plainProp,
       focusIndicator: focusIndicatorProp,
       readOnly = false,
@@ -1211,7 +1212,7 @@ const DateTimeInput = forwardRef(
               ref={containerRef}
               direction="row"
               border={!plainProp}
-              fill
+              fill={pickerInline ? 'horizontal' : true}
               round={theme.dateTimeInput?.container?.round}
               disabled={disabled}
               readOnlyProp={readOnly}
@@ -1305,7 +1306,7 @@ const DateTimeInput = forwardRef(
                   plain
                 />
               </StyledDateTimeInputField>
-              {!readOnly && (
+              {!readOnly && !pickerInline && (
                 <Button
                   ref={triggerRef}
                   icon={<CalendarIcon />}
@@ -1334,47 +1335,84 @@ const DateTimeInput = forwardRef(
               value={value || ''}
             />
           )}
-          {open && (
-            <Drop
-              id={dropId}
-              target={dropTarget}
-              align={{ top: 'bottom', left: 'left' }}
-              onEsc={closePicker}
-              onClickOutside={closePicker}
+          {pickerInline ? (
+            <Box
+              direction="row"
+              pad={theme.dateTimeInput?.drop?.pad}
+              gap={theme.dateTimeInput?.drop?.gap}
             >
+              <Calendar
+                size="small"
+                date={getCalendarDate(sections)}
+                initialFocus="days"
+                onSelect={handleCalendarSelect}
+              />
               <Box
-                direction="row"
-                pad={theme.dateTimeInput?.drop?.pad}
-                gap={theme.dateTimeInput?.drop?.gap}
+                alignSelf="stretch"
+                flex={false}
+                border={{
+                  side: 'start',
+                  color: theme.dateTimeInput?.drop?.border?.color,
+                  size: theme.dateTimeInput?.drop?.border?.size,
+                }}
+              />
+              <TimeInput
+                inline
+                columnMaxHeight="small"
+                format={resolvedFormat}
+                value={timeValue}
+                showSeconds={showSeconds}
+                messages={messages}
+                minuteStep={normalizedMinuteStep}
+                disabled={disabled}
+                readOnly={readOnly}
+                onChange={handleTimeSelect}
+                onPartialChange={handleTimePartialChange}
+              />
+            </Box>
+          ) : (
+            open && (
+              <Drop
+                id={dropId}
+                target={dropTarget}
+                align={{ top: 'bottom', left: 'left' }}
+                onEsc={closePicker}
+                onClickOutside={closePicker}
               >
-                <Calendar
-                  date={getCalendarDate(sections)}
-                  initialFocus="days"
-                  onSelect={handleCalendarSelect}
-                />
                 <Box
-                  alignSelf="stretch"
-                  flex={false}
-                  border={{
-                    side: 'start',
-                    color: theme.dateTimeInput?.drop?.border?.color,
-                    size: theme.dateTimeInput?.drop?.border?.size,
-                  }}
-                />
-                <TimeInput
-                  inline
-                  format={resolvedFormat}
-                  value={timeValue}
-                  showSeconds={showSeconds}
-                  messages={messages}
-                  minuteStep={normalizedMinuteStep}
-                  disabled={disabled}
-                  readOnly={readOnly}
-                  onChange={handleTimeSelect}
-                  onPartialChange={handleTimePartialChange}
-                />
-              </Box>
-            </Drop>
+                  direction="row"
+                  pad={theme.dateTimeInput?.drop?.pad}
+                  gap={theme.dateTimeInput?.drop?.gap}
+                >
+                  <Calendar
+                    date={getCalendarDate(sections)}
+                    initialFocus="days"
+                    onSelect={handleCalendarSelect}
+                  />
+                  <Box
+                    alignSelf="stretch"
+                    flex={false}
+                    border={{
+                      side: 'start',
+                      color: theme.dateTimeInput?.drop?.border?.color,
+                      size: theme.dateTimeInput?.drop?.border?.size,
+                    }}
+                  />
+                  <TimeInput
+                    inline
+                    format={resolvedFormat}
+                    value={timeValue}
+                    showSeconds={showSeconds}
+                    messages={messages}
+                    minuteStep={normalizedMinuteStep}
+                    disabled={disabled}
+                    readOnly={readOnly}
+                    onChange={handleTimeSelect}
+                    onPartialChange={handleTimePartialChange}
+                  />
+                </Box>
+              </Drop>
+            )
           )}
         </Box>
       </Keyboard>

--- a/src/js/components/DateTimeInput/DateTimeInput.js
+++ b/src/js/components/DateTimeInput/DateTimeInput.js
@@ -1345,7 +1345,9 @@ const DateTimeInput = forwardRef(
                 size="small"
                 date={getCalendarDate(sections)}
                 initialFocus="days"
-                onSelect={handleCalendarSelect}
+                onSelect={
+                  disabled || readOnly ? undefined : handleCalendarSelect
+                }
               />
               <Box
                 alignSelf="stretch"
@@ -1366,8 +1368,10 @@ const DateTimeInput = forwardRef(
                 minuteStep={normalizedMinuteStep}
                 disabled={disabled}
                 readOnly={readOnly}
-                onChange={handleTimeSelect}
-                onPartialChange={handleTimePartialChange}
+                onChange={disabled || readOnly ? undefined : handleTimeSelect}
+                onPartialChange={
+                  disabled || readOnly ? undefined : handleTimePartialChange
+                }
               />
             </Box>
           ) : (

--- a/src/js/components/DateTimeInput/DateTimeInput.js
+++ b/src/js/components/DateTimeInput/DateTimeInput.js
@@ -391,7 +391,6 @@ const DateTimeInput = forwardRef(
       minuteStep = 1,
       name,
       onChange,
-      pickerInline = false,
       plain: plainProp,
       focusIndicator: focusIndicatorProp,
       readOnly = false,
@@ -808,7 +807,7 @@ const DateTimeInput = forwardRef(
       setOpen(false);
 
       requestAnimationFrame(() => {
-        if (inline) {
+        if (inline === true) {
           triggerRef.current?.focus();
           return;
         }
@@ -1183,14 +1182,15 @@ const DateTimeInput = forwardRef(
       : formatMessage({ id: 'dateTimeInput.inputLabel', messages });
     const CalendarIcon =
       theme.dateTimeInput?.icon?.calendar || GrommetCalendarIcon;
-    const dropTarget = inline ? triggerRef.current : containerRef.current;
+    const dropTarget =
+      inline === true ? triggerRef.current : containerRef.current;
     const generatedId = useId();
     const dropId = `${id || generatedId}__drop`;
 
     return (
       <Keyboard onEsc={open ? closePicker : undefined}>
         <Box>
-          {inline ? (
+          {inline === true ? (
             <Box direction="row" align="center">
               <Button
                 ref={triggerRef}
@@ -1212,7 +1212,7 @@ const DateTimeInput = forwardRef(
               ref={containerRef}
               direction="row"
               border={!plainProp}
-              fill={pickerInline ? 'horizontal' : true}
+              fill={inline === 'all' ? 'horizontal' : true}
               round={theme.dateTimeInput?.container?.round}
               disabled={disabled}
               readOnlyProp={readOnly}
@@ -1306,7 +1306,7 @@ const DateTimeInput = forwardRef(
                   plain
                 />
               </StyledDateTimeInputField>
-              {!readOnly && !pickerInline && (
+              {!readOnly && inline !== 'all' && (
                 <Button
                   ref={triggerRef}
                   icon={<CalendarIcon />}
@@ -1335,7 +1335,7 @@ const DateTimeInput = forwardRef(
               value={value || ''}
             />
           )}
-          {pickerInline ? (
+          {inline === 'all' ? (
             <Box
               direction="row"
               pad={theme.dateTimeInput?.drop?.pad}

--- a/src/js/components/DateTimeInput/StyledDateTimeInput.js
+++ b/src/js/components/DateTimeInput/StyledDateTimeInput.js
@@ -71,6 +71,7 @@ export const StyledDateTimeInputDisplay = styled.div.withConfig(
   display: flex;
   align-items: center;
   overflow: hidden;
+  outline: none;
   ${(props) =>
     props.theme.global.input.padding &&
     (typeof props.theme.global.input.padding !== 'object'

--- a/src/js/components/DateTimeInput/__tests__/DateTimeInput-test.tsx
+++ b/src/js/components/DateTimeInput/__tests__/DateTimeInput-test.tsx
@@ -544,7 +544,10 @@ describe('DateTimeInput', () => {
     );
   });
 
-  test('pickerInline readOnly disables time columns but shows picker', () => {
+  test('pickerInline readOnly disables time columns but shows picker', async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+
     render(
       <Grommet>
         <DateTimeInput
@@ -553,6 +556,7 @@ describe('DateTimeInput', () => {
           pickerInline
           readOnly
           value="2026-07-22T13:00:00.000Z"
+          onChange={onChange}
         />
       </Grommet>,
     );
@@ -560,6 +564,10 @@ describe('DateTimeInput', () => {
     expect(screen.getByRole('listbox', { name: 'hour' })).toBeInTheDocument();
     const hourSegment = screen.getByRole('spinbutton', { name: 'hours' });
     expect(hourSegment).toHaveAttribute('aria-readonly', 'true');
+
+    const dayButton = screen.getByRole('button', { name: /Jul 25 2026/i });
+    await user.click(dayButton);
+    expect(onChange).not.toHaveBeenCalled();
   });
 
   test('increments minutes by minuteStep on keyboard arrow', async () => {

--- a/src/js/components/DateTimeInput/__tests__/DateTimeInput-test.tsx
+++ b/src/js/components/DateTimeInput/__tests__/DateTimeInput-test.tsx
@@ -501,6 +501,67 @@ describe('DateTimeInput', () => {
     expect(document.getElementById(controlsId as string)).toBeFalsy();
   });
 
+  test('pickerInline renders calendar and time picker without a trigger', () => {
+    render(
+      <Grommet>
+        <DateTimeInput
+          id="dt-picker-inline"
+          format="24"
+          pickerInline
+          value="2026-07-22T13:00:00.000Z"
+        />
+      </Grommet>,
+    );
+
+    expect(screen.getByRole('listbox', { name: 'hour' })).toBeInTheDocument();
+    expect(screen.getByRole('listbox', { name: 'minute' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /date and time/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('pickerInline calendar selection updates the value', async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+
+    render(
+      <Grommet>
+        <DateTimeInput
+          id="dt-picker-inline-select"
+          format="24"
+          pickerInline
+          value="2026-07-22T13:00:00.000Z"
+          onChange={onChange}
+        />
+      </Grommet>,
+    );
+
+    const dayButton = screen.getByRole('button', { name: /Jul 25 2026/i });
+    await user.click(dayButton);
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ value: expect.stringContaining('2026-07-25') }),
+    );
+  });
+
+  test('pickerInline readOnly disables time columns but shows picker', () => {
+    render(
+      <Grommet>
+        <DateTimeInput
+          id="dt-picker-inline-readonly"
+          format="24"
+          pickerInline
+          readOnly
+          value="2026-07-22T13:00:00.000Z"
+        />
+      </Grommet>,
+    );
+
+    expect(screen.getByRole('listbox', { name: 'hour' })).toBeInTheDocument();
+    const hourSegment = screen.getByRole('spinbutton', { name: 'hours' });
+    expect(hourSegment).toHaveAttribute('aria-readonly', 'true');
+  });
+
   test('increments minutes by minuteStep on keyboard arrow', async () => {
     const user = userEvent.setup();
 

--- a/src/js/components/DateTimeInput/__tests__/DateTimeInput-test.tsx
+++ b/src/js/components/DateTimeInput/__tests__/DateTimeInput-test.tsx
@@ -501,13 +501,13 @@ describe('DateTimeInput', () => {
     expect(document.getElementById(controlsId as string)).toBeFalsy();
   });
 
-  test('pickerInline renders calendar and time picker without a trigger', () => {
+  test('inline="all" renders calendar and time picker without a trigger', () => {
     render(
       <Grommet>
         <DateTimeInput
           id="dt-picker-inline"
           format="24"
-          pickerInline
+          inline="all"
           value="2026-07-22T13:00:00.000Z"
         />
       </Grommet>,
@@ -520,7 +520,7 @@ describe('DateTimeInput', () => {
     ).not.toBeInTheDocument();
   });
 
-  test('pickerInline calendar selection updates the value', async () => {
+  test('inline="all" calendar selection updates the value', async () => {
     const user = userEvent.setup();
     const onChange = jest.fn();
 
@@ -529,7 +529,7 @@ describe('DateTimeInput', () => {
         <DateTimeInput
           id="dt-picker-inline-select"
           format="24"
-          pickerInline
+          inline="all"
           value="2026-07-22T13:00:00.000Z"
           onChange={onChange}
         />
@@ -544,7 +544,7 @@ describe('DateTimeInput', () => {
     );
   });
 
-  test('pickerInline readOnly disables time columns but shows picker', async () => {
+  test('inline="all" readOnly disables time columns but shows picker', async () => {
     const user = userEvent.setup();
     const onChange = jest.fn();
 
@@ -553,7 +553,7 @@ describe('DateTimeInput', () => {
         <DateTimeInput
           id="dt-picker-inline-readonly"
           format="24"
-          pickerInline
+          inline="all"
           readOnly
           value="2026-07-22T13:00:00.000Z"
           onChange={onChange}

--- a/src/js/components/DateTimeInput/index.d.ts
+++ b/src/js/components/DateTimeInput/index.d.ts
@@ -8,8 +8,7 @@ export interface DateTimeInputProps {
   format?: '12' | '24';
   id?: string;
   locale?: string;
-  inline?: boolean;
-  pickerInline?: boolean;
+  inline?: boolean | 'all';
   messages?: {
     activeSection?: string;
     activeSectionValue?: string;

--- a/src/js/components/DateTimeInput/index.d.ts
+++ b/src/js/components/DateTimeInput/index.d.ts
@@ -9,6 +9,7 @@ export interface DateTimeInputProps {
   id?: string;
   locale?: string;
   inline?: boolean;
+  pickerInline?: boolean;
   messages?: {
     activeSection?: string;
     activeSectionValue?: string;

--- a/src/js/components/DateTimeInput/propTypes.js
+++ b/src/js/components/DateTimeInput/propTypes.js
@@ -10,8 +10,7 @@ if (process.env.NODE_ENV !== 'production') {
     format: PropTypes.oneOf(['12', '24']),
     id: PropTypes.string,
     locale: PropTypes.string,
-    inline: PropTypes.bool,
-    pickerInline: PropTypes.bool,
+    inline: PropTypes.oneOfType([PropTypes.bool, PropTypes.oneOf(['all'])]),
     messages: PropTypes.shape({
       activeSection: PropTypes.string,
       activeSectionValue: PropTypes.string,

--- a/src/js/components/DateTimeInput/propTypes.js
+++ b/src/js/components/DateTimeInput/propTypes.js
@@ -11,6 +11,7 @@ if (process.env.NODE_ENV !== 'production') {
     id: PropTypes.string,
     locale: PropTypes.string,
     inline: PropTypes.bool,
+    pickerInline: PropTypes.bool,
     messages: PropTypes.shape({
       activeSection: PropTypes.string,
       activeSectionValue: PropTypes.string,

--- a/src/js/components/DateTimeInput/stories/Range.stories.tsx
+++ b/src/js/components/DateTimeInput/stories/Range.stories.tsx
@@ -83,7 +83,7 @@ export const Range = function RangeStory() {
       <DateTimeInput
         id={`range-${label.toLowerCase()}`}
         format="24"
-        pickerInline
+        inline="all"
         value={value}
         onChange={({ value: next }: { value?: string }) => onChange(next || '')}
         messages={{

--- a/src/js/components/DateTimeInput/stories/Range.stories.tsx
+++ b/src/js/components/DateTimeInput/stories/Range.stories.tsx
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
 // SPDX-License-Identifier: Apache-2.0
 import React, { useMemo, useState } from 'react';
-import type { Meta, StoryObj } from '@storybook/react';
 
 import { Box, Button, DropButton, Text } from 'grommet';
 import { Calendar as CalendarIcon } from 'grommet-icons';
@@ -22,173 +21,163 @@ const QUICK_RANGES = [
   { label: 'Last 90 days', minutes: 90 * 24 * 60, value: '90d' },
 ];
 
-const meta: Meta<typeof DateTimeInput> = {
-  title: 'Input/DateTimeInput/Range',
-  component: DateTimeInput,
-};
+export const Range = function RangeStory() {
+  const [range, setRange] = useState({
+    start: '2026-07-22T13:00:00.000Z',
+    end: '2026-07-22T18:30:00.000Z',
+    preset: undefined as string | undefined,
+  });
+  const [draftRange, setDraftRange] = useState(range);
+  const [open, setOpen] = useState(false);
 
-export default meta;
+  const endBeforeStart = useMemo(
+    () =>
+      !!draftRange.start &&
+      !!draftRange.end &&
+      new Date(draftRange.end).getTime() < new Date(draftRange.start).getTime(),
+    [draftRange],
+  );
 
-type Story = StoryObj<typeof DateTimeInput>;
-
-export const Range: Story = {
-  render: function RangeStory() {
-    const [range, setRange] = useState({
-      start: '2026-07-22T13:00:00.000Z',
-      end: '2026-07-22T18:30:00.000Z',
-      preset: undefined as string | undefined,
+  const formatRange = () => {
+    const preset = QUICK_RANGES.find(({ value }) => value === range.preset);
+    if (preset) return preset.label;
+    const format = new Intl.DateTimeFormat(undefined, {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
     });
-    const [draftRange, setDraftRange] = useState(range);
-    const [open, setOpen] = useState(false);
+    return `${format.format(new Date(range.start))} - ${format.format(
+      new Date(range.end),
+    )}`;
+  };
 
-    const endBeforeStart = useMemo(
-      () =>
-        !!draftRange.start &&
-        !!draftRange.end &&
-        new Date(draftRange.end).getTime() <
-          new Date(draftRange.start).getTime(),
-      [draftRange],
-    );
+  const selectQuickRange = (minutes: number, preset: string) => {
+    const now = new Date();
+    setDraftRange({
+      end: now.toISOString(),
+      start: new Date(now.getTime() - minutes * 60 * 1000).toISOString(),
+      preset,
+    });
+  };
 
-    const formatRange = () => {
-      const preset = QUICK_RANGES.find(({ value }) => value === range.preset);
-      if (preset) return preset.label;
-      const format = new Intl.DateTimeFormat(undefined, {
-        month: 'short',
-        day: 'numeric',
-        year: 'numeric',
-        hour: 'numeric',
-        minute: '2-digit',
-      });
-      return `${format.format(new Date(range.start))} - ${format.format(
-        new Date(range.end),
-      )}`;
-    };
+  const applyRange = () => {
+    if (endBeforeStart) return;
+    setRange(draftRange);
+    setOpen(false);
+  };
 
-    const selectQuickRange = (minutes: number, preset: string) => {
-      const now = new Date();
-      setDraftRange({
-        end: now.toISOString(),
-        start: new Date(now.getTime() - minutes * 60 * 1000).toISOString(),
-        preset,
-      });
-    };
+  const cancelRange = () => {
+    setDraftRange(range);
+    setOpen(false);
+  };
 
-    const applyRange = () => {
-      if (endBeforeStart) return;
-      setRange(draftRange);
-      setOpen(false);
-    };
+  const renderDateTimePicker = (
+    label: string,
+    value: string,
+    onChange: (nextValue: string) => void,
+  ) => (
+    <Box gap="small">
+      <Text weight="bold">{label}</Text>
+      <DateTimeInput
+        id={`range-${label.toLowerCase()}`}
+        format="24"
+        pickerInline
+        value={value}
+        onChange={({ value: next }: { value?: string }) => onChange(next || '')}
+        messages={{
+          inputLabel: `Range ${label.toLowerCase()} date and time`,
+        }}
+      />
+    </Box>
+  );
 
-    const cancelRange = () => {
-      setDraftRange(range);
-      setOpen(false);
-    };
-
-    const renderDateTimePicker = (
-      label: string,
-      value: string,
-      onChange: (nextValue: string) => void,
-    ) => (
-      <Box gap="small">
-        <Text weight="bold">{label}</Text>
-        <DateTimeInput
-          id={`range-${label.toLowerCase()}`}
-          format="24"
-          pickerInline
-          value={value}
-          onChange={({ value: next }: { value?: string }) =>
-            onChange(next || '')
-          }
-          messages={{
-            inputLabel: `Range ${label.toLowerCase()} date and time`,
-          }}
-        />
-      </Box>
-    );
-
-    return (
-      <Box width="large" pad="large">
-        <DropButton
-          open={open}
-          onOpen={() => {
-            setDraftRange(range);
-            setOpen(true);
-          }}
-          onClose={cancelRange}
-          dropAlign={{ top: 'bottom', left: 'left' }}
-          dropContent={
-            <Box direction="row" flex={false}>
-              <Box
-                background="background-contrast"
-                border={{ side: 'right', color: 'border' }}
-                gap="xsmall"
-                height={{ max: 'medium' }}
-                overflow="auto"
-                pad="small"
-                width="small"
-                role="listbox"
-              >
-                {QUICK_RANGES.map(({ label, minutes, value }, index) => {
-                  const selected = draftRange.preset === value;
-                  return (
-                    <SelectOption
-                      key={value}
-                      active={false}
-                      aria-posinset={index + 1}
-                      aria-selected={selected}
-                      aria-setsize={QUICK_RANGES.length}
-                      kind="option"
-                      label={label}
-                      role="option"
-                      selected={selected}
-                      tabIndex={selected ? 0 : -1}
-                      onClick={() => selectQuickRange(minutes, value)}
-                    />
-                  );
-                })}
-              </Box>
-              <Box gap="medium" pad="medium">
-                <Box direction="row" gap="medium" flex={false}>
-                  {renderDateTimePicker('Start', draftRange.start, (start) =>
-                    setDraftRange({
-                      ...draftRange,
-                      start,
-                      preset: undefined,
-                    }),
-                  )}
-                  {renderDateTimePicker('End', draftRange.end, (end) =>
-                    setDraftRange({
-                      ...draftRange,
-                      end,
-                      preset: undefined,
-                    }),
-                  )}
-                </Box>
-                {endBeforeStart && (
-                  <Text color="status-critical" size="small">
-                    End date/time must be after the start date/time.
-                  </Text>
-                )}
-                <Box direction="row" gap="small" justify="end">
-                  <Button label="Cancel" onClick={cancelRange} />
-                  <Button
-                    disabled={endBeforeStart}
-                    label="Apply"
-                    primary
-                    onClick={applyRange}
+  return (
+    <Box width="large" pad="large">
+      <DropButton
+        open={open}
+        onOpen={() => {
+          setDraftRange(range);
+          setOpen(true);
+        }}
+        onClose={cancelRange}
+        dropAlign={{ top: 'bottom', left: 'left' }}
+        dropContent={
+          <Box direction="row" flex={false}>
+            <Box
+              background="background-contrast"
+              border={{ side: 'right', color: 'border' }}
+              gap="xsmall"
+              height={{ max: 'medium' }}
+              overflow="auto"
+              pad="small"
+              width="small"
+              role="listbox"
+            >
+              {QUICK_RANGES.map(({ label, minutes, value }, index) => {
+                const selected = draftRange.preset === value;
+                return (
+                  <SelectOption
+                    key={value}
+                    active={false}
+                    aria-posinset={index + 1}
+                    aria-selected={selected}
+                    aria-setsize={QUICK_RANGES.length}
+                    kind="option"
+                    label={label}
+                    role="option"
+                    selected={selected}
+                    tabIndex={selected ? 0 : -1}
+                    onClick={() => selectQuickRange(minutes, value)}
                   />
-                </Box>
+                );
+              })}
+            </Box>
+            <Box gap="medium" pad="medium">
+              <Box direction="row" gap="medium" flex={false}>
+                {renderDateTimePicker('Start', draftRange.start, (start) =>
+                  setDraftRange({
+                    ...draftRange,
+                    start,
+                    preset: undefined,
+                  }),
+                )}
+                {renderDateTimePicker('End', draftRange.end, (end) =>
+                  setDraftRange({
+                    ...draftRange,
+                    end,
+                    preset: undefined,
+                  }),
+                )}
+              </Box>
+              {endBeforeStart && (
+                <Text color="status-critical" size="small">
+                  End date/time must be after the start date/time.
+                </Text>
+              )}
+              <Box direction="row" gap="small" justify="end">
+                <Button label="Cancel" onClick={cancelRange} />
+                <Button
+                  disabled={endBeforeStart}
+                  label="Apply"
+                  primary
+                  onClick={applyRange}
+                />
               </Box>
             </Box>
-          }
-        >
-          <Box direction="row" align="center" gap="small" pad="small">
-            <CalendarIcon />
-            <Text>{formatRange()}</Text>
           </Box>
-        </DropButton>
-      </Box>
-    );
-  },
+        }
+      >
+        <Box direction="row" align="center" gap="small" pad="small">
+          <CalendarIcon />
+          <Text>{formatRange()}</Text>
+        </Box>
+      </DropButton>
+    </Box>
+  );
+};
+
+export default {
+  title: 'Input/DateTimeInput/Range',
 };

--- a/src/js/components/DateTimeInput/stories/Range.stories.tsx
+++ b/src/js/components/DateTimeInput/stories/Range.stories.tsx
@@ -1,0 +1,194 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
+import React, { useMemo, useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Box, Button, DropButton, Text } from 'grommet';
+import { Calendar as CalendarIcon } from 'grommet-icons';
+// @ts-ignore StyledSelect is an existing internal JavaScript module.
+import { SelectOption } from '../../Select/StyledSelect';
+import { DateTimeInput } from '../index';
+
+const QUICK_RANGES = [
+  { label: 'Last 1 hour', minutes: 60, value: '1h' },
+  { label: 'Last 4 hours', minutes: 4 * 60, value: '4h' },
+  { label: 'Last 8 hours', minutes: 8 * 60, value: '8h' },
+  { label: 'Last 12 hours', minutes: 12 * 60, value: '12h' },
+  { label: 'Last day', minutes: 24 * 60, value: '1d' },
+  { label: 'Last 7 days', minutes: 7 * 24 * 60, value: '7d' },
+  { label: 'Last 15 days', minutes: 15 * 24 * 60, value: '15d' },
+  { label: 'Last 30 days', minutes: 30 * 24 * 60, value: '30d' },
+  { label: 'Last 60 days', minutes: 60 * 24 * 60, value: '60d' },
+  { label: 'Last 90 days', minutes: 90 * 24 * 60, value: '90d' },
+];
+
+const meta: Meta<typeof DateTimeInput> = {
+  title: 'Input/DateTimeInput/Range',
+  component: DateTimeInput,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof DateTimeInput>;
+
+export const Range: Story = {
+  render: function RangeStory() {
+    const [range, setRange] = useState({
+      start: '2026-07-22T13:00:00.000Z',
+      end: '2026-07-22T18:30:00.000Z',
+      preset: undefined as string | undefined,
+    });
+    const [draftRange, setDraftRange] = useState(range);
+    const [open, setOpen] = useState(false);
+
+    const endBeforeStart = useMemo(
+      () =>
+        !!draftRange.start &&
+        !!draftRange.end &&
+        new Date(draftRange.end).getTime() <
+          new Date(draftRange.start).getTime(),
+      [draftRange],
+    );
+
+    const formatRange = () => {
+      const preset = QUICK_RANGES.find(({ value }) => value === range.preset);
+      if (preset) return preset.label;
+      const format = new Intl.DateTimeFormat(undefined, {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+      });
+      return `${format.format(new Date(range.start))} - ${format.format(
+        new Date(range.end),
+      )}`;
+    };
+
+    const selectQuickRange = (minutes: number, preset: string) => {
+      const now = new Date();
+      setDraftRange({
+        end: now.toISOString(),
+        start: new Date(now.getTime() - minutes * 60 * 1000).toISOString(),
+        preset,
+      });
+    };
+
+    const applyRange = () => {
+      if (endBeforeStart) return;
+      setRange(draftRange);
+      setOpen(false);
+    };
+
+    const cancelRange = () => {
+      setDraftRange(range);
+      setOpen(false);
+    };
+
+    const renderDateTimePicker = (
+      label: string,
+      value: string,
+      onChange: (nextValue: string) => void,
+    ) => (
+      <Box gap="small">
+        <Text weight="bold">{label}</Text>
+        <DateTimeInput
+          id={`range-${label.toLowerCase()}`}
+          format="24"
+          pickerInline
+          value={value}
+          onChange={({ value: next }: { value?: string }) =>
+            onChange(next || '')
+          }
+          messages={{
+            inputLabel: `Range ${label.toLowerCase()} date and time`,
+          }}
+        />
+      </Box>
+    );
+
+    return (
+      <Box width="large" pad="large">
+        <DropButton
+          open={open}
+          onOpen={() => {
+            setDraftRange(range);
+            setOpen(true);
+          }}
+          onClose={cancelRange}
+          dropAlign={{ top: 'bottom', left: 'left' }}
+          dropContent={
+            <Box direction="row" flex={false}>
+              <Box
+                background="background-contrast"
+                border={{ side: 'right', color: 'border' }}
+                gap="xsmall"
+                height={{ max: 'medium' }}
+                overflow="auto"
+                pad="small"
+                width="small"
+                role="listbox"
+              >
+                {QUICK_RANGES.map(({ label, minutes, value }, index) => {
+                  const selected = draftRange.preset === value;
+                  return (
+                    <SelectOption
+                      key={value}
+                      active={false}
+                      aria-posinset={index + 1}
+                      aria-selected={selected}
+                      aria-setsize={QUICK_RANGES.length}
+                      kind="option"
+                      label={label}
+                      role="option"
+                      selected={selected}
+                      tabIndex={selected ? 0 : -1}
+                      onClick={() => selectQuickRange(minutes, value)}
+                    />
+                  );
+                })}
+              </Box>
+              <Box gap="medium" pad="medium">
+                <Box direction="row" gap="medium" flex={false}>
+                  {renderDateTimePicker('Start', draftRange.start, (start) =>
+                    setDraftRange({
+                      ...draftRange,
+                      start,
+                      preset: undefined,
+                    }),
+                  )}
+                  {renderDateTimePicker('End', draftRange.end, (end) =>
+                    setDraftRange({
+                      ...draftRange,
+                      end,
+                      preset: undefined,
+                    }),
+                  )}
+                </Box>
+                {endBeforeStart && (
+                  <Text color="status-critical" size="small">
+                    End date/time must be after the start date/time.
+                  </Text>
+                )}
+                <Box direction="row" gap="small" justify="end">
+                  <Button label="Cancel" onClick={cancelRange} />
+                  <Button
+                    disabled={endBeforeStart}
+                    label="Apply"
+                    primary
+                    onClick={applyRange}
+                  />
+                </Box>
+              </Box>
+            </Box>
+          }
+        >
+          <Box direction="row" align="center" gap="small" pad="small">
+            <CalendarIcon />
+            <Text>{formatRange()}</Text>
+          </Box>
+        </DropButton>
+      </Box>
+    );
+  },
+};

--- a/src/js/components/DateTimeInput/stories/RangeToggle.stories.tsx
+++ b/src/js/components/DateTimeInput/stories/RangeToggle.stories.tsx
@@ -103,7 +103,7 @@ export const RangeToggle = function RangeToggleStory() {
                 <DateTimeInput
                   id="toggle-range-start"
                   format="24"
-                  pickerInline
+                  inline="all"
                   value={draftRange.start}
                   onChange={({ value: next }: { value?: string }) =>
                     setDraftRange({
@@ -119,7 +119,7 @@ export const RangeToggle = function RangeToggleStory() {
                 <DateTimeInput
                   id="toggle-range-end"
                   format="24"
-                  pickerInline
+                  inline="all"
                   value={draftRange.end}
                   onChange={({ value: next }: { value?: string }) =>
                     setDraftRange({

--- a/src/js/components/DateTimeInput/stories/RangeToggle.stories.tsx
+++ b/src/js/components/DateTimeInput/stories/RangeToggle.stories.tsx
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
 // SPDX-License-Identifier: Apache-2.0
 import React, { useMemo, useRef, useState } from 'react';
-import type { Meta, StoryObj } from '@storybook/react';
 
 import { Box, Button, Drop, Text, ToggleGroup } from 'grommet';
 import { Calendar as CalendarIcon } from 'grommet-icons';
@@ -16,156 +15,146 @@ const PRESET_OPTIONS = [
   { label: '3M', value: '3m', minutes: 90 * 24 * 60 },
 ];
 
-const meta: Meta<typeof DateTimeInput> = {
-  title: 'Input/DateTimeInput/RangeToggle',
-  component: DateTimeInput,
-};
+export const RangeToggle = function RangeToggleStory() {
+  const now = new Date();
+  const [range, setRange] = useState({
+    start: new Date(now.getTime() - 8 * 60 * 60 * 1000).toISOString(),
+    end: now.toISOString(),
+    preset: '8h' as string | undefined,
+  });
+  const [draftRange, setDraftRange] = useState(range);
+  const [customOpen, setCustomOpen] = useState(false);
+  const calendarButtonRef = useRef<HTMLButtonElement & HTMLAnchorElement>(null);
 
-export default meta;
+  const endBeforeStart = useMemo(
+    () =>
+      !!draftRange.start &&
+      !!draftRange.end &&
+      new Date(draftRange.end).getTime() < new Date(draftRange.start).getTime(),
+    [draftRange],
+  );
 
-type Story = StoryObj<typeof DateTimeInput>;
-
-export const RangeToggle: Story = {
-  render: function RangeToggleStory() {
-    const now = new Date();
-    const [range, setRange] = useState({
-      start: new Date(now.getTime() - 8 * 60 * 60 * 1000).toISOString(),
-      end: now.toISOString(),
-      preset: '8h' as string | undefined,
+  const selectPreset = (value: string) => {
+    const preset = PRESET_OPTIONS.find((p) => p.value === value);
+    if (!preset) return;
+    const next = new Date();
+    setRange({
+      start: new Date(
+        next.getTime() - preset.minutes * 60 * 1000,
+      ).toISOString(),
+      end: next.toISOString(),
+      preset: value,
     });
-    const [draftRange, setDraftRange] = useState(range);
-    const [customOpen, setCustomOpen] = useState(false);
-    const calendarButtonRef = useRef<HTMLButtonElement & HTMLAnchorElement>(
-      null,
-    );
+  };
 
-    const endBeforeStart = useMemo(
-      () =>
-        !!draftRange.start &&
-        !!draftRange.end &&
-        new Date(draftRange.end).getTime() <
-          new Date(draftRange.start).getTime(),
-      [draftRange],
-    );
+  const formatRange = () => {
+    const fmt = new Intl.DateTimeFormat(undefined, {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+    });
+    return `${fmt.format(new Date(range.start))} – ${fmt.format(
+      new Date(range.end),
+    )}`;
+  };
 
-    const selectPreset = (value: string) => {
-      const preset = PRESET_OPTIONS.find((p) => p.value === value);
-      if (!preset) return;
-      const next = new Date();
-      setRange({
-        start: new Date(
-          next.getTime() - preset.minutes * 60 * 1000,
-        ).toISOString(),
-        end: next.toISOString(),
-        preset: value,
-      });
-    };
+  const closeCustom = () => {
+    setDraftRange(range);
+    setCustomOpen(false);
+  };
 
-    const formatRange = () => {
-      const fmt = new Intl.DateTimeFormat(undefined, {
-        month: 'short',
-        day: 'numeric',
-        year: 'numeric',
-        hour: 'numeric',
-        minute: '2-digit',
-      });
-      return `${fmt.format(new Date(range.start))} – ${fmt.format(
-        new Date(range.end),
-      )}`;
-    };
-
-    const closeCustom = () => {
-      setDraftRange(range);
-      setCustomOpen(false);
-    };
-
-    return (
-      <Box pad="large" gap="small">
-        <Box direction="row" align="center">
-          <ToggleGroup
-            options={PRESET_OPTIONS.map(({ label, value }) => ({
-              label,
-              value,
-            }))}
-            value={range.preset}
-            onToggle={({ value }) => {
-              if (typeof value === 'string') selectPreset(value);
-            }}
-          />
-          <Button
-            ref={calendarButtonRef}
-            icon={<CalendarIcon />}
-            tip="Custom range"
-            onClick={() => {
-              setDraftRange(range);
-              setCustomOpen(true);
-            }}
-          />
-        </Box>
-        <Text size="small">{formatRange()}</Text>
-        {customOpen && (
-          <Drop
-            target={calendarButtonRef.current ?? undefined}
-            align={{ top: 'bottom', right: 'right' }}
-            onClickOutside={closeCustom}
-            onEsc={closeCustom}
-          >
-            <Box pad="medium" gap="medium">
-              <Box direction="row" gap="medium">
-                <Box gap="small">
-                  <Text weight="bold">Start</Text>
-                  <DateTimeInput
-                    id="toggle-range-start"
-                    format="24"
-                    pickerInline
-                    value={draftRange.start}
-                    onChange={({ value: next }: { value?: string }) =>
-                      setDraftRange({
-                        ...draftRange,
-                        start: next || '',
-                        preset: undefined,
-                      })
-                    }
-                  />
-                </Box>
-                <Box gap="small">
-                  <Text weight="bold">End</Text>
-                  <DateTimeInput
-                    id="toggle-range-end"
-                    format="24"
-                    pickerInline
-                    value={draftRange.end}
-                    onChange={({ value: next }: { value?: string }) =>
-                      setDraftRange({
-                        ...draftRange,
-                        end: next || '',
-                        preset: undefined,
-                      })
-                    }
-                  />
-                </Box>
+  return (
+    <Box pad="large" gap="small">
+      <Box direction="row" align="center">
+        <ToggleGroup
+          options={PRESET_OPTIONS.map(({ label, value }) => ({
+            label,
+            value,
+          }))}
+          value={range.preset}
+          onToggle={({ value }) => {
+            if (typeof value === 'string') selectPreset(value);
+          }}
+        />
+        <Button
+          ref={calendarButtonRef}
+          icon={<CalendarIcon />}
+          tip="Custom range"
+          onClick={() => {
+            setDraftRange(range);
+            setCustomOpen(true);
+          }}
+        />
+      </Box>
+      <Text size="small">{formatRange()}</Text>
+      {customOpen && (
+        <Drop
+          target={calendarButtonRef.current ?? undefined}
+          align={{ top: 'bottom', right: 'right' }}
+          onClickOutside={closeCustom}
+          onEsc={closeCustom}
+        >
+          <Box pad="medium" gap="medium">
+            <Box direction="row" gap="medium">
+              <Box gap="small">
+                <Text weight="bold">Start</Text>
+                <DateTimeInput
+                  id="toggle-range-start"
+                  format="24"
+                  pickerInline
+                  value={draftRange.start}
+                  onChange={({ value: next }: { value?: string }) =>
+                    setDraftRange({
+                      ...draftRange,
+                      start: next || '',
+                      preset: undefined,
+                    })
+                  }
+                />
               </Box>
-              {endBeforeStart && (
-                <Text color="status-critical" size="small">
-                  End date/time must be after the start date/time.
-                </Text>
-              )}
-              <Box direction="row" gap="small" justify="end">
-                <Button label="Cancel" onClick={closeCustom} />
-                <Button
-                  label="Apply"
-                  primary
-                  disabled={endBeforeStart}
-                  onClick={() => {
-                    setRange({ ...draftRange, preset: undefined });
-                    setCustomOpen(false);
-                  }}
+              <Box gap="small">
+                <Text weight="bold">End</Text>
+                <DateTimeInput
+                  id="toggle-range-end"
+                  format="24"
+                  pickerInline
+                  value={draftRange.end}
+                  onChange={({ value: next }: { value?: string }) =>
+                    setDraftRange({
+                      ...draftRange,
+                      end: next || '',
+                      preset: undefined,
+                    })
+                  }
                 />
               </Box>
             </Box>
-          </Drop>
-        )}
-      </Box>
-    );
-  },
+            {endBeforeStart && (
+              <Text color="status-critical" size="small">
+                End date/time must be after the start date/time.
+              </Text>
+            )}
+            <Box direction="row" gap="small" justify="end">
+              <Button label="Cancel" onClick={closeCustom} />
+              <Button
+                label="Apply"
+                primary
+                disabled={endBeforeStart}
+                onClick={() => {
+                  setRange({ ...draftRange, preset: undefined });
+                  setCustomOpen(false);
+                }}
+              />
+            </Box>
+          </Box>
+        </Drop>
+      )}
+    </Box>
+  );
+};
+
+export default {
+  title: 'Input/DateTimeInput/RangeToggle',
 };

--- a/src/js/components/DateTimeInput/stories/RangeToggle.stories.tsx
+++ b/src/js/components/DateTimeInput/stories/RangeToggle.stories.tsx
@@ -1,0 +1,171 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
+import React, { useMemo, useRef, useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Box, Button, Drop, Text, ToggleGroup } from 'grommet';
+import { Calendar as CalendarIcon } from 'grommet-icons';
+import { DateTimeInput } from '../index';
+
+const PRESET_OPTIONS = [
+  { label: '1H', value: '1h', minutes: 60 },
+  { label: '8H', value: '8h', minutes: 8 * 60 },
+  { label: '1D', value: '1d', minutes: 24 * 60 },
+  { label: '1W', value: '1w', minutes: 7 * 24 * 60 },
+  { label: '1M', value: '1m', minutes: 30 * 24 * 60 },
+  { label: '3M', value: '3m', minutes: 90 * 24 * 60 },
+];
+
+const meta: Meta<typeof DateTimeInput> = {
+  title: 'Input/DateTimeInput/RangeToggle',
+  component: DateTimeInput,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof DateTimeInput>;
+
+export const RangeToggle: Story = {
+  render: function RangeToggleStory() {
+    const now = new Date();
+    const [range, setRange] = useState({
+      start: new Date(now.getTime() - 8 * 60 * 60 * 1000).toISOString(),
+      end: now.toISOString(),
+      preset: '8h' as string | undefined,
+    });
+    const [draftRange, setDraftRange] = useState(range);
+    const [customOpen, setCustomOpen] = useState(false);
+    const calendarButtonRef = useRef<HTMLButtonElement & HTMLAnchorElement>(
+      null,
+    );
+
+    const endBeforeStart = useMemo(
+      () =>
+        !!draftRange.start &&
+        !!draftRange.end &&
+        new Date(draftRange.end).getTime() <
+          new Date(draftRange.start).getTime(),
+      [draftRange],
+    );
+
+    const selectPreset = (value: string) => {
+      const preset = PRESET_OPTIONS.find((p) => p.value === value);
+      if (!preset) return;
+      const next = new Date();
+      setRange({
+        start: new Date(
+          next.getTime() - preset.minutes * 60 * 1000,
+        ).toISOString(),
+        end: next.toISOString(),
+        preset: value,
+      });
+    };
+
+    const formatRange = () => {
+      const fmt = new Intl.DateTimeFormat(undefined, {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+      });
+      return `${fmt.format(new Date(range.start))} – ${fmt.format(
+        new Date(range.end),
+      )}`;
+    };
+
+    const closeCustom = () => {
+      setDraftRange(range);
+      setCustomOpen(false);
+    };
+
+    return (
+      <Box pad="large" gap="small">
+        <Box direction="row" align="center">
+          <ToggleGroup
+            options={PRESET_OPTIONS.map(({ label, value }) => ({
+              label,
+              value,
+            }))}
+            value={range.preset}
+            onToggle={({ value }) => {
+              if (typeof value === 'string') selectPreset(value);
+            }}
+          />
+          <Button
+            ref={calendarButtonRef}
+            icon={<CalendarIcon />}
+            tip="Custom range"
+            onClick={() => {
+              setDraftRange(range);
+              setCustomOpen(true);
+            }}
+          />
+        </Box>
+        <Text size="small">{formatRange()}</Text>
+        {customOpen && (
+          <Drop
+            target={calendarButtonRef.current ?? undefined}
+            align={{ top: 'bottom', right: 'right' }}
+            onClickOutside={closeCustom}
+            onEsc={closeCustom}
+          >
+            <Box pad="medium" gap="medium">
+              <Box direction="row" gap="medium">
+                <Box gap="small">
+                  <Text weight="bold">Start</Text>
+                  <DateTimeInput
+                    id="toggle-range-start"
+                    format="24"
+                    pickerInline
+                    value={draftRange.start}
+                    onChange={({ value: next }: { value?: string }) =>
+                      setDraftRange({
+                        ...draftRange,
+                        start: next || '',
+                        preset: undefined,
+                      })
+                    }
+                  />
+                </Box>
+                <Box gap="small">
+                  <Text weight="bold">End</Text>
+                  <DateTimeInput
+                    id="toggle-range-end"
+                    format="24"
+                    pickerInline
+                    value={draftRange.end}
+                    onChange={({ value: next }: { value?: string }) =>
+                      setDraftRange({
+                        ...draftRange,
+                        end: next || '',
+                        preset: undefined,
+                      })
+                    }
+                  />
+                </Box>
+              </Box>
+              {endBeforeStart && (
+                <Text color="status-critical" size="small">
+                  End date/time must be after the start date/time.
+                </Text>
+              )}
+              <Box direction="row" gap="small" justify="end">
+                <Button label="Cancel" onClick={closeCustom} />
+                <Button
+                  label="Apply"
+                  primary
+                  disabled={endBeforeStart}
+                  onClick={() => {
+                    setRange({ ...draftRange, preset: undefined });
+                    setCustomOpen(false);
+                  }}
+                />
+              </Box>
+            </Box>
+          </Drop>
+        )}
+      </Box>
+    );
+  },
+};

--- a/src/js/components/TimeInput/TimeInputPopup.js
+++ b/src/js/components/TimeInput/TimeInputPopup.js
@@ -93,6 +93,7 @@ const getDefaultPopupOption = ({ section, format, options }) => {
 
 const PopupColumn = ({
   activeSection,
+  columnMaxHeight,
   format,
   formatMessage,
   inline,
@@ -106,11 +107,12 @@ const PopupColumn = ({
   sections,
   theme,
 }) => {
-  // When inline (in DateTimeInput), use 'medium' to match Calendar height.
-  // Otherwise use timeInput drop maxHeight with fallback to 'small'.
-  const maxHeightToken = inline ? 'medium' : null;
+  // When inline, default to 'medium' to match Calendar medium height.
+  // columnMaxHeight overrides this (e.g. 'small' to match Calendar size="small").
+  const inlineHeightToken = columnMaxHeight || (inline ? 'medium' : null);
   const maxHeight =
-    (maxHeightToken && theme.global.size?.[maxHeightToken]) ||
+    (inlineHeightToken &&
+      (theme.global.size?.[inlineHeightToken] || inlineHeightToken)) ||
     theme.timeInput?.drop?.column?.maxHeight ||
     theme.global.size.small;
 
@@ -200,6 +202,7 @@ const PopupColumn = ({
 const TimeInputPopup = ({
   activeSection,
   align,
+  columnMaxHeight,
   format,
   formatMessage,
   hoursOptions,
@@ -635,6 +638,7 @@ const TimeInputPopup = ({
         <PopupColumn
           key={sectionLabel}
           activeSection={activeSection}
+          columnMaxHeight={columnMaxHeight}
           format={format}
           formatMessage={formatMessage}
           inline={inline}

--- a/src/js/components/TimeInput/TimeInputPopup.js
+++ b/src/js/components/TimeInput/TimeInputPopup.js
@@ -438,9 +438,10 @@ const TimeInputPopup = ({
           selectedNode.scrollIntoView({ block: 'nearest' });
         }
 
-        // Center selected value in each listbox so all sections (hh/mm/ss)
-        // are consistently aligned on open, not just the focused section.
-        const selectedOffsetTop = selectedNode.offsetTop;
+        // Subtract listboxNode.offsetTop so the position is relative to the
+        // listbox content origin, not the nearest positioned ancestor.
+        const selectedOffsetTop =
+          selectedNode.offsetTop - listboxNode.offsetTop;
         const selectedHeight = selectedNode.offsetHeight;
         const targetScrollTop =
           selectedOffsetTop -
@@ -503,7 +504,7 @@ const TimeInputPopup = ({
     const selector = `[data-option-key="${keyMap[activeSection]}"]`;
     const node = dialogRef.current?.querySelector(selector);
     if (node) {
-      node.focus();
+      node.focus({ preventScroll: true });
       return true;
     }
 
@@ -516,7 +517,7 @@ const TimeInputPopup = ({
       `[role="listbox"][aria-label="${sectionLabel}"] [role="option"]`,
     );
     if (fallbackNode) {
-      fallbackNode.focus();
+      fallbackNode.focus({ preventScroll: true });
       return true;
     }
 
@@ -534,6 +535,15 @@ const TimeInputPopup = ({
     // Avoid stealing pointer interactions: while the user is actively
     // clicking inside the popup, let that click settle before refocusing.
     if (pointerDownInsideRef.current) return undefined;
+
+    // When inline (embedded in a parent), only manage focus if it already
+    // lives inside the popup — otherwise just keep the options scrolled.
+    if (inline && !dialogRef.current?.contains(document.activeElement)) {
+      const scrollRaf = requestAnimationFrame(() => {
+        scrollSelectedOptionsIntoView();
+      });
+      return () => window.cancelAnimationFrame(scrollRaf);
+    }
 
     const scrollRaf = requestAnimationFrame(() => {
       scrollSelectedOptionsIntoView();
@@ -557,7 +567,7 @@ const TimeInputPopup = ({
       window.cancelAnimationFrame(rafA);
       if (rafB) window.cancelAnimationFrame(rafB);
     };
-  }, [focusCurrentPopupOption, scrollSelectedOptionsIntoView]);
+  }, [focusCurrentPopupOption, inline, scrollSelectedOptionsIntoView]);
 
   const popupContent = (
     <Box

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -372,6 +372,7 @@ exports[`Components loads 1`] = `
       "minuteStep": [Function],
       "name": [Function],
       "onChange": [Function],
+      "pickerInline": [Function],
       "readOnly": [Function],
       "showSeconds": [Function],
       "value": [Function],

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -372,7 +372,6 @@ exports[`Components loads 1`] = `
       "minuteStep": [Function],
       "name": [Function],
       "onChange": [Function],
-      "pickerInline": [Function],
       "readOnly": [Function],
       "showSeconds": [Function],
       "value": [Function],


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Adds a `pickerInline` prop to `DateTimeInput` that renders the calendar and
time picker directly below the input always visible, no
drop.

#### Where should the reviewer start?

- `DateTimeInput.js` `pickerInline`
- `/stories/Range.stories.tsx` and
  `RangeToggle.stories.tsx` -  usage examples

#### What testing has been done on this PR?

- 3 new Jest tests for `pickerInline`

#### How should this be manually tested?

1. Open the `Input/DateTimeInput/Range` story click the trigger, verify the
   embedded calendar + time picker appear below the inputs and that selecting a
   date/time updates the value
2. Open the `Input/DateTimeInput/RangeToggle` story  verify preset buttons set
   the range immediately; click the calendar icon to open the custom range drop
   with embedded pickers

#### Do Jest tests follow these best practices?

- [x] `screen` is used for querying
- [x] The correct query is used (`getByRole` with semantic roles)
- [ ] `asFragment()` is used for snapshot testing — N/A, no snapshots added

#### Any background context you want to provide?

We needed a way to show the DateTimeInput picker outside of a drop and directly below the input. I'm open to feedback on the naming since we've been referring to the drop content as the "picker," `pickerInline` felt natural, but this is a new concept in Grommet and the name is worth discussing before it lands.

The `columnMaxHeight` prop added to `TimeInputPopup` is intentionally not
exposed in `TimeInput`'s public types  it is an internal detail used by
`DateTimeInput`. `TimeInput inline` is also intentionally not exposed in this
PR and will be introduced separately if we see fit.

#### What are the relevant issues?

related to https://github.com/grommet/hpe-design-system/issues/6448

#### Screenshots (if appropriate)
none

#### Do the grommet docs need to be updated?

Yes

#### Should this PR be mentioned in the release notes?

Yes

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible