### PR TITLE
Drop: measure the layout size, not the animated size, when placing

### DIFF
--- a/src/js/components/Drop/DropContainer.js
+++ b/src/js/components/Drop/DropContainer.js
@@ -59,6 +59,29 @@ const getContainingBlock = (element) => {
 
 const defaultAlign = { top: 'top', left: 'left' };
 
+// The drop animates in with a scale transform (see StyledDrop). A
+// getBoundingClientRect() taken while that animation is running returns the
+// scaled size, so a drop placed mid-animation would be sized too small.
+// Undo the current transform to get the layout size.
+const getLayoutRect = (element) => {
+  const rect = element.getBoundingClientRect();
+  const { transform } = window.getComputedStyle(element);
+  const match = transform && transform.match(/^matrix(3d)?\((.+)\)$/);
+  if (!match) return rect;
+  const values = match[2].split(',').map(Number);
+  const [a, b, c, d] = match[1]
+    ? [values[0], values[1], values[4], values[5]]
+    : values;
+  const scaleX = Math.hypot(a, b);
+  const scaleY = Math.hypot(c, d);
+  if (!scaleX || !scaleY || (scaleX === 1 && scaleY === 1)) return rect;
+  return {
+    ...rect,
+    width: rect.width / scaleX,
+    height: rect.height / scaleY,
+  };
+};
+
 const DropContainer = forwardRef(
   (
     {
@@ -165,7 +188,7 @@ const DropContainer = forwardRef(
           }
           // get bounds
           const targetRect = target.getBoundingClientRect();
-          const containerRect = container.getBoundingClientRect();
+          const containerRect = getLayoutRect(container);
           // determine width
           let width;
           if (stretch) {

--- a/src/js/components/Drop/__tests__/Drop-test.tsx
+++ b/src/js/components/Drop/__tests__/Drop-test.tsx
@@ -408,6 +408,51 @@ describe('Drop', () => {
     { bottom: 'bottom', right: 'left' },
   ];
 
+  test('sizes to the layout width while the open animation scales it', () => {
+    render(<TestInput align={{ top: 'bottom', left: 'left' }} />);
+
+    const inputEl = screen.getByLabelText('test');
+    const dropEl = document.getElementById('drop-node') as HTMLElement;
+
+    const rect = (width: number, height: number): DOMRect =>
+      ({
+        x: 0,
+        y: 0,
+        top: 0,
+        left: 0,
+        right: width,
+        bottom: height,
+        width,
+        height,
+        toJSON: () => ({}),
+      } as DOMRect);
+    jest.spyOn(inputEl, 'getBoundingClientRect').mockReturnValue(rect(100, 40));
+    // mid-animation: the drop is drawn at scale(0.8), its layout width is 400
+    jest.spyOn(dropEl, 'getBoundingClientRect').mockReturnValue(rect(320, 240));
+    const originalGetComputedStyle = window.getComputedStyle;
+    jest
+      .spyOn(window, 'getComputedStyle')
+      .mockImplementation((element, pseudoElement) => {
+        const style = originalGetComputedStyle.call(
+          window,
+          element,
+          pseudoElement,
+        );
+        if (element === dropEl) {
+          Object.defineProperty(style, 'transform', {
+            value: 'matrix(0.8, 0, 0, 0.8, 0, 0)',
+            configurable: true,
+          });
+        }
+        return style;
+      });
+
+    fireEvent(window, new Event('resize', { bubbles: true, cancelable: true }));
+
+    expect(dropEl.style.width).toBe('400.1px');
+    jest.restoreAllMocks();
+  });
+
   describe('responsive placement when neither side fully fits', () => {
     const mockRect = (
       element: Element,


### PR DESCRIPTION
#### What does this PR do?

Fixes the drop being sized too narrow when it is placed while its open animation is running. `StyledDrop` animates in with `transform: scale(0.8)` → `scale(1)` (0.1s, after a 0.01s delay). `DropContainer`'s `place()` runs in an effect on mount and took the drop's size from `getBoundingClientRect()`, which reports the *transformed* box. Whenever that effect ran after the animation had started, `container.style.width` was locked to roughly 80% of the content width; the content overflowed, the drop scrolled horizontally as focus moved into it, and its left side was clipped.

`place()` now divides the measured width and height by the scale of the element's current computed transform, so the drop is sized from its layout box regardless of when it is placed relative to the animation. Elements with no transform are unaffected (`getComputedStyle(...).transform === 'none'` returns the rect unchanged).

#### Where should the reviewer start?

`src/js/components/Drop/DropContainer.js`: the new `getLayoutRect` helper and its single call site in `place()` (replacing `container.getBoundingClientRect()`).

#### What testing has been done on this PR?

- New Jest test in `Drop-test.tsx`: with the drop's rect mocked at scale(0.8) (320px for a 400px layout width) and `getComputedStyle` reporting `matrix(0.8, 0, 0, 0.8, 0, 0)` for that element, the drop is sized to `400.1px`. On `master` this test receives `320.1px`.
- Existing Drop, DropButton, Select, SelectMultiple, Menu, Tip, DateInput, Calendar, TimeInput and DateTimeInput suites pass (the only failures on this Windows machine are the pre-existing timezone/rAF-dependent cases noted in #8110, which also fail on an unmodified `master`).
- `eslint` and `prettier --check` on the changed files: clean.
- Reproduced and verified in headless Chrome 152 driven over CDP against the local Storybook (`Input/DateTimeInput/Form`, 1174px viewport). Sequence: open with the calendar icon, close, click the `day` segment, press Space, then read the drop's inline width / `scrollWidth` / `scrollLeft` 500ms later.
  - `master`, 4 of 4 runs: `width: 456px`, `scrollWidth: 502`, `scrollLeft: 36` — calendar clipped on the left, horizontal scrollbar.
  - This branch, 4 of 4 runs: `width: 562.897px`, `scrollWidth: 563`, `scrollLeft: 0`.
  - Opening with the icon button gave `562.897px` in both cases. Sampling the content width every frame after opening shows it growing 456 → 492 → 527 → 558 → 563 over ~250ms, i.e. the scale animation; 456 / 563 = 0.81, which is where the broken measurement came from.

#### How should this be manually tested?

1. Run Storybook and open `Input/DateTimeInput/Form`.
2. Open the picker with the calendar icon, close it, click one of the input segments and press Space.
3. Before this change the drop is narrower than its content (the calendar is cut off on the left and the drop scrolls horizontally); after it the drop matches the content width, the same as when opened with the icon.

#### Do Jest tests follow these best practices?

- [x] `screen` is used for querying.
- [x] The correct query is used. (`screen.getByLabelText('test')` for the target input, as in the neighbouring placement tests; the drop node is looked up by id the same way those tests do)
- [x] `asFragment()` is used for snapshot testing. (no snapshots added)

#### Any background context you want to provide?

The scaled measurement can affect any `Drop` placed mid-animation, not only DateTimeInput; keyboard-driven opens seem to land in that window more often than clicks. The fix is in `DropContainer` so every consumer benefits. `matrix3d(...)` values are handled as well as `matrix(...)`.

#### What are the relevant issues?

Fixes #8059

#### Screenshots (if appropriate)

N/A — measurements are listed above; the issue already has before/after screenshots.

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

Yes: "Drop is no longer sized too small when it is positioned while its open animation is running (for example DateTimeInput opened with the keyboard)."

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible. Drops that were measured after the animation finished get the same size as before; only the mid-animation case changes.
