### PR TITLE
fix(DataTable): show sortable header affordance on keyboard focus

### DIFF
--- a/src/js/components/DataTable/Header.js
+++ b/src/js/components/DataTable/Header.js
@@ -72,7 +72,8 @@ const buttonStyle = ({ pad, theme, verticalAlign }) => {
     if (partStyles.length > 0)
       styles.push(
         css`
-          &:hover {
+          &:hover,
+          &:focus-visible {
             ${partStyles}
           }
         `,

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.tsx.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.tsx.snap
@@ -3854,7 +3854,8 @@ exports[`DataTable custom theme 1`] = `
   padding: 6px 12px;
 }
 
-.c7:hover {
+.c7:hover,
+.c7:focus-visible {
   background-color: rgba(242, 242, 242, 1);
   color: #444444;
 }
@@ -4110,7 +4111,7 @@ exports[`DataTable custom theme 2`] = `
           >
             <button
               aria-labelledby="grommet-data-table-header-a-label grommet-data-table-header-a-sort-status"
-              class="StyledButton-sc-323bzc-0 fukeSz Header__StyledHeaderCellButton-sc-1baku5q-0 idAFoS"
+              class="StyledButton-sc-323bzc-0 fukeSz Header__StyledHeaderCellButton-sc-1baku5q-0 ZJQtp"
               type="button"
             >
               <div

--- a/src/js/components/DataTable/stories/CustomThemed/Custom.stories.js
+++ b/src/js/components/DataTable/stories/CustomThemed/Custom.stories.js
@@ -43,7 +43,8 @@ const customTheme = {
             sort &&
             sort.property !== column &&
             `
-              &:hover {
+              &:hover,
+              &:focus-visible {
                 svg {
                   opacity: 100%;
                 }


### PR DESCRIPTION
## Summary

Fixes #8113

Adds the sortable `DataTable` header hover affordance to `:focus-visible` so keyboard users get the same visual indication as mouse users.

## Changes

* Updated `Header.js` to apply the hover styling on `:focus-visible`.
* Updated the Custom Themed DataTable story to show the affordance on keyboard focus.
* Updated the affected snapshot.

## Testing

* `npx jest src/js/components/DataTable` — 91 tests passed.
* `npx eslint src/js/components/DataTable/Header.js` — passed.

Before :
<img width="1919" height="971" alt="Screenshot 2026-09-08 180321" src="https://github.com/user-attachments/assets/adf8095f-ba24-49d4-b741-e09a27b2f1b4" />

After:
<img width="1915" height="971" alt="Screenshot 2026-09-08 180305" src="https://github.com/user-attachments/assets/dde1c71d-d0df-430e-920c-34dc569531a9" />

