### PR TITLE
clean up timeinput theme

### DIFF
--- a/src/js/components/TimeInput/TimeInputPopup.js
+++ b/src/js/components/TimeInput/TimeInputPopup.js
@@ -30,9 +30,27 @@ const PopupOption = styled.div`
   box-sizing: border-box;
   cursor: pointer;
   display: flex;
-  padding: ${(props) =>
-    `${props.theme.global.edgeSize.xxsmall} ${props.theme.global.edgeSize.xsmall}`};
-  border-radius: ${(props) => props.theme.global.control?.border?.radius};
+  padding: ${(props) => {
+    const padToken = props.theme.timeInput?.drop?.option?.pad;
+    if (!padToken) {
+      return `${props.theme.global.edgeSize.xxsmall} ${props.theme.global.edgeSize.xsmall}`;
+    }
+    if (typeof padToken === 'string') {
+      return props.theme.global.edgeSize?.[padToken] || padToken;
+    }
+    const v =
+      props.theme.global.edgeSize?.[padToken.vertical] || padToken.vertical;
+    const h =
+      props.theme.global.edgeSize?.[padToken.horizontal] || padToken.horizontal;
+    return `${v} ${h}`;
+  }};
+  border-radius: ${(props) => {
+    const round = props.theme.timeInput?.drop?.option?.round;
+    return (
+      (round && (props.theme.global.edgeSize?.[round] || round)) ||
+      props.theme.global.control?.border?.radius
+    );
+  }};
   background: ${(props) => {
     if (props.$selected) {
       return normalizeColor(
@@ -118,7 +136,7 @@ const PopupColumn = ({
     <PopupColumnBox
       role="listbox"
       aria-label={label}
-      gap="xxsmall"
+      gap={theme.timeInput?.drop?.option?.gap || 'xxsmall'}
       height={{
         max: maxHeight,
       }}
@@ -185,7 +203,11 @@ const PopupColumn = ({
             onFocus={() => onSetSection(section)}
           >
             <Text
-              size={theme.global.input.font.size || 'small'}
+              size={
+                theme.timeInput?.drop?.option?.size ||
+                theme.global.input.font.size ||
+                'small'
+              }
               color={optionColor}
             >
               {section === SECTION_PERIOD ? option : pad(option)}
@@ -564,7 +586,7 @@ const TimeInputPopup = ({
       direction="row"
       width={{ width: theme.timeInput?.drop?.width, max: '100%' }}
       minHeight={theme.timeInput?.drop?.minHeight}
-      gap="xsmall"
+      gap={theme.timeInput?.drop?.gap || 'xsmall'}
       pad={inline ? 'none' : theme.timeInput?.drop?.pad || 'small'}
       onPointerDownCapture={markInteractionInProgress}
       onPointerUpCapture={releaseInteractionAfterClick}

--- a/src/js/components/TimeInput/TimeInputPopup.js
+++ b/src/js/components/TimeInput/TimeInputPopup.js
@@ -5,7 +5,7 @@ import React, { useCallback, useEffect, useRef } from 'react';
 import styled from 'styled-components';
 
 import { useLayoutEffect } from '../../utils/use-isomorphic-layout-effect';
-import { focusStyle, normalizeColor } from '../../utils';
+import { edgeStyle, focusStyle, normalizeColor, roundStyle } from '../../utils';
 import { useThemeValue } from '../../utils/useThemeValue';
 
 import { Box } from '../Box';
@@ -30,27 +30,25 @@ const PopupOption = styled.div`
   box-sizing: border-box;
   cursor: pointer;
   display: flex;
-  padding: ${(props) => {
-    const padToken = props.theme.timeInput?.drop?.option?.pad;
-    if (!padToken) {
-      return `${props.theme.global.edgeSize.xxsmall} ${props.theme.global.edgeSize.xsmall}`;
-    }
-    if (typeof padToken === 'string') {
-      return props.theme.global.edgeSize?.[padToken] || padToken;
-    }
-    const v =
-      props.theme.global.edgeSize?.[padToken.vertical] || padToken.vertical;
-    const h =
-      props.theme.global.edgeSize?.[padToken.horizontal] || padToken.horizontal;
-    return `${v} ${h}`;
-  }};
-  border-radius: ${(props) => {
-    const round = props.theme.timeInput?.drop?.option?.round;
+  ${(props) => {
+    const optionPad = props.theme.timeInput?.drop?.option?.pad;
     return (
-      (round && (props.theme.global.edgeSize?.[round] || round)) ||
-      props.theme.global.control?.border?.radius
+      optionPad &&
+      edgeStyle(
+        'padding',
+        optionPad,
+        false,
+        props.theme.box.responsiveBreakpoint,
+        props.theme,
+      )
     );
-  }};
+  }}
+  ${(props) => {
+    const round =
+      props.theme.timeInput?.drop?.option?.round ||
+      props.theme.global.control?.border?.radius;
+    return round && roundStyle(round, false, props.theme);
+  }}
   background: ${(props) => {
     if (props.$selected) {
       return normalizeColor(

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -2409,8 +2409,13 @@ export interface ThemeType {
       };
     };
     drop?: {
+      gap?: GapType;
       option?: {
         background?: ColorType;
+        gap?: GapType;
+        size?: string;
+        pad?: PadType;
+        round?: RoundType;
         hover?: {
           background?: ColorType;
         };

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -2663,8 +2663,13 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         },
       },
       drop: {
+        // gap: undefined,
         option: {
           // background: undefined,
+          // gap: undefined,
+          // size: undefined,
+          // pad: undefined,
+          // round: undefined,
           hover: {
             background: 'active-background',
           },

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -2668,7 +2668,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
           // background: undefined,
           // gap: undefined,
           // size: undefined,
-          // pad: undefined,
+          pad: { vertical: 'xxsmall', horizontal: 'xsmall' },
           // round: undefined,
           hover: {
             background: 'active-background',


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR adds a few more items to the TimeInput theme so that in hpe theme we can change the values
#### Where should the reviewer start?
base theme
#### What testing has been done on this PR?
locally 

you can see the changes need from the figma file here 
https://www.figma.com/design/PWNGorPUwzzjj7exRUV808/branch/wOrLVmWRIFlxSjLzz7mYTP/-6285---TimeInput?timeline=keyframe&node-id=2909-5939&t=cFhaW7aotBWnPMaS-0


#### How should this be manually tested?
locally 

test with these for hpe theme

```
    timeInput: {
      container: {
        round:
          components.hpe.formField.default.medium.input.container.borderRadius,
      },
      button: {
        margin: { right: '3xsmall' },
      },
      active: {
        background: 'background-active',
        pad: '5xsmall',
        indicator: {
          color: 'focus',
        },
      },
      drop: {
        gap: '3xsmall',
        pad: 'xsmall',
        option: {
          gap: '4xsmall',
          pad: { vertical: '5xsmall', horizontal: 'xsmall' },
          size: 'medium',
          hover: {
            background: 'background-active',
          },
          selected: {
            background: 'background-selected-primary-strong',
            color: textOnSelectedPrimaryStrong,
            hover: { background: 'background-selected-primary-strong-hover' },
          },
        },
      },
      icon: {
        clock: ClockIcon,
      },
    },
```
#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
There was some discrepancies between the TimeInput now and the Figma that we needed to adjust see the figma file for more details

### `TimeInputPopup.js` changes

| # | Theme key | Change |
|---|-----------|--------|
| 1 | `timeInput.drop.gap` | `gap: "xsmall"` (outer Box) → `gap: theme.timeInput?.drop?.gap \|\| "xsmall"` |
| 2 | `timeInput.drop.option.gap` | `gap: "xxsmall"` (PopupColumnBox) → `gap: theme.timeInput?.drop?.option?.gap \|\| "xxsmall"` |
| 3 | `timeInput.drop.option.size` | `size: theme.global.input.font.size \|\| 'small'` → prepend `theme.timeInput?.drop?.option?.size \|\|` |
| 4 | `timeInput.drop.option.pad` | `PopupOption` padding hardcoded to `edgeSize.xxsmall + " " + edgeSize.xsmall` → resolve from `theme.timeInput?.drop?.option?.pad` (object with `vertical`/`horizontal`) with fallback |
| 5 | `timeInput.drop.option.round` | `PopupOption` border-radius hardcoded to `global.control.border?.radius` → `theme.timeInput?.drop?.option?.round \|\| global.control.border?.radius` |

#### What are the relevant issues?
none 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
yes
#### Should this PR be mentioned in the release notes?
beta
#### Is this change backwards compatible or is it a breaking change?
backwards compatible