### PR TITLE
[Stepper] Connector to use t-shirt size instead of px

### DIFF
--- a/src/js/components/Stepper/StyledStepper.js
+++ b/src/js/components/Stepper/StyledStepper.js
@@ -14,6 +14,9 @@ const getMetricSize = (theme, size) =>
 const getTextMetric = (theme, size, metric) =>
   theme.text?.[size]?.[metric] || theme.text?.medium?.[metric];
 
+const getBorderWidth = (theme, size) =>
+  theme.global?.borderSize?.[size] || theme.global?.borderSize?.xsmall;
+
 const getSubStepSizeToken = (indicatorSize) => {
   switch (indicatorSize) {
     case 'large':
@@ -252,10 +255,10 @@ const StyledConnector = styled.span.withConfig(styledComponentsConfig)`
       props.theme.global?.edgeSize?.[
         props.theme.stepper?.button?.pad || 'xxsmall'
       ];
-    const connectorThickness =
-      theme.stepper?.connector?.stroke?.width ||
-      theme.global?.borderSize?.small ||
-      '2px';
+    const connectorStrokeToken =
+      theme.stepper?.connector?.stroke?.width || 'small';
+    const connectorThickness = getBorderWidth(theme, connectorStrokeToken);
+
     const connectorRadius = theme.global?.edgeSize?.xsmall || '4px';
     const connectorOffset = `calc(${parentSize} / 2 + ${buttonPad})`;
     const connectorGap = '4px';

--- a/src/js/components/Stepper/StyledStepper.js
+++ b/src/js/components/Stepper/StyledStepper.js
@@ -15,7 +15,7 @@ const getTextMetric = (theme, size, metric) =>
   theme.text?.[size]?.[metric] || theme.text?.medium?.[metric];
 
 const getBorderWidth = (theme, size) =>
-  theme.global?.borderSize?.[size] || theme.global?.borderSize?.xsmall;
+  theme.global?.borderSize?.[size] || size || theme.global?.borderSize?.xsmall;
 
 const getSubStepSizeToken = (indicatorSize) => {
   switch (indicatorSize) {

--- a/src/js/components/Stepper/__tests__/Stepper-test.js
+++ b/src/js/components/Stepper/__tests__/Stepper-test.js
@@ -133,6 +133,45 @@ describe('Stepper', () => {
     expect(getByTestId('custom-error-icon')).toBeTruthy();
   });
 
+  test('resolves connector thickness from a t-shirt border size token', () => {
+    const { container } = render(
+      <Grommet
+        theme={{
+          global: { borderSize: { small: '2px', large: '8px' } },
+          stepper: { connector: { stroke: { width: 'large' } } },
+        }}
+      >
+        <Stepper
+          steps={basicSteps}
+          currentStep="step1"
+          direction="horizontal"
+        />
+      </Grommet>,
+    );
+
+    const connector = container.querySelector('span[aria-hidden="true"]');
+    expect(connector).toHaveStyleRule('height', '8px');
+  });
+
+  test('resolves connector thickness from a literal CSS length', () => {
+    const { container } = render(
+      <Grommet
+        theme={{
+          stepper: { connector: { stroke: { width: '5px' } } },
+        }}
+      >
+        <Stepper
+          steps={basicSteps}
+          currentStep="step1"
+          direction="horizontal"
+        />
+      </Grommet>,
+    );
+
+    const connector = container.querySelector('span[aria-hidden="true"]');
+    expect(connector).toHaveStyleRule('height', '5px');
+  });
+
   test('renders disabled step with reason', () => {
     const steps = [
       { id: 'step1', title: 'Step 1', status: 'pending' },

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -2374,7 +2374,7 @@ export const generate = (baseSpacing = 24, scale = 6) => {
         },
       },
       connector: {
-        stroke: { width: '2px' },
+        stroke: { width: 'small' },
       },
       description: {
         size: 'small',


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

This pull request refactors how the connector stroke width is handled in the `Stepper` component, making it more consistent with theme tokens and improving maintainability. The main change is to use theme-based border size tokens instead of hardcoded pixel values for the connector thickness.

**Theme consistency and refactoring:**

* Added a `getBorderWidth` utility function in `StyledStepper.js` to retrieve border width from theme tokens, defaulting to `xsmall` if not specified.
* Updated the connector thickness logic in `StyledStepper.js` to use the new `getBorderWidth` function and theme tokens, replacing direct pixel values.
* Changed the default `stroke.width` for the stepper connector in the base theme from `'2px'` to the theme token `'small'` for better consistency across the design system.

#### Where should the reviewer start?

StepConnector.js

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

https://github.com/grommet/grommet/issues/8076

#### What are the relevant issues?

https://github.com/grommet/grommet/issues/8076

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

No. Type is unchanged. Still type = 'string'

#### Should this PR be mentioned in the release notes?

No.

#### Is this change backwards compatible or is it a breaking change?


Backwards compatible