### PR TITLE
fix: time input on drop keyboard direction

### DIFF
--- a/src/js/components/TimeInput/TimeInputPopup.js
+++ b/src/js/components/TimeInput/TimeInputPopup.js
@@ -641,10 +641,10 @@ const TimeInputPopup = ({
           setActiveSection(getAdjacentSection(eventSection, 1));
         } else if (event.key === 'ArrowUp') {
           event.preventDefault();
-          incrementSection(eventSection, 1);
+          incrementSection(eventSection, -1);
         } else if (event.key === 'ArrowDown') {
           event.preventDefault();
-          incrementSection(eventSection, -1);
+          incrementSection(eventSection, 1);
         }
 
         onKeyDownProp?.(event);

--- a/src/js/components/TimeInput/__tests__/TimeInput-test.tsx
+++ b/src/js/components/TimeInput/__tests__/TimeInput-test.tsx
@@ -2190,4 +2190,68 @@ describe('TimeInput', () => {
     expect(getDisplayInput()).toHaveValue('hh:mm:02');
     expect(secondSegment).toHaveTextContent('02');
   });
+
+  test('updates displayed value on ArrowDown in hour inside drop', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Grommet>
+        <TimeInput format="24" />
+      </Grommet>,
+    );
+
+    const chooseTimeButton = screen.getByRole('button', {
+      name: 'Choose time',
+    });
+    await user.click(chooseTimeButton);
+    expect(getDisplayInput()).toHaveValue('hh:mm');
+
+    await user.keyboard('{ArrowDown}');
+    expect(getDisplayInput()).toHaveValue('00:mm');
+    await user.keyboard('{ArrowDown}');
+    expect(getDisplayInput()).toHaveValue('01:mm');
+  });
+
+  test('initialises hour with zero on ArrowUp in hour inside drop', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Grommet>
+        <TimeInput format="24" />
+      </Grommet>,
+    );
+
+    const choostTimeButton = screen.getByRole('button', {
+      name: 'Choose time',
+    });
+
+    await user.click(choostTimeButton);
+    expect(getDisplayInput()).toHaveValue('hh:mm');
+
+    await user.keyboard('{ArrowUp}');
+    expect(getDisplayInput()).toHaveValue('00:mm');
+  });
+
+  test('updates displayed value on ArrowUp in hour inside drop', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Grommet>
+        <TimeInput format="24" />
+      </Grommet>,
+    );
+
+    const choostTimeButton = screen.getByRole('button', {
+      name: 'Choose time',
+    });
+
+    await user.click(choostTimeButton);
+    expect(getDisplayInput()).toHaveValue('hh:mm');
+
+    await user.keyboard('{ArrowUp}');
+    expect(getDisplayInput()).toHaveValue('00:mm');
+
+    await user.keyboard('{ArrowUp}');
+    expect(getDisplayInput()).toHaveValue('23:mm');
+  });
 });

--- a/src/js/components/TimeInput/useSectionedTimeField.js
+++ b/src/js/components/TimeInput/useSectionedTimeField.js
@@ -241,7 +241,11 @@ export const useSectionedTimeField = ({
       const current = sections[key];
 
       if (current === undefined) {
-        setSectionValue(section, delta > 0 ? minValue : maxValue);
+        if (section === SECTION_HOUR) {
+          setSectionValue(section, format === '12' ? maxValue : minValue);
+        } else {
+          setSectionValue(section, delta > 0 ? minValue : maxValue);
+        }
         return;
       }
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

This PR fixes the arrow key direction in TimeInput on the drop component.

#### Where should the reviewer start?

The reviewer can start by looking at `src/js/components/TimeInput/TimeInputPopup.js` and the tests.

#### What testing has been done on this PR?

Three new tests have been added to check the validity of the change.

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [x] `screen` is used for querying.
- [x] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

Fixes #8124 

#### Screenshots (if appropriate)
<img width="1088" height="527" alt="time-input-key-up-down" src="https://github.com/user-attachments/assets/6eee0b2f-0040-4870-8022-796b36918f6f" />


#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
