### PR TITLE
fix inline behavior for datetimeinput

### DIFF
--- a/src/js/components/DateTimeInput/DateTimeInput.js
+++ b/src/js/components/DateTimeInput/DateTimeInput.js
@@ -1188,51 +1188,74 @@ const DateTimeInput = forwardRef(
     const generatedId = useId();
     const dropId = `${id || generatedId}__drop`;
 
-    if (inline) {
-      return (
-        <Box
-          direction="row"
-          pad={theme.dateTimeInput?.drop?.pad}
-          gap={theme.dateTimeInput?.drop?.gap}
+    const hiddenInput = name ? (
+      <input
+        aria-hidden="true"
+        name={name}
+        readOnly
+        tabIndex={-1}
+        type="hidden"
+        value={value || ''}
+      />
+    ) : null;
+
+    const pickerContent = (
+      <Box
+        direction="row"
+        pad={theme.dateTimeInput?.drop?.pad}
+        gap={theme.dateTimeInput?.drop?.gap}
+      >
+        <ThemeContext.Extend
+          value={{
+            calendar: {
+              day: {
+                selected: {
+                  background:
+                    theme.dateTimeInput?.calendar?.day?.selected?.background ||
+                    theme.calendar?.day?.selected?.background,
+                },
+              },
+            },
+          }}
         >
-          {name && (
-            <input
-              aria-hidden="true"
-              name={name}
-              readOnly
-              tabIndex={-1}
-              type="hidden"
-              value={value || ''}
-            />
-          )}
           <Calendar
             date={getCalendarDate(sections)}
+            initialFocus={inline ? undefined : 'days'}
             onSelect={disabled || readOnly ? undefined : handleCalendarSelect}
           />
-          <Box
-            alignSelf="stretch"
-            flex={false}
-            border={{
-              side: 'start',
-              color: theme.dateTimeInput?.drop?.border?.color,
-              size: theme.dateTimeInput?.drop?.border?.size,
-            }}
-          />
-          <TimeInput
-            inline
-            format={resolvedFormat}
-            value={timeValue}
-            showSeconds={showSeconds}
-            messages={messages}
-            minuteStep={normalizedMinuteStep}
-            disabled={disabled}
-            readOnly={readOnly}
-            onChange={disabled || readOnly ? undefined : handleTimeSelect}
-            onPartialChange={
-              disabled || readOnly ? undefined : handleTimePartialChange
-            }
-          />
-        </Box>
+        </ThemeContext.Extend>
+        <Box
+          alignSelf="stretch"
+          flex={false}
+          border={{
+            side: 'start',
+            color: theme.dateTimeInput?.drop?.border?.color,
+            size: theme.dateTimeInput?.drop?.border?.size,
+          }}
+        />
+        <TimeInput
+          inline
+          format={resolvedFormat}
+          value={timeValue}
+          showSeconds={showSeconds}
+          messages={messages}
+          minuteStep={normalizedMinuteStep}
+          disabled={disabled}
+          readOnly={readOnly}
+          onChange={disabled || readOnly ? undefined : handleTimeSelect}
+          onPartialChange={
+            disabled || readOnly ? undefined : handleTimePartialChange
+          }
+        />
+      </Box>
+    );
+
+    if (inline) {
+      return (
+        <>
+          {hiddenInput}
+          {pickerContent}
+        </>
       );
     }
 
@@ -1351,16 +1374,7 @@ const DateTimeInput = forwardRef(
               />
             )}
           </StyledDateTimeInputContainer>
-          {name && (
-            <input
-              aria-hidden="true"
-              name={name}
-              readOnly
-              tabIndex={-1}
-              type="hidden"
-              value={value || ''}
-            />
-          )}
+          {hiddenInput}
           {open && (
             <Drop
               id={dropId}
@@ -1369,53 +1383,7 @@ const DateTimeInput = forwardRef(
               onEsc={closePicker}
               onClickOutside={closePicker}
             >
-              <Box
-                direction="row"
-                pad={theme.dateTimeInput?.drop?.pad}
-                gap={theme.dateTimeInput?.drop?.gap}
-              >
-                <ThemeContext.Extend
-                  value={{
-                    calendar: {
-                      day: {
-                        selected: {
-                          background:
-                            theme.dateTimeInput?.calendar?.day?.selected
-                              ?.background ||
-                            theme.calendar?.day?.selected?.background,
-                        },
-                      },
-                    },
-                  }}
-                >
-                  <Calendar
-                    date={getCalendarDate(sections)}
-                    initialFocus="days"
-                    onSelect={handleCalendarSelect}
-                  />
-                </ThemeContext.Extend>
-                <Box
-                  alignSelf="stretch"
-                  flex={false}
-                  border={{
-                    side: 'start',
-                    color: theme.dateTimeInput?.drop?.border?.color,
-                    size: theme.dateTimeInput?.drop?.border?.size,
-                  }}
-                />
-                <TimeInput
-                  inline
-                  format={resolvedFormat}
-                  value={timeValue}
-                  showSeconds={showSeconds}
-                  messages={messages}
-                  minuteStep={normalizedMinuteStep}
-                  disabled={disabled}
-                  readOnly={readOnly}
-                  onChange={handleTimeSelect}
-                  onPartialChange={handleTimePartialChange}
-                />
-              </Box>
+              {pickerContent}
             </Drop>
           )}
         </Box>

--- a/src/js/components/DateTimeInput/DateTimeInput.js
+++ b/src/js/components/DateTimeInput/DateTimeInput.js
@@ -1201,6 +1201,9 @@ const DateTimeInput = forwardRef(
 
     const pickerContent = (
       <Box
+        role="group"
+        aria-label={groupLabel}
+        aria-labelledby={formFieldLabelId}
         direction="row"
         pad={theme.dateTimeInput?.drop?.pad}
         gap={theme.dateTimeInput?.drop?.gap}

--- a/src/js/components/DateTimeInput/DateTimeInput.js
+++ b/src/js/components/DateTimeInput/DateTimeInput.js
@@ -813,13 +813,9 @@ const DateTimeInput = forwardRef(
       setOpen(false);
 
       requestAnimationFrame(() => {
-        if (inline) {
-          triggerRef.current?.focus();
-          return;
-        }
         focusSection(activeSectionRef.current);
       });
-    }, [focusSection, inline]);
+    }, [focusSection]);
 
     const onDisplaySectionMouseDown = useCallback(
       (section, event) => {
@@ -1188,20 +1184,162 @@ const DateTimeInput = forwardRef(
       : formatMessage({ id: 'dateTimeInput.inputLabel', messages });
     const CalendarIcon =
       theme.dateTimeInput?.icon?.calendar || GrommetCalendarIcon;
-    const dropTarget = inline ? triggerRef.current : containerRef.current;
+    const dropTarget = containerRef.current;
     const generatedId = useId();
     const dropId = `${id || generatedId}__drop`;
+
+    if (inline) {
+      return (
+        <Box
+          direction="row"
+          pad={theme.dateTimeInput?.drop?.pad}
+          gap={theme.dateTimeInput?.drop?.gap}
+        >
+          {name && (
+            <input
+              aria-hidden="true"
+              name={name}
+              readOnly
+              tabIndex={-1}
+              type="hidden"
+              value={value || ''}
+            />
+          )}
+          <Calendar
+            date={getCalendarDate(sections)}
+            onSelect={disabled || readOnly ? undefined : handleCalendarSelect}
+          />
+          <Box
+            alignSelf="stretch"
+            flex={false}
+            border={{
+              side: 'start',
+              color: theme.dateTimeInput?.drop?.border?.color,
+              size: theme.dateTimeInput?.drop?.border?.size,
+            }}
+          />
+          <TimeInput
+            inline
+            format={resolvedFormat}
+            value={timeValue}
+            showSeconds={showSeconds}
+            messages={messages}
+            minuteStep={normalizedMinuteStep}
+            disabled={disabled}
+            readOnly={readOnly}
+            onChange={disabled || readOnly ? undefined : handleTimeSelect}
+            onPartialChange={
+              disabled || readOnly ? undefined : handleTimePartialChange
+            }
+          />
+        </Box>
+      );
+    }
 
     return (
       <Keyboard onEsc={open ? closePicker : undefined}>
         <Box>
-          {inline ? (
-            <Box direction="row" align="center">
+          <StyledDateTimeInputContainer
+            ref={containerRef}
+            direction="row"
+            border={!plainProp}
+            fill
+            round={theme.dateTimeInput?.container?.round}
+            disabled={disabled}
+            readOnlyProp={readOnly}
+            focusIndicator={focusIndicatorProp ?? true}
+            {...passThemeFlag}
+          >
+            <StyledDateTimeInputField {...passThemeFlag}>
+              <StyledDateTimeInputDisplay
+                role="group"
+                aria-label={groupLabel}
+                aria-labelledby={formFieldLabelId}
+                onMouseDown={onDisplayMouseDown}
+                {...passThemeFlag}
+              >
+                {displaySections.map(({ section, prefix, text, filled }) => {
+                  const sectionLimits = getSectionLimits(
+                    section,
+                    resolvedFormat,
+                    sections,
+                  );
+                  const key = getSectionKeyFromType(
+                    sectionTypeFromSection(section),
+                  );
+                  let numericValue;
+                  if (section === SECTION_PERIOD) {
+                    numericValue = sections[key] === 'PM' ? 1 : 0;
+                  } else {
+                    numericValue = sections[key] ?? sectionLimits.min;
+                  }
+
+                  return (
+                    <React.Fragment key={section}>
+                      {!!prefix && (
+                        <StyledDateTimeInputSeparator
+                          $filled={hasDisplayValue}
+                          $paddingInline={dateTimeSeparatorPadding}
+                          {...passThemeFlag}
+                        >
+                          {prefix}
+                        </StyledDateTimeInputSeparator>
+                      )}
+                      <StyledDateTimeInputSegment
+                        ref={(segmentNode) => {
+                          segmentRefs.current[section] = segmentNode;
+                        }}
+                        tabIndex={
+                          !readOnly && !disabled && activeSection === section
+                            ? 0
+                            : -1
+                        }
+                        $active={showActiveSection && activeSection === section}
+                        $filled={filled}
+                        onFocus={() => onSegmentFocus(section)}
+                        onBlur={onSegmentBlur}
+                        onKeyDown={(event) => onSegmentKeyDown(section, event)}
+                        data-section={section}
+                        role="spinbutton"
+                        aria-label={getSectionName(
+                          section,
+                          formatMessage,
+                          messages,
+                        )}
+                        aria-disabled={disabled || undefined}
+                        aria-readonly={readOnly || undefined}
+                        aria-valuenow={numericValue}
+                        aria-valuemin={sectionLimits.min}
+                        aria-valuemax={sectionLimits.max}
+                        aria-valuetext={sectionValueAnnouncement(section)}
+                        {...passThemeFlag}
+                      >
+                        {text}
+                      </StyledDateTimeInputSegment>
+                    </React.Fragment>
+                  );
+                })}
+              </StyledDateTimeInputDisplay>
+              <StyledDateTimeInput
+                tabIndex={-1}
+                {...rest}
+                id={id}
+                ref={inputRef}
+                value={inputValue}
+                aria-hidden="true"
+                disabled={disabled}
+                readOnly
+                focusIndicator={false}
+                plain
+              />
+            </StyledDateTimeInputField>
+            {!readOnly && (
               <Button
                 ref={triggerRef}
                 icon={<CalendarIcon />}
                 plain
-                disabled={disabled || readOnly}
+                disabled={disabled}
+                margin={theme.dateTimeInput?.button?.margin}
                 aria-label={formatMessage({
                   id: 'dateTimeInput.chooseDateTime',
                   messages,
@@ -1211,125 +1349,8 @@ const DateTimeInput = forwardRef(
                 aria-controls={dropId}
                 onClick={open ? closePicker : openPicker}
               />
-            </Box>
-          ) : (
-            <StyledDateTimeInputContainer
-              ref={containerRef}
-              direction="row"
-              border={!plainProp}
-              fill
-              round={theme.dateTimeInput?.container?.round}
-              disabled={disabled}
-              readOnlyProp={readOnly}
-              focusIndicator={focusIndicatorProp ?? true}
-              {...passThemeFlag}
-            >
-              <StyledDateTimeInputField {...passThemeFlag}>
-                <StyledDateTimeInputDisplay
-                  role="group"
-                  aria-label={groupLabel}
-                  aria-labelledby={formFieldLabelId}
-                  onMouseDown={onDisplayMouseDown}
-                  {...passThemeFlag}
-                >
-                  {displaySections.map(({ section, prefix, text, filled }) => {
-                    const sectionLimits = getSectionLimits(
-                      section,
-                      resolvedFormat,
-                      sections,
-                    );
-                    const key = getSectionKeyFromType(
-                      sectionTypeFromSection(section),
-                    );
-                    let numericValue;
-                    if (section === SECTION_PERIOD) {
-                      numericValue = sections[key] === 'PM' ? 1 : 0;
-                    } else {
-                      numericValue = sections[key] ?? sectionLimits.min;
-                    }
-
-                    return (
-                      <React.Fragment key={section}>
-                        {!!prefix && (
-                          <StyledDateTimeInputSeparator
-                            $filled={hasDisplayValue}
-                            $paddingInline={dateTimeSeparatorPadding}
-                            {...passThemeFlag}
-                          >
-                            {prefix}
-                          </StyledDateTimeInputSeparator>
-                        )}
-                        <StyledDateTimeInputSegment
-                          ref={(segmentNode) => {
-                            segmentRefs.current[section] = segmentNode;
-                          }}
-                          tabIndex={
-                            !readOnly && !disabled && activeSection === section
-                              ? 0
-                              : -1
-                          }
-                          $active={
-                            showActiveSection && activeSection === section
-                          }
-                          $filled={filled}
-                          onFocus={() => onSegmentFocus(section)}
-                          onBlur={onSegmentBlur}
-                          onKeyDown={(event) =>
-                            onSegmentKeyDown(section, event)
-                          }
-                          data-section={section}
-                          role="spinbutton"
-                          aria-label={getSectionName(
-                            section,
-                            formatMessage,
-                            messages,
-                          )}
-                          aria-disabled={disabled || undefined}
-                          aria-readonly={readOnly || undefined}
-                          aria-valuenow={numericValue}
-                          aria-valuemin={sectionLimits.min}
-                          aria-valuemax={sectionLimits.max}
-                          aria-valuetext={sectionValueAnnouncement(section)}
-                          {...passThemeFlag}
-                        >
-                          {text}
-                        </StyledDateTimeInputSegment>
-                      </React.Fragment>
-                    );
-                  })}
-                </StyledDateTimeInputDisplay>
-                <StyledDateTimeInput
-                  tabIndex={-1}
-                  {...rest}
-                  id={id}
-                  ref={inputRef}
-                  value={inputValue}
-                  aria-hidden="true"
-                  disabled={disabled}
-                  readOnly
-                  focusIndicator={false}
-                  plain
-                />
-              </StyledDateTimeInputField>
-              {!readOnly && (
-                <Button
-                  ref={triggerRef}
-                  icon={<CalendarIcon />}
-                  plain
-                  disabled={disabled}
-                  margin={theme.dateTimeInput?.button?.margin}
-                  aria-label={formatMessage({
-                    id: 'dateTimeInput.chooseDateTime',
-                    messages,
-                  })}
-                  aria-haspopup="dialog"
-                  aria-expanded={open}
-                  aria-controls={dropId}
-                  onClick={open ? closePicker : openPicker}
-                />
-              )}
-            </StyledDateTimeInputContainer>
-          )}
+            )}
+          </StyledDateTimeInputContainer>
           {name && (
             <input
               aria-hidden="true"

--- a/src/js/components/DateTimeInput/DateTimeInput.js
+++ b/src/js/components/DateTimeInput/DateTimeInput.js
@@ -1253,7 +1253,17 @@ const DateTimeInput = forwardRef(
     if (inline) {
       return (
         <>
-          {hiddenInput}
+          <input
+            {...rest}
+            aria-hidden="true"
+            id={id}
+            name={name}
+            readOnly
+            ref={inputRef}
+            tabIndex={-1}
+            type="hidden"
+            value={value || ''}
+          />
           {pickerContent}
         </>
       );

--- a/src/js/components/DateTimeInput/__tests__/DateTimeInput-test.tsx
+++ b/src/js/components/DateTimeInput/__tests__/DateTimeInput-test.tsx
@@ -498,7 +498,8 @@ describe('DateTimeInput', () => {
     expect(scoped.getByRole('listbox', { name: 'second' })).toBeInTheDocument();
   });
 
-  test('inline readOnly mode renders picker but disables selection', () => {
+  test('inline readOnly mode renders picker but disables selection', async () => {
+    const user = userEvent.setup();
     const onChange = jest.fn();
 
     render(
@@ -518,6 +519,11 @@ describe('DateTimeInput', () => {
     expect(
       screen.queryByRole('button', { name: /date and time/i }),
     ).not.toBeInTheDocument();
+
+    // Clicking a calendar day does not fire onChange in readOnly mode
+    const dayButton = screen.getByRole('button', { name: /Jul 25 2026/i });
+    await user.click(dayButton);
+    expect(onChange).not.toHaveBeenCalled();
   });
 
   test('increments minutes by minuteStep on keyboard arrow', async () => {
@@ -717,7 +723,7 @@ describe('DateTimeInput', () => {
     ).not.toBeInTheDocument();
   });
 
-  test('inline picker supports Tab/Arrow navigation without dialog semantics', () => {
+  test('inline picker supports Arrow navigation without dialog semantics', () => {
     render(
       <Grommet>
         <DateTimeInput

--- a/src/js/components/DateTimeInput/__tests__/DateTimeInput-test.tsx
+++ b/src/js/components/DateTimeInput/__tests__/DateTimeInput-test.tsx
@@ -141,9 +141,7 @@ describe('DateTimeInput', () => {
     ).not.toBeInTheDocument();
   });
 
-  test('inline mode renders icon trigger and opens date-time drop', async () => {
-    const user = userEvent.setup();
-
+  test('inline mode renders picker content directly without a trigger', () => {
     render(
       <Grommet>
         <DateTimeInput
@@ -156,21 +154,15 @@ describe('DateTimeInput', () => {
       </Grommet>,
     );
 
+    // No trigger button — picker is always visible
     expect(
-      screen.queryByRole('spinbutton', { name: 'day' }),
+      screen.queryByRole('button', { name: /date and time/i }),
     ).not.toBeInTheDocument();
 
-    const trigger = screen.getByRole('button', {
-      name: /date and time/i,
-    });
-    await user.click(trigger);
-
-    const drop = getDropFromTrigger(trigger);
-
-    const scoped = within(drop);
-    expect(scoped.getByRole('listbox', { name: 'hour' })).toBeInTheDocument();
-    expect(scoped.getByRole('listbox', { name: 'minute' })).toBeInTheDocument();
-    expect(scoped.getByRole('listbox', { name: 'second' })).toBeInTheDocument();
+    // Calendar and time columns are immediately in the document
+    expect(screen.getByRole('listbox', { name: 'hour' })).toBeInTheDocument();
+    expect(screen.getByRole('listbox', { name: 'minute' })).toBeInTheDocument();
+    expect(screen.getByRole('listbox', { name: 'second' })).toBeInTheDocument();
   });
 
   test('selecting a calendar day does not move focus into the hour listbox', async () => {
@@ -506,25 +498,26 @@ describe('DateTimeInput', () => {
     expect(scoped.getByRole('listbox', { name: 'second' })).toBeInTheDocument();
   });
 
-  test('inline readOnly mode keeps icon visible and does not open drop', async () => {
-    const user = userEvent.setup();
+  test('inline readOnly mode renders picker but disables selection', () => {
+    const onChange = jest.fn();
 
     render(
       <Grommet>
-        <DateTimeInput id="dt-inline-readonly" inline readOnly />
+        <DateTimeInput
+          id="dt-inline-readonly"
+          inline
+          readOnly
+          value="2026-07-22T18:30:00.000Z"
+          onChange={onChange}
+        />
       </Grommet>,
     );
 
-    const trigger = screen.getByRole('button', {
-      name: /date and time/i,
-    });
-    expect(trigger).toBeDisabled();
-
-    await user.click(trigger);
-
-    expect(trigger).toHaveAttribute('aria-expanded', 'false');
-    const controlsId = trigger.getAttribute('aria-controls');
-    expect(document.getElementById(controlsId as string)).toBeFalsy();
+    // Picker is always shown — no trigger button
+    expect(screen.getByRole('listbox', { name: 'hour' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /date and time/i }),
+    ).not.toBeInTheDocument();
   });
 
   test('increments minutes by minuteStep on keyboard arrow', async () => {
@@ -724,9 +717,7 @@ describe('DateTimeInput', () => {
     ).not.toBeInTheDocument();
   });
 
-  test('inline popup supports Tab/Arrow navigation without dialog semantics', async () => {
-    const user = userEvent.setup();
-
+  test('inline picker supports Tab/Arrow navigation without dialog semantics', () => {
     render(
       <Grommet>
         <DateTimeInput
@@ -735,23 +726,14 @@ describe('DateTimeInput', () => {
           format="12"
           value="2026-07-22T18:30:00.000Z"
         />
-        <Button type="button" label="After inline picker" />
       </Grommet>,
     );
 
-    const trigger = screen.getByRole('button', {
-      name: /date and time/i,
-    });
-    await user.click(trigger);
+    // No dialog, no trigger — listboxes are directly accessible
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
 
-    const drop = getDropFromTrigger(trigger);
-    const scoped = within(drop);
-    expect(
-      scoped.queryByRole('dialog', { name: /date and time/i }),
-    ).not.toBeInTheDocument();
-
-    const hourList = scoped.getByRole('listbox', { name: 'hour' });
-    const minuteList = scoped.getByRole('listbox', { name: 'minute' });
+    const hourList = screen.getByRole('listbox', { name: 'hour' });
+    const minuteList = screen.getByRole('listbox', { name: 'minute' });
     const popupContent = hourList.parentElement as HTMLElement;
 
     const selectedHourOption = within(hourList)
@@ -759,20 +741,13 @@ describe('DateTimeInput', () => {
       .find((option) => option.getAttribute('aria-selected') === 'true');
     expect(selectedHourOption).toBeTruthy();
 
-    fireEvent.keyDown(popupContent, { key: 'Tab' });
-    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    fireEvent.keyDown(popupContent, { key: 'ArrowRight' });
+    fireEvent.keyDown(popupContent, { key: 'ArrowDown' });
 
     const selectedMinuteOption = within(minuteList)
       .getAllByRole('option')
       .find((option) => option.getAttribute('aria-selected') === 'true');
     expect(selectedMinuteOption).toBeTruthy();
-
-    fireEvent.keyDown(popupContent, { key: 'ArrowRight' });
-    fireEvent.keyDown(popupContent, { key: 'ArrowDown' });
-    expect(trigger).toHaveAttribute('aria-expanded', 'true');
-
-    fireEvent.keyDown(popupContent, { key: 'Enter' });
-    expect(trigger).toHaveAttribute('aria-expanded', 'true');
   });
 
   test('non-inline drop applies hour option ArrowDown from popup option target', async () => {

--- a/src/js/components/DateTimeInput/stories/Inline.stories.tsx
+++ b/src/js/components/DateTimeInput/stories/Inline.stories.tsx
@@ -2,23 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 
-import { Box, Text } from 'grommet';
+import { Box } from 'grommet';
 import { DateTimeInput } from '../index';
 
 export const Inline = () => {
   const [value, setValue] = React.useState('2026-07-22T18:30:00.000Z');
-  const localValue = value
-    ? new Date(value).toLocaleString(undefined, {
-        year: 'numeric',
-        month: '2-digit',
-        day: '2-digit',
-        hour: '2-digit',
-        minute: '2-digit',
-        second: '2-digit',
-        hour12: true,
-        timeZoneName: 'short',
-      })
-    : 'none';
 
   return (
     <Box align="center" pad="large" gap="small">

--- a/src/js/components/DateTimeInput/stories/Inline.stories.tsx
+++ b/src/js/components/DateTimeInput/stories/Inline.stories.tsx
@@ -21,7 +21,7 @@ export const Inline = () => {
     : 'none';
 
   return (
-    <Box pad="large" gap="small" width="large">
+    <Box align="center" pad="large" gap="small">
       <DateTimeInput
         id="inline-date-time"
         inline
@@ -30,12 +30,6 @@ export const Inline = () => {
           setValue(next || '');
         }}
       />
-      <Text size="small" truncate>
-        Local display: {localValue}
-      </Text>
-      <Text size="small" truncate>
-        UTC ISO value: {value || 'none'}
-      </Text>
     </Box>
   );
 };


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Corrects the behavior of the `inline` prop on `DateTimeInput` to match the
pattern established by `DateInput`. Previously, `inline` rendered a calendar
icon button that opened a floating Drop which is the same as the default
mode, just with a different trigger appearance. The correct behavior is to
render the picker content (Calendar + time columns) directly in the page with
no trigger and no Drop, giving consumers a fully embedded date-time picker.
#### Where should the reviewer start?
datetimeinput.js
#### What testing has been done on this PR?
changed the test that was currently there for `inline`
#### How should this be manually tested?
storybook
#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
DateInput with inline already returns the popup content directly DateTimeInput should follow the same contract so consumers can embed both pickers consistently.
#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
not sure
#### Should this PR be mentioned in the release notes?
maybe
#### Is this change backwards compatible or is it a breaking change?
backwards compatible