### PR TITLE
feat: add optional border to box on hover

### DIFF
--- a/src/js/components/Box/StyledBox.js
+++ b/src/js/components/Box/StyledBox.js
@@ -22,6 +22,7 @@ import {
   parseMetricToNum,
   responsiveBorderStyle,
   widthStyle,
+  getHoverIndicatorBorderStyle,
 } from '../../utils';
 
 import { roundStyle, styledComponentsConfig } from '../../utils/styles';
@@ -195,6 +196,13 @@ const interactiveStyle = css`
     ${(props) =>
       props.hoverIndicator &&
       getHoverIndicatorStyle(props.hoverIndicator, props.theme)}
+    ${(props) =>
+      props.hoverIndicator &&
+      getHoverIndicatorBorderStyle(
+        props.hoverIndicator,
+        props.responsive,
+        props.theme,
+      )}
   }
 `;
 

--- a/src/js/components/Box/__tests__/Box-style-test.tsx
+++ b/src/js/components/Box/__tests__/Box-style-test.tsx
@@ -324,4 +324,19 @@ describe('Box', () => {
 
     expect(container.firstChild).toMatchSnapshot();
   });
+
+  test('hoverIndicator with border', () => {
+    const { container } = render(
+      <Grommet>
+        <Box>
+          <Box
+            onClick={() => {}}
+            hoverIndicator={{ border: { color: 'status-ok' } }}
+          ></Box>
+        </Box>
+      </Grommet>,
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
 });

--- a/src/js/components/Box/__tests__/__snapshots__/Box-style-test.tsx.snap
+++ b/src/js/components/Box/__tests__/__snapshots__/Box-style-test.tsx.snap
@@ -1430,6 +1430,60 @@ exports[`Box hoverIndicator 1`] = `
 </div>
 `;
 
+exports[`Box hoverIndicator with border 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c1 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.c2 {
+  display: flex;
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  cursor: pointer;
+}
+
+.c2:hover {
+  border: solid 1px #009E67;
+}
+
+@media only screen and (max-width: 768px) {
+  .c2:hover {
+    border: solid 1px #009E67;
+  }
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+  >
+    <div
+      class="c2"
+      tabindex="0"
+    />
+  </div>
+</div>
+`;
+
 exports[`Box round 1`] = `
 .c0 {
   font-size: 18px;

--- a/src/js/components/Box/index.d.ts
+++ b/src/js/components/Box/index.d.ts
@@ -44,7 +44,11 @@ export interface BoxProps {
   gap?: GapType | { row?: GapType; column?: GapType };
   height?: HeightType;
   hoverIndicator?:
-    | { background?: BackgroundType; elevation?: ElevationType }
+    | {
+        background?: BackgroundType;
+        elevation?: ElevationType;
+        border?: BorderType;
+      }
     | BackgroundType
     | boolean;
   justify?:

--- a/src/js/components/Box/stories/OnClick.stories.js
+++ b/src/js/components/Box/stories/OnClick.stories.js
@@ -8,7 +8,7 @@ import { Box, Text } from 'grommet';
 export const OnClickBox = () => (
   // Uncomment <Grommet> lines when using outside of storybook
   // <Grommet theme={...}>
-  <Box justify="center" align="center" pad="large">
+  <Box justify="center" align="center" pad="large" gap={{ row: 'small' }}>
     {/* eslint-disable no-alert */}
     <Box
       border
@@ -28,6 +28,27 @@ export const OnClickBox = () => (
     >
       <Attraction size="large" />
       <Text>Party</Text>
+    </Box>
+    <Box
+      border
+      pad="large"
+      align="center"
+      round
+      gap="small"
+      hoverIndicator={{
+        background: {
+          color: 'background-contrast',
+        },
+        border: {
+          color: 'status-ok',
+        },
+      }}
+      onClick={() => {
+        alert('clicked');
+      }}
+    >
+      <Attraction size="large" />
+      <Text>Party With Border</Text>
     </Box>
   </Box>
   // </Grommet>

--- a/src/js/components/CheckBoxGroup/__tests__/__snapshots__/CheckBoxGroup-test.tsx.snap
+++ b/src/js/components/CheckBoxGroup/__tests__/__snapshots__/CheckBoxGroup-test.tsx.snap
@@ -1353,7 +1353,7 @@ exports[`CheckBoxGroup onClick for check and uncheck a CheckBox 2`] = `
   class="StyledGrommet-sc-19lkkz7-0 eVypbb"
 >
   <div
-    class="StyledBox-sc-13pk1d4-0 kCujUd StyledCheckBoxGroup-sc-2nhc5d-0"
+    class="StyledBox-sc-13pk1d4-0 lkuHSR StyledCheckBoxGroup-sc-2nhc5d-0"
     role="group"
     tabindex="0"
   >

--- a/src/js/components/List/__tests__/__snapshots__/List-test.tsx.snap
+++ b/src/js/components/List/__tests__/__snapshots__/List-test.tsx.snap
@@ -3626,14 +3626,14 @@ exports[`List events Enter key 2`] = `
     role="listbox"
   >
     <li
-      class="StyledBox-sc-13pk1d4-0 hjepzd List__StyledItem-sc-130gdqg-1 lgldaM"
+      class="StyledBox-sc-13pk1d4-0 csncjt List__StyledItem-sc-130gdqg-1 lgldaM"
       role="option"
       tabindex="-1"
     >
       alpha
     </li>
     <li
-      class="StyledBox-sc-13pk1d4-0 eWMkPm List__StyledItem-sc-130gdqg-1 lgldaM"
+      class="StyledBox-sc-13pk1d4-0 dGDpOq List__StyledItem-sc-130gdqg-1 lgldaM"
       role="option"
       tabindex="0"
     >
@@ -3833,14 +3833,14 @@ exports[`List events focus and blur 2`] = `
     role="listbox"
   >
     <li
-      class="StyledBox-sc-13pk1d4-0 hjepzd List__StyledItem-sc-130gdqg-1 lgldaM"
+      class="StyledBox-sc-13pk1d4-0 csncjt List__StyledItem-sc-130gdqg-1 lgldaM"
       role="option"
       tabindex="-1"
     >
       alpha
     </li>
     <li
-      class="StyledBox-sc-13pk1d4-0 dkgnCT List__StyledItem-sc-130gdqg-1 lgldaM"
+      class="StyledBox-sc-13pk1d4-0 hTWFyD List__StyledItem-sc-130gdqg-1 lgldaM"
       role="option"
       tabindex="0"
     >
@@ -4003,14 +4003,14 @@ exports[`List events mouse events 2`] = `
     role="listbox"
   >
     <li
-      class="StyledBox-sc-13pk1d4-0 hjepzd List__StyledItem-sc-130gdqg-1 lgldaM"
+      class="StyledBox-sc-13pk1d4-0 csncjt List__StyledItem-sc-130gdqg-1 lgldaM"
       role="option"
       tabindex="0"
     >
       alpha
     </li>
     <li
-      class="StyledBox-sc-13pk1d4-0 gcasPz List__StyledItem-sc-130gdqg-1 lgldaM"
+      class="StyledBox-sc-13pk1d4-0 AMRLz List__StyledItem-sc-130gdqg-1 lgldaM"
       role="option"
       tabindex="-1"
     >
@@ -14001,14 +14001,14 @@ exports[`List onClickItem 2`] = `
     role="listbox"
   >
     <li
-      class="StyledBox-sc-13pk1d4-0 hjepzd List__StyledItem-sc-130gdqg-1 lgldaM"
+      class="StyledBox-sc-13pk1d4-0 csncjt List__StyledItem-sc-130gdqg-1 lgldaM"
       role="option"
       tabindex="-1"
     >
       alpha
     </li>
     <li
-      class="StyledBox-sc-13pk1d4-0 eWMkPm List__StyledItem-sc-130gdqg-1 lgldaM"
+      class="StyledBox-sc-13pk1d4-0 dGDpOq List__StyledItem-sc-130gdqg-1 lgldaM"
       role="option"
       tabindex="0"
     >

--- a/src/js/utils/border.js
+++ b/src/js/utils/border.js
@@ -106,3 +106,23 @@ export const borderStyle = (borderData, responsive, theme) => {
 
   return borderStyles;
 };
+
+export const getHoverIndicatorBorderStyle = (
+  hoverIndicator,
+  responsive,
+  theme,
+) => {
+  let border;
+  if (typeof hoverIndicator === 'object') {
+    if (hoverIndicator.border) {
+      border = hoverIndicator.border;
+    } else {
+      return null;
+    }
+  } else {
+    return null;
+  }
+  return css`
+    ${borderStyle(border, responsive, theme)}
+  `;
+};


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

This PR adds an optional border parameter to the Box element when onClick is present. The border parameter is added to the hoverIndicator and is of BorderType.

#### Where should the reviewer start?

The reviewer can start by looking at `src/js/components/Box/StyledBox.js`

#### What testing has been done on this PR?

An additional test has been added to `Box-style-test.tsx` to test if the border is being applied.
#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [x] `screen` is used for querying.
- [x] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

Fixes #7632 

#### Screenshots (if appropriate)

<img width="1088" height="527" alt="box-with-border-hover" src="https://github.com/user-attachments/assets/448c55ea-b322-4af7-929e-6f0671eb53bc" />


#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
