### PR TITLE
fix calendar selected color in grommet dark mode

### DIFF
--- a/src/js/components/DateTimeInput/DateTimeInput.js
+++ b/src/js/components/DateTimeInput/DateTimeInput.js
@@ -18,6 +18,7 @@ import { normalizeStep, pad } from '../../utils/dates';
 import { useForwardedRef } from '../../utils';
 import { useSectionedField } from '../../utils/useSectionedField';
 import { useThemeValue } from '../../utils/useThemeValue';
+import { ThemeContext } from '../../contexts/ThemeContext';
 import { Box } from '../Box';
 import { Button } from '../Button';
 import { Calendar } from '../Calendar';
@@ -1347,11 +1348,29 @@ const DateTimeInput = forwardRef(
                 pad={theme.dateTimeInput?.drop?.pad}
                 gap={theme.dateTimeInput?.drop?.gap}
               >
-                <Calendar
-                  date={getCalendarDate(sections)}
-                  initialFocus="days"
-                  onSelect={handleCalendarSelect}
-                />
+                <ThemeContext.Extend
+                  value={{
+                    calendar: {
+                      day: {
+                        selected: {
+                          background:
+                            // Preserve an existing theme value first to avoid
+                            // breaking its auto-computed text contrast color
+                            // in hpe theme.
+                            theme.calendar?.day?.selected?.background ||
+                            theme.dateTimeInput?.calendar?.day?.selected
+                              ?.background,
+                        },
+                      },
+                    },
+                  }}
+                >
+                  <Calendar
+                    date={getCalendarDate(sections)}
+                    initialFocus="days"
+                    onSelect={handleCalendarSelect}
+                  />
+                </ThemeContext.Extend>
                 <Box
                   alignSelf="stretch"
                   flex={false}

--- a/src/js/components/DateTimeInput/DateTimeInput.js
+++ b/src/js/components/DateTimeInput/DateTimeInput.js
@@ -1357,7 +1357,7 @@ const DateTimeInput = forwardRef(
                             // Preserve an existing theme value first to avoid
                             // breaking its auto-computed text contrast color
                             // in hpe theme.
-                            theme.calendar?.day?.selected?.background ||
+                            theme.calendar?.day?.selected?.background ??
                             theme.dateTimeInput?.calendar?.day?.selected
                               ?.background,
                         },

--- a/src/js/components/DateTimeInput/DateTimeInput.js
+++ b/src/js/components/DateTimeInput/DateTimeInput.js
@@ -1354,12 +1354,9 @@ const DateTimeInput = forwardRef(
                       day: {
                         selected: {
                           background:
-                            // Preserve an existing theme value first to avoid
-                            // breaking its auto-computed text contrast color
-                            // in hpe theme.
-                            theme.calendar?.day?.selected?.background ??
                             theme.dateTimeInput?.calendar?.day?.selected
-                              ?.background,
+                              ?.background ||
+                            theme.calendar?.day?.selected?.background,
                         },
                       },
                     },

--- a/src/js/components/DateTimeInput/__tests__/DateTimeInput-test.tsx
+++ b/src/js/components/DateTimeInput/__tests__/DateTimeInput-test.tsx
@@ -1014,4 +1014,38 @@ describe('DateTimeInput', () => {
 
     expect(screen.getByText('Custom Calendar Icon')).toBeInTheDocument();
   });
+
+  test('applies dateTimeInput.calendar.day.selected.background in dark mode', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Grommet
+        theme={
+          {
+            dark: true,
+            dateTimeInput: {
+              calendar: {
+                day: {
+                  selected: { background: '#ABCDEF' },
+                },
+              },
+            },
+          } as any
+        }
+      >
+        <DateTimeInput format="24" value="2026-07-22T18:30:00.000Z" />
+      </Grommet>,
+    );
+
+    const trigger = screen.getByRole('button', { name: /date and time/i });
+    await user.click(trigger);
+
+    const drop = getDropFromTrigger(trigger);
+    const selectedDayButton = within(drop).getByRole('button', {
+      name: /Jul 22 2026/i,
+    });
+    // StyledDay is the first child div — it carries the background-color rule.
+    const dayCircle = selectedDayButton.querySelector('div');
+    expect(dayCircle).toHaveStyleRule('background-color', '#ABCDEF');
+  });
 });

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -1050,6 +1050,13 @@ export interface ThemeType {
         size?: string;
       };
     };
+    calendar?: {
+      day?: {
+        selected?: {
+          background?: BackgroundType;
+        };
+      };
+    };
     icon?: {
       calendar?: React.ReactNode | Icon;
     };

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1079,6 +1079,13 @@ export const generate = (baseSpacing = 24, scale = 6) => {
           size: 'xsmall',
         },
       },
+      calendar: {
+        day: {
+          selected: {
+            background: 'selected',
+          },
+        },
+      },
       icon: {
         calendar: undefined,
       },


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds a `theme.dateTimeInput.calendar.day.selected.background` theme value (defaults to `'selected'`) and applies it to the `Calendar` inside DateTimeInput's picker via `ThemeContext.Extend`. This aligns the selected day highlight color with the TimeInput's selected option color, which was inconsistent in dark mode where `'control'` (Calendar's fallback) resolves to `accent-1`
#### Where should the reviewer start?
base theme
#### What testing has been done on this PR?
locally 
#### How should this be manually tested?
locally look at storybook in darkmode
#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
`StyledCalendar.js` hardcodes `'control'` as the fallback for `calendar.day.selected.background`. In dark mode, `'control'` resolves to `accent-1` while `'selected'` resolves to `brand` causing the two pickers inside DateTimeInput to visually mismatch. The existing `theme.calendar?.day?.selected?.background` value takes priority inside the `ThemeContext.Extend` to avoid breaking hpe themes that already explicitly set the calendar selection color.
#### What are the relevant issues?
closes #8063 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
yes
#### Should this PR be mentioned in the release notes?
yes
#### Is this change backwards compatible or is it a breaking change?
 backwards compatible