### PR TITLE
[FormField] Allow input config to override formField.hover theme property

### DIFF
--- a/package.json
+++ b/package.json
@@ -217,7 +217,7 @@
   "bundlesize": [
     {
       "path": "./dist/grommet.min.js",
-      "maxSize": "216 kB"
+      "maxSize": "217 kB"
     }
   ],
   "keywords": [

--- a/src/js/components/FormField/FormField.js
+++ b/src/js/components/FormField/FormField.js
@@ -103,15 +103,16 @@ const getHoverStyle = (role) => (props) => {
   const ownsBorder =
     role === 'outer' ? position === 'outer' : position === 'inner';
 
-  const hasComponentBorderOverride =
-    componentHover && componentHover.border !== undefined;
-  const hasComponentBackgroundOverride =
-    componentHover && componentHover.background !== undefined;
+  const componentHoverBorder = componentHover?.border ?? undefined;
+  const componentHoverBackground = componentHover?.background ?? undefined;
+
+  const hasComponentBorderOverride = componentHoverBorder !== undefined;
+  const hasComponentBackgroundOverride = componentHoverBackground !== undefined;
 
   let borderColor;
   if (ownsBorder) {
     if (hasComponentBorderOverride) {
-      borderColor = componentHover.border.color;
+      borderColor = componentHoverBorder.color;
     } else {
       borderColor = hover?.border?.color;
     }
@@ -120,7 +121,7 @@ const getHoverStyle = (role) => (props) => {
   let background;
   if (role === 'content') {
     if (hasComponentBackgroundOverride) {
-      background = componentHover.background;
+      background = componentHoverBackground;
     } else {
       background = hover?.background;
     }

--- a/src/js/components/FormField/FormField.js
+++ b/src/js/components/FormField/FormField.js
@@ -95,17 +95,40 @@ const getFocusStyle = (props) => {
 // FormField sets allowHover only when no higher priority state (disabled,
 // readOnly, error, focus) applies.
 const getHoverStyle = (role) => (props) => {
-  const hover = props.theme.formField?.hover;
-  if (!props.allowHover || !hover) return undefined;
-  const position = props.theme.formField?.border?.position;
+  const formFieldTheme = props.theme.formField;
+  const hover = formFieldTheme?.hover;
+  const componentHover = formFieldTheme?.[props.componentName]?.hover;
+  if (!props.allowHover || (!hover && !componentHover)) return undefined;
+  const position = formFieldTheme?.border?.position;
   const ownsBorder =
     role === 'outer' ? position === 'outer' : position === 'inner';
-  const borderColor = ownsBorder ? hover.border?.color : undefined;
-  const background = role === 'content' ? hover.background : undefined;
+
+  const hasComponentBorderOverride =
+    componentHover && componentHover.border !== undefined;
+  const hasComponentBackgroundOverride =
+    componentHover && componentHover.background !== undefined;
+
+  let borderColor;
+  if (ownsBorder) {
+    if (hasComponentBorderOverride) {
+      borderColor = componentHover.border.color;
+    } else {
+      borderColor = hover?.border?.color;
+    }
+  }
+
+  let background;
+  if (role === 'content') {
+    if (hasComponentBackgroundOverride) {
+      background = componentHover.background;
+    } else {
+      background = hover?.background;
+    }
+  }
   if (!borderColor && background === undefined) return undefined;
   return css`
     &:hover {
-      ${borderColor &&
+      ${borderColor !== undefined &&
       `border-color: ${normalizeColor(borderColor, props.theme)};`}
       ${backgroundStyle(background, props.theme, false)}
     }

--- a/src/js/components/FormField/__tests__/FormField-test.tsx
+++ b/src/js/components/FormField/__tests__/FormField-test.tsx
@@ -993,6 +993,31 @@ describe('FormField', () => {
       ).toHaveStyleRule('border-color', '#112233', { modifier: ':hover' });
     });
 
+    test('allows a child input to override the shared hover background color', () => {
+      const { container } = render(
+        <Grommet
+          theme={{
+            formField: {
+              ...hoverTheme.formField,
+              radioButtonGroup: {
+                hover: {
+                  background: '#223344',
+                },
+              },
+            },
+          }}
+        >
+          <FormField label="Label">
+            <RadioButtonGroup name="test" options={['One', 'Two']} />
+          </FormField>
+        </Grommet>,
+      );
+
+      expect(
+        container.querySelector('[class*="FormFieldContentBox"]'),
+      ).toHaveStyleRule('background-color', '#223344', { modifier: ':hover' });
+    });
+
     test('does not apply hover styling when disabled', () => {
       const { container } = render(
         <Grommet theme={hoverTheme}>

--- a/src/js/components/FormField/__tests__/FormField-test.tsx
+++ b/src/js/components/FormField/__tests__/FormField-test.tsx
@@ -943,6 +943,56 @@ describe('FormField', () => {
       ).toHaveStyleRule('background-color', '#654321', { modifier: ':hover' });
     });
 
+    test('allows a child input to opt out of the shared hover border color', () => {
+      const { container } = render(
+        <Grommet
+          theme={{
+            formField: {
+              ...hoverTheme.formField,
+              radioButtonGroup: {
+                hover: {
+                  border: { color: undefined },
+                },
+              },
+            },
+          }}
+        >
+          <FormField label="Label">
+            <RadioButtonGroup name="test" options={['One', 'Two']} />
+          </FormField>
+        </Grommet>,
+      );
+
+      expect(
+        container.querySelector('[class*="FormFieldContentBox"]'),
+      ).not.toHaveStyleRule('border-color', '#AAFF00', { modifier: ':hover' });
+    });
+
+    test('allows a child input to override the shared hover border color', () => {
+      const { container } = render(
+        <Grommet
+          theme={{
+            formField: {
+              ...hoverTheme.formField,
+              radioButtonGroup: {
+                hover: {
+                  border: { color: '#112233' },
+                },
+              },
+            },
+          }}
+        >
+          <FormField label="Label">
+            <RadioButtonGroup name="test" options={['One', 'Two']} />
+          </FormField>
+        </Grommet>,
+      );
+
+      expect(
+        container.querySelector('[class*="FormFieldContentBox"]'),
+      ).toHaveStyleRule('border-color', '#112233', { modifier: ':hover' });
+    });
+
     test('does not apply hover styling when disabled', () => {
       const { container } = render(
         <Grommet theme={hoverTheme}>

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -297,6 +297,12 @@ type ContainerExtend = {
   container?: {
     extend?: ExtendType;
   };
+  hover?: {
+    background?: BackgroundType;
+    border?: {
+      color?: ColorType;
+    };
+  };
 };
 
 interface StepperStateType {

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -1290,7 +1290,15 @@ export const generate = (baseSpacing = 24, scale = 6) => {
       // [inputname]: {
       //  container: {
       //    extend: undefined,
-      //   }
+      //   },
+      //   hover: {
+      //     background: {
+      //       color: undefined,
+      //     },
+      //     border: {
+      //       color: undefined,
+      //     },
+      //   },
       // }
       border: {
         color: 'border',


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Extends https://github.com/grommet/grommet/pull/8092

When applying the formfield hover border treatments to grommet-theme-hpe, there were components such as CheckBoxGroup and RadioButtonGroup which also received the hover border. This PR allows input components to opt-out of the hover treatment if desired.

This pull request enhances the theming flexibility of the `FormField` component by allowing child input components to override or opt out of shared hover styles, specifically for border and background colors. It also adds comprehensive tests to ensure these new behaviors work as intended, and updates the theme documentation to reflect the new hover override options.

**Theming and Styling Enhancements:**

* Updated `getHoverStyle` in `FormField.js` to support per-component hover overrides for border and background colors, enabling child components (like `RadioButtonGroup`) to either override or opt out of shared hover styles.
* Extended the base theme (`base.js`) documentation to show how input components can define their own `hover` styles for background and border colors.

**Testing Improvements:**

* Added tests to verify that child components can opt out of or override the shared hover border color in `FormField`, ensuring correct application of the new theming options.

#### Where should the reviewer start?

FormField-test.tsx

#### What testing has been done on this PR?

Jest + Storybook

#### How should this be manually tested?

Modify Storybook with theme config similar to the added test

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

https://github.com/grommet/grommet/pull/8092

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

Yes.

#### Should this PR be mentioned in the release notes?

Yes.

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible