### PR TITLE
Improve release note generation script

### DIFF
--- a/tools/generate-release-notes.js
+++ b/tools/generate-release-notes.js
@@ -393,7 +393,7 @@ function getSection(pr) {
  */
 function formatEntry(pr) {
   const sentence = formatReleaseSentence(pr).replace(/[.!?]+$/, '');
-  return `- ${sentence}. ([${pr.title} #${pr.number}](${GH_PR_URL}/${pr.number}))`;
+  return `- ${sentence}. [#${pr.number}](${GH_PR_URL}/${pr.number})`;
 }
 
 function lowerFirst(value) {
@@ -681,7 +681,8 @@ function formatReleaseNotes(sections) {
     const entries = sections.get(name);
     if (!entries || entries.length === 0) continue;
 
-    const heading = `${name}:`;
+    const heading =
+      name === 'Beta' ? 'Beta - APIs are subject to change:' : `${name}:`;
 
     // Only print the section heading when there are multiple sections
     // (matches the pattern: single-section releases omit headings)


### PR DESCRIPTION
#### What does this PR do?
Minor adjustments to the release note generation script

- Remove PR title from link
- Change `Beta:` heading to `Beta - APIs are subject to change:`

Before:
```
General:

- DataTable: fix sortable column accessibility issue (aria-sort, discoverability, sort status). ([DataTable: fix sortable column accessibility issue (aria-sort, discoverability, sort status) #7988](https://github.com/grommet/grommet/pull/7988))
- 6425 opsramp textinput password affordance. ([6425 opsramp textinput password affordance #8020](https://github.com/grommet/grommet/pull/8020))
- Added script for release notes and announcement. ([add script for release notes and announcement #8070](https://github.com/grommet/grommet/pull/8070))
- [FormField] Added formField.hover theme property. ([[FormField] Added formField.hover theme property #8092](https://github.com/grommet/grommet/pull/8092))
- [FormField] Allow input config to override formField.hover theme property. ([[FormField] Allow input config to override formField.hover theme property #8098](https://github.com/grommet/grommet/pull/8098))
- Update password to be action-orientated. ([update password to be action-orientated #8120](https://github.com/grommet/grommet/pull/8120))

Beta:

- Fixed TimeInput popup closes when clicking on non-button area inside drop (#8058). ([fix: TimeInput popup closes when clicking on non-button area inside drop (#8058) #8067](https://github.com/grommet/grommet/pull/8067))
- [Stepper] Connector to use t-shirt size instead of px. ([[Stepper] Connector to use t-shirt size instead of px #8094](https://github.com/grommet/grommet/pull/8094))
- ITOM-125490: DateTimeInput: First ArrowUp press skips 01 and sets value to 02. ([ITOM-125490: DateTimeInput: First ArrowUp press skips 01 and sets value to 02 #8087](https://github.com/grommet/grommet/pull/8087))
- Fixed TimeInput Defaults to 01 Instead of 00. ([Fix: TimeInput Defaults to 01 Instead of 00 #8088](https://github.com/grommet/grommet/pull/8088))
- Fixed calendar selected color in grommet dark mode. ([fix calendar selected color in grommet dark mode #8096](https://github.com/grommet/grommet/pull/8096))
- Clean up timeinput theme. ([clean up timeinput theme #8091](https://github.com/grommet/grommet/pull/8091))
- Fixed inline behavior for datetimeinput. ([fix inline behavior for datetimeinput #8097](https://github.com/grommet/grommet/pull/8097))
- StepperStep to use Grommet Button. ([StepperStep to use Grommet Button #8093](https://github.com/grommet/grommet/pull/8093))
- [Stepper] Added ability to control error announcement prominence. ([[Stepper] Added ability to control error announcement prominence #8095](https://github.com/grommet/grommet/pull/8095))
- Fixed TimeInput keyboard behavior. ([TimeInput - fix keyboard behavior #8099](https://github.com/grommet/grommet/pull/8099))
- TimeInput - wire up the text weight. ([TimeInput - wire up the text weight #8100](https://github.com/grommet/grommet/pull/8100))
- Fixed the initial focus on datetimeinput. ([fix the initial focus on datetimeinput #8103](https://github.com/grommet/grommet/pull/8103))
```

After
```
General:

- DataTable: fix sortable column accessibility issue (aria-sort, discoverability, sort status). [#7988](https://github.com/grommet/grommet/pull/7988)
- 6425 opsramp textinput password affordance. [#8020](https://github.com/grommet/grommet/pull/8020)
- Added script for release notes and announcement. [#8070](https://github.com/grommet/grommet/pull/8070)
- [FormField] Added formField.hover theme property. [#8092](https://github.com/grommet/grommet/pull/8092)
- [FormField] Allow input config to override formField.hover theme property. [#8098](https://github.com/grommet/grommet/pull/8098)
- Update password to be action-orientated. [#8120](https://github.com/grommet/grommet/pull/8120)

Beta - APIs are subject to change:

- Fixed TimeInput popup closes when clicking on non-button area inside drop (#8058). [#8067](https://github.com/grommet/grommet/pull/8067)
- [Stepper] Connector to use t-shirt size instead of px. [#8094](https://github.com/grommet/grommet/pull/8094)
- ITOM-125490: DateTimeInput: First ArrowUp press skips 01 and sets value to 02. [#8087](https://github.com/grommet/grommet/pull/8087)
- Fixed TimeInput Defaults to 01 Instead of 00. [#8088](https://github.com/grommet/grommet/pull/8088)
- Fixed calendar selected color in grommet dark mode. [#8096](https://github.com/grommet/grommet/pull/8096)
- Clean up timeinput theme. [#8091](https://github.com/grommet/grommet/pull/8091)
- Fixed inline behavior for datetimeinput. [#8097](https://github.com/grommet/grommet/pull/8097)
- StepperStep to use Grommet Button. [#8093](https://github.com/grommet/grommet/pull/8093)
- [Stepper] Added ability to control error announcement prominence. [#8095](https://github.com/grommet/grommet/pull/8095)
- Fixed TimeInput keyboard behavior. [#8099](https://github.com/grommet/grommet/pull/8099)
- TimeInput - wire up the text weight. [#8100](https://github.com/grommet/grommet/pull/8100)
- Fixed the initial focus on datetimeinput. [#8103](https://github.com/grommet/grommet/pull/8103)

```

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?
no
#### Should this PR be mentioned in the release notes?
no
#### Is this change backwards compatible or is it a breaking change?
backwards compatible