### PR TITLE
fix(DataChart): guard `onMouseLeave` against unset activeIndex ref

### DIFF
--- a/src/js/components/DataChart/Detail.js
+++ b/src/js/components/DataChart/Detail.js
@@ -65,6 +65,12 @@ const Detail = ({
   }, [padProp, theme.global.edgeSize, thickness]);
 
   const onMouseLeave = useCallback((event) => {
+    // activeIndex.current is only set on mouse hover. If detail was
+    // opened via keyboard navigation, it may be unset here.
+    if (!activeIndex.current) {
+      setDetailIndex(undefined);
+      return;
+    }
     // Only remove detail if the mouse isn't over the active index.
     // This helps distinguish leaving the drop on the edge where it is
     // anchored.

--- a/src/js/components/DataChart/__tests__/DataChart-test.tsx
+++ b/src/js/components/DataChart/__tests__/DataChart-test.tsx
@@ -210,6 +210,20 @@ describe('DataChart', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  test('detail onMouseLeave does not throw without a prior mouse over', () => {
+    // Simulates a mouse leaving a detail hit target (or the detail Drop)
+    // when the detail was opened via keyboard navigation instead of a
+    // mouse over, so activeIndex.current was never set.
+    render(
+      <Grommet>
+        <DataChart data={data} series="a" detail />
+      </Grommet>,
+    );
+
+    const [firstItem] = screen.getAllByRole('listitem');
+    expect(() => fireEvent.mouseLeave(firstItem)).not.toThrow();
+  });
+
   test('detail pad + thickness', () => {
     const { container } = render(
       <Grommet>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Fixes a crash in `DataChart`'s detail popup. `Detail.js`'s `onMouseLeave` handler called `activeIndex.current.getBoundingClientRect()` without checking that the ref was set. 
`activeIndex.current` is only assigned on mouse over, but the detail popup can also be opened via keyboard navigation (arrow keys) without ever setting it. 
When the mouse then left the detail hit target or the open `Drop`, this threw `TypeError: Cannot read properties of undefined (reading 'getBoundingClientRect')`. 
The fix guards against the unset ref and simply closes the detail in that case.

#### Where should the reviewer start?

- `src/js/components/DataChart/Detail.js` about the `onMouseLeave` callback.

#### What testing has been done on this PR?

Added a regression test in `DataChart-test.tsx` that fires `mouseLeave` on a detail list item without a prior `mouseOver` and asserts it no longer throws. 

Ran the test `npx jest src/js/components/DataChart` and all 32 tests were passed.

#### How should this be manually tested?

1. Render `<DataChart data={data} series="a" detail />`.
2. Position the mouse cursor over the chart area (without moving it once the chart renders — e.g. rest it there before the page/story loads) so no `mouseover` ever fires on a detail item.
3. Tab to focus the detail control, then press the Right arrow key to open the detail popup via keyboard.
4. Move the mouse away from the chart.
5. Before this fix: this throws `TypeError: Cannot read properties of undefined (reading 'getBoundingClientRect')` and crashes the chart.
6. After this fix: the detail popup closes normally with no error.

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

Found via a component-by-component bug review of `src/js/components`.

#### What are the relevant issues?

Nothing.

#### Screenshots (if appropriate)

N/A

#### Do the grommet docs need to be updated?

No

#### Should this PR be mentioned in the release notes?

Yes

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.