### PR TITLE
StepperStep to use Grommet Button

### DIFF
--- a/src/js/components/Stepper/StepperStep.js
+++ b/src/js/components/Stepper/StepperStep.js
@@ -118,6 +118,8 @@ export const StepperStep = ({
       >
         <StyledStepButton
           plain
+          // indicator provides focus-visible treatment; avoid a second ring
+          focusIndicator={false}
           forwardedAs={isReadOnly ? 'div' : 'button'}
           role={isReadOnly ? 'group' : undefined}
           ref={(el) => {

--- a/src/js/components/Stepper/StepperStep.js
+++ b/src/js/components/Stepper/StepperStep.js
@@ -139,7 +139,6 @@ export const StepperStep = ({
           isSubStep={isSubStep}
           direction={direction}
           {...focusableProps}
-          {...passThemeFlag}
         >
           <StepperIndicator />
           <StyledStepContent

--- a/src/js/components/Stepper/StepperStep.js
+++ b/src/js/components/Stepper/StepperStep.js
@@ -94,7 +94,9 @@ export const StepperStep = ({
   }
 
   const focusableProps = isReadOnly
-    ? {}
+    ? // null rather than undefined, so Button's `type = 'button'` default
+      // parameter doesn't put a type attribute on the rendered div
+      { type: null }
     : {
         tabIndex: focusedIndex === index ? 0 : -1,
         onClick: handleClick,
@@ -115,7 +117,8 @@ export const StepperStep = ({
         {...passThemeFlag}
       >
         <StyledStepButton
-          as={isReadOnly ? 'div' : 'button'}
+          plain
+          forwardedAs={isReadOnly ? 'div' : 'button'}
           role={isReadOnly ? 'group' : undefined}
           ref={(el) => {
             if (stepRefs) {

--- a/src/js/components/Stepper/StyledStepper.js
+++ b/src/js/components/Stepper/StyledStepper.js
@@ -7,6 +7,7 @@ import {
   normalizeColor,
   styledComponentsConfig,
 } from '../../utils';
+import { Button } from '../Button';
 
 const getMetricSize = (theme, size) =>
   theme.global?.edgeSize?.[size] || theme.global?.size?.[size] || size;
@@ -69,18 +70,17 @@ const StyledStepItem = styled.li.withConfig({
   }}
 `;
 
-const StyledStepButton = styled.button.withConfig({
-  shouldForwardProp: (prop) => isPropValid(prop) && prop !== 'direction',
+// Button is rendered `plain`, which already clears border, outline and padding.
+// `direction` is stripped because isPropValid lets it reach the DOM.
+const StyledStepButton = styled(Button).withConfig({
+  shouldForwardProp: (prop) => prop !== 'direction',
 })`
   display: flex;
-  background: none;
-  border: none;
   padding: ${(props) =>
     props.theme.global?.edgeSize?.[
       props.theme.stepper?.button?.pad || 'xxsmall'
     ]};
   cursor: ${(props) => (props.isClickable ? 'pointer' : 'default')};
-  outline: none;
   ${(props) =>
     props.direction === 'vertical'
       ? css`

--- a/src/js/components/Stepper/__tests__/Stepper-test.js
+++ b/src/js/components/Stepper/__tests__/Stepper-test.js
@@ -225,7 +225,7 @@ describe('Stepper', () => {
     );
 
     const step1 = getByLabelText(/Step 1 of 3/);
-    step1.focus();
+    act(() => step1.focus());
     fireEvent.keyDown(step1, { key: 'ArrowRight' });
 
     const step2 = getByLabelText(/Step 2 of 3/);
@@ -240,7 +240,7 @@ describe('Stepper', () => {
     );
 
     const step2 = getByLabelText(/Step 2 of 3/);
-    step2.focus();
+    act(() => step2.focus());
     fireEvent.keyDown(step2, { key: 'End' });
 
     const step3 = getByLabelText(/Step 3 of 3/);
@@ -417,7 +417,7 @@ describe('Stepper', () => {
     );
 
     const step1 = getByLabelText(/Step 1 of 3/);
-    step1.focus();
+    act(() => step1.focus());
     fireEvent.keyDown(step1, { key: 'ArrowDown' });
 
     const step2 = getByLabelText(/Step 2 of 3/);

--- a/src/js/components/Stepper/__tests__/__snapshots__/Stepper-test.js.snap
+++ b/src/js/components/Stepper/__tests__/__snapshots__/Stepper-test.js.snap
@@ -14,6 +14,387 @@ exports[`Stepper renders horizontal steps 1`] = `
   overflow: hidden;
 }
 
+.c7 {
+  display: inline-block;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  fill: currentColor;
+  stroke: currentColor;
+}
+
+.c7 g {
+  fill: inherit;
+  stroke: inherit;
+}
+
+.c7 *:not([stroke])[fill='none'] {
+  stroke-width: 0;
+}
+
+.c7 *[stroke*='#'],
+.c7 *[STROKE*='#'] {
+  stroke: inherit;
+  fill: none;
+}
+
+.c7 *[fill-rule],
+.c7 *[FILL-RULE],
+.c7 *[fill*='#'],
+.c7 *[FILL*='#'] {
+  fill: inherit;
+  stroke: none;
+}
+
+.c9 {
+  font-size: 18px;
+  line-height: 24px;
+  white-space: nowrap;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: #7D4CDB;
+}
+
+.c12 {
+  font-size: 18px;
+  line-height: 24px;
+  white-space: nowrap;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: #444444;
+}
+
+.c3 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c3:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus >circle,
+.c3:focus >ellipse,
+.c3:focus >line,
+.c3:focus >path,
+.c3:focus >polygon,
+.c3:focus >polyline,
+.c3:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c3:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c3:focus:not(:focus-visible) >circle,
+.c3:focus:not(:focus-visible) >ellipse,
+.c3:focus:not(:focus-visible) >line,
+.c3:focus:not(:focus-visible) >path,
+.c3:focus:not(:focus-visible) >polygon,
+.c3:focus:not(:focus-visible) >polyline,
+.c3:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c3:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c2 {
+  display: flex;
+  position: relative;
+  flex-direction: column;
+  align-items: center;
+  flex: 1;
+  min-width: 0;
+  overflow: visible;
+}
+
+.c5 {
+  display: flex;
+  padding: 3px;
+  cursor: pointer;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  text-align: center;
+  width: 100%;
+}
+
+.c8 {
+  display: flex;
+  flex-direction: column;
+}
+
+.c6 {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  transition: transform 0.1s ease,background-color 0.15s ease,border-color 0.15s ease,color 0.15s ease;
+  width: 24px;
+  height: 24px;
+  min-width: 24px;
+  min-height: 24px;
+  border: 2px solid;
+  background: #7D4CDB;
+  color: #FFFFFF;
+  border-color: #7D4CDB;
+}
+
+.c4:focus-visible .c6 {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus-visible .c6 >circle,
+.c4:focus-visible .c6 >ellipse,
+.c4:focus-visible .c6 >line,
+.c4:focus-visible .c6 >path,
+.c4:focus-visible .c6 >polygon,
+.c4:focus-visible .c6 >polyline,
+.c4:focus-visible .c6 >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus-visible .c6 ::-moz-focus-inner {
+  border: 0;
+}
+
+.c4:not([aria-disabled]):active .c6 {
+  transform: scale(0.95);
+}
+
+.c4:not([aria-disabled]):hover .c6 {
+  background: color-mix(in srgb, #7D4CDB 80%, black);
+  border-color: color-mix(in srgb, #7D4CDB 80%, black);
+  color: #FFFFFF;
+}
+
+.c11 {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  transition: transform 0.1s ease,background-color 0.15s ease,border-color 0.15s ease,color 0.15s ease;
+  width: 24px;
+  height: 24px;
+  min-width: 24px;
+  min-height: 24px;
+  border: 2px solid;
+  background: #FFFFFF;
+  color: #000000;
+  border-color: #666666;
+}
+
+.c4:focus-visible .c11 {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus-visible .c11 >circle,
+.c4:focus-visible .c11 >ellipse,
+.c4:focus-visible .c11 >line,
+.c4:focus-visible .c11 >path,
+.c4:focus-visible .c11 >polygon,
+.c4:focus-visible .c11 >polyline,
+.c4:focus-visible .c11 >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c4:focus-visible .c11 ::-moz-focus-inner {
+  border: 0;
+}
+
+.c4:not([aria-disabled]):active .c11 {
+  transform: scale(0.95);
+}
+
+.c4:not([aria-disabled]):hover .c11 {
+  background: #FFFFFF;
+  border-color: #000000;
+  color: color-mix(in srgb, #000000 80%, black);
+}
+
+.c10 {
+  border-radius: 6px;
+  top: calc(24px / 2 + 3px);
+  left: calc(50% + calc(24px / 2 + 3px));
+  right: calc(-50% + calc(24px / 2 + 3px));
+  height: 2px;
+  margin-inline: 3px;
+  position: absolute;
+  background: rgba(0, 0, 0, 0.33);
+}
+
+@media only screen and (max-width: 768px) {
+  .c1 {
+    margin: 0px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .c1 {
+    padding: 0px;
+  }
+}
+
+<div
+  class="c0"
+>
+  <ol
+    aria-label="Progress"
+    class="c1"
+    style="list-style: none;"
+  >
+    <li
+      class="c2"
+    >
+      <button
+        aria-current="step"
+        aria-label="Step 1 of 3: Step 1"
+        class="c3 c4 c5"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          class="c6"
+        >
+          <svg
+            aria-hidden="true"
+            aria-label="Status is okay"
+            class="c7"
+            viewBox="0 0 12 12"
+          >
+            <circle
+              cx="6"
+              cy="6"
+              fill-rule="evenodd"
+              r="5"
+              stroke="#000"
+            />
+          </svg>
+        </span>
+        <span
+          class="c8"
+        >
+          <span
+            class="c9"
+          >
+            Step 1
+          </span>
+        </span>
+      </button>
+      <span
+        aria-hidden="true"
+        class="c10"
+        direction="horizontal"
+      />
+    </li>
+    <li
+      class="c2"
+    >
+      <button
+        aria-label="Step 2 of 3: Step 2"
+        class="c3 c4 c5"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="c11"
+        />
+        <span
+          class="c8"
+        >
+          <span
+            class="c12"
+          >
+            Step 2
+          </span>
+        </span>
+      </button>
+      <span
+        aria-hidden="true"
+        class="c10"
+        direction="horizontal"
+      />
+    </li>
+    <li
+      class="c2"
+    >
+      <button
+        aria-label="Step 3 of 3: Step 3"
+        class="c3 c4 c5"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="c11"
+        />
+        <span
+          class="c8"
+        >
+          <span
+            class="c12"
+          >
+            Step 3
+          </span>
+        </span>
+      </button>
+    </li>
+  </ol>
+</div>
+`;
+
+exports[`Stepper renders outside Grommet wrapper 1`] = `
+.c0 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  margin: 0px;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: row;
+  width: 100%;
+  padding: 0px;
+  overflow: hidden;
+}
+
 .c6 {
   display: inline-block;
   flex: 0 0 auto;
@@ -66,17 +447,64 @@ exports[`Stepper renders horizontal steps 1`] = `
   color: #444444;
 }
 
-.c0 {
-  font-size: 18px;
-  line-height: 24px;
+.c2 {
+  display: inline-block;
   box-sizing: border-box;
-  -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
 }
 
-.c2 {
+.c2:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c2:focus >circle,
+.c2:focus >ellipse,
+.c2:focus >line,
+.c2:focus >path,
+.c2:focus >polygon,
+.c2:focus >polyline,
+.c2:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c2:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c2:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c2:focus:not(:focus-visible) >circle,
+.c2:focus:not(:focus-visible) >ellipse,
+.c2:focus:not(:focus-visible) >line,
+.c2:focus:not(:focus-visible) >path,
+.c2:focus:not(:focus-visible) >polygon,
+.c2:focus:not(:focus-visible) >polyline,
+.c2:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c2:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
+}
+
+.c1 {
   display: flex;
   position: relative;
   flex-direction: column;
@@ -88,11 +516,8 @@ exports[`Stepper renders horizontal steps 1`] = `
 
 .c4 {
   display: flex;
-  background: none;
-  border: none;
   padding: 3px;
   cursor: pointer;
-  outline: none;
   flex-direction: column;
   align-items: center;
   gap: 6px;
@@ -209,323 +634,6 @@ exports[`Stepper renders horizontal steps 1`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c1 {
-    margin: 0px;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c1 {
-    padding: 0px;
-  }
-}
-
-<div
-  class="c0"
->
-  <ol
-    aria-label="Progress"
-    class="c1"
-    style="list-style: none;"
-  >
-    <li
-      class="c2"
-    >
-      <button
-        aria-current="step"
-        aria-label="Step 1 of 3: Step 1"
-        class="c3 c4"
-        tabindex="0"
-        type="button"
-      >
-        <span
-          class="c5"
-        >
-          <svg
-            aria-hidden="true"
-            aria-label="Status is okay"
-            class="c6"
-            viewBox="0 0 12 12"
-          >
-            <circle
-              cx="6"
-              cy="6"
-              fill-rule="evenodd"
-              r="5"
-              stroke="#000"
-            />
-          </svg>
-        </span>
-        <span
-          class="c7"
-        >
-          <span
-            class="c8"
-          >
-            Step 1
-          </span>
-        </span>
-      </button>
-      <span
-        aria-hidden="true"
-        class="c9"
-        direction="horizontal"
-      />
-    </li>
-    <li
-      class="c2"
-    >
-      <button
-        aria-label="Step 2 of 3: Step 2"
-        class="c3 c4"
-        tabindex="-1"
-        type="button"
-      >
-        <span
-          class="c10"
-        />
-        <span
-          class="c7"
-        >
-          <span
-            class="c11"
-          >
-            Step 2
-          </span>
-        </span>
-      </button>
-      <span
-        aria-hidden="true"
-        class="c9"
-        direction="horizontal"
-      />
-    </li>
-    <li
-      class="c2"
-    >
-      <button
-        aria-label="Step 3 of 3: Step 3"
-        class="c3 c4"
-        tabindex="-1"
-        type="button"
-      >
-        <span
-          class="c10"
-        />
-        <span
-          class="c7"
-        >
-          <span
-            class="c11"
-          >
-            Step 3
-          </span>
-        </span>
-      </button>
-    </li>
-  </ol>
-</div>
-`;
-
-exports[`Stepper renders outside Grommet wrapper 1`] = `
-.c0 {
-  display: flex;
-  box-sizing: border-box;
-  max-width: 100%;
-  margin: 0px;
-  min-width: 0;
-  min-height: 0;
-  flex-direction: row;
-  width: 100%;
-  padding: 0px;
-  overflow: hidden;
-}
-
-.c5 {
-  display: inline-block;
-  flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
-  fill: currentColor;
-  stroke: currentColor;
-}
-
-.c5 g {
-  fill: inherit;
-  stroke: inherit;
-}
-
-.c5 *:not([stroke])[fill='none'] {
-  stroke-width: 0;
-}
-
-.c5 *[stroke*='#'],
-.c5 *[STROKE*='#'] {
-  stroke: inherit;
-  fill: none;
-}
-
-.c5 *[fill-rule],
-.c5 *[FILL-RULE],
-.c5 *[fill*='#'],
-.c5 *[FILL*='#'] {
-  fill: inherit;
-  stroke: none;
-}
-
-.c7 {
-  font-size: 18px;
-  line-height: 24px;
-  white-space: nowrap;
-  max-width: 100%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  color: #7D4CDB;
-}
-
-.c10 {
-  font-size: 18px;
-  line-height: 24px;
-  white-space: nowrap;
-  max-width: 100%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  color: #444444;
-}
-
-.c1 {
-  display: flex;
-  position: relative;
-  flex-direction: column;
-  align-items: center;
-  flex: 1;
-  min-width: 0;
-  overflow: visible;
-}
-
-.c3 {
-  display: flex;
-  background: none;
-  border: none;
-  padding: 3px;
-  cursor: pointer;
-  outline: none;
-  flex-direction: column;
-  align-items: center;
-  gap: 6px;
-  text-align: center;
-  width: 100%;
-}
-
-.c6 {
-  display: flex;
-  flex-direction: column;
-}
-
-.c4 {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 50%;
-  transition: transform 0.1s ease,background-color 0.15s ease,border-color 0.15s ease,color 0.15s ease;
-  width: 24px;
-  height: 24px;
-  min-width: 24px;
-  min-height: 24px;
-  border: 2px solid;
-  background: #7D4CDB;
-  color: #FFFFFF;
-  border-color: #7D4CDB;
-}
-
-.c2:focus-visible .c4 {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c2:focus-visible .c4 >circle,
-.c2:focus-visible .c4 >ellipse,
-.c2:focus-visible .c4 >line,
-.c2:focus-visible .c4 >path,
-.c2:focus-visible .c4 >polygon,
-.c2:focus-visible .c4 >polyline,
-.c2:focus-visible .c4 >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c2:focus-visible .c4 ::-moz-focus-inner {
-  border: 0;
-}
-
-.c2:not([aria-disabled]):active .c4 {
-  transform: scale(0.95);
-}
-
-.c2:not([aria-disabled]):hover .c4 {
-  background: color-mix(in srgb, #7D4CDB 80%, black);
-  border-color: color-mix(in srgb, #7D4CDB 80%, black);
-  color: #FFFFFF;
-}
-
-.c9 {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 50%;
-  transition: transform 0.1s ease,background-color 0.15s ease,border-color 0.15s ease,color 0.15s ease;
-  width: 24px;
-  height: 24px;
-  min-width: 24px;
-  min-height: 24px;
-  border: 2px solid;
-  background: #FFFFFF;
-  color: #000000;
-  border-color: #666666;
-}
-
-.c2:focus-visible .c9 {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c2:focus-visible .c9 >circle,
-.c2:focus-visible .c9 >ellipse,
-.c2:focus-visible .c9 >line,
-.c2:focus-visible .c9 >path,
-.c2:focus-visible .c9 >polygon,
-.c2:focus-visible .c9 >polyline,
-.c2:focus-visible .c9 >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c2:focus-visible .c9 ::-moz-focus-inner {
-  border: 0;
-}
-
-.c2:not([aria-disabled]):active .c9 {
-  transform: scale(0.95);
-}
-
-.c2:not([aria-disabled]):hover .c9 {
-  background: #FFFFFF;
-  border-color: #000000;
-  color: color-mix(in srgb, #000000 80%, black);
-}
-
-.c8 {
-  border-radius: 6px;
-  top: calc(24px / 2 + 3px);
-  left: calc(50% + calc(24px / 2 + 3px));
-  right: calc(-50% + calc(24px / 2 + 3px));
-  height: 2px;
-  margin-inline: 3px;
-  position: absolute;
-  background: rgba(0, 0, 0, 0.33);
-}
-
-@media only screen and (max-width: 768px) {
   .c0 {
     margin: 0px;
   }
@@ -548,17 +656,17 @@ exports[`Stepper renders outside Grommet wrapper 1`] = `
     <button
       aria-current="step"
       aria-label="Step 1 of 3: Step 1"
-      class="c2 c3"
+      class="c2 c3 c4"
       tabindex="0"
       type="button"
     >
       <span
-        class="c4"
+        class="c5"
       >
         <svg
           aria-hidden="true"
           aria-label="Status is okay"
-          class="c5"
+          class="c6"
           viewBox="0 0 12 12"
         >
           <circle
@@ -571,10 +679,10 @@ exports[`Stepper renders outside Grommet wrapper 1`] = `
         </svg>
       </span>
       <span
-        class="c6"
+        class="c7"
       >
         <span
-          class="c7"
+          class="c8"
         >
           Step 1
         </span>
@@ -582,7 +690,7 @@ exports[`Stepper renders outside Grommet wrapper 1`] = `
     </button>
     <span
       aria-hidden="true"
-      class="c8"
+      class="c9"
       direction="horizontal"
     />
   </li>
@@ -591,18 +699,18 @@ exports[`Stepper renders outside Grommet wrapper 1`] = `
   >
     <button
       aria-label="Step 2 of 3: Step 2"
-      class="c2 c3"
+      class="c2 c3 c4"
       tabindex="-1"
       type="button"
     >
       <span
-        class="c9"
+        class="c10"
       />
       <span
-        class="c6"
+        class="c7"
       >
         <span
-          class="c10"
+          class="c11"
         >
           Step 2
         </span>
@@ -610,7 +718,7 @@ exports[`Stepper renders outside Grommet wrapper 1`] = `
     </button>
     <span
       aria-hidden="true"
-      class="c8"
+      class="c9"
       direction="horizontal"
     />
   </li>
@@ -619,18 +727,18 @@ exports[`Stepper renders outside Grommet wrapper 1`] = `
   >
     <button
       aria-label="Step 3 of 3: Step 3"
-      class="c2 c3"
+      class="c2 c3 c4"
       tabindex="-1"
       type="button"
     >
       <span
-        class="c9"
+        class="c10"
       />
       <span
-        class="c6"
+        class="c7"
       >
         <span
-          class="c10"
+          class="c11"
         >
           Step 3
         </span>
@@ -654,7 +762,7 @@ exports[`Stepper renders vertical steps 1`] = `
   overflow: hidden;
 }
 
-.c10 {
+.c11 {
   display: inline-block;
   flex: 0 0 auto;
   width: 24px;
@@ -663,39 +771,96 @@ exports[`Stepper renders vertical steps 1`] = `
   stroke: currentColor;
 }
 
-.c10 g {
+.c11 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c10 *:not([stroke])[fill='none'] {
+.c11 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c10 *[stroke*='#'],
-.c10 *[STROKE*='#'] {
+.c11 *[stroke*='#'],
+.c11 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c10 *[fill-rule],
-.c10 *[FILL-RULE],
-.c10 *[fill*='#'],
-.c10 *[FILL*='#'] {
+.c11 *[fill-rule],
+.c11 *[FILL-RULE],
+.c11 *[fill*='#'],
+.c11 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
 
-.c7 {
+.c8 {
   font-size: 18px;
   line-height: 24px;
   color: #444444;
 }
 
-.c11 {
+.c12 {
   font-size: 18px;
   line-height: 24px;
   color: #7D4CDB;
+}
+
+.c3 {
+  display: inline-block;
+  box-sizing: border-box;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
+  text-transform: none;
+  color: inherit;
+  outline: none;
+  border: none;
+  padding: 0;
+  text-align: inherit;
+}
+
+.c3:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus >circle,
+.c3:focus >ellipse,
+.c3:focus >line,
+.c3:focus >path,
+.c3:focus >polygon,
+.c3:focus >polyline,
+.c3:focus >rect {
+  outline: none;
+  box-shadow: 0 0 2px 2px #6FFFB0;
+}
+
+.c3:focus ::-moz-focus-inner {
+  border: 0;
+}
+
+.c3:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.c3:focus:not(:focus-visible) >circle,
+.c3:focus:not(:focus-visible) >ellipse,
+.c3:focus:not(:focus-visible) >line,
+.c3:focus:not(:focus-visible) >path,
+.c3:focus:not(:focus-visible) >polygon,
+.c3:focus:not(:focus-visible) >polyline,
+.c3:focus:not(:focus-visible) >rect {
+  outline: none;
+  box-shadow: none;
+}
+
+.c3:focus:not(:focus-visible) ::-moz-focus-inner {
+  border: 0;
 }
 
 .c0 {
@@ -716,7 +881,7 @@ exports[`Stepper renders vertical steps 1`] = `
   padding-bottom: 24px;
 }
 
-.c12 {
+.c13 {
   display: flex;
   position: relative;
   flex-direction: column;
@@ -724,26 +889,23 @@ exports[`Stepper renders vertical steps 1`] = `
   padding-bottom: 0px;
 }
 
-.c4 {
+.c5 {
   display: flex;
-  background: none;
-  border: none;
   padding: 3px;
   cursor: pointer;
-  outline: none;
   flex-direction: row;
   align-items: flex-start;
   gap: 12px;
   text-align: left;
 }
 
-.c6 {
+.c7 {
   display: flex;
   flex-direction: column;
   padding-top: calc((24px - 20px) / 2);
 }
 
-.c5 {
+.c6 {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -759,37 +921,37 @@ exports[`Stepper renders vertical steps 1`] = `
   border-color: #666666;
 }
 
-.c3:focus-visible .c5 {
+.c4:focus-visible .c6 {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus-visible .c5 >circle,
-.c3:focus-visible .c5 >ellipse,
-.c3:focus-visible .c5 >line,
-.c3:focus-visible .c5 >path,
-.c3:focus-visible .c5 >polygon,
-.c3:focus-visible .c5 >polyline,
-.c3:focus-visible .c5 >rect {
+.c4:focus-visible .c6 >circle,
+.c4:focus-visible .c6 >ellipse,
+.c4:focus-visible .c6 >line,
+.c4:focus-visible .c6 >path,
+.c4:focus-visible .c6 >polygon,
+.c4:focus-visible .c6 >polyline,
+.c4:focus-visible .c6 >rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus-visible .c5 ::-moz-focus-inner {
+.c4:focus-visible .c6 ::-moz-focus-inner {
   border: 0;
 }
 
-.c3:not([aria-disabled]):active .c5 {
+.c4:not([aria-disabled]):active .c6 {
   transform: scale(0.95);
 }
 
-.c3:not([aria-disabled]):hover .c5 {
+.c4:not([aria-disabled]):hover .c6 {
   background: #FFFFFF;
   border-color: #000000;
   color: color-mix(in srgb, #000000 80%, black);
 }
 
-.c9 {
+.c10 {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -805,37 +967,37 @@ exports[`Stepper renders vertical steps 1`] = `
   border-color: #7D4CDB;
 }
 
-.c3:focus-visible .c9 {
+.c4:focus-visible .c10 {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus-visible .c9 >circle,
-.c3:focus-visible .c9 >ellipse,
-.c3:focus-visible .c9 >line,
-.c3:focus-visible .c9 >path,
-.c3:focus-visible .c9 >polygon,
-.c3:focus-visible .c9 >polyline,
-.c3:focus-visible .c9 >rect {
+.c4:focus-visible .c10 >circle,
+.c4:focus-visible .c10 >ellipse,
+.c4:focus-visible .c10 >line,
+.c4:focus-visible .c10 >path,
+.c4:focus-visible .c10 >polygon,
+.c4:focus-visible .c10 >polyline,
+.c4:focus-visible .c10 >rect {
   outline: none;
   box-shadow: 0 0 2px 2px #6FFFB0;
 }
 
-.c3:focus-visible .c9 ::-moz-focus-inner {
+.c4:focus-visible .c10 ::-moz-focus-inner {
   border: 0;
 }
 
-.c3:not([aria-disabled]):active .c9 {
+.c4:not([aria-disabled]):active .c10 {
   transform: scale(0.95);
 }
 
-.c3:not([aria-disabled]):hover .c9 {
+.c4:not([aria-disabled]):hover .c10 {
   background: color-mix(in srgb, #7D4CDB 80%, black);
   border-color: color-mix(in srgb, #7D4CDB 80%, black);
   color: #FFFFFF;
 }
 
-.c8 {
+.c9 {
   border-radius: 6px;
   left: calc( calc(24px / 2 + 3px) + 2px - 2px / 2 );
   top: calc(24px + 3px +       (2px * 2) + 4px);
@@ -872,18 +1034,18 @@ exports[`Stepper renders vertical steps 1`] = `
     >
       <button
         aria-label="Step 1 of 3: Step 1"
-        class="c3 c4"
+        class="c3 c4 c5"
         tabindex="-1"
         type="button"
       >
         <span
-          class="c5"
+          class="c6"
         />
         <span
-          class="c6"
+          class="c7"
         >
           <span
-            class="c7"
+            class="c8"
           >
             Step 1
           </span>
@@ -891,7 +1053,7 @@ exports[`Stepper renders vertical steps 1`] = `
       </button>
       <span
         aria-hidden="true"
-        class="c8"
+        class="c9"
         direction="vertical"
       />
     </li>
@@ -901,17 +1063,17 @@ exports[`Stepper renders vertical steps 1`] = `
       <button
         aria-current="step"
         aria-label="Step 2 of 3: Step 2"
-        class="c3 c4"
+        class="c3 c4 c5"
         tabindex="0"
         type="button"
       >
         <span
-          class="c9"
+          class="c10"
         >
           <svg
             aria-hidden="true"
             aria-label="Status is okay"
-            class="c10"
+            class="c11"
             viewBox="0 0 12 12"
           >
             <circle
@@ -924,10 +1086,10 @@ exports[`Stepper renders vertical steps 1`] = `
           </svg>
         </span>
         <span
-          class="c6"
+          class="c7"
         >
           <span
-            class="c11"
+            class="c12"
           >
             Step 2
           </span>
@@ -935,27 +1097,27 @@ exports[`Stepper renders vertical steps 1`] = `
       </button>
       <span
         aria-hidden="true"
-        class="c8"
+        class="c9"
         direction="vertical"
       />
     </li>
     <li
-      class="c12"
+      class="c13"
     >
       <button
         aria-label="Step 3 of 3: Step 3"
-        class="c3 c4"
+        class="c3 c4 c5"
         tabindex="-1"
         type="button"
       >
         <span
-          class="c5"
+          class="c6"
         />
         <span
-          class="c6"
+          class="c7"
         >
           <span
-            class="c7"
+            class="c8"
           >
             Step 3
           </span>

--- a/src/js/components/Stepper/__tests__/__snapshots__/Stepper-test.js.snap
+++ b/src/js/components/Stepper/__tests__/__snapshots__/Stepper-test.js.snap
@@ -83,26 +83,6 @@ exports[`Stepper renders horizontal steps 1`] = `
   text-align: inherit;
 }
 
-.c3:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c3:focus >circle,
-.c3:focus >ellipse,
-.c3:focus >line,
-.c3:focus >path,
-.c3:focus >polygon,
-.c3:focus >polyline,
-.c3:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c3:focus ::-moz-focus-inner {
-  border: 0;
-}
-
 .c3:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -464,26 +444,6 @@ exports[`Stepper renders outside Grommet wrapper 1`] = `
   text-align: inherit;
 }
 
-.c2:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c2:focus >circle,
-.c2:focus >ellipse,
-.c2:focus >line,
-.c2:focus >path,
-.c2:focus >polygon,
-.c2:focus >polyline,
-.c2:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c2:focus ::-moz-focus-inner {
-  border: 0;
-}
-
 .c2:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
@@ -821,26 +781,6 @@ exports[`Stepper renders vertical steps 1`] = `
   border: none;
   padding: 0;
   text-align: inherit;
-}
-
-.c3:focus {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c3:focus >circle,
-.c3:focus >ellipse,
-.c3:focus >line,
-.c3:focus >path,
-.c3:focus >polygon,
-.c3:focus >polyline,
-.c3:focus >rect {
-  outline: none;
-  box-shadow: 0 0 2px 2px #6FFFB0;
-}
-
-.c3:focus ::-moz-focus-inner {
-  border: 0;
 }
 
 .c3:focus:not(:focus-visible) {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

This pull request refactors the `Stepper` component to improve accessibility, code maintainability, and styling consistency. The most significant changes involve updating how the step buttons are rendered and styled, as well as minor test adjustments for React best practices.

**Component and Styling Refactor:**

* The `StyledStepButton` is now based on the shared `Button` component instead of a native `button` element, ensuring consistent styling and behavior across the app. The `plain` prop is used to clear default button styles, and unnecessary CSS is removed. (`src/js/components/Stepper/StyledStepper.js` [[1]](diffhunk://#diff-2fcd426f025d5c79eea03aaa904576385b5001f572cb9363081601d06ba1abbbR10) [[2]](diffhunk://#diff-2fcd426f025d5c79eea03aaa904576385b5001f572cb9363081601d06ba1abbbL72-L83)
* The `StyledStepButton` is rendered with `forwardedAs` to switch between a `div` (for read-only steps) and a `button` (for interactive steps), and the `plain` prop is always set. (`src/js/components/Stepper/StepperStep.js` [src/js/components/Stepper/StepperStep.jsL118-R121](diffhunk://#diff-a59bde8156de272987f64c201c6a63e374e5f16ab98c324dc6d7a17e64ab913fL118-R121))

**Accessibility and Behavior:**

* For read-only steps, the `type` prop is now explicitly set to `null` to prevent unwanted `type` attributes on rendered `div` elements, improving semantic correctness. (`src/js/components/Stepper/StepperStep.js` [src/js/components/Stepper/StepperStep.jsL97-R99](diffhunk://#diff-a59bde8156de272987f64c201c6a63e374e5f16ab98c324dc6d7a17e64ab913fL97-R99))

**Testing Improvements:**

* Tests are updated to use the `act()` helper when focusing elements, aligning with React Testing Library best practices and ensuring proper state updates during tests. (`src/js/components/Stepper/__tests__/Stepper-test.js` [[1]](diffhunk://#diff-c7ead732b43a863dc213d08bc9f36f1560251f7320972ce84e3afca27f02ca20L228-R228) [[2]](diffhunk://#diff-c7ead732b43a863dc213d08bc9f36f1560251f7320972ce84e3afca27f02ca20L243-R243) [[3]](diffhunk://#diff-c7ead732b43a863dc213d08bc9f36f1560251f7320972ce84e3afca27f02ca20L420-R420)

#### Where should the reviewer start?

StepperStep.js

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

https://github.com/grommet/grommet/issues/8076

#### What are the relevant issues?

https://github.com/grommet/grommet/issues/8076

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No

#### Should this PR be mentioned in the release notes?

No

#### Is this change backwards compatible or is it a breaking change?

Backwards compatabile.
