### PR TITLE
fix: honor dark mode in Drop-based scrollable option lists (#8105)

### DIFF
--- a/src/js/components/DataFilter/__tests__/__snapshots__/DataFilter-test.tsx.snap
+++ b/src/js/components/DataFilter/__tests__/__snapshots__/DataFilter-test.tsx.snap
@@ -8692,6 +8692,7 @@ exports[`DataFilter theme rangeSelector size and round, selectMultiple dropHeigh
   scroll-behavior: smooth;
   overflow: auto;
   outline: none;
+  scrollbar-color: rgba(0, 0, 0, 0.33) transparent;
 }
 
 .c14 {

--- a/src/js/components/DataSort/__tests__/__snapshots__/DataSort-test.tsx.snap
+++ b/src/js/components/DataSort/__tests__/__snapshots__/DataSort-test.tsx.snap
@@ -306,6 +306,7 @@ exports[`DataSort properties 1`] = `
   scroll-behavior: smooth;
   overflow: auto;
   outline: none;
+  scrollbar-color: rgba(0, 0, 0, 0.33) transparent;
 }
 
 .c2 {

--- a/src/js/components/MaskedInput/MaskedInput.js
+++ b/src/js/components/MaskedInput/MaskedInput.js
@@ -16,7 +16,12 @@ import { Button } from '../Button';
 import { Drop } from '../Drop';
 import { FormContext } from '../Form/FormContext';
 import { Keyboard } from '../Keyboard';
-import { sizeStyle, useForwardedRef, useSizedIcon } from '../../utils';
+import {
+  normalizeColor,
+  sizeStyle,
+  useForwardedRef,
+  useSizedIcon,
+} from '../../utils';
 
 import {
   StyledMaskedInput,
@@ -152,6 +157,8 @@ const ContainerBox = styled(Box)`
     props.dropHeight
       ? sizeStyle('max-height', props.dropHeight, props.theme)
       : 'max-height: inherit;'};
+  scrollbar-color: ${(props) =>
+    `${normalizeColor('border', props.theme)} transparent`};
 `;
 
 const dropAlign = { top: 'bottom', left: 'left' };

--- a/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.tsx.snap
+++ b/src/js/components/MaskedInput/__tests__/__snapshots__/MaskedInput-test.tsx.snap
@@ -1080,6 +1080,7 @@ exports[`MaskedInput event target props are available option via mouse 2`] = `
 
 .c3 {
   max-height: inherit;
+  scrollbar-color: rgba(0, 0, 0, 0.33) transparent;
 }
 
 @media only screen and (max-width: 768px) {
@@ -1715,6 +1716,7 @@ exports[`MaskedInput mask 2`] = `
 
 .c3 {
   max-height: inherit;
+  scrollbar-color: rgba(0, 0, 0, 0.33) transparent;
 }
 
 @media only screen and (max-width: 768px) {
@@ -2579,6 +2581,7 @@ exports[`MaskedInput option via mouse 2`] = `
 
 .c3 {
   max-height: inherit;
+  scrollbar-color: rgba(0, 0, 0, 0.33) transparent;
 }
 
 @media only screen and (max-width: 768px) {

--- a/src/js/components/Menu/Menu.js
+++ b/src/js/components/Menu/Menu.js
@@ -477,6 +477,7 @@ const Menu = forwardRef((props, ref) => {
                 role="menu"
                 a11yTitle={a11y}
                 {...(!grouped ? theme.menu.container : {})}
+                {...passThemeFlag}
               >
                 {menuContent}
               </MenuItemsBox>

--- a/src/js/components/Menu/Menu.js
+++ b/src/js/components/Menu/Menu.js
@@ -38,6 +38,11 @@ const ContainerBox = styled(Box)`
   ${(props) => props.theme.menu.extend};
 `;
 
+const MenuItemsBox = styled(Box)`
+  scrollbar-color: ${(props) =>
+    `${normalizeColor('border', props.theme)} transparent`};
+`;
+
 /* Notes on keyboard interactivity (based on W3) // For details reference: https://www.w3.org/TR/wai-aria-practices/#menu
 
 To open menu when menu button is focused:
@@ -467,14 +472,14 @@ const Menu = forwardRef((props, ref) => {
               align.top !== 'bottom'
                 ? controlMirror
                 : undefined}
-              <Box
+              <MenuItemsBox
                 overflow="auto"
                 role="menu"
                 a11yTitle={a11y}
                 {...(!grouped ? theme.menu.container : {})}
               >
                 {menuContent}
-              </Box>
+              </MenuItemsBox>
               {/*
                 If align.top was defined,
                 don't show controlMirror when window height has shrunk

--- a/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
+++ b/src/js/components/Menu/__tests__/__snapshots__/Menu-test.js.snap
@@ -475,7 +475,7 @@ exports[`Menu close by clicking outside 2`] = `
   flex: 0 0 auto;
 }
 
-.c11 {
+.c12 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -599,6 +599,10 @@ exports[`Menu close by clicking outside 2`] = `
   outline: none;
 }
 
+.c11 {
+  scrollbar-color: rgba(0, 0, 0, 0.33) transparent;
+}
+
 @media only screen and (max-width: 768px) {
   .c6 {
     padding: 6px;
@@ -606,7 +610,7 @@ exports[`Menu close by clicking outside 2`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c11 {
+  .c12 {
     padding: 6px;
   }
 }
@@ -677,7 +681,7 @@ exports[`Menu close by clicking outside 2`] = `
       </button>
     </div>
     <div
-      class="c10"
+      class="c10 c11"
       role="menu"
     >
       <div
@@ -690,7 +694,7 @@ exports[`Menu close by clicking outside 2`] = `
           type="button"
         >
           <div
-            class="c11"
+            class="c12"
           >
             Item 1
           </div>
@@ -706,7 +710,7 @@ exports[`Menu close by clicking outside 2`] = `
           type="button"
         >
           <div
-            class="c11"
+            class="c12"
           >
             Item 2
           </div>
@@ -3284,7 +3288,7 @@ exports[`Menu open and close on click 3`] = `
   flex: 0 0 auto;
 }
 
-.c11 {
+.c12 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -3408,6 +3412,10 @@ exports[`Menu open and close on click 3`] = `
   outline: none;
 }
 
+.c11 {
+  scrollbar-color: rgba(0, 0, 0, 0.33) transparent;
+}
+
 @media only screen and (max-width: 768px) {
   .c6 {
     padding: 6px;
@@ -3415,7 +3423,7 @@ exports[`Menu open and close on click 3`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c11 {
+  .c12 {
     padding: 6px;
   }
 }
@@ -3486,7 +3494,7 @@ exports[`Menu open and close on click 3`] = `
       </button>
     </div>
     <div
-      class="c10"
+      class="c10 c11"
       role="menu"
     >
       <div
@@ -3499,7 +3507,7 @@ exports[`Menu open and close on click 3`] = `
           type="button"
         >
           <div
-            class="c11"
+            class="c12"
           >
             Item 1
           </div>
@@ -3515,7 +3523,7 @@ exports[`Menu open and close on click 3`] = `
           type="button"
         >
           <div
-            class="c11"
+            class="c12"
           >
             Item 2
           </div>
@@ -3531,7 +3539,7 @@ exports[`Menu open and close on click 3`] = `
           role="menuitem"
         >
           <div
-            class="c11"
+            class="c12"
           >
             Item 3
           </div>
@@ -3951,7 +3959,7 @@ exports[`Menu open on up close on esc 2`] = `
   flex: 0 0 auto;
 }
 
-.c11 {
+.c12 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -4075,6 +4083,10 @@ exports[`Menu open on up close on esc 2`] = `
   outline: none;
 }
 
+.c11 {
+  scrollbar-color: rgba(0, 0, 0, 0.33) transparent;
+}
+
 @media only screen and (max-width: 768px) {
   .c6 {
     padding: 6px;
@@ -4082,7 +4094,7 @@ exports[`Menu open on up close on esc 2`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c11 {
+  .c12 {
     padding: 6px;
   }
 }
@@ -4153,7 +4165,7 @@ exports[`Menu open on up close on esc 2`] = `
       </button>
     </div>
     <div
-      class="c10"
+      class="c10 c11"
       role="menu"
     >
       <div
@@ -4166,7 +4178,7 @@ exports[`Menu open on up close on esc 2`] = `
           type="button"
         >
           <div
-            class="c11"
+            class="c12"
           >
             Item 1
           </div>
@@ -4182,7 +4194,7 @@ exports[`Menu open on up close on esc 2`] = `
           type="button"
         >
           <div
-            class="c11"
+            class="c12"
           >
             Item 2
           </div>
@@ -4768,7 +4780,7 @@ exports[`Menu should apply theme.menu.container 1`] = `
   overflow: auto;
 }
 
-.c5 {
+.c6 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -4778,7 +4790,7 @@ exports[`Menu should apply theme.menu.container 1`] = `
   flex: 0 0 auto;
 }
 
-.c7 {
+.c8 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -4789,7 +4801,7 @@ exports[`Menu should apply theme.menu.container 1`] = `
   padding: 12px;
 }
 
-.c8 {
+.c9 {
   flex: 0 0 auto;
   align-self: stretch;
   height: 6px;
@@ -4815,7 +4827,7 @@ exports[`Menu should apply theme.menu.container 1`] = `
   animation-delay: 0.01s;
 }
 
-.c6 {
+.c7 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -4832,28 +4844,28 @@ exports[`Menu should apply theme.menu.container 1`] = `
   text-align: inherit;
 }
 
-.c6:hover {
+.c7:hover {
   background-color: rgba(221, 221, 221, 0.4);
   color: #000000;
 }
 
-.c6:focus:not(:focus-visible) {
+.c7:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c6:focus:not(:focus-visible) >circle,
-.c6:focus:not(:focus-visible) >ellipse,
-.c6:focus:not(:focus-visible) >line,
-.c6:focus:not(:focus-visible) >path,
-.c6:focus:not(:focus-visible) >polygon,
-.c6:focus:not(:focus-visible) >polyline,
-.c6:focus:not(:focus-visible) >rect {
+.c7:focus:not(:focus-visible) >circle,
+.c7:focus:not(:focus-visible) >ellipse,
+.c7:focus:not(:focus-visible) >line,
+.c7:focus:not(:focus-visible) >path,
+.c7:focus:not(:focus-visible) >polygon,
+.c7:focus:not(:focus-visible) >polyline,
+.c7:focus:not(:focus-visible) >rect {
   outline: none;
   box-shadow: none;
 }
 
-.c6:focus:not(:focus-visible) ::-moz-focus-inner {
+.c7:focus:not(:focus-visible) ::-moz-focus-inner {
   border: 0;
 }
 
@@ -4863,6 +4875,10 @@ exports[`Menu should apply theme.menu.container 1`] = `
 
 .c3:focus {
   outline: none;
+}
+
+.c5 {
+  scrollbar-color: rgba(0, 0, 0, 0.33) transparent;
 }
 
 @media only screen and (max-width: 768px) {
@@ -4876,7 +4892,7 @@ exports[`Menu should apply theme.menu.container 1`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c7 {
+  .c8 {
     padding: 6px;
   }
 }
@@ -4886,7 +4902,7 @@ exports[`Menu should apply theme.menu.container 1`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c8 {
+  .c9 {
     height: 3px;
   }
 }
@@ -4916,39 +4932,39 @@ exports[`Menu should apply theme.menu.container 1`] = `
     tabindex="-1"
   >
     <div
-      class="c4"
+      class="c4 c5"
       role="menu"
     >
       <div
-        class="c5"
+        class="c6"
         role="none"
       >
         <button
-          class="c6"
+          class="c7"
           role="menuitem"
           type="button"
         >
           <div
-            class="c7"
+            class="c8"
           >
             Item 1
           </div>
         </button>
       </div>
       <div
-        class="c8"
+        class="c9"
       />
       <div
-        class="c5"
+        class="c6"
         role="none"
       >
         <button
-          class="c6"
+          class="c7"
           role="menuitem"
           type="button"
         >
           <div
-            class="c7"
+            class="c8"
           >
             Item 2
           </div>
@@ -5213,7 +5229,7 @@ exports[`Menu should group items 1`] = `
   flex: 0 0 auto;
 }
 
-.c11 {
+.c12 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -5224,7 +5240,7 @@ exports[`Menu should group items 1`] = `
   padding-bottom: 6px;
 }
 
-.c12 {
+.c13 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -5235,7 +5251,7 @@ exports[`Menu should group items 1`] = `
   padding: 12px;
 }
 
-.c13 {
+.c14 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -5246,7 +5262,7 @@ exports[`Menu should group items 1`] = `
   padding-right: 12px;
 }
 
-.c14 {
+.c15 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -5369,6 +5385,10 @@ exports[`Menu should group items 1`] = `
   outline: none;
 }
 
+.c11 {
+  scrollbar-color: rgba(0, 0, 0, 0.33) transparent;
+}
+
 @media only screen and (max-width: 768px) {
   .c6 {
     padding: 6px;
@@ -5376,27 +5396,27 @@ exports[`Menu should group items 1`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c11 {
+  .c12 {
     padding-top: 3px;
     padding-bottom: 3px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c12 {
+  .c13 {
     padding: 6px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c13 {
+  .c14 {
     padding-left: 6px;
     padding-right: 6px;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .c14 {
+  .c15 {
     border-top: solid 1px rgba(0, 0, 0, 0.33);
   }
 }
@@ -5467,14 +5487,14 @@ exports[`Menu should group items 1`] = `
       </button>
     </div>
     <div
-      class="c10"
+      class="c10 c11"
       role="menu"
     >
       <div
         class="c4"
       >
         <div
-          class="c11"
+          class="c12"
         >
           <div
             class="c4"
@@ -5486,7 +5506,7 @@ exports[`Menu should group items 1`] = `
               type="button"
             >
               <div
-                class="c12"
+                class="c13"
               >
                 Item 1
               </div>
@@ -5502,7 +5522,7 @@ exports[`Menu should group items 1`] = `
               type="button"
             >
               <div
-                class="c12"
+                class="c13"
               >
                 Item 2
               </div>
@@ -5514,14 +5534,14 @@ exports[`Menu should group items 1`] = `
         class="c4"
       >
         <div
-          class="c13"
+          class="c14"
         >
           <div
-            class="c14"
+            class="c15"
           />
         </div>
         <div
-          class="c11"
+          class="c12"
         >
           <div
             class="c4"
@@ -5533,7 +5553,7 @@ exports[`Menu should group items 1`] = `
               type="button"
             >
               <div
-                class="c12"
+                class="c13"
               >
                 Item 3
               </div>
@@ -6061,7 +6081,7 @@ exports[`Menu with dropAlign bottom renders 1`] = `
 `;
 
 exports[`Menu with dropAlign bottom renders 2`] = `
-.c8 {
+.c9 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -6103,7 +6123,7 @@ exports[`Menu with dropAlign bottom renders 2`] = `
   overflow: auto;
 }
 
-.c5 {
+.c6 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -6113,7 +6133,7 @@ exports[`Menu with dropAlign bottom renders 2`] = `
   flex: 0 0 auto;
 }
 
-.c7 {
+.c8 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -6124,13 +6144,13 @@ exports[`Menu with dropAlign bottom renders 2`] = `
   padding: 12px;
 }
 
-.c10 {
+.c11 {
   flex: 0 0 auto;
   align-self: stretch;
   width: 12px;
 }
 
-.c11 {
+.c12 {
   display: inline-block;
   flex: 0 0 auto;
   width: 24px;
@@ -6139,25 +6159,25 @@ exports[`Menu with dropAlign bottom renders 2`] = `
   stroke: #7D4CDB;
 }
 
-.c11 g {
+.c12 g {
   fill: inherit;
   stroke: inherit;
 }
 
-.c11 *:not([stroke])[fill='none'] {
+.c12 *:not([stroke])[fill='none'] {
   stroke-width: 0;
 }
 
-.c11 *[stroke*='#'],
-.c11 *[STROKE*='#'] {
+.c12 *[stroke*='#'],
+.c12 *[STROKE*='#'] {
   stroke: inherit;
   fill: none;
 }
 
-.c11 *[fill-rule],
-.c11 *[FILL-RULE],
-.c11 *[fill*='#'],
-.c11 *[FILL*='#'] {
+.c12 *[fill-rule],
+.c12 *[FILL-RULE],
+.c12 *[fill*='#'],
+.c12 *[FILL*='#'] {
   fill: inherit;
   stroke: none;
 }
@@ -6182,12 +6202,12 @@ exports[`Menu with dropAlign bottom renders 2`] = `
   animation-delay: 0.01s;
 }
 
-.c9 {
+.c10 {
   font-size: 18px;
   line-height: 24px;
 }
 
-.c6 {
+.c7 {
   display: inline-block;
   box-sizing: border-box;
   cursor: pointer;
@@ -6204,28 +6224,28 @@ exports[`Menu with dropAlign bottom renders 2`] = `
   text-align: inherit;
 }
 
-.c6:hover {
+.c7:hover {
   background-color: rgba(221, 221, 221, 0.4);
   color: #000000;
 }
 
-.c6:focus:not(:focus-visible) {
+.c7:focus:not(:focus-visible) {
   outline: none;
   box-shadow: none;
 }
 
-.c6:focus:not(:focus-visible) >circle,
-.c6:focus:not(:focus-visible) >ellipse,
-.c6:focus:not(:focus-visible) >line,
-.c6:focus:not(:focus-visible) >path,
-.c6:focus:not(:focus-visible) >polygon,
-.c6:focus:not(:focus-visible) >polyline,
-.c6:focus:not(:focus-visible) >rect {
+.c7:focus:not(:focus-visible) >circle,
+.c7:focus:not(:focus-visible) >ellipse,
+.c7:focus:not(:focus-visible) >line,
+.c7:focus:not(:focus-visible) >path,
+.c7:focus:not(:focus-visible) >polygon,
+.c7:focus:not(:focus-visible) >polyline,
+.c7:focus:not(:focus-visible) >rect {
   outline: none;
   box-shadow: none;
 }
 
-.c6:focus:not(:focus-visible) ::-moz-focus-inner {
+.c7:focus:not(:focus-visible) ::-moz-focus-inner {
   border: 0;
 }
 
@@ -6237,6 +6257,16 @@ exports[`Menu with dropAlign bottom renders 2`] = `
   outline: none;
 }
 
+.c5 {
+  scrollbar-color: rgba(0, 0, 0, 0.33) transparent;
+}
+
+@media only screen and (max-width: 768px) {
+  .c9 {
+    padding: 6px;
+  }
+}
+
 @media only screen and (max-width: 768px) {
   .c8 {
     padding: 6px;
@@ -6244,13 +6274,7 @@ exports[`Menu with dropAlign bottom renders 2`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c7 {
-    padding: 6px;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  .c10 {
+  .c11 {
     width: 6px;
   }
 }
@@ -6280,36 +6304,36 @@ exports[`Menu with dropAlign bottom renders 2`] = `
     tabindex="-1"
   >
     <div
-      class="c4"
+      class="c4 c5"
       role="menu"
     >
       <div
-        class="c5"
+        class="c6"
         role="none"
       >
         <button
-          class="c6"
+          class="c7"
           role="menuitem"
           type="button"
         >
           <div
-            class="c7"
+            class="c8"
           >
             Item 1
           </div>
         </button>
       </div>
       <div
-        class="c5"
+        class="c6"
         role="none"
       >
         <button
-          class="c6"
+          class="c7"
           role="menuitem"
           type="button"
         >
           <div
-            class="c7"
+            class="c8"
           >
             Item 2
           </div>
@@ -6317,28 +6341,28 @@ exports[`Menu with dropAlign bottom renders 2`] = `
       </div>
     </div>
     <div
-      class="c5"
+      class="c6"
     >
       <button
         aria-label="Close Menu"
-        class="c6"
+        class="c7"
         tabindex="-1"
         type="button"
       >
         <div
-          class="c8"
+          class="c9"
         >
           <span
-            class="c9"
+            class="c10"
           >
             Test
           </span>
           <div
-            class="c10"
+            class="c11"
           />
           <svg
             aria-label="FormDown"
-            class="c11"
+            class="c12"
             viewBox="0 0 24 24"
           >
             <path
@@ -6590,7 +6614,7 @@ exports[`Menu with dropAlign top renders 2`] = `
   flex: 0 0 auto;
 }
 
-.c11 {
+.c12 {
   display: flex;
   box-sizing: border-box;
   max-width: 100%;
@@ -6714,6 +6738,10 @@ exports[`Menu with dropAlign top renders 2`] = `
   outline: none;
 }
 
+.c11 {
+  scrollbar-color: rgba(0, 0, 0, 0.33) transparent;
+}
+
 @media only screen and (max-width: 768px) {
   .c6 {
     padding: 6px;
@@ -6721,7 +6749,7 @@ exports[`Menu with dropAlign top renders 2`] = `
 }
 
 @media only screen and (max-width: 768px) {
-  .c11 {
+  .c12 {
     padding: 6px;
   }
 }
@@ -6792,7 +6820,7 @@ exports[`Menu with dropAlign top renders 2`] = `
       </button>
     </div>
     <div
-      class="c10"
+      class="c10 c11"
       role="menu"
     >
       <div
@@ -6805,7 +6833,7 @@ exports[`Menu with dropAlign top renders 2`] = `
           type="button"
         >
           <div
-            class="c11"
+            class="c12"
           >
             Item 1
           </div>
@@ -6821,7 +6849,7 @@ exports[`Menu with dropAlign top renders 2`] = `
           type="button"
         >
           <div
-            class="c11"
+            class="c12"
           >
             Item 2
           </div>

--- a/src/js/components/Select/SelectContainer.js
+++ b/src/js/components/Select/SelectContainer.js
@@ -455,6 +455,7 @@ const SelectContainer = forwardRef(
               ref={optionsRef}
               aria-multiselectable={multiple}
               onMouseMove={() => setKeyboardNavigation(false)}
+              {...passThemeFlag}
             >
               <InfiniteScroll
                 items={options}

--- a/src/js/components/Select/StyledSelect.js
+++ b/src/js/components/Select/StyledSelect.js
@@ -10,6 +10,7 @@ import {
   getHoverIndicatorStyle,
   selectedStyle,
   controlBorderStyle,
+  normalizeColor,
   sizeStyle,
   styledComponentsConfig,
 } from '../../utils';
@@ -35,6 +36,8 @@ export const OptionsContainer = styled.div.withConfig(styledComponentsConfig)`
   scroll-behavior: smooth;
   overflow: auto;
   outline: none;
+  scrollbar-color: ${(props) =>
+    `${normalizeColor('border', props.theme)} transparent`};
   ${(props) => {
     if (props.selectMultiple)
       return (

--- a/src/js/components/Select/__tests__/__snapshots__/Select-multiple-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-multiple-test.js.snap
@@ -953,6 +953,7 @@ exports[`Select Controlled multiple onChange toggle with valueKey reduce 2`] = `
   scroll-behavior: smooth;
   overflow: auto;
   outline: none;
+  scrollbar-color: rgba(0, 0, 0, 0.33) transparent;
 }
 
 .c6 {
@@ -1452,6 +1453,7 @@ exports[`Select Controlled multiple onChange with valueKey reduce 2`] = `
   scroll-behavior: smooth;
   overflow: auto;
   outline: none;
+  scrollbar-color: rgba(0, 0, 0, 0.33) transparent;
 }
 
 .c6 {
@@ -1944,6 +1946,7 @@ exports[`Select Controlled multiple onChange with valueKey string 2`] = `
   scroll-behavior: smooth;
   overflow: auto;
   outline: none;
+  scrollbar-color: rgba(0, 0, 0, 0.33) transparent;
 }
 
 .c6 {
@@ -2438,6 +2441,7 @@ exports[`Select Controlled multiple onChange without labelKey 2`] = `
   scroll-behavior: smooth;
   overflow: auto;
   outline: none;
+  scrollbar-color: rgba(0, 0, 0, 0.33) transparent;
 }
 
 .c6 {
@@ -2556,7 +2560,7 @@ exports[`Select Controlled multiple onChange without labelKey 4`] = `
     <div
       aria-label="list of options"
       aria-multiselectable="true"
-      class="StyledSelect__OptionsContainer-sc-znp66n-1 kCVsZc"
+      class="StyledSelect__OptionsContainer-sc-znp66n-1 jJZbyW"
       role="listbox"
       tabindex="-1"
     >
@@ -2630,7 +2634,7 @@ exports[`Select Controlled multiple onChange without labelKey 6`] = `
     <div
       aria-label="list of options"
       aria-multiselectable="true"
-      class="StyledSelect__OptionsContainer-sc-znp66n-1 kCVsZc"
+      class="StyledSelect__OptionsContainer-sc-znp66n-1 jJZbyW"
       role="listbox"
       tabindex="-1"
     >
@@ -3346,6 +3350,7 @@ exports[`Select Controlled multiple onChange without valueKey 2`] = `
   scroll-behavior: smooth;
   overflow: auto;
   outline: none;
+  scrollbar-color: rgba(0, 0, 0, 0.33) transparent;
 }
 
 .c6 {
@@ -3464,7 +3469,7 @@ exports[`Select Controlled multiple onChange without valueKey 4`] = `
     <div
       aria-label="list of options"
       aria-multiselectable="true"
-      class="StyledSelect__OptionsContainer-sc-znp66n-1 kCVsZc"
+      class="StyledSelect__OptionsContainer-sc-znp66n-1 jJZbyW"
       role="listbox"
       tabindex="-1"
     >
@@ -3538,7 +3543,7 @@ exports[`Select Controlled multiple onChange without valueKey 6`] = `
     <div
       aria-label="list of options"
       aria-multiselectable="true"
-      class="StyledSelect__OptionsContainer-sc-znp66n-1 kCVsZc"
+      class="StyledSelect__OptionsContainer-sc-znp66n-1 jJZbyW"
       role="listbox"
       tabindex="-1"
     >
@@ -4256,6 +4261,7 @@ exports[`Select Controlled multiple onChange without valueKey or labelKey 2`] = 
   scroll-behavior: smooth;
   overflow: auto;
   outline: none;
+  scrollbar-color: rgba(0, 0, 0, 0.33) transparent;
 }
 
 .c6 {
@@ -4374,7 +4380,7 @@ exports[`Select Controlled multiple onChange without valueKey or labelKey 4`] = 
     <div
       aria-label="list of options"
       aria-multiselectable="true"
-      class="StyledSelect__OptionsContainer-sc-znp66n-1 kCVsZc"
+      class="StyledSelect__OptionsContainer-sc-znp66n-1 jJZbyW"
       role="listbox"
       tabindex="-1"
     >
@@ -4446,7 +4452,7 @@ exports[`Select Controlled multiple onChange without valueKey or labelKey 6`] = 
     <div
       aria-label="list of options"
       aria-multiselectable="true"
-      class="StyledSelect__OptionsContainer-sc-znp66n-1 kCVsZc"
+      class="StyledSelect__OptionsContainer-sc-znp66n-1 jJZbyW"
       role="listbox"
       tabindex="-1"
     >
@@ -5216,6 +5222,7 @@ exports[`Select Controlled multiple values 3`] = `
   scroll-behavior: smooth;
   overflow: auto;
   outline: none;
+  scrollbar-color: rgba(0, 0, 0, 0.33) transparent;
 }
 
 .c6 {
@@ -5710,6 +5717,7 @@ exports[`Select Controlled multiple with empty results 2`] = `
   scroll-behavior: smooth;
   overflow: auto;
   outline: none;
+  scrollbar-color: rgba(0, 0, 0, 0.33) transparent;
 }
 
 .c6 {

--- a/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/js/components/Select/__tests__/__snapshots__/Select-test.js.snap
@@ -505,6 +505,7 @@ exports[`Select Clear option renders - bottom 1`] = `
   scroll-behavior: smooth;
   overflow: auto;
   outline: none;
+  scrollbar-color: rgba(0, 0, 0, 0.33) transparent;
 }
 
 .c10 {
@@ -775,6 +776,7 @@ exports[`Select Clear option renders correct label when wrapped in FormField 1`]
   scroll-behavior: smooth;
   overflow: auto;
   outline: none;
+  scrollbar-color: rgba(0, 0, 0, 0.33) transparent;
 }
 
 .c6 {
@@ -1020,6 +1022,7 @@ exports[`Select Clear option renders custom label 1`] = `
   scroll-behavior: smooth;
   overflow: auto;
   outline: none;
+  scrollbar-color: rgba(0, 0, 0, 0.33) transparent;
 }
 
 .c6 {
@@ -1371,6 +1374,7 @@ exports[`Select Clear option renders- top 1`] = `
   scroll-behavior: smooth;
   overflow: auto;
   outline: none;
+  scrollbar-color: rgba(0, 0, 0, 0.33) transparent;
 }
 
 .c14 {
@@ -3434,6 +3438,7 @@ exports[`Select complex options and children 3`] = `
   scroll-behavior: smooth;
   overflow: auto;
   outline: none;
+  scrollbar-color: rgba(0, 0, 0, 0.33) transparent;
 }
 
 .c6 {
@@ -4292,6 +4297,7 @@ exports[`Select default value clear 1`] = `
   scroll-behavior: smooth;
   overflow: auto;
   outline: none;
+  scrollbar-color: rgba(0, 0, 0, 0.33) transparent;
 }
 
 .c10 {
@@ -5443,6 +5449,7 @@ exports[`Select disabled key 2`] = `
   scroll-behavior: smooth;
   overflow: auto;
   outline: none;
+  scrollbar-color: rgba(0, 0, 0, 0.33) transparent;
 }
 
 .c6 {
@@ -5747,6 +5754,7 @@ exports[`Select disabled option value 1`] = `
   scroll-behavior: smooth;
   overflow: auto;
   outline: none;
+  scrollbar-color: rgba(0, 0, 0, 0.33) transparent;
 }
 
 .c6 {
@@ -6357,6 +6365,7 @@ exports[`Select large drop container height 1`] = `
   scroll-behavior: smooth;
   overflow: auto;
   outline: none;
+  scrollbar-color: rgba(0, 0, 0, 0.33) transparent;
 }
 
 .c6 {
@@ -6585,6 +6594,7 @@ exports[`Select medium drop container height 1`] = `
   scroll-behavior: smooth;
   overflow: auto;
   outline: none;
+  scrollbar-color: rgba(0, 0, 0, 0.33) transparent;
 }
 
 .c6 {
@@ -7581,6 +7591,7 @@ exports[`Select onChange with valueKey object 2`] = `
   scroll-behavior: smooth;
   overflow: auto;
   outline: none;
+  scrollbar-color: rgba(0, 0, 0, 0.33) transparent;
 }
 
 .c6 {
@@ -8340,6 +8351,7 @@ exports[`Select onChange with valueKey string 2`] = `
   scroll-behavior: smooth;
   overflow: auto;
   outline: none;
+  scrollbar-color: rgba(0, 0, 0, 0.33) transparent;
 }
 
 .c6 {
@@ -9044,6 +9056,7 @@ exports[`Select onChange with valueLabel 2`] = `
   scroll-behavior: smooth;
   overflow: auto;
   outline: none;
+  scrollbar-color: rgba(0, 0, 0, 0.33) transparent;
 }
 
 .c6 {
@@ -9537,6 +9550,7 @@ exports[`Select onChange without labelKey 2`] = `
   scroll-behavior: smooth;
   overflow: auto;
   outline: none;
+  scrollbar-color: rgba(0, 0, 0, 0.33) transparent;
 }
 
 .c6 {
@@ -10296,6 +10310,7 @@ exports[`Select onChange without labelKey or valueKey 2`] = `
   scroll-behavior: smooth;
   overflow: auto;
   outline: none;
+  scrollbar-color: rgba(0, 0, 0, 0.33) transparent;
 }
 
 .c6 {
@@ -11055,6 +11070,7 @@ exports[`Select onChange without valueKey 2`] = `
   scroll-behavior: smooth;
   overflow: auto;
   outline: none;
+  scrollbar-color: rgba(0, 0, 0, 0.33) transparent;
 }
 
 .c6 {
@@ -12389,6 +12405,7 @@ exports[`Select prop: onOpen 3`] = `
   scroll-behavior: smooth;
   overflow: auto;
   outline: none;
+  scrollbar-color: rgba(0, 0, 0, 0.33) transparent;
 }
 
 .c6 {
@@ -12494,7 +12511,7 @@ exports[`Select prop: onOpen 4`] = `
 exports[`Select prop: onOpen 5`] = `
 <div
   aria-label="list of options"
-  class="StyledSelect__OptionsContainer-sc-znp66n-1 kCVsZc"
+  class="StyledSelect__OptionsContainer-sc-znp66n-1 jJZbyW"
   role="listbox"
   tabindex="-1"
 >
@@ -13051,6 +13068,7 @@ exports[`Select renders custom clear selection styling 2`] = `
   scroll-behavior: smooth;
   overflow: auto;
   outline: none;
+  scrollbar-color: rgba(0, 0, 0, 0.33) transparent;
 }
 
 .c10 {
@@ -13644,6 +13662,7 @@ exports[`Select renders custom listbox styling 1`] = `
   scroll-behavior: smooth;
   overflow: auto;
   outline: none;
+  scrollbar-color: rgba(0, 0, 0, 0.33) transparent;
   padding: 24px;
 }
 
@@ -15994,6 +16013,7 @@ exports[`Select search 2`] = `
   scroll-behavior: smooth;
   overflow: auto;
   outline: none;
+  scrollbar-color: rgba(0, 0, 0, 0.33) transparent;
 }
 
 .c11 {
@@ -16673,6 +16693,7 @@ exports[`Select search and select 2`] = `
   scroll-behavior: smooth;
   overflow: auto;
   outline: none;
+  scrollbar-color: rgba(0, 0, 0, 0.33) transparent;
 }
 
 .c11 {
@@ -19802,6 +19823,7 @@ exports[`Select small drop container height 1`] = `
   scroll-behavior: smooth;
   overflow: auto;
   outline: none;
+  scrollbar-color: rgba(0, 0, 0, 0.33) transparent;
 }
 
 .c6 {
@@ -20153,6 +20175,7 @@ exports[`Select theme search pad 1`] = `
   scroll-behavior: smooth;
   overflow: auto;
   outline: none;
+  scrollbar-color: rgba(0, 0, 0, 0.33) transparent;
 }
 
 .c11 {

--- a/src/js/components/SelectMultiple/__tests__/__snapshots__/SelectMultiple-test.tsx.snap
+++ b/src/js/components/SelectMultiple/__tests__/__snapshots__/SelectMultiple-test.tsx.snap
@@ -6443,6 +6443,7 @@ exports[`SelectMultiple with portal renders custom listbox styling 1`] = `
   scroll-behavior: smooth;
   overflow: auto;
   outline: none;
+  scrollbar-color: rgba(0, 0, 0, 0.33) transparent;
   padding: 24px;
 }
 
@@ -8481,6 +8482,7 @@ exports[`SelectMultiple with portal theme selectMultiple test 2`] = `
   scroll-behavior: smooth;
   overflow: auto;
   outline: none;
+  scrollbar-color: rgba(0, 0, 0, 0.33) transparent;
 }
 
 .c19 {

--- a/src/js/components/TextInput/TextInput.js
+++ b/src/js/components/TextInput/TextInput.js
@@ -22,6 +22,7 @@ import { AnnounceContext } from '../../contexts';
 import {
   isNodeAfterScroll,
   isNodeBeforeScroll,
+  normalizeColor,
   sizeStyle,
   useForwardedRef,
   useSizedIcon,
@@ -70,6 +71,8 @@ const ContainerBox = styled(Box)`
     props.dropHeight
       ? sizeStyle('max-height', props.dropHeight, props.theme)
       : 'max-height: inherit;'};
+  scrollbar-color: ${(props) =>
+    `${normalizeColor('border', props.theme)} transparent`};
 
   /* IE11 hack to get drop contents to not overflow */
   @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {

--- a/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.tsx.snap
+++ b/src/js/components/TextInput/__tests__/__snapshots__/TextInput-test.tsx.snap
@@ -402,6 +402,7 @@ exports[`TextInput calls onSuggestionsClose 2`] = `
 
 .c3 {
   max-height: inherit;
+  scrollbar-color: rgba(0, 0, 0, 0.33) transparent;
 }
 
 @media only screen and (max-width: 768px) {
@@ -617,6 +618,7 @@ exports[`TextInput calls onSuggestionsOpen 1`] = `
 
 .c3 {
   max-height: inherit;
+  scrollbar-color: rgba(0, 0, 0, 0.33) transparent;
 }
 
 @media only screen and (max-width: 768px) {
@@ -909,6 +911,7 @@ exports[`TextInput close suggestion drop 2`] = `
 
 .c3 {
   max-height: inherit;
+  scrollbar-color: rgba(0, 0, 0, 0.33) transparent;
 }
 
 @media only screen and (max-width: 768px) {
@@ -1222,6 +1225,7 @@ exports[`TextInput complex suggestions 2`] = `
 
 .c3 {
   max-height: inherit;
+  scrollbar-color: rgba(0, 0, 0, 0.33) transparent;
 }
 
 @media only screen and (max-width: 768px) {
@@ -1979,6 +1983,7 @@ exports[`TextInput large drop height 1`] = `
 
 .c3 {
   max-height: 768px;
+  scrollbar-color: rgba(0, 0, 0, 0.33) transparent;
 }
 
 @media only screen and (max-width: 768px) {
@@ -2570,6 +2575,7 @@ exports[`TextInput medium drop height 1`] = `
 
 .c3 {
   max-height: 384px;
+  scrollbar-color: rgba(0, 0, 0, 0.33) transparent;
 }
 
 @media only screen and (max-width: 768px) {
@@ -4723,6 +4729,7 @@ exports[`TextInput select suggestion 2`] = `
 
 .c3 {
   max-height: inherit;
+  scrollbar-color: rgba(0, 0, 0, 0.33) transparent;
 }
 
 @media only screen and (max-width: 768px) {
@@ -5653,6 +5660,7 @@ exports[`TextInput small drop height 1`] = `
 
 .c3 {
   max-height: 192px;
+  scrollbar-color: rgba(0, 0, 0, 0.33) transparent;
 }
 
 @media only screen and (max-width: 768px) {
@@ -5931,6 +5939,7 @@ exports[`TextInput suggestions 2`] = `
 
 .c3 {
   max-height: inherit;
+  scrollbar-color: rgba(0, 0, 0, 0.33) transparent;
 }
 
 @media only screen and (max-width: 768px) {

--- a/src/js/components/TimeInput/TimeInputPopup.js
+++ b/src/js/components/TimeInput/TimeInputPopup.js
@@ -24,6 +24,8 @@ import {
 const PopupColumnBox = styled(Box)`
   scrollbar-gutter: stable;
   scrollbar-width: thin;
+  scrollbar-color: ${(props) =>
+    `${normalizeColor('border', props.theme)} transparent`};
 `;
 
 const PopupOption = styled.div`

--- a/src/js/components/TimeInput/TimeInputPopup.js
+++ b/src/js/components/TimeInput/TimeInputPopup.js
@@ -123,6 +123,7 @@ const PopupColumn = ({
   section,
   sections,
   theme,
+  passThemeFlag,
 }) => {
   // When inline (in DateTimeInput), use 'medium' to match Calendar height.
   // Otherwise use timeInput drop maxHeight with fallback to 'small'.
@@ -142,6 +143,7 @@ const PopupColumn = ({
       }}
       overflow="auto"
       flex={{ grow: 0, shrink: 0 }}
+      {...passThemeFlag}
     >
       {options.map((option) => {
         const key = optionKey(label, option);
@@ -243,7 +245,7 @@ const TimeInputPopup = ({
   onKeyDown: onKeyDownProp,
   ...rest
 }) => {
-  const { theme } = useThemeValue();
+  const { theme, passThemeFlag } = useThemeValue();
   const dialogRef = useRef();
   const pointerDownInsideRef = useRef(false);
   const pointerSelectionCommittedRef = useRef(false);
@@ -676,6 +678,7 @@ const TimeInputPopup = ({
           section={section}
           sections={sections}
           theme={theme}
+          passThemeFlag={passThemeFlag}
         />
       ))}
     </Box>


### PR DESCRIPTION
## Summary

Fixes #8105.

Several Drop-based scrollable containers (Select's options list, TimeInput's
time popup, Menu's items list, MaskedInput's and TextInput's suggestion
drops) set `overflow: auto` but never set `scrollbar-color`, so the browser
falls back to its default *light* scrollbar regardless of the active theme.
Against a dark-mode Drop background this creates a harsh, unstyled-looking
scrollbar.

This PR adds `scrollbar-color: <theme border color> transparent` to each
affected container, using the existing `border` color token so it
automatically resolves to the light or dark value based on the theme —
no new theme keys needed.

## Changes

- `Select` — `OptionsContainer`
- `TimeInput` — `PopupColumnBox`
- `Menu` — new `MenuItemsBox` styled wrapper (replaces a plain `Box`)
- `MaskedInput` — `ContainerBox`
- `TextInput` — `ContainerBox`


## Testing

- Ran the full test suites for `Select`, `SelectMultiple`, `TimeInput`,
  `Menu`, `MaskedInput`, `TextInput`, `DataFilter`, and `DataSort`
  (`DataFilter`/`DataSort` render `Select` internally, so their snapshots
  picked up the change) — all 332 tests / 349 snapshots pass.
- Verified manually in Storybook with dark mode toggled on:
  - `Select → Many Options`
  - `TimeInput → Theming Light Dark`
  - `Menu` (a story with enough items to overflow)
  - `MaskedInput` and `TextInput` autocomplete suggestions
- Linted and Prettier-checked all changed files.

## Screenshots

**Before (light scrollbar in dark mode):**
<img width="1513" height="470" alt="Screenshot 2026-09-04 132658" src="https://github.com/user-attachments/assets/30eb395b-a22c-4d2b-99cb-dd77623b0ec2" />
<img width="1472" height="474" alt="Screenshot 2026-09-04 141636" src="https://github.com/user-attachments/assets/cff80844-bf2c-44a8-a6ce-bf88366bfae0" />
<img width="1537" height="537" alt="Screenshot 2026-09-04 141716" src="https://github.com/user-attachments/assets/bf937ee4-0934-4574-9f8c-54a19637ebf0" />
<img width="1548" height="558" alt="Screenshot 2026-09-04 141802" src="https://github.com/user-attachments/assets/af37aa47-0407-4cee-a12a-0465c48b379c" />
<img width="1544" height="506" alt="Screenshot 2026-09-04 141852" src="https://github.com/user-attachments/assets/83fd090f-d52e-4831-899a-ed40156af5f2" />




**After (scrollbar matches theme):**
<img width="1386" height="515" alt="Screenshot 2026-09-04 141607" src="https://github.com/user-attachments/assets/6d307dc5-8487-4831-b116-089d45c04c7f" />
<img width="1483" height="508" alt="Screenshot 2026-09-04 141644" src="https://github.com/user-attachments/assets/76ee79b9-c1ed-4146-aaf6-bc8227cde64a" />
<img width="1539" height="565" alt="Screenshot 2026-09-04 141742" src="https://github.com/user-attachments/assets/88616a8a-2a19-4de7-83ac-deb7ffd70ee7" />
<img width="1533" height="544" alt="Screenshot 2026-09-04 141828" src="https://github.com/user-attachments/assets/52d08add-6a15-4762-81c9-fae41df99e4b" />
<img width="1543" height="478" alt="Screenshot 2026-09-04 141911" src="https://github.com/user-attachments/assets/0cafdbe0-c806-47f9-92bf-31b9868c1765" />
