### PR TITLE
add wizard step gap

### DIFF
--- a/src/js/components/Wizard/Wizard.js
+++ b/src/js/components/Wizard/Wizard.js
@@ -683,7 +683,7 @@ const Wizard = forwardRef(
                 {effectiveShowProgress &&
                   responsiveSize !== 'small' &&
                   responsiveSize !== 'xsmall' && <WizardProgress />}
-                <Box flex="grow">
+                <Box gap={theme.wizard?.step?.gap} flex="grow">
                   <WizardStepHeader />
                   <WizardContent />
                 </Box>

--- a/src/js/themes/base.d.ts
+++ b/src/js/themes/base.d.ts
@@ -2555,12 +2555,14 @@ export interface ThemeType {
         margin?: MarginType;
       };
     };
+    step?: {
+      gap?: GapType;
+    };
     content?: {
       pad?: PadType;
       gap?: GapType;
       background?: BackgroundType;
       round?: RoundType;
-      margin?: MarginType;
     };
     footer?: {
       background?: BackgroundType;

--- a/src/js/themes/base.js
+++ b/src/js/themes/base.js
@@ -2833,12 +2833,14 @@ export const generate = (baseSpacing = 24, scale = 6) => {
           margin: { top: 'xsmall', bottom: 'none' },
         },
       },
+      step: {
+        gap: 'medium',
+      },
       content: {
         pad: 'medium',
         gap: 'medium',
         background: 'background-front',
         round: 'small',
-        margin: { top: 'medium' },
       },
       footer: {
         pad: { horizontal: 'large', vertical: 'small' },


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds `theme.wizard.step.gap` to create a space between the step header and step content in a wizard.
#### Where should the reviewer start?
base.js
#### What testing has been done on this PR?
locally 
#### How should this be manually tested?
locally 
#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
https://github.com/grommet/grommet-theme-hpe/pull/618
#### What are the relevant issues?
closes #8034 
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
yes
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
backwards compatible