### PR TITLE
fix: add padding between timeparts and scrollbar

### DIFF
--- a/src/js/components/TimeInput/TimeInputPopup.js
+++ b/src/js/components/TimeInput/TimeInputPopup.js
@@ -24,6 +24,14 @@ import {
 const PopupColumnBox = styled(Box)`
   scrollbar-gutter: stable;
   scrollbar-width: thin;
+  ${(props) =>
+    edgeStyle(
+      'padding',
+      'xsmall',
+      false,
+      props.theme.box.responsiveBreakpoint,
+      props.theme,
+    )}
 `;
 
 const PopupOption = styled.div`
@@ -584,7 +592,7 @@ const TimeInputPopup = ({
       direction="row"
       width={{ width: theme.timeInput?.drop?.width, max: '100%' }}
       minHeight={theme.timeInput?.drop?.minHeight}
-      gap={theme.timeInput?.drop?.gap || 'xsmall'}
+      gap={theme.timeInput?.drop?.gap || 'none'}
       pad={inline ? 'none' : theme.timeInput?.drop?.pad || 'small'}
       onPointerDownCapture={markInteractionInProgress}
       onPointerUpCapture={releaseInteractionAfterClick}

--- a/src/js/components/TimeInput/__tests__/TimeInput-test.tsx
+++ b/src/js/components/TimeInput/__tests__/TimeInput-test.tsx
@@ -2162,4 +2162,30 @@ describe('TimeInput', () => {
     expect(getDisplayInput()).toHaveValue('hh:mm:02');
     expect(secondSegment).toHaveTextContent('02');
   });
+
+  test('column box should have padding', async () => {
+    const user = userEvent.setup();
+    const Controlled = () => {
+      const [value, setValue] = React.useState('09:10:11');
+      const onChange = ({ value: next }: { value?: string }) => {
+        setValue(next || '');
+      };
+      return (
+        <>
+          <TimeInput value={value} onChange={onChange} format="12" />
+        </>
+      );
+    };
+
+    render(
+      <Grommet>
+        <Controlled />
+      </Grommet>,
+    );
+    await user.click(screen.getByRole('button', { name: 'Choose time' }));
+    const boxes = screen.getAllByRole('listbox');
+    expect(boxes[0]).toHaveStyleRule('padding', '6px');
+    expect(boxes[1]).toHaveStyleRule('padding', '6px');
+    expect(boxes[2]).toHaveStyleRule('padding', '6px');
+  });
 });


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

This PR adds symmetrical space between options and the scrollbar, while also maintaining horizontal gap between time parts.

#### Where should the reviewer start?

Reviewer can start by looking at the storybook for controlled time input component.

#### What testing has been done on this PR?
One additional test has been written to verify if the padding is being added to the listbox.

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [x] `screen` is used for querying.
- [x] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

Fixes #8106 

#### Screenshots (if appropriate)
<img width="333" height="340" alt="Screenshot 2026-09-08 at 12 24 30 AM" src="https://github.com/user-attachments/assets/15404855-5c51-49f1-9234-a4bcfe78fec2" />

#### Do the grommet docs need to be updated?

No

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
