### PR TITLE
[FormField] Added formField.hover theme property

### DIFF
--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-controlled.tsx.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-controlled.tsx.snap
@@ -199,10 +199,10 @@ exports[`Form controlled controlled 2`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 dVwWlz"
+      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 eRYfaf"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 cavXRX"
+        class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 jOSlAf"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 cJjrXo"
@@ -233,10 +233,10 @@ exports[`Form controlled controlled 3`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 dVwWlz"
+      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 eRYfaf"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 cavXRX"
+        class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 jOSlAf"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 cJjrXo"
@@ -581,10 +581,10 @@ exports[`Form controlled controlled Array of Form Fields 2`] = `
       class="StyledBox-sc-13pk1d4-0 koPUgN"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 dVwWlz"
+        class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 eRYfaf"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 cavXRX"
+          class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 jOSlAf"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 cJjrXo"
@@ -600,10 +600,10 @@ exports[`Form controlled controlled Array of Form Fields 2`] = `
         </div>
       </div>
       <div
-        class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 dVwWlz"
+        class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 eRYfaf"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 cavXRX"
+          class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 jOSlAf"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 cJjrXo"
@@ -623,10 +623,10 @@ exports[`Form controlled controlled Array of Form Fields 2`] = `
       class="StyledBox-sc-13pk1d4-0 koPUgN"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 dVwWlz"
+        class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 eRYfaf"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 cavXRX"
+          class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 jOSlAf"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 cJjrXo"
@@ -642,10 +642,10 @@ exports[`Form controlled controlled Array of Form Fields 2`] = `
         </div>
       </div>
       <div
-        class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 dVwWlz"
+        class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 eRYfaf"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 cavXRX"
+          class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 jOSlAf"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 cJjrXo"
@@ -665,10 +665,10 @@ exports[`Form controlled controlled Array of Form Fields 2`] = `
       class="StyledBox-sc-13pk1d4-0 koPUgN"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 dVwWlz"
+        class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 eRYfaf"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 cavXRX"
+          class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 jOSlAf"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 cJjrXo"
@@ -684,10 +684,10 @@ exports[`Form controlled controlled Array of Form Fields 2`] = `
         </div>
       </div>
       <div
-        class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 dVwWlz"
+        class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 eRYfaf"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 cavXRX"
+          class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 jOSlAf"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 cJjrXo"
@@ -722,10 +722,10 @@ exports[`Form controlled controlled Array of Form Fields 3`] = `
       class="StyledBox-sc-13pk1d4-0 koPUgN"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 dVwWlz"
+        class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 eRYfaf"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 cavXRX"
+          class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 jOSlAf"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 cJjrXo"
@@ -741,10 +741,10 @@ exports[`Form controlled controlled Array of Form Fields 3`] = `
         </div>
       </div>
       <div
-        class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 dVwWlz"
+        class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 eRYfaf"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 cavXRX"
+          class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 jOSlAf"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 cJjrXo"
@@ -764,10 +764,10 @@ exports[`Form controlled controlled Array of Form Fields 3`] = `
       class="StyledBox-sc-13pk1d4-0 koPUgN"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 dVwWlz"
+        class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 eRYfaf"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 cavXRX"
+          class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 jOSlAf"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 cJjrXo"
@@ -783,10 +783,10 @@ exports[`Form controlled controlled Array of Form Fields 3`] = `
         </div>
       </div>
       <div
-        class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 dVwWlz"
+        class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 eRYfaf"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 cavXRX"
+          class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 jOSlAf"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 cJjrXo"
@@ -806,10 +806,10 @@ exports[`Form controlled controlled Array of Form Fields 3`] = `
       class="StyledBox-sc-13pk1d4-0 koPUgN"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 dVwWlz"
+        class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 eRYfaf"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 cavXRX"
+          class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 jOSlAf"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 cJjrXo"
@@ -825,10 +825,10 @@ exports[`Form controlled controlled Array of Form Fields 3`] = `
         </div>
       </div>
       <div
-        class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 dVwWlz"
+        class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 eRYfaf"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 cavXRX"
+          class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 jOSlAf"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 cJjrXo"
@@ -1132,10 +1132,10 @@ exports[`Form controlled controlled Array of Form Fields onValidate 2`] = `
       class="StyledBox-sc-13pk1d4-0 koPUgN"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 dVwWlz"
+        class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 eRYfaf"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 hwtHNC FormField__FormFieldContentBox-sc-m9hood-1 cavXRX"
+          class="StyledBox-sc-13pk1d4-0 hwtHNC FormField__FormFieldContentBox-sc-m9hood-1 jOSlAf"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 cJjrXo"
@@ -1179,10 +1179,10 @@ exports[`Form controlled controlled Array of Form Fields onValidate 2`] = `
         </span>
       </div>
       <div
-        class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 dVwWlz"
+        class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 eRYfaf"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 cavXRX"
+          class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 jOSlAf"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 cJjrXo"
@@ -1202,10 +1202,10 @@ exports[`Form controlled controlled Array of Form Fields onValidate 2`] = `
       class="StyledBox-sc-13pk1d4-0 koPUgN"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 dVwWlz"
+        class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 eRYfaf"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 hwtHNC FormField__FormFieldContentBox-sc-m9hood-1 cavXRX"
+          class="StyledBox-sc-13pk1d4-0 hwtHNC FormField__FormFieldContentBox-sc-m9hood-1 jOSlAf"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 cJjrXo"
@@ -1249,10 +1249,10 @@ exports[`Form controlled controlled Array of Form Fields onValidate 2`] = `
         </span>
       </div>
       <div
-        class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 dVwWlz"
+        class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 eRYfaf"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 cavXRX"
+          class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 jOSlAf"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 cJjrXo"
@@ -1556,10 +1556,10 @@ exports[`Form controlled controlled Array of Form Fields onValidate custom error
       class="StyledBox-sc-13pk1d4-0 koPUgN"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 dVwWlz"
+        class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 eRYfaf"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 cavXRX"
+          class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 jOSlAf"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 cJjrXo"
@@ -1575,10 +1575,10 @@ exports[`Form controlled controlled Array of Form Fields onValidate custom error
         </div>
       </div>
       <div
-        class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 dVwWlz"
+        class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 eRYfaf"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 cavXRX"
+          class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 jOSlAf"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 cJjrXo"
@@ -1598,10 +1598,10 @@ exports[`Form controlled controlled Array of Form Fields onValidate custom error
       class="StyledBox-sc-13pk1d4-0 koPUgN"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 dVwWlz"
+        class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 eRYfaf"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 hwtHNC FormField__FormFieldContentBox-sc-m9hood-1 cavXRX"
+          class="StyledBox-sc-13pk1d4-0 hwtHNC FormField__FormFieldContentBox-sc-m9hood-1 jOSlAf"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 cJjrXo"
@@ -1645,10 +1645,10 @@ exports[`Form controlled controlled Array of Form Fields onValidate custom error
         </span>
       </div>
       <div
-        class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 dVwWlz"
+        class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 eRYfaf"
       >
         <div
-          class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 cavXRX"
+          class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 jOSlAf"
         >
           <div
             class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 cJjrXo"
@@ -1889,7 +1889,7 @@ exports[`Form controlled controlled FormField deprecated 2`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 dVwWlz"
+      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 eRYfaf"
     >
       <label
         class="StyledText-sc-1sadyjn-0 cdcdWR"
@@ -1899,7 +1899,7 @@ exports[`Form controlled controlled FormField deprecated 2`] = `
         test
       </label>
       <div
-        class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 cavXRX"
+        class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 jOSlAf"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 cJjrXo"
@@ -1930,7 +1930,7 @@ exports[`Form controlled controlled FormField deprecated 3`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 dVwWlz"
+      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 eRYfaf"
     >
       <label
         class="StyledText-sc-1sadyjn-0 cdcdWR"
@@ -1940,7 +1940,7 @@ exports[`Form controlled controlled FormField deprecated 3`] = `
         test
       </label>
       <div
-        class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 cavXRX"
+        class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 jOSlAf"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 cJjrXo"
@@ -2164,10 +2164,10 @@ exports[`Form controlled controlled input 2`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 dVwWlz"
+      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 eRYfaf"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 cavXRX"
+        class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 jOSlAf"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 cJjrXo"
@@ -2198,10 +2198,10 @@ exports[`Form controlled controlled input 3`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 dVwWlz"
+      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 eRYfaf"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 cavXRX"
+        class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 jOSlAf"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 cJjrXo"
@@ -2425,10 +2425,10 @@ exports[`Form controlled controlled input lazy 2`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 dVwWlz"
+      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 eRYfaf"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 cavXRX"
+        class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 jOSlAf"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 cJjrXo"
@@ -2459,10 +2459,10 @@ exports[`Form controlled controlled input lazy 3`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 dVwWlz"
+      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 eRYfaf"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 cavXRX"
+        class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 jOSlAf"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 cJjrXo"
@@ -2686,10 +2686,10 @@ exports[`Form controlled controlled lazy 2`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 dVwWlz"
+      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 eRYfaf"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 cavXRX"
+        class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 jOSlAf"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 cJjrXo"
@@ -2720,10 +2720,10 @@ exports[`Form controlled controlled lazy 3`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 dVwWlz"
+      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 eRYfaf"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 cavXRX"
+        class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 jOSlAf"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 cJjrXo"
@@ -3140,10 +3140,10 @@ exports[`Form controlled controlled onValidate 2`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 dVwWlz"
+      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 eRYfaf"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 hwtHNC FormField__FormFieldContentBox-sc-m9hood-1 cavXRX"
+        class="StyledBox-sc-13pk1d4-0 hwtHNC FormField__FormFieldContentBox-sc-m9hood-1 jOSlAf"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 cJjrXo"
@@ -3395,10 +3395,10 @@ exports[`Form controlled controlled onValidate custom error 2`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 dVwWlz"
+      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 eRYfaf"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 hwtHNC FormField__FormFieldContentBox-sc-m9hood-1 cavXRX"
+        class="StyledBox-sc-13pk1d4-0 hwtHNC FormField__FormFieldContentBox-sc-m9hood-1 jOSlAf"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 cJjrXo"
@@ -3650,10 +3650,10 @@ exports[`Form controlled controlled onValidate custom info 2`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 dVwWlz"
+      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 eRYfaf"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 cavXRX"
+        class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 jOSlAf"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 cJjrXo"
@@ -4263,10 +4263,10 @@ exports[`Form controlled dynamicly removed fields using blur validation\\n  don'
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 dVwWlz"
+      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 eRYfaf"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 cavXRX"
+        class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 jOSlAf"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 cJjrXo"
@@ -4282,10 +4282,10 @@ exports[`Form controlled dynamicly removed fields using blur validation\\n  don'
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 dVwWlz"
+      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 eRYfaf"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 vatJD FormField__FormFieldContentBox-sc-m9hood-1 cavXRX"
+        class="StyledBox-sc-13pk1d4-0 vatJD FormField__FormFieldContentBox-sc-m9hood-1 jOSlAf"
       >
         <label
           class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dOWXkA"
@@ -4491,10 +4491,10 @@ exports[`Form controlled dynamicly removed fields using blur validation\\n  don'
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 dVwWlz"
+      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 eRYfaf"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 cavXRX"
+        class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 jOSlAf"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 cJjrXo"
@@ -4510,10 +4510,10 @@ exports[`Form controlled dynamicly removed fields using blur validation\\n  don'
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 dVwWlz"
+      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 eRYfaf"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 vatJD FormField__FormFieldContentBox-sc-m9hood-1 uIZRw"
+        class="StyledBox-sc-13pk1d4-0 vatJD FormField__FormFieldContentBox-sc-m9hood-1 iDyRNM"
       >
         <label
           class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 NUQQS"

--- a/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.tsx.snap
+++ b/src/js/components/Form/__tests__/__snapshots__/Form-test-uncontrolled.tsx.snap
@@ -1127,10 +1127,10 @@ exports[`Form uncontrolled dynamically removed fields should be removed from for
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 dVwWlz"
+      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 eRYfaf"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 cavXRX"
+        class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 jOSlAf"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 cJjrXo"
@@ -1145,10 +1145,10 @@ exports[`Form uncontrolled dynamically removed fields should be removed from for
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 dVwWlz"
+      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 eRYfaf"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 vatJD FormField__FormFieldContentBox-sc-m9hood-1 cavXRX"
+        class="StyledBox-sc-13pk1d4-0 vatJD FormField__FormFieldContentBox-sc-m9hood-1 jOSlAf"
       >
         <label
           class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dOWXkA"
@@ -1501,10 +1501,10 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation\\n  do
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 dVwWlz"
+      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 eRYfaf"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 cavXRX"
+        class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 jOSlAf"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 cJjrXo"
@@ -1519,10 +1519,10 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation\\n  do
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 dVwWlz"
+      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 eRYfaf"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 vatJD FormField__FormFieldContentBox-sc-m9hood-1 cavXRX"
+        class="StyledBox-sc-13pk1d4-0 vatJD FormField__FormFieldContentBox-sc-m9hood-1 jOSlAf"
       >
         <label
           class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dOWXkA"
@@ -1727,10 +1727,10 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation\\n  do
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 dVwWlz"
+      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 eRYfaf"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 cavXRX"
+        class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 jOSlAf"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 cJjrXo"
@@ -1745,10 +1745,10 @@ exports[`Form uncontrolled dynamicly removed fields using blur validation\\n  do
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 dVwWlz"
+      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 eRYfaf"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 vatJD FormField__FormFieldContentBox-sc-m9hood-1 uIZRw"
+        class="StyledBox-sc-13pk1d4-0 vatJD FormField__FormFieldContentBox-sc-m9hood-1 iDyRNM"
       >
         <label
           class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 NUQQS"
@@ -2941,7 +2941,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 dVwWlz"
+      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 eRYfaf"
     >
       <label
         class="StyledText-sc-1sadyjn-0 cdcdWR"
@@ -2951,7 +2951,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
         Select Size
       </label>
       <div
-        class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 cavXRX"
+        class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 jOSlAf"
       >
         <button
           aria-expanded="false"
@@ -3006,7 +3006,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 dVwWlz"
+      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 eRYfaf"
     >
       <label
         class="StyledText-sc-1sadyjn-0 cdcdWR"
@@ -3016,7 +3016,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
         CheckBox
       </label>
       <div
-        class="StyledBox-sc-13pk1d4-0 vatJD FormField__FormFieldContentBox-sc-m9hood-1 cavXRX"
+        class="StyledBox-sc-13pk1d4-0 vatJD FormField__FormFieldContentBox-sc-m9hood-1 jOSlAf"
       >
         <label
           class="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 dOWXkA"
@@ -3042,7 +3042,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
       </div>
     </div>
     <div
-      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 dVwWlz"
+      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 eRYfaf"
     >
       <label
         class="StyledText-sc-1sadyjn-0 cdcdWR"
@@ -3052,7 +3052,7 @@ exports[`Form uncontrolled reset clears select, checkbox, radiobuttongroup 2`] =
         RadioButtonGroup
       </label>
       <div
-        class="StyledBox-sc-13pk1d4-0 vatJD FormField__FormFieldContentBox-sc-m9hood-1 cavXRX"
+        class="StyledBox-sc-13pk1d4-0 vatJD FormField__FormFieldContentBox-sc-m9hood-1 jOSlAf"
       >
         <div
           aria-labelledby="grommet-test-radiobuttongroup__label"
@@ -3352,10 +3352,10 @@ exports[`Form uncontrolled uncontrolled 2`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 dVwWlz"
+      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 eRYfaf"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 cavXRX"
+        class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 jOSlAf"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 cJjrXo"
@@ -3385,10 +3385,10 @@ exports[`Form uncontrolled uncontrolled 3`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 dVwWlz"
+      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 eRYfaf"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 cavXRX"
+        class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 jOSlAf"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 cJjrXo"
@@ -3610,10 +3610,10 @@ exports[`Form uncontrolled uncontrolled onValidate 2`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 dVwWlz"
+      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 eRYfaf"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 hwtHNC FormField__FormFieldContentBox-sc-m9hood-1 cavXRX"
+        class="StyledBox-sc-13pk1d4-0 hwtHNC FormField__FormFieldContentBox-sc-m9hood-1 jOSlAf"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 cJjrXo"
@@ -3863,10 +3863,10 @@ exports[`Form uncontrolled uncontrolled onValidate custom error 2`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 dVwWlz"
+      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 eRYfaf"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 hwtHNC FormField__FormFieldContentBox-sc-m9hood-1 cavXRX"
+        class="StyledBox-sc-13pk1d4-0 hwtHNC FormField__FormFieldContentBox-sc-m9hood-1 jOSlAf"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 cJjrXo"
@@ -4116,10 +4116,10 @@ exports[`Form uncontrolled uncontrolled onValidate custom info 2`] = `
 >
   <form>
     <div
-      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 dVwWlz"
+      class="StyledBox-sc-13pk1d4-0 ijynHY FormField__FormFieldBox-sc-m9hood-0 eRYfaf"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 cavXRX"
+        class="StyledBox-sc-13pk1d4-0 bidgoa FormField__FormFieldContentBox-sc-m9hood-1 jOSlAf"
       >
         <div
           class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 cJjrXo"

--- a/src/js/components/FormField/FormField.js
+++ b/src/js/components/FormField/FormField.js
@@ -9,10 +9,12 @@ import React, {
   useMemo,
   useState,
 } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import {
+  backgroundStyle,
   containsFocus,
+  normalizeColor,
   shouldKeepFocus,
   withinDropPortal,
   PortalContext,
@@ -87,19 +89,40 @@ const getFocusStyle = (props) => {
   return props.focus ? focusStyle({ justBorder: true }) : undefined;
 };
 
+// allowHover is set by FormField only on the element rendering the field
+// container, and only when no higher priority state (disabled, readOnly,
+// error, focus) applies. When the theme has no border, only the background
+// portion of the hover config has anything to paint.
+const getHoverStyle = (props) => {
+  const hover = props.theme.formField?.hover;
+  if (!props.allowHover || !hover) return undefined;
+  const borderColor = hover.border?.color;
+  if (!borderColor && hover.background === undefined) return undefined;
+  return css`
+    &:hover {
+      ${borderColor &&
+      `border-color: ${normalizeColor(borderColor, props.theme)};`}
+      ${backgroundStyle(hover.background, props.theme)}
+    }
+  `;
+};
+
 const FormFieldBox = styled(Box)`
   ${(props) => getFocusStyle(props)}
+  ${(props) => getHoverStyle(props)}
   ${(props) => props.theme.formField?.extend}
 `;
 
 const FormFieldContentBox = styled(Box)`
   ${(props) => getFocusStyle(props)}
+  ${(props) => getHoverStyle(props)}
   ${(props) =>
     props.theme.formField &&
     props.theme.formField[props?.componentName]?.container?.extend}
 `;
 
 const StyledContentsBox = styled(Box)`
+  ${(props) => getHoverStyle(props)}
   ${(props) =>
     props.theme.formField &&
     props.theme.formField[props?.componentName]?.container?.extend}
@@ -486,6 +509,8 @@ const FormField = forwardRef(
       }
     });
 
+    const allowHover = !disabled && !readOnlyField && !error && !focus;
+
     if (!themeBorder) {
       contents = (
         <StyledContentsBox
@@ -494,6 +519,7 @@ const FormField = forwardRef(
           componentName={childName}
           {...themeContentProps}
           {...contentProps}
+          allowHover={allowHover} // internal prop
         >
           {contents}
         </StyledContentsBox>
@@ -597,6 +623,8 @@ const FormField = forwardRef(
           {...innerProps}
           {...contentProps}
           containerFocus={containerFocus} // internal prop
+          // internal prop
+          allowHover={allowHover && themeBorder.position === 'inner'}
           {...passThemeFlag}
         >
           {contents}
@@ -695,6 +723,8 @@ const FormField = forwardRef(
         {...outerProps}
         style={outerStyle}
         containerFocus={containerFocus} // internal prop
+        // internal prop
+        allowHover={allowHover && themeBorder?.position === 'outer'}
         onFocus={(event) => {
           const root = formFieldRef.current?.getRootNode();
           if (root) {

--- a/src/js/components/FormField/FormField.js
+++ b/src/js/components/FormField/FormField.js
@@ -89,40 +89,45 @@ const getFocusStyle = (props) => {
   return props.focus ? focusStyle({ justBorder: true }) : undefined;
 };
 
-// allowHover is set by FormField only on the element rendering the field
-// container, and only when no higher priority state (disabled, readOnly,
-// error, focus) applies. When the theme has no border, only the background
-// portion of the hover config has anything to paint.
-const getHoverStyle = (props) => {
+// The border color has to be painted by whichever element owns the border,
+// but the background belongs on the content element so it doesn't bleed
+// behind the label and messages when the border is positioned 'outer'.
+// FormField sets allowHover only when no higher priority state (disabled,
+// readOnly, error, focus) applies.
+const getHoverStyle = (role) => (props) => {
   const hover = props.theme.formField?.hover;
   if (!props.allowHover || !hover) return undefined;
-  const borderColor = hover.border?.color;
-  if (!borderColor && hover.background === undefined) return undefined;
+  const position = props.theme.formField?.border?.position;
+  const ownsBorder =
+    role === 'outer' ? position === 'outer' : position === 'inner';
+  const borderColor = ownsBorder ? hover.border?.color : undefined;
+  const background = role === 'content' ? hover.background : undefined;
+  if (!borderColor && background === undefined) return undefined;
   return css`
     &:hover {
       ${borderColor &&
       `border-color: ${normalizeColor(borderColor, props.theme)};`}
-      ${backgroundStyle(hover.background, props.theme)}
+      ${backgroundStyle(background, props.theme)}
     }
   `;
 };
 
 const FormFieldBox = styled(Box)`
   ${(props) => getFocusStyle(props)}
-  ${(props) => getHoverStyle(props)}
+  ${getHoverStyle('outer')}
   ${(props) => props.theme.formField?.extend}
 `;
 
 const FormFieldContentBox = styled(Box)`
   ${(props) => getFocusStyle(props)}
-  ${(props) => getHoverStyle(props)}
+  ${getHoverStyle('content')}
   ${(props) =>
     props.theme.formField &&
     props.theme.formField[props?.componentName]?.container?.extend}
 `;
 
 const StyledContentsBox = styled(Box)`
-  ${(props) => getHoverStyle(props)}
+  ${getHoverStyle('content')}
   ${(props) =>
     props.theme.formField &&
     props.theme.formField[props?.componentName]?.container?.extend}
@@ -623,8 +628,7 @@ const FormField = forwardRef(
           {...innerProps}
           {...contentProps}
           containerFocus={containerFocus} // internal prop
-          // internal prop
-          allowHover={allowHover && themeBorder.position === 'inner'}
+          allowHover={allowHover} // internal prop
           {...passThemeFlag}
         >
           {contents}
@@ -723,8 +727,7 @@ const FormField = forwardRef(
         {...outerProps}
         style={outerStyle}
         containerFocus={containerFocus} // internal prop
-        // internal prop
-        allowHover={allowHover && themeBorder?.position === 'outer'}
+        allowHover={allowHover} // internal prop
         onFocus={(event) => {
           const root = formFieldRef.current?.getRootNode();
           if (root) {

--- a/src/js/components/FormField/FormField.js
+++ b/src/js/components/FormField/FormField.js
@@ -102,7 +102,7 @@ const getHoverStyle = (props) => {
     &:hover {
       ${borderColor &&
       `border-color: ${normalizeColor(borderColor, props.theme)};`}
-      ${backgroundStyle(hover.background, props.theme)}
+      ${backgroundStyle(hover.background, props.theme, false)}
     }
   `;
 };

--- a/src/js/components/FormField/__tests__/FormField-test.tsx
+++ b/src/js/components/FormField/__tests__/FormField-test.tsx
@@ -908,6 +908,25 @@ describe('FormField', () => {
       ).toHaveStyleRule('border-color', '#AAFF00', { modifier: ':hover' });
     });
 
+    test('keeps hover background off the outer box so it does not cover the label', () => {
+      const { container } = render(
+        <Grommet theme={outerHoverTheme}>
+          <FormField label="Label">
+            <TextInput />
+          </FormField>
+        </Grommet>,
+      );
+
+      expect(
+        container.querySelector('[class*="FormFieldBox"]'),
+      ).not.toHaveStyleRule('background-color', '#654321', {
+        modifier: ':hover',
+      });
+      expect(
+        container.querySelector('[class*="FormFieldContentBox"]'),
+      ).toHaveStyleRule('background-color', '#654321', { modifier: ':hover' });
+    });
+
     test('applies theme hover background when theme has no border', () => {
       const { container } = render(
         <Grommet

--- a/src/js/components/FormField/__tests__/FormField-test.tsx
+++ b/src/js/components/FormField/__tests__/FormField-test.tsx
@@ -856,4 +856,131 @@ describe('FormField', () => {
     );
     expect(textContentBox).not.toHaveStyleRule('background-color', '#123456');
   });
+
+  describe('hover', () => {
+    const hoverTheme = {
+      formField: {
+        hover: {
+          background: '#654321',
+          border: { color: '#AAFF00' },
+        },
+      },
+    };
+
+    const outerHoverTheme = {
+      formField: {
+        ...hoverTheme.formField,
+        border: { position: 'outer' as const, side: 'all' as const },
+      },
+    };
+
+    test('applies theme hover border and background to inner border', () => {
+      const { container } = render(
+        <Grommet theme={hoverTheme}>
+          <FormField label="Label">
+            <TextInput />
+          </FormField>
+        </Grommet>,
+      );
+
+      const contentBox = container.querySelector(
+        '[class*="FormFieldContentBox"]',
+      );
+      expect(contentBox).toHaveStyleRule('border-color', '#AAFF00', {
+        modifier: ':hover',
+      });
+      expect(contentBox).toHaveStyleRule('background-color', '#654321', {
+        modifier: ':hover',
+      });
+    });
+
+    test('applies theme hover border to outer border', () => {
+      const { container } = render(
+        <Grommet theme={outerHoverTheme}>
+          <FormField label="Label">
+            <TextInput />
+          </FormField>
+        </Grommet>,
+      );
+
+      expect(
+        container.querySelector('[class*="FormFieldBox"]'),
+      ).toHaveStyleRule('border-color', '#AAFF00', { modifier: ':hover' });
+    });
+
+    test('applies theme hover background when theme has no border', () => {
+      const { container } = render(
+        <Grommet
+          theme={{ formField: { ...hoverTheme.formField, border: false } }}
+        >
+          <FormField label="Label">
+            <TextInput />
+          </FormField>
+        </Grommet>,
+      );
+
+      expect(
+        container.querySelector('[class*="StyledContentsBox"]'),
+      ).toHaveStyleRule('background-color', '#654321', { modifier: ':hover' });
+    });
+
+    test('does not apply hover styling when disabled', () => {
+      const { container } = render(
+        <Grommet theme={hoverTheme}>
+          <FormField label="Label" disabled>
+            <TextInput disabled />
+          </FormField>
+        </Grommet>,
+      );
+
+      expect(
+        container.querySelector('[class*="FormFieldContentBox"]'),
+      ).not.toHaveStyleRule('border-color', '#AAFF00', { modifier: ':hover' });
+    });
+
+    test('does not apply hover styling when readOnly', () => {
+      const { container } = render(
+        <Grommet theme={hoverTheme}>
+          <FormField label="Label">
+            <TextInput readOnly />
+          </FormField>
+        </Grommet>,
+      );
+
+      expect(
+        container.querySelector('[class*="FormFieldContentBox"]'),
+      ).not.toHaveStyleRule('border-color', '#AAFF00', { modifier: ':hover' });
+    });
+
+    test('does not apply hover styling when there is an error', () => {
+      const { container } = render(
+        <Grommet theme={hoverTheme}>
+          <FormField label="Label" error="Required">
+            <TextInput />
+          </FormField>
+        </Grommet>,
+      );
+
+      expect(
+        container.querySelector('[class*="FormFieldContentBox"]'),
+      ).not.toHaveStyleRule('border-color', '#AAFF00', { modifier: ':hover' });
+    });
+
+    test('does not apply hover styling when focused', async () => {
+      const user = userEvent.setup();
+      const { container } = render(
+        <Grommet theme={hoverTheme}>
+          <FormField label="Label">
+            <TextInput />
+          </FormField>
+        </Grommet>,
+      );
+
+      await user.click(screen.getByRole('textbox'));
+
+      expect(
+        container.querySelector('[class*="FormFieldContentBox"]'),
+      ).not.toHaveStyleRule('border-color', '#AAFF00', { modifier: ':hover' });
+    });
+  });
 });

--- a/src/js/components/FormField/__tests__/__snapshots__/FormField-test.tsx.snap
+++ b/src/js/components/FormField/__tests__/__snapshots__/FormField-test.tsx.snap
@@ -3067,7 +3067,7 @@ exports[`FormField pad with border undefined 1`] = `
         label
       </label>
       <div
-        class="c3 FormField__StyledContentsBox-sc-m9hood-2"
+        class="c3 "
       >
         <div
           class="c4"

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -1261,6 +1261,12 @@ export interface ThemeType {
       container?: BoxProps;
       icon?: any;
     };
+    hover?: {
+      background?: BackgroundType;
+      border?: {
+        color?: ColorType;
+      };
+    };
     help?: {
       color?: ColorType;
       margin?: MarginType;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1337,6 +1337,14 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         // container: {}, // any Box props
         // icon: undefined,
       },
+      // hover: {
+      //   background: {
+      //     color: undefined,
+      //   },
+      //   border: {
+      //     color: undefined,
+      //   },
+      // },
       // extend: undefined,
       help: {
         color: 'dark-2',


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Adds ability for callers to define a FormField's hover state (specifically border and background colors) in their theme.

#### Where should the reviewer start?

- https://github.com/grommet/hpe-design-system/issues/6506
- FormField.js

#### What testing has been done on this PR?

Storybook + Jest

#### How should this be manually tested?

```js
// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
// SPDX-License-Identifier: Apache-2.0
import React from 'react';

import { Box, FormField, Grommet, TextInput } from 'grommet';
import { grommet, ThemeType } from 'grommet/themes';
import { deepMerge } from 'grommet/utils';

// Type annotations can only be used in TypeScript files.
// Remove ': ThemeType' if you are not using Typescript.
const customTheme: ThemeType = {
  formField: {
    hover: {
      background: 'background-contrast',
      border: {
        color: 'brand',
      },
    },
  },
};

export const Hover = () => (
  <Grommet theme={deepMerge(grommet, customTheme)}>
    <Box align="center" gap="medium" pad="large">
      <FormField label="Hover me" htmlFor="hover">
        <TextInput id="hover" placeholder="placeholder" />
      </FormField>
      <FormField label="Disabled" htmlFor="disabled" disabled>
        <TextInput id="disabled" placeholder="disabled" disabled />
      </FormField>
      <FormField label="Read only" htmlFor="read-only">
        <TextInput id="read-only" value="read only" readOnly />
      </FormField>
      <FormField label="Error" htmlFor="error" error="Required">
        <TextInput id="error" placeholder="placeholder" />
      </FormField>
    </Box>
  </Grommet>
);

export default {
  title: 'Input/FormField/Custom Themed/Hover',
};

```

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

https://github.com/grommet/hpe-design-system/issues/6506

#### What are the relevant issues?

https://github.com/grommet/hpe-design-system/issues/6506

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

Yes, FormField theme docs

#### Should this PR be mentioned in the release notes?

Yes.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible
