### PR TITLE
fix(Avatar): avoid remounting custom children on every `re-render`

### DIFF
--- a/src/js/components/Avatar/Avatar.js
+++ b/src/js/components/Avatar/Avatar.js
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
 // SPDX-License-Identifier: Apache-2.0
-import React, { useCallback, useMemo } from 'react';
+import React, { useMemo } from 'react';
 
 import { Image } from '../Image';
 import { StyledAvatar, StyledAvatarText } from './StyledAvatar';
@@ -35,15 +35,6 @@ const Avatar = ({
       width: avatarSize,
     }),
     [align, avatarSize, justify, round],
-  );
-
-  const AvatarChildren = useCallback(
-    () => (
-      <StyledAvatar {...avatarProps} {...rest}>
-        {children}
-      </StyledAvatar>
-    ),
-    [avatarProps, children, rest],
   );
 
   if (height || width) {
@@ -83,7 +74,11 @@ const Avatar = ({
     );
   }
 
-  return <AvatarChildren />;
+  return (
+    <StyledAvatar {...avatarProps} {...rest}>
+      {children}
+    </StyledAvatar>
+  );
 };
 
 Avatar.propTypes = AvatarPropTypes;

--- a/src/js/components/Avatar/__tests__/Avatar-test.tsx
+++ b/src/js/components/Avatar/__tests__/Avatar-test.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
 // SPDX-License-Identifier: Apache-2.0
-import React from 'react';
-import { render } from '@testing-library/react';
+import React, { useEffect, useState } from 'react';
+import { fireEvent, render } from '@testing-library/react';
 import 'jest-styled-components';
 
 import { Favorite } from 'grommet-icons';
@@ -173,5 +173,40 @@ describe('Avatar', () => {
     );
 
     expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test('custom children are not remounted when parent re-renders', () => {
+    const onMount = jest.fn();
+    const Child = () => {
+      useEffect(() => {
+        onMount();
+      }, []);
+      return <span>child</span>;
+    };
+    const Test = () => {
+      const [count, setCount] = useState(0);
+      return (
+        <Grommet>
+          <button type="button" onClick={() => setCount(count + 1)}>
+            rerender {count}
+          </button>
+          <Avatar background="brand">
+            <Child />
+          </Avatar>
+        </Grommet>
+      );
+    };
+
+    const { getByText, getByRole } = render(<Test />);
+
+    const avatarChild = getByText('child');
+    expect(onMount).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(getByRole('button', { name: 'rerender 0' }));
+
+    // the same DOM node should still be there and the child should not
+    // have gone through another mount cycle
+    expect(getByText('child')).toBe(avatarChild);
+    expect(onMount).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Fixes `Avatar` unmounting and remounting its custom JSX children on every parent re-render.
`Avatar` created an `AvatarChildren` component inside its render via `useCallback`. 
Since the `rest` props object is a new reference on every render, the callback — and therefore the component type — changed on every render, so React tore down and rebuilt the whole `StyledAvatar` subtree each time the parent re-rendered. 
Any custom child (icon, `Text`, interactive element, etc.) lost its DOM node, local state and focus.
So, this PR renders `StyledAvatar` directly instead of through a per-render component, so children are reconciled normally. The string-children and `src` code paths are unchanged.

#### Where should the reviewer start?

- `src/js/components/Avatar/Avatar.js` — removal of the `useCallback`-defined `AvatarChildren` and the direct `<StyledAvatar>` return at the bottom.
- `src/js/components/Avatar/__tests__/Avatar-test.tsx` — new test `custom children are not remounted when parent re-renders`.

#### What testing has been done on this PR?

- Added a regression test that renders a custom child with a mount effect inside `Avatar`, triggers a parent re-render, and asserts that the child's DOM node is the same instance and the mount effect ran only once. The test fails on `master` and passes with this change.
- `jest src/js/components/Avatar` — 11 passed (10 existing snapshots unchanged).
- `jest src/js/components/Sidebar` (renders `Avatar`) — 7 passed.
- Full `yarn test` via the pre-commit hook — 1912 passed, plus the timezone Calendar/DateInput runs.

#### How should this be manually tested?

1. Render an `Avatar` with a stateful or focusable child inside a component that re-renders, e.g.:
   ```jsx
   const Demo = () => {
     const [n, setN] = useState(0);
     return (
       <Box gap="small">
         <Button label={`re-render ${n}`} onClick={() => setN(n + 1)} />
         <Avatar background="brand">
           <TextInput placeholder="type here" />
         </Avatar>
       </Box>
     );
   };


2. Focus the input and type something, then click the button.
3. Before: the input loses focus and its typed value on every click (it is remounted). After: focus and value are preserved.

#### Do Jest tests follow these best practices?

- [ ] screen is used for querying. — the new test uses getByText / getByRole destructured from render(), matching the existing style in this file. Happy to switch to screen if preferred.
- [x] The correct query is used. (getByRole('button', { name }) for the trigger, getByText for the plain-text child)
- [ ] asFragment() is used for snapshot testing. — N/A, no snapshot added.

#### Any background context you want to provide?

The AvatarChildren wrapper has been present since the early implementation of Avatar; there is no functional reason for it to be a separate component. 
Defining a component inside another component's render is a known React anti-pattern that always results in remounts, so the fix is to inline it.

#### What are the relevant issues?

None filed.

#### Screenshots (if appropriate)

N/A.

#### Do the grommet docs need to be updated?

No.

#### Should this PR be mentioned in the release notes?

Yes. "Fixed Avatar remounting custom children on every parent re-render."

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.