### PR TITLE
fix DateTimeInput underline focus sync

### DIFF
--- a/src/js/components/DateTimeInput/DateTimeInput.js
+++ b/src/js/components/DateTimeInput/DateTimeInput.js
@@ -1047,8 +1047,8 @@ const DateTimeInput = forwardRef(
         suppressTimePartialSyncRef.current = true;
         setPendingDigits({});
         editStateRef.current = { section: activeSection, buffer: '' };
-        activeSectionRef.current = SECTION_HOUR;
-        setActiveSection(SECTION_HOUR);
+        activeSectionRef.current = SECTION_DAY;
+        setActiveSection(SECTION_DAY);
         commitSections(nextSections);
       },
       [
@@ -1175,6 +1175,24 @@ const DateTimeInput = forwardRef(
       return `${pad(sections.hour)}:${pad(minute)}:${pad(resolvedSecond)}`;
     }, [resolvedFormat, sections, showSeconds]);
 
+    const handleTimeActiveSectionChange = useCallback(
+      (changedTimeSectionIndex) => {
+        const dtSection = TIME_TO_DT_SECTION[changedTimeSectionIndex];
+        if (dtSection !== undefined) setActiveSection(dtSection);
+      },
+      [setActiveSection, TIME_TO_DT_SECTION],
+    );
+
+    const handleCalendarFocus = useCallback(
+      (event) => {
+        if (disabled || readOnly) return;
+        if (event.target.closest?.('[role="grid"]')) {
+          setActiveSection(SECTION_DAY);
+        }
+      },
+      [disabled, readOnly, setActiveSection],
+    );
+
     const showActiveSection =
       (segmentFocused || open) && !readOnly && !disabled;
     const { inForm } = formContext.useFormField({});
@@ -1224,6 +1242,7 @@ const DateTimeInput = forwardRef(
           <Calendar
             date={getCalendarDate(sections)}
             initialFocus={inline ? undefined : 'days'}
+            onFocus={handleCalendarFocus}
             onSelect={disabled || readOnly ? undefined : handleCalendarSelect}
           />
         </ThemeContext.Extend>
@@ -1246,6 +1265,9 @@ const DateTimeInput = forwardRef(
           disabled={disabled}
           readOnly={readOnly}
           onChange={disabled || readOnly ? undefined : handleTimeSelect}
+          onActiveSectionChange={
+            disabled || readOnly ? undefined : handleTimeActiveSectionChange
+          }
           onPartialChange={
             disabled || readOnly ? undefined : handleTimePartialChange
           }

--- a/src/js/components/DateTimeInput/__tests__/DateTimeInput-test.tsx
+++ b/src/js/components/DateTimeInput/__tests__/DateTimeInput-test.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import 'jest-styled-components';
 import {
+  act,
   fireEvent,
   render,
   screen,
@@ -234,6 +235,109 @@ describe('DateTimeInput', () => {
     ).toHaveTextContent('45');
   });
 
+  test('marks the day segment active after selecting a calendar day', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Grommet>
+        <DateTimeInput
+          id="dt-calendar-active-section"
+          format="12"
+          value="2026-07-22T18:30:00.000Z"
+        />
+      </Grommet>,
+    );
+
+    const trigger = screen.getByRole('button', {
+      name: /date and time/i,
+    });
+    await user.click(trigger);
+
+    const drop = getDropFromTrigger(trigger);
+    await user.click(
+      within(drop).getByRole('button', { name: /Jul 23 2026/i }),
+    );
+
+    // ::after underline marks the active segment; #000000 is its theme default.
+    expect(
+      screen.getByRole('spinbutton', { name: 'day', hidden: true }),
+    ).toHaveStyleRule('background-color', '#000000', { modifier: '::after' });
+    expect(
+      screen.getByRole('spinbutton', { name: 'hours', hidden: true }),
+    ).not.toHaveStyleRule('background-color', '#000000', {
+      modifier: '::after',
+    });
+  });
+
+  test('marks the segment active for the focused popup time column', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Grommet>
+        <DateTimeInput
+          id="dt-popup-focus-section"
+          format="12"
+          value="2026-07-22T18:30:00.000Z"
+        />
+      </Grommet>,
+    );
+
+    const trigger = screen.getByRole('button', {
+      name: /date and time/i,
+    });
+    await user.click(trigger);
+
+    const drop = getDropFromTrigger(trigger);
+    // Focus without committing a value — the underline must still follow.
+    fireEvent.focus(
+      within(within(drop).getByRole('listbox', { name: 'minute' })).getByRole(
+        'option',
+        { name: '30 minutes' },
+      ),
+    );
+
+    expect(
+      screen.getByRole('spinbutton', { name: 'minutes', hidden: true }),
+    ).toHaveStyleRule('background-color', '#000000', { modifier: '::after' });
+  });
+
+  test('marks the day segment active when focus moves back to a calendar day', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Grommet>
+        <DateTimeInput
+          id="dt-calendar-refocus"
+          format="12"
+          value="2026-07-22T18:30:00.000Z"
+        />
+      </Grommet>,
+    );
+
+    const trigger = screen.getByRole('button', {
+      name: /date and time/i,
+    });
+    await user.click(trigger);
+
+    const drop = getDropFromTrigger(trigger);
+    fireEvent.focus(
+      within(within(drop).getByRole('listbox', { name: 'minute' })).getByRole(
+        'option',
+        { name: '30 minutes' },
+      ),
+    );
+    fireEvent.focus(within(drop).getByRole('button', { name: /Jul 21 2026/i }));
+
+    expect(
+      screen.getByRole('spinbutton', { name: 'day', hidden: true }),
+    ).toHaveStyleRule('background-color', '#000000', { modifier: '::after' });
+    expect(
+      screen.getByRole('spinbutton', { name: 'minutes', hidden: true }),
+    ).not.toHaveStyleRule('background-color', '#000000', {
+      modifier: '::after',
+    });
+  });
+
   test('selecting time in drop selects a calendar day when date is empty', async () => {
     const user = userEvent.setup();
 
@@ -329,11 +433,13 @@ describe('DateTimeInput', () => {
 
     const drop = getDropFromTrigger(trigger);
     const hourList = within(drop).getByRole('listbox', { name: 'hour' });
-    await waitFor(() =>
-      expect(
-        within(hourList).getByRole('option', { name: '00 hours' }),
-      ).toHaveFocus(),
-    );
+    const hourOption = within(hourList).getByRole('option', {
+      name: '00 hours',
+    });
+    act(() => {
+      hourOption.focus();
+    });
+    await waitFor(() => expect(hourOption).toHaveFocus());
     await user.keyboard('{ArrowUp}');
 
     expect(

--- a/src/js/components/TimeInput/TimeInput.js
+++ b/src/js/components/TimeInput/TimeInput.js
@@ -113,6 +113,7 @@ const TimeInput = forwardRef(
       minuteStep = 1,
       name,
       onChange,
+      onActiveSectionChange,
       onPartialChange,
       readOnly = false,
       showSeconds,
@@ -223,7 +224,7 @@ const TimeInput = forwardRef(
       moveSection,
       parsePasted,
       sections,
-      setActiveSection,
+      setActiveSection: setActiveSectionState,
       setSectionValue,
       pendingDigits,
     } = useSectionedTimeField({
@@ -247,6 +248,15 @@ const TimeInput = forwardRef(
       },
       onInvalid: handleInvalid,
     });
+
+    // makes DateTimeInput track focus-driven section changes, not just commits.
+    const setActiveSection = useCallback(
+      (section) => {
+        setActiveSectionState(section);
+        onActiveSectionChange?.(section);
+      },
+      [onActiveSectionChange, setActiveSectionState],
+    );
 
     // Builds the announcement text for a given section: its current value
     // (e.g. "3 hours") if it has one, or just the section name (e.g. "hours

--- a/src/js/components/TimeInput/TimeInputPopup.js
+++ b/src/js/components/TimeInput/TimeInputPopup.js
@@ -559,6 +559,9 @@ const TimeInputPopup = ({
     let rafB;
     const rafA = requestAnimationFrame(() => {
       scrollSelectedOptionsIntoView();
+      // Inline pickers share focus with the calendar; only refocus within them.
+      if (inline && !dialogRef.current?.contains(document.activeElement))
+        return;
       const focused = focusCurrentPopupOption();
       // Retry one more frame to handle occasional mount timing races.
       if (!focused) {
@@ -574,7 +577,7 @@ const TimeInputPopup = ({
       window.cancelAnimationFrame(rafA);
       if (rafB) window.cancelAnimationFrame(rafB);
     };
-  }, [focusCurrentPopupOption, scrollSelectedOptionsIntoView]);
+  }, [focusCurrentPopupOption, inline, scrollSelectedOptionsIntoView]);
 
   const popupContent = (
     <Box

--- a/src/js/components/TimeInput/index.d.ts
+++ b/src/js/components/TimeInput/index.d.ts
@@ -23,6 +23,7 @@ export interface TimeInputProps {
   };
   minuteStep?: number;
   name?: string;
+  onActiveSectionChange?: (activeSection: number) => void;
   onChange?: (event: { value?: string }) => void;
   readOnly?: boolean;
   showSeconds?: boolean;

--- a/src/js/components/TimeInput/propTypes.js
+++ b/src/js/components/TimeInput/propTypes.js
@@ -25,6 +25,7 @@ if (process.env.NODE_ENV !== 'production') {
     }),
     minuteStep: PropTypes.number,
     name: PropTypes.string,
+    onActiveSectionChange: PropTypes.func,
     onChange: PropTypes.func,
     readOnly: PropTypes.bool,
     showSeconds: PropTypes.bool,

--- a/src/js/components/__tests__/__snapshots__/components-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/components-test.js.snap
@@ -1193,6 +1193,7 @@ exports[`Components loads 1`] = `
       "messages": [Function],
       "minuteStep": [Function],
       "name": [Function],
+      "onActiveSectionChange": [Function],
       "onChange": [Function],
       "readOnly": [Function],
       "showSeconds": [Function],


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Keeps the DateTimeInput segment underline in sync with popup focus.

- Calendar day focus/selection now marks the `day` segment instead of forcing `hours`.
- Focusing a time column (Tab / arrows) updates the underline, not just committed values.
- The inline time picker no longer steals focus from the calendar.

#### Where should the reviewer start?
`DateTimeInput.js` — `handleCalendarFocus` and `handleTimeActiveSectionChange`.

#### What testing has been done on this PR?
3 new tests in `DateTimeInput-test.tsx`; DateTimeInput + TimeInput suites pass (114).

#### How should this be manually tested?
Open **Input → DateTimeInput → Simple**, open the picker, then Tab between the time columns and back into the calendar. The underline should follow focus.

#### Do Jest tests follow these best practices?

- [x] `screen` is used for querying.
- [x] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
The underline previously only updated on **commit**, so focus-only navigation left it stale. Tests assert the `::after` underline rather than `tabindex`, which the open Drop's focus trap rewrites.

#### What are the relevant issues?
Closes #8044

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?
Yes

#### Is this change backwards compatible or is it a breaking change?
Backwards compatible.